### PR TITLE
fix package md's into wheel, and fix it copying

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "arckit-cli"
-version = "0.3.3"
+version = "0.3.4"
 description = "ArcKit CLI - Enterprise Architecture Governance & Vendor Procurement Toolkit"
 requires-python = ">=3.11"
 dependencies = [
@@ -11,12 +11,17 @@ dependencies = [
     "readchar",
     "truststore>=0.10.4",
 ]
-authors = [
-    {name = "Your Name", email = "your.email@example.com"}
-]
+authors = [{ name = "Your Name", email = "your.email@example.com" }]
 readme = "README.md"
-license = {text = "MIT"}
-keywords = ["architecture", "enterprise", "governance", "procurement", "rfp", "vendor-selection"]
+license = { text = "MIT" }
+keywords = [
+    "architecture",
+    "enterprise",
+    "governance",
+    "procurement",
+    "rfp",
+    "vendor-selection",
+]
 classifiers = [
     "Development Status :: 3 - Alpha",
     "Intended Audience :: Developers",
@@ -44,3 +49,8 @@ build-backend = "hatchling.build"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/arckit_cli"]
+
+[tool.hatch.build.targets.wheel.shared-data]
+"templates" = "share/arckit/templates"
+".claude" = "share/arckit/.claude"
+"scripts" = "share/arckit/scripts"


### PR DESCRIPTION
__Summary:__ This commit addresses packaging issues by fixing how markdown files and project assets are bundled into the Python wheel distribution and resolving file copying problems during project initialization.

### Changes Made:

#### 1. __Package Configuration Updates__ (`pyproject.toml`)

- __Version bump:__ Updated from `0.3.3` to `0.3.4`

- __Formatting improvements:__ Reformatted authors, license, and keywords arrays for better readability

- __Wheel packaging fix:__ Added `[tool.hatch.build.targets.wheel.shared-data]` section to properly include:

  - `templates` → `share/arckit/templates`
  - `.claude` → `share/arckit/.claude`
  - `scripts` → `share/arckit/scripts`

#### 2. __CLI Module Enhancements__ (`src/arckit_cli/__init__.py`)

- __New dependency:__ Added `platformdirs` import for cross-platform data directory handling

- __Robust path resolution:__ Implemented `get_data_paths()` function with multiple fallback strategies:

  - UV tool installs (`~/.local/share/uv/tools/arckit-cli/share/arckit/`)
  - Regular pip installs (site-packages)
  - Platformdirs approach
  - Development mode fallback

- __Enhanced project initialization:__

  - Replaced hardcoded relative paths with dynamic path resolution
  - Added comprehensive debug logging showing resolved paths
  - Improved error handling with warning messages for missing resources
  - Added counters for copied templates and commands
  - Better user feedback during the setup process

### Technical Impact:

__Before:__ The CLI relied on relative paths that only worked in development mode, causing failures when installed as a package.

__After:__ The CLI now properly locates templates, scripts, and commands regardless of installation method (pip, uv, development mode).

### Files Changed:

- `pyproject.toml` (+6 lines, -6 lines) - Package configuration fixes
- `src/arckit_cli/__init__.py` (+80 lines, -7 lines) - Path resolution and initialization improvements

### Benefits:

1. __Packaging reliability:__ Templates and assets are now properly included in wheel distributions
2. __Installation flexibility:__ Works with pip, uv, and development installations
3. __Better user experience:__ Clear feedback and warnings during project setup
4. __Maintainability:__ Centralized path resolution logic with fallback strategies

This fix ensures the ArcKit CLI works correctly when installed as a package, resolving the "missing templates" issue that users encountered with packaged installations.
