### PR TITLE
feat: enhance diagram command with C4 layout science and validation checklist

### DIFF
--- a/arckit-plugin/CHANGELOG.md
+++ b/arckit-plugin/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **C4 layout science reference template** — `c4-diagram-reference.md` with research-backed graph drawing guidance: Sugiyama algorithm, tier-based declaration ordering, edge crossing targets (Purchase et al.), C4 colour standards, node shape reference, PlantUML directional hints, prompt antipatterns, and iterative refinement process
+- **Diagram quality gate** — structured 6-criterion validation checklist added to `/arckit:diagram` command (edge crossings, visual hierarchy, grouping, flow direction, traceability, abstraction level)
+- **C4 layout science guide** — `docs/guides/c4-layout-science.md` standalone reference for C4 diagram best practices
+
+---
+
 ## [2.7.1] - 2026-02-20
 
 ### Added

--- a/arckit-plugin/commands/diagram.md
+++ b/arckit-plugin/commands/diagram.md
@@ -54,6 +54,24 @@ If the user specified a type (e.g., `/arckit.diagram deployment`), skip this que
 
 Apply the user's selection when choosing which Mode (A-F) to generate in Step 2 below.
 
+## Step 1d: Load Layout Science Reference
+
+Read `${CLAUDE_PLUGIN_ROOT}/templates/c4-diagram-reference.md` for research-backed graph drawing guidance. This reference covers:
+
+- **Sugiyama algorithm** — why declaration order affects the Dagre layout engine's crossing minimisation stage
+- **Tier-based declaration ordering** — declare elements from actors (left) to external systems (right) to give the layout engine an optimal starting position
+- **Edge crossing targets** — Purchase et al. research on comprehension: 0 crossings for simple diagrams (6 or fewer elements), fewer than 3 for medium (7-12), fewer than 5 for complex (more than 12)
+- **C4 colour standards** — hex codes for Person (#08427B), System (#1168BD), Container (#438DD5), Component (#85BBF0), External (#999999)
+- **PlantUML directional hints** — `Rel_Right`, `Rel_Down`, `Lay_Right`, `Lay_Down` for complex diagrams exceeding Mermaid's layout capabilities
+- **Prompt antipatterns** — common mistakes (random element order, relationships before elements, mixed abstraction levels) and their fixes
+
+Apply these principles when generating diagrams in Step 3. In particular:
+
+1. **Declare all elements before any relationships**
+2. **Order element declarations** to match the intended reading direction (left-to-right for `flowchart LR`, top-to-bottom for `flowchart TB`)
+3. **Apply `classDef` styling** using the C4 colour palette for visual consistency
+4. **Use `subgraph`** to group related elements within architectural boundaries
+
 ## Step 2: Determine the Diagram Type
 
 Based on the user's request and available artifacts, select the appropriate diagram type:
@@ -641,6 +659,28 @@ Before finalizing, validate the diagram:
 - [ ] Grouping (subgraphs) is logical
 - [ ] Complexity is appropriate for audience
 - [ ] Split into multiple diagrams if too complex
+
+## Step 5b: Diagram Quality Gate
+
+After generating the diagram, evaluate it against the following quality criteria derived from graph drawing research (Purchase et al.) and C4 best practices. Report the results as part of the output:
+
+| Criterion | Target | Result | Status |
+|-----------|--------|--------|--------|
+| Edge crossings | fewer than 5 for complex diagrams, 0 for simple (6 or fewer elements) | {count or estimate} | {PASS/FAIL} |
+| Visual hierarchy | System boundary is the most prominent visual element | {assessment} | {PASS/FAIL} |
+| Grouping | Related elements are proximate (Gestalt proximity principle) | {assessment} | {PASS/FAIL} |
+| Flow direction | Consistent left-to-right or top-to-bottom throughout | {direction} | {PASS/FAIL} |
+| Relationship traceability | Each line can be followed from source to target without ambiguity | {assessment} | {PASS/FAIL} |
+| Abstraction level | One C4 level per diagram (context, container, component, or code) | {level} | {PASS/FAIL} |
+
+**If any criterion fails:**
+
+1. **Reorder element declarations** to match the intended tier layout (actors first, external systems last)
+2. **Add `subgraph` containers** for related elements to improve visual grouping
+3. **For PlantUML:** use directional hints (`Rel_Right`, `Rel_Down`, `Lay_Right`, `Lay_Down`) to control placement
+4. **Re-generate and re-evaluate** until all criteria pass or document accepted trade-offs in the Architecture Decisions section
+
+**Accepted trade-offs:** If a crossing or layout imperfection cannot be eliminated without sacrificing clarity elsewhere, document the trade-off explicitly. For example: "One edge crossing between the Payment API and Cache is accepted to maintain the left-to-right tier ordering of all other elements."
 
 ## Step 6: Integration with ArcKit Workflow
 

--- a/arckit-plugin/templates/c4-diagram-reference.md
+++ b/arckit-plugin/templates/c4-diagram-reference.md
@@ -1,0 +1,439 @@
+# C4 Diagram Layout Reference
+
+A research-backed reference for creating readable C4 architecture diagrams with minimal edge crossings and clear visual hierarchy. This document supplements the `/arckit:diagram` command with graph drawing science, layout optimisation techniques, and quality targets.
+
+---
+
+## 1. Why Declaration Order Matters
+
+Mermaid uses the **Dagre layout algorithm**, which implements the Sugiyama hierarchical layout method. Understanding this algorithm explains why the order you declare elements directly affects diagram quality.
+
+The Sugiyama algorithm proceeds in four stages:
+
+| Stage | Name | What It Does |
+|-------|------|-------------|
+| 1 | Cycle removal | Temporarily reverses edges to eliminate cycles |
+| 2 | Layer assignment | Assigns nodes to horizontal/vertical layers (ranks) |
+| 3 | Crossing minimisation | Reorders nodes within each layer to reduce edge crossings |
+| 4 | Coordinate assignment | Calculates final x/y positions for rendering |
+
+**Declaration order directly affects Stage 3.** The barycentric method — the most common crossing minimisation heuristic — computes the average position of each node's connected neighbours in the adjacent layer. The initial ordering of nodes within each layer comes from the order they appear in the source code. A better starting order means the heuristic converges to fewer crossings.
+
+**In practical terms:** if you declare your elements in the order you want them to appear (left-to-right for `flowchart LR`, top-to-bottom for `flowchart TB`), the layout engine starts from a position much closer to optimal and produces cleaner diagrams.
+
+---
+
+## 2. Tier-Based Declaration Ordering
+
+Declare elements in your intended reading order. For a typical `flowchart LR` (left-to-right) architecture diagram, this means:
+
+1. **Actors** (leftmost) — users, administrators, external clients
+2. **Presentation layer** — web applications, mobile apps, portals
+3. **API layer** — API gateways, load balancers, reverse proxies
+4. **Service layer** — business logic services, orchestrators, workers
+5. **Data layer** — databases, caches, message queues, object stores
+6. **External systems** (rightmost) — third-party APIs, legacy systems, SaaS providers
+
+### Example Declaration Order (Mermaid)
+
+```mermaid
+flowchart LR
+    %% 1. Actors
+    Citizen["Citizen"]
+    CaseWorker["Case Worker"]
+
+    %% 2. Presentation
+    WebApp["Web Application"]
+
+    %% 3. API
+    APIGateway["API Gateway"]
+
+    %% 4. Services
+    PaymentService["Payment Service"]
+    NotificationService["Notification Service"]
+
+    %% 5. Data
+    Database[("PostgreSQL")]
+    Cache["Redis Cache"]
+    Queue(["Message Queue"])
+
+    %% 6. External
+    GOVUKPay["GOV.UK Pay"]
+    GOVUKNotify["GOV.UK Notify"]
+    BankSystem["Bank System"]
+
+    %% Relationships AFTER all elements
+    Citizen --> WebApp
+    CaseWorker --> WebApp
+    WebApp --> APIGateway
+    APIGateway --> PaymentService
+    APIGateway --> NotificationService
+    PaymentService --> Database
+    PaymentService --> Cache
+    PaymentService --> Queue
+    PaymentService --> GOVUKPay
+    NotificationService --> GOVUKNotify
+    GOVUKPay --> BankSystem
+```
+
+### For C4 Native Syntax
+
+C4 diagrams (`C4Context`, `C4Container`) follow the same principle. Declare elements in this order:
+
+1. `Person(...)` — all actors first
+2. `System(...)` — the system being described
+3. `System_Boundary(...)` with nested `Container(...)` — internal containers
+4. `System_Ext(...)` — external systems last
+5. `Rel(...)` — all relationships after all elements
+
+---
+
+## 3. Edge Crossing Targets
+
+Purchase et al. proved that **edge crossings are the strongest predictor of diagram comprehension**, more important than node overlap, edge bends, or alignment. Their experimental work demonstrated that diagrams with fewer crossings were understood significantly faster and with fewer errors.
+
+### Targets by Complexity
+
+| Complexity | Elements | Target Crossings | Rationale |
+|-----------|----------|-----------------|-----------|
+| Simple | 6 or fewer | 0 | Achievable with careful ordering; no crossings expected |
+| Medium | 7-12 | fewer than 3 | Barycentric heuristic handles well with good initial order |
+| Complex | More than 12 | fewer than 5 | May require subgraph grouping or diagram splitting |
+
+### When Targets Are Exceeded
+
+If your diagram exceeds these targets:
+
+1. **Reorder declarations** to match intended tier layout
+2. **Group related elements** using `subgraph` (Gestalt proximity principle)
+3. **Split into multiple diagrams** at natural architectural boundaries
+4. **Switch to PlantUML** if Mermaid's layout cannot achieve acceptable results (see Section 7)
+
+---
+
+## 4. C4 Colour Standards
+
+The C4 model defines a standard colour palette that communicates element type at a glance. These colours should be applied consistently across all diagrams using `classDef` in Mermaid or `skinparam` in PlantUML.
+
+| Element | Hex Code | RGB | Usage |
+|---------|----------|-----|-------|
+| Person | `#08427B` | 8, 66, 123 | Users, actors, human roles |
+| Software System (internal) | `#1168BD` | 17, 104, 189 | The system being described |
+| Container | `#438DD5` | 67, 141, 213 | Applications, services, databases within the system |
+| Component | `#85BBF0` | 133, 187, 240 | Internal components within a container |
+| External System | `#999999` | 153, 153, 153 | Third-party systems, external APIs, SaaS providers |
+| Boundary | `stroke:#1168BD,stroke-dasharray:5 5` | — | System boundaries, trust boundaries |
+
+### Applying Colours in Mermaid
+
+```mermaid
+flowchart LR
+    classDef person fill:#08427B,stroke:#073B6F,color:#fff
+    classDef system fill:#1168BD,stroke:#0E5CA8,color:#fff
+    classDef container fill:#438DD5,stroke:#3A7ABE,color:#fff
+    classDef component fill:#85BBF0,stroke:#78A8D8,color:#000
+    classDef external fill:#999999,stroke:#888888,color:#fff
+    classDef boundary stroke:#1168BD,stroke-dasharray:5 5,fill:none
+
+    Citizen["Citizen"]:::person
+    PaymentGateway["Government Payment Gateway"]:::system
+    BankSystem["Bank System"]:::external
+```
+
+### Colour Accessibility
+
+The C4 palette provides sufficient contrast ratios for most uses. For WCAG 2.2 AA compliance in printed or projected diagrams, ensure text labels maintain a minimum 4.5:1 contrast ratio against the fill colour. The standard white text on dark fills (#08427B, #1168BD) meets this requirement; the lighter Component blue (#85BBF0) should use dark text.
+
+---
+
+## 5. Node Shape Reference
+
+Mermaid supports several node shapes, each carrying semantic meaning in architecture diagrams:
+
+| Shape | Syntax | Renders As | Use For |
+|-------|--------|-----------|---------|
+| Rectangle | `Node["text"]` | Standard box | Containers, components, systems, services |
+| Rounded rectangle | `Node("text")` | Rounded box | Processes, functions, lightweight services |
+| Cylinder | `Node[("text")]` | Database symbol | Databases, data stores, data warehouses |
+| Stadium | `Node(["text"])` | Pill shape | Queues, topics, message brokers, event streams |
+| Hexagon | `Node{{"text"}}` | Hexagon | Decision points, routing logic, gateways |
+| Parallelogram | `Node[/"text"/]` | Slanted box | Input/output, file systems, external data |
+| Trapezoid | `Node[\"text"\]` | Trapezoid | Manual processes, human-in-the-loop steps |
+| Circle | `Node(("text"))` | Circle | Start/end points, events, triggers |
+| Diamond | `Node{"text"}` | Diamond | Conditional branching, decision nodes |
+
+### Recommended Shape Conventions for C4
+
+| Architecture Element | Shape | Example |
+|---------------------|-------|---------|
+| Web application | Rectangle | `WebApp["Web Application<br/><i>React, TypeScript</i>"]` |
+| API service | Rectangle | `API["Payment API<br/><i>Node.js, Express</i>"]` |
+| Database | Cylinder | `DB[("PostgreSQL<br/>Transaction Data")]` |
+| Message queue | Stadium | `Queue(["RabbitMQ<br/>Async Processing"])` |
+| Cache | Rectangle | `Cache["Redis Cache<br/>Session Store"]` |
+| External system | Rectangle (grey) | `ExtSys["Bank System"]:::external` |
+
+---
+
+## 6. Label Format
+
+Architecture diagram labels should convey three pieces of information: the element name, its type/technology, and a brief description. The recommended format uses HTML-like tags supported by Mermaid:
+
+### Standard Format
+
+```
+["<b>Name</b><br/><i>[Type: Technology]</i><br/><br/>Description"]
+```
+
+### Examples
+
+```mermaid
+%% Full label with name, type, and description
+WebApp["<b>Web Application</b><br/><i>[Container: React]</i><br/><br/>Provides payment interface<br/>to citizens"]
+
+%% Shorter label for simpler elements
+DB["<b>Transaction Database</b><br/><i>[Container: PostgreSQL]</i>"]
+
+%% Minimal label for context diagrams
+PayGateway["<b>Government Payment Gateway</b><br/><i>[Software System]</i>"]
+```
+
+### Label Guidelines
+
+- **Context diagrams**: Name and type only (keep labels short for high-level view)
+- **Container diagrams**: Name, technology, and brief responsibility
+- **Component diagrams**: Name, technology/pattern, and specific responsibility
+- **Avoid wrapping**: Keep labels under 4 lines to prevent visual clutter
+- **Line breaks**: Use `<br/>` for node labels in all diagram types; use comma-separated text (not `<br/>`) for edge labels in flowcharts
+
+---
+
+## 7. PlantUML Directional Hints
+
+For complex diagrams that exceed Mermaid's layout capabilities (typically more than 12-15 elements), PlantUML with the C4-PlantUML library provides directional relationship hints that give explicit control over layout.
+
+### Directional Relationship Functions
+
+| Hint | Effect | Use For |
+|------|--------|---------|
+| `Rel_Down(a, b, ...)` | Places a above b | Hierarchical tiers (user above system) |
+| `Rel_Up(a, b, ...)` | Places a below b | Callbacks, reverse dependencies |
+| `Rel_Right(a, b, ...)` | Places a left of b | Horizontal data flow (L-to-R reading) |
+| `Rel_Left(a, b, ...)` | Places a right of b | Reverse horizontal flow |
+| `Rel_Neighbor(a, b, ...)` | Forces a and b adjacent | Tightly coupled components |
+
+### Invisible Layout Relationships
+
+| Hint | Effect | Use For |
+|------|--------|---------|
+| `Lay_Right(a, b)` | Forces a to appear left of b | Aligning elements within the same tier |
+| `Lay_Down(a, b)` | Forces a to appear above b | Vertical tier alignment |
+| `Lay_Distance(a, b, 2)` | Increases spacing between a and b | Separating logical groups |
+
+### Example: Controlling Layout with Directional Hints
+
+```plantuml
+@startuml
+!include https://raw.githubusercontent.com/plantuml-stdlib/C4-PlantUML/master/C4_Container.puml
+
+Person(citizen, "Citizen", "Makes payments to government services")
+
+System_Boundary(pg, "Government Payment Gateway") {
+    Container(web, "Web Application", "React", "Payment interface")
+    Container(api, "Payment API", "Node.js", "Processes payment requests")
+    Container(orch, "Payment Orchestrator", "Python", "Routes to payment providers")
+    ContainerDb(db, "Database", "PostgreSQL", "Transaction records")
+    ContainerQueue(queue, "Message Queue", "RabbitMQ", "Async event processing")
+}
+
+System_Ext(govukpay, "GOV.UK Pay", "Government payment provider")
+System_Ext(bank, "Bank System", "Processes financial transactions")
+
+Rel_Down(citizen, web, "Makes payment", "HTTPS")
+Rel_Right(web, api, "Calls", "REST/JSON")
+Rel_Right(api, orch, "Routes", "gRPC")
+Rel_Down(api, db, "Reads/Writes", "SQL")
+Rel_Down(api, queue, "Publishes", "AMQP")
+Rel_Right(orch, govukpay, "Processes via", "API")
+Rel_Right(govukpay, bank, "Transfers", "BACS")
+
+Lay_Right(web, api)
+Lay_Right(api, orch)
+Lay_Right(db, queue)
+
+@enduml
+```
+
+### When to Use PlantUML over Mermaid
+
+| Criterion | Mermaid | PlantUML |
+|----------|---------|----------|
+| Element count | 12 or fewer | More than 12 |
+| Layout control needed | Low | High |
+| Rendering environment | GitHub, VS Code, web | CI/CD pipelines, docs-as-code |
+| Edge crossing control | Limited (declaration order only) | Extensive (directional hints) |
+| Native C4 support | C4Context/C4Container syntax | C4-PlantUML library (full C4) |
+
+---
+
+## 8. Prompt Antipatterns
+
+Common mistakes when generating architecture diagrams and how to fix them:
+
+| Antipattern | Why It Fails | Fix |
+|------------|-------------|-----|
+| Random element order | Dagre starts crossing minimisation from a poor initial position, producing more crossings | Declare elements in tier order matching the intended data flow direction |
+| Relationships before elements | Layout engine encounters references to undeclared nodes, producing unpredictable positioning | Declare ALL elements before ANY relationships |
+| Mixed abstraction levels | Database tables appearing on a container diagram, or infrastructure on a context diagram | Maintain one abstraction level per diagram (C4 Level 1, 2, 3, or 4) |
+| Too many elements (more than 15) | Exceeds Mermaid's Dagre engine capacity for readable layout; crossings multiply exponentially | Split into multiple diagrams at natural boundaries, or switch to PlantUML with directional hints |
+| Bidirectional edges everywhere | Creates visual noise; every edge crossing doubles in visual complexity | Use unidirectional edges showing primary data flow; annotate reverse flow in descriptions |
+| No subgraph grouping | Related elements scattered across the diagram without visual proximity | Group related elements in `subgraph` blocks (Gestalt proximity principle) |
+| Overly long labels | Labels wrap unpredictably, distorting node sizes and pushing elements apart | Keep labels under 4 lines; use abbreviations with a legend table |
+| Using `<br/>` in flowchart edge labels | Mermaid flowchart parser rejects HTML in edge labels (causes "Parse error") | Use comma-separated text in edge labels (e.g., `"Uses, HTTPS"`) |
+
+---
+
+## 9. Iterative Refinement
+
+When a diagram renders with too many edge crossings or poor readability, follow this systematic refinement process:
+
+### Step-by-Step Process
+
+1. **Reorder element declarations** to match the intended tier layout (see Section 2). Place actors first, external systems last, and everything else in data-flow order between them.
+
+2. **Add `subgraph` containers** for logically related elements. The Gestalt principle of proximity means that visually grouping elements communicates their relationship and reduces perceived complexity.
+
+3. **Reorder declarations within subgraphs.** The layout engine processes elements within each subgraph independently, so the same tier-ordering principle applies at every level of nesting.
+
+4. **For Mermaid:** If reordering alone is insufficient, try:
+   - Splitting into two diagrams at a natural architectural boundary
+   - Using `flowchart LR` instead of `flowchart TB` (or vice versa) to find a better orientation
+   - Reducing the number of elements by collapsing tightly-coupled components into a single node
+
+5. **For PlantUML:** Change generic `Rel` to directional variants:
+   - `Rel_Right(a, b, ...)` for horizontal flow
+   - `Rel_Down(a, b, ...)` for hierarchical relationships
+   - Add invisible `Lay_Right` / `Lay_Down` relationships to force alignment
+
+6. **Split the diagram** if complexity exceeds the threshold (more than 15 elements). Natural split points include:
+   - System boundary (context vs. internal)
+   - Trust boundary (public vs. private network)
+   - Domain boundary (bounded contexts in DDD)
+   - Deployment boundary (cloud regions, availability zones)
+
+7. **Document accepted trade-offs.** If a crossing cannot be eliminated without sacrificing clarity elsewhere, note it in the diagram's architecture decisions section.
+
+---
+
+## 10. Worked Examples
+
+### Example 1: C4 Context Diagram — Government Payment Gateway
+
+A context-level diagram showing the Government Payment Gateway system and its interactions with users and external systems.
+
+```mermaid
+flowchart LR
+    classDef person fill:#08427B,stroke:#073B6F,color:#fff
+    classDef system fill:#1168BD,stroke:#0E5CA8,color:#fff
+    classDef external fill:#999999,stroke:#888888,color:#fff
+
+    %% 1. Actors (leftmost)
+    Citizen["<b>Citizen</b><br/><i>[Person]</i><br/><br/>Makes payments to<br/>government services"]:::person
+
+    %% 2. System under description
+    PayGateway["<b>Government Payment Gateway</b><br/><i>[Software System]</i><br/><br/>Processes citizen payments<br/>across government services"]:::system
+
+    %% 3. External systems (rightmost)
+    GOVUKPay["<b>GOV.UK Pay</b><br/><i>[External System]</i><br/><br/>Government payment<br/>processing platform"]:::external
+    BankSystem["<b>Bank System</b><br/><i>[External System]</i><br/><br/>Processes financial<br/>transactions via BACS"]:::external
+    GOVUKNotify["<b>GOV.UK Notify</b><br/><i>[External System]</i><br/><br/>Sends payment confirmations<br/>via email and SMS"]:::external
+
+    %% Relationships (ALL after elements)
+    Citizen -->|"Submits payment, HTTPS"| PayGateway
+    PayGateway -->|"Processes payment, API"| GOVUKPay
+    PayGateway -->|"Sends confirmation, API"| GOVUKNotify
+    GOVUKPay -->|"Transfers funds, BACS"| BankSystem
+```
+
+**Layout notes:**
+- Declaration order matches left-to-right reading: Citizen, then the system, then external systems
+- All relationships declared after all elements
+- 5 elements = Simple complexity; target is 0 crossings
+- Edge labels use comma-separated text (no `<br/>`)
+
+### Example 2: C4 Container Diagram — Government Payment Gateway
+
+A container-level diagram showing the technical architecture within the system boundary.
+
+```mermaid
+flowchart LR
+    classDef person fill:#08427B,stroke:#073B6F,color:#fff
+    classDef container fill:#438DD5,stroke:#3A7ABE,color:#fff
+    classDef database fill:#438DD5,stroke:#3A7ABE,color:#fff
+    classDef queue fill:#438DD5,stroke:#3A7ABE,color:#fff
+    classDef external fill:#999999,stroke:#888888,color:#fff
+    classDef boundary stroke:#1168BD,stroke-dasharray:5 5,fill:none
+
+    %% 1. Actors
+    Citizen["<b>Citizen</b><br/><i>[Person]</i>"]:::person
+
+    %% 2-5. System boundary with containers in tier order
+    subgraph PayGateway["Government Payment Gateway"]
+        direction LR
+
+        %% Presentation tier
+        WebApp["<b>Web Application</b><br/><i>[Container: React]</i><br/><br/>Provides payment interface<br/>with WCAG 2.2 AA compliance"]:::container
+
+        %% API tier
+        PayAPI["<b>Payment API</b><br/><i>[Container: Node.js]</i><br/><br/>RESTful API handling<br/>payment requests"]:::container
+
+        %% Service tier
+        Orchestrator["<b>Payment Orchestrator</b><br/><i>[Container: Python]</i><br/><br/>Routes payments to<br/>appropriate provider"]:::container
+
+        %% Data tier
+        DB[("<b>Database</b><br/><i>[Container: PostgreSQL]</i><br/><br/>Transaction records")]:::database
+        Queue(["<b>Message Queue</b><br/><i>[Container: RabbitMQ]</i><br/><br/>Async event processing"]):::queue
+        Cache["<b>Cache</b><br/><i>[Container: Redis]</i><br/><br/>Session and response cache"]:::container
+    end
+
+    %% 6. External systems
+    GOVUKPay["<b>GOV.UK Pay</b><br/><i>[External System]</i>"]:::external
+    GOVUKNotify["<b>GOV.UK Notify</b><br/><i>[External System]</i>"]:::external
+
+    %% Relationships (ALL after elements)
+    Citizen -->|"Uses, HTTPS"| WebApp
+    WebApp -->|"Calls, REST/JSON"| PayAPI
+    PayAPI -->|"Routes payment"| Orchestrator
+    PayAPI -->|"Reads/Writes, SQL"| DB
+    PayAPI -->|"Publishes events, AMQP"| Queue
+    PayAPI -->|"Gets/Sets, Redis Protocol"| Cache
+    Orchestrator -->|"Processes via, API"| GOVUKPay
+    PayAPI -->|"Sends confirmation, API"| GOVUKNotify
+```
+
+**Layout notes:**
+- 8 containers + 1 actor + 2 external = 11 elements (Medium complexity); target is fewer than 3 crossings
+- `subgraph` groups all internal containers within the system boundary
+- Elements within the subgraph follow tier order: presentation, API, service, data
+- Cylinder shape `[("...")]` signals the database; stadium shape `(["..."])` signals the queue
+- External systems declared last to appear on the right edge
+
+---
+
+## 11. References
+
+1. **Purchase, H.C. et al.** (2002). "Graph Drawing Aesthetics and the Comprehension of UML Class Diagrams: An Empirical Study." *Australian Computer Science Communications*, 24(1), 11-20. Key finding: edge crossings are the strongest negative predictor of diagram comprehension.
+
+2. **Sugiyama, K., Tagawa, S., and Toda, M.** (1981). "Methods for Visual Understanding of Hierarchical System Structures." *IEEE Transactions on Systems, Man, and Cybernetics*, 11(2), 109-125. Foundation of the layered graph drawing algorithm used by Dagre/Mermaid.
+
+3. **C4 Model** — Simon Brown. [https://c4model.com](https://c4model.com). The four-level architecture visualisation model (Context, Container, Component, Code).
+
+4. **Mermaid Flowchart Syntax** — [https://mermaid.js.org/syntax/flowchart.html](https://mermaid.js.org/syntax/flowchart.html). Official Mermaid documentation for flowchart diagram syntax.
+
+5. **C4-PlantUML** — [https://github.com/plantuml-stdlib/C4-PlantUML](https://github.com/plantuml-stdlib/C4-PlantUML). PlantUML macros for C4 model diagrams with directional layout hints.
+
+6. **Wertheimer, M.** (1923). Gestalt principles of perceptual organisation. The proximity principle — elements placed close together are perceived as belonging to the same group — underpins the use of `subgraph` containers in architecture diagrams.
+
+---
+
+*This reference is maintained as part of the ArcKit plugin. For the full diagram generation command, see `/arckit:diagram`.*

--- a/docs/guides/c4-layout-science.md
+++ b/docs/guides/c4-layout-science.md
@@ -1,0 +1,278 @@
+# C4 Layout Science Guide
+
+A research-backed guide to creating readable C4 architecture diagrams with minimal edge crossings and clear visual hierarchy. This guide covers the graph drawing theory behind layout engines, practical declaration ordering strategies, quality targets from empirical research, and a structured validation checklist.
+
+For the full reference template used by the `/arckit:diagram` command, see `arckit-plugin/templates/c4-diagram-reference.md`.
+
+---
+
+## Graph Drawing Theory
+
+### The Sugiyama Algorithm
+
+Mermaid's layout engine uses Dagre, which implements the **Sugiyama hierarchical layout algorithm** — the most widely-used method for drawing directed graphs in layers. Understanding how this algorithm works explains why certain authoring choices produce better diagrams.
+
+The algorithm proceeds in four stages:
+
+**Stage 1: Cycle Removal**
+The algorithm temporarily reverses edges that create cycles in the graph. This ensures the graph can be processed as a directed acyclic graph (DAG). Reversed edges are restored with their original direction after layout is complete.
+
+**Stage 2: Layer Assignment**
+Each node is assigned to a horizontal or vertical layer (rank). Nodes that depend on other nodes are placed in later layers, creating the top-to-bottom or left-to-right hierarchy. Long edges that span multiple layers are broken into segments with invisible intermediate nodes.
+
+**Stage 3: Crossing Minimisation**
+This is the critical stage where declaration order matters. The algorithm reorders nodes within each layer to minimise the number of edge crossings. The most common technique is the **barycentric method**: for each node, compute the average position of its connected neighbours in the adjacent layer, then sort nodes by this average.
+
+The barycentric method is a local optimisation heuristic — it improves an initial ordering but does not guarantee a global optimum. This means the initial order (determined by the order nodes appear in the source code) significantly affects the final result. A good starting order produces fewer crossings.
+
+**Stage 4: Coordinate Assignment**
+Final x/y coordinates are calculated for each node, respecting minimum spacing, edge routing, and the layer assignments from Stage 2.
+
+### Why This Matters for Architecture Diagrams
+
+When you write a Mermaid or PlantUML diagram, you are providing the initial ordering for Stage 3. If your declaration order already matches the intended visual layout, the crossing minimisation heuristic starts from a near-optimal position and produces a clean diagram. If elements are declared in random order, the heuristic starts from a poor position and may converge to a layout with unnecessary crossings.
+
+---
+
+## Declaration Ordering
+
+### The Tier-Based Strategy
+
+For architecture diagrams, the most effective declaration strategy is **tier-based ordering**: declare elements in the order they should appear visually, following the natural data flow of the system.
+
+For a `flowchart LR` (left-to-right) diagram:
+
+| Order | Tier | Examples | Position |
+|-------|------|----------|----------|
+| 1 | Actors | Citizens, administrators, operators | Leftmost |
+| 2 | Presentation | Web applications, mobile apps, portals | Left |
+| 3 | API | API gateways, load balancers, BFF services | Centre-left |
+| 4 | Service | Business logic, orchestrators, workers | Centre |
+| 5 | Data | Databases, caches, queues, object stores | Centre-right |
+| 6 | External systems | Third-party APIs, GOV.UK services, banks | Rightmost |
+
+For a `flowchart TB` (top-to-bottom) diagram, the same tiers apply vertically: actors at the top, external systems at the bottom.
+
+### Three Rules
+
+1. **Declare ALL elements before ANY relationships.** The layout engine positions nodes as it encounters them. If a relationship references an undeclared node, the engine creates it at that point, often in a suboptimal position.
+
+2. **Within each tier, declare elements in the order you want them to appear.** For a horizontal layout, declare left-to-right. For a vertical layout, declare top-to-bottom.
+
+3. **Group related elements with `subgraph`.** This constrains the layout engine to keep grouped elements together, reinforcing the visual hierarchy.
+
+### C4-Specific Ordering
+
+For C4 native syntax (`C4Context`, `C4Container`), the recommended declaration order is:
+
+1. `Person(...)` — all actors
+2. `System(...)` — the system being described
+3. `System_Boundary(...)` — system boundaries containing:
+   - `Container(...)` — in tier order within the boundary
+   - `ContainerDb(...)` — databases
+   - `ContainerQueue(...)` — queues (PlantUML only)
+4. `System_Ext(...)` — all external systems
+5. `Rel(...)` — all relationships last
+
+---
+
+## Edge Crossing Targets
+
+### The Research
+
+Purchase et al. conducted empirical studies measuring how different graph aesthetics affect human comprehension. Their key finding: **edge crossings are the strongest negative predictor of diagram comprehension**, significantly more impactful than:
+
+- Node overlap
+- Edge bends
+- Symmetry violations
+- Minimum angle between edges
+
+Participants shown diagrams with fewer crossings understood them faster, answered questions about them more accurately, and rated them as more readable.
+
+### Practical Targets
+
+Based on this research and practical experience with architecture diagrams:
+
+| Complexity | Element Count | Target Crossings | Notes |
+|-----------|--------------|-----------------|-------|
+| Simple | 6 or fewer | 0 | Easily achievable with tier-based ordering |
+| Medium | 7-12 | Fewer than 3 | Requires careful ordering; subgraphs help |
+| Complex | More than 12 | Fewer than 5 | May need diagram splitting or PlantUML hints |
+
+### Counting Crossings
+
+When evaluating a rendered diagram:
+
+- Count each point where two edges intersect (not at a node)
+- Self-loops and edges to/from the same subgraph boundary do not count
+- Edges that run parallel closely but do not intersect do not count
+- If you cannot count crossings easily, the diagram is too complex — split it
+
+---
+
+## Visual Hierarchy
+
+### The Gestalt Proximity Principle
+
+The Gestalt principle of proximity states that elements placed close together are perceived as belonging to the same group. In architecture diagrams, this principle supports two practices:
+
+1. **Use `subgraph` blocks** to visually group related elements. Mermaid draws a visible boundary around subgraph contents, creating an immediate visual grouping.
+
+2. **Nest subgraphs** to represent hierarchical containment. For example, a system boundary containing multiple subsystem boundaries containing individual containers.
+
+### Applying Visual Hierarchy in C4
+
+| C4 Level | Visual Treatment | How to Achieve |
+|----------|-----------------|----------------|
+| Context | System boundary is the largest visual element | Single `subgraph` or `System_Boundary` containing all internal elements |
+| Container | Containers grouped by architectural tier | Nested `subgraph` blocks for presentation, service, and data tiers |
+| Component | Components grouped by responsibility | `subgraph` blocks for handlers, services, repositories |
+| Deployment | Infrastructure zones (VPC, subnets, regions) | Deeply nested `subgraph` blocks matching network topology |
+
+### Boundary Styling
+
+Use dashed borders for trust boundaries and solid borders for system boundaries:
+
+```mermaid
+%% Trust boundary (dashed)
+subgraph TrustBoundary["DMZ"]
+    style TrustBoundary stroke:#1168BD,stroke-dasharray:5 5,fill:none
+end
+
+%% System boundary (solid)
+subgraph SystemBoundary["Payment Gateway"]
+    style SystemBoundary stroke:#1168BD,stroke-width:2px,fill:#E8F0FE
+end
+```
+
+---
+
+## Validation Checklist
+
+After generating any architecture diagram, evaluate it against these six criteria:
+
+| # | Criterion | Target | How to Evaluate |
+|---|-----------|--------|----------------|
+| 1 | **Edge crossings** | 0 for simple, fewer than 3 for medium, fewer than 5 for complex | Count intersection points of edges (not at nodes) |
+| 2 | **Visual hierarchy** | System boundary is the most prominent visual element | Check that the main system boundary is immediately identifiable |
+| 3 | **Grouping** | Related elements are proximate | Verify that architecturally-related elements appear visually close |
+| 4 | **Flow direction** | Consistent left-to-right or top-to-bottom | Check that the primary data flow follows one consistent direction |
+| 5 | **Relationship traceability** | Each line can be followed from source to target | Trace each edge visually — if any edge is ambiguous, the diagram needs improvement |
+| 6 | **Abstraction level** | One C4 level per diagram | Verify that the diagram does not mix context-level and container-level elements |
+
+### Quality Gate Integration
+
+The `/arckit:diagram` command includes a **Step 5b: Diagram Quality Gate** that automatically evaluates generated diagrams against these criteria and reports results in a structured table. Any failing criterion triggers an iterative refinement cycle.
+
+---
+
+## Iterative Refinement
+
+When a diagram fails one or more validation criteria, follow this systematic process:
+
+### Step 1: Reorder Declarations
+
+The most common fix. Rearrange element declarations to match the intended tier layout:
+
+- Actors first (leftmost or topmost)
+- Internal elements in data-flow order
+- External systems last (rightmost or bottommost)
+
+This alone resolves most edge crossing issues.
+
+### Step 2: Add Subgraph Grouping
+
+Group related elements using `subgraph` blocks:
+
+```mermaid
+subgraph Services["Business Services"]
+    PaymentService["Payment Service"]
+    NotificationService["Notification Service"]
+    AuditService["Audit Service"]
+end
+```
+
+This constrains the layout engine to keep grouped elements together, reducing crossings between unrelated edges.
+
+### Step 3: Reorder Within Subgraphs
+
+The same tier-ordering principle applies within each subgraph. If elements within a group produce crossings, reorder their declarations.
+
+### Step 4: Change Orientation
+
+Try switching between `flowchart LR` and `flowchart TB`. Some architectures produce fewer crossings in one orientation than the other:
+
+- **Horizontal (LR)** works well for data-flow architectures (request flows left to right)
+- **Vertical (TB)** works well for hierarchical architectures (users at top, infrastructure at bottom)
+
+### Step 5: Use PlantUML Directional Hints
+
+If Mermaid cannot achieve acceptable results, switch to PlantUML with the C4-PlantUML library and use directional hints:
+
+| Hint | Effect |
+|------|--------|
+| `Rel_Down(a, b, ...)` | Places a above b |
+| `Rel_Right(a, b, ...)` | Places a left of b |
+| `Lay_Right(a, b)` | Forces a left of b (invisible) |
+| `Lay_Down(a, b)` | Forces a above b (invisible) |
+
+### Step 6: Split the Diagram
+
+If the element count exceeds 15 or crossings remain above the target after all other refinements, split the diagram at a natural boundary:
+
+- **System boundary** — separate context from internal structure
+- **Trust boundary** — separate public-facing from internal components
+- **Domain boundary** — separate bounded contexts
+- **Deployment boundary** — separate cloud regions or availability zones
+
+### Step 7: Document Trade-Offs
+
+If a crossing or layout imperfection cannot be eliminated without sacrificing clarity elsewhere, document it explicitly in the diagram's architecture decisions section.
+
+---
+
+## Format Selection Guide
+
+Choose the right format based on diagram complexity and requirements:
+
+| Scenario | Format | Reason |
+|----------|--------|--------|
+| Simple C4 (12 or fewer elements) | Mermaid `C4Context` / `C4Container` | Native C4 syntax, renders in GitHub markdown and VS Code |
+| Complex C4 (more than 12 elements) | PlantUML with C4-PlantUML | Directional hints (`Rel_Right`, `Lay_Down`) for precise crossing control |
+| Deployment diagrams | Mermaid `flowchart` | `subgraph` nesting maps naturally to infrastructure zones (VPC, subnets, AZs) |
+| Sequence diagrams | Mermaid `sequenceDiagram` | Native support for request/response flows, alt/opt blocks, participant ordering |
+| Data flow diagrams | Mermaid `flowchart` | PII annotations, data classification labels, retention metadata in node labels |
+| Wardley Maps | Online Wardley Mapping (OWM) | Specialised positioning by evolution and value chain; not achievable in Mermaid |
+
+### Rendering Environments
+
+| Environment | Mermaid Support | PlantUML Support |
+|-------------|----------------|-----------------|
+| GitHub markdown | Native rendering | Requires image embedding |
+| VS Code | Mermaid Preview extension | PlantUML extension |
+| mermaid.live | Full interactive editor | N/A |
+| PlantUML Server | N/A | Full rendering |
+| Confluence | Mermaid plugin (varies) | PlantUML plugin |
+| PDF export | Via Mermaid CLI (`mmdc`) | Via PlantUML JAR |
+
+---
+
+## References
+
+1. **Purchase, H.C., Cohen, R.F., and James, M.I.** (1997). "An Experimental Study of the Basis for Graph Drawing Aesthetics." *Journal of Visual Languages and Computing*, 8(1), 32-50.
+
+2. **Purchase, H.C.** (2002). "Metrics for Graph Drawing Aesthetics." *Journal of Visual Languages and Computing*, 13(5), 501-516. Establishes that edge crossings have the strongest negative effect on comprehension.
+
+3. **Sugiyama, K., Tagawa, S., and Toda, M.** (1981). "Methods for Visual Understanding of Hierarchical System Structures." *IEEE Transactions on Systems, Man, and Cybernetics*, 11(2), 109-125. The foundational algorithm for layered graph drawing.
+
+4. **Brown, S.** The C4 Model for Visualising Software Architecture. [https://c4model.com](https://c4model.com). Defines the four abstraction levels (Context, Container, Component, Code) and standard visual notation.
+
+5. **Wertheimer, M.** (1923). "Untersuchungen zur Lehre von der Gestalt II." *Psychologische Forschung*, 4(1), 301-350. Establishes the proximity principle used to justify subgraph grouping.
+
+6. **Mermaid Documentation** — Flowchart Syntax. [https://mermaid.js.org/syntax/flowchart.html](https://mermaid.js.org/syntax/flowchart.html).
+
+7. **C4-PlantUML** — PlantUML macros for C4 diagrams. [https://github.com/plantuml-stdlib/C4-PlantUML](https://github.com/plantuml-stdlib/C4-PlantUML).
+
+---
+
+*This guide is part of the ArcKit documentation. For the template used by the diagram command, see `arckit-plugin/templates/c4-diagram-reference.md`. For the diagram command itself, see `/arckit:diagram`.*


### PR DESCRIPTION
## Summary
- Adds research-backed C4 diagram layout guidance to `/arckit:diagram`
- New `c4-diagram-reference.md` template covering Sugiyama algorithm, tier-based ordering, edge crossing targets (Purchase et al.)
- New validation quality gate with 6-criterion checklist
- Standalone `docs/guides/c4-layout-science.md` reference guide

## Motivation
ArcKit's diagram command generates Mermaid/PlantUML diagrams but layout quality varies. This adds research-backed layout science and validation for consistently readable C4 diagrams.

## Test plan
- [ ] Run `/arckit:diagram` and verify layout reference is loaded
- [ ] Verify validation checklist appears in output
- [ ] Test with both Mermaid C4 and PlantUML output paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)