### PR TITLE
feat: spawn vendor profiles and tech notes from research output

### DIFF
--- a/arckit-plugin/CHANGELOG.md
+++ b/arckit-plugin/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Knowledge compounding from research** — research agent now spawns standalone vendor profiles and tech notes from research findings, extracting reusable knowledge that persists beyond the originating project
+- New `vendor-profile-template.md` and `tech-note-template.md` templates for spawned knowledge files
+- `--no-spawn` flag for `/arckit.research` to skip knowledge compounding when only the main research document is needed
+- Documentation: `docs/guides/knowledge-compounding.md` explaining the compound knowledge pattern, deduplication, and directory structure
+
+---
+
 ## [2.7.1] - 2026-02-20
 
 ### Added

--- a/arckit-plugin/agents/arckit-research.md
+++ b/arckit-plugin/agents/arckit-research.md
@@ -230,6 +230,74 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
+### Step 11b: Spawn Reusable Knowledge
+
+> **Skip this step** if the user passed `--no-spawn` in the original command arguments.
+
+After writing the main research document, extract reusable knowledge into standalone files so that findings persist beyond this project and can be discovered by future research runs.
+
+**Slug Generation Rule:**
+To ensure consistent deduplication, slugs must be generated deterministically:
+1. Take the vendor/topic name (e.g., "Amazon Web Services", "Event-Driven Architecture")
+2. Convert to lowercase: "amazon web services"
+3. Replace spaces with hyphens: "amazon-web-services"
+4. Remove special characters (slashes, ampersands, periods — omit or replace with hyphens)
+5. Remove leading/trailing hyphens
+6. Collapse multiple consecutive hyphens to single
+
+Examples:
+- "AWS" → "aws"
+- "Auth0" → "auth0"
+- "Event-Driven Architecture" → "event-driven-architecture"
+- "SAP SuccessFactors" → "sap-successfactors"
+- ".NET Core" → "net-core"
+
+**Vendor Profiles:**
+
+1. For each vendor evaluated in depth (3+ data points gathered — e.g., pricing, features, compliance), check whether a vendor profile already exists:
+   ```bash
+   ls projects/{project-dir}/vendors/*{vendor-slug}* 2>/dev/null
+   ```
+2. **If no profile exists**: Read the vendor profile template at `${CLAUDE_PLUGIN_ROOT}/templates/vendor-profile-template.md` and create a new file at `projects/{project-dir}/vendors/{vendor-slug}-profile.md`. Populate all sections from the research findings. Set `Confidence` based on the depth of data gathered (high = 5+ data points, medium = 3-4, low = fewer).
+3. **If a profile exists**: Read the existing profile and apply these merge rules per section:
+   - **Overview**: Keep existing text; append new strategic insights only if vendor positioning has materially changed
+   - **Products & Services**: Merge new product lines; do not remove old ones (append "(deprecated as of YYYY-MM-DD)" if a product is no longer available)
+   - **Pricing Model**: Replace with current pricing; note the date of change (e.g., "Updated YYYY-MM-DD — previously X, now Y")
+   - **UK Government Presence**: Update only if new research confirms a change in G-Cloud/DOS listing or data centre status
+   - **Strengths/Weaknesses**: Append new items; do not remove old ones (append "(addressed as of YYYY-MM-DD)" if a weakness has been resolved or a strength is no longer relevant)
+   - **Projects Referenced In**: Add this project if not already listed
+   - **Last Researched**: Update to today's date
+
+**Tech Notes:**
+
+4. For each significant technology finding (a technology, protocol, or standard researched with 2+ substantive facts), check whether a tech note already exists:
+   ```bash
+   ls projects/{project-dir}/tech-notes/*{topic-slug}* 2>/dev/null
+   ```
+5. **If no tech note exists**: Read the tech note template at `${CLAUDE_PLUGIN_ROOT}/templates/tech-note-template.md` and create a new file at `projects/{project-dir}/tech-notes/{topic-slug}.md`. Populate from research findings.
+6. **If a tech note exists**: Read the existing note and apply these merge rules per section:
+   - **Summary**: Update only if understanding has significantly changed; otherwise keep existing
+   - **Key Findings**: Append new findings; mark outdated ones with "(superseded as of YYYY-MM-DD)" rather than removing
+   - **Relevance to Projects**: Add this project if not already listed
+   - **Last Updated**: Update to today's date
+
+**Traceability:**
+
+7. Append a `## Spawned Knowledge` section at the end of the main research document listing all created or updated files:
+   ```markdown
+   ## Spawned Knowledge
+
+   The following standalone knowledge files were created or updated from this research:
+
+   ### Vendor Profiles
+   - `vendors/{vendor-slug}-profile.md` — {Created | Updated}
+
+   ### Tech Notes
+   - `tech-notes/{topic-slug}.md` — {Created | Updated}
+   ```
+
+**Deduplication rule:** Always search for existing coverage before creating. Use filename glob patterns: `projects/{project-dir}/vendors/*{vendor-name}*` and `projects/{project-dir}/tech-notes/*{topic}*`. Slugs must be lowercase with hyphens (e.g., `aws-profile.md`, `event-driven-architecture.md`).
+
 ### Step 12: Return Summary
 
 Return ONLY a concise summary including:
@@ -241,6 +309,7 @@ Return ONLY a concise summary including:
 - Requirements coverage percentage
 - Top 3 recommended vendors
 - Key findings (3-5 bullet points)
+- Spawned knowledge (number of vendor profiles and tech notes created/updated, unless `--no-spawn` was used)
 - Next steps (run `/arckit:wardley`, `/arckit:sobc`, `/arckit:sow`)
 
 ## Quality Standards

--- a/arckit-plugin/commands/research.md
+++ b/arckit-plugin/commands/research.md
@@ -28,8 +28,10 @@ Research technology and service options for the project in projects/{project-dir
 
 User's additional context: {$ARGUMENTS}
 
-Follow your full process: read requirements, identify categories, conduct web research, build vs buy analysis, TCO comparison, write document, return summary.
+Follow your full process: read requirements, identify categories, conduct web research, build vs buy analysis, TCO comparison, write document, spawn reusable knowledge, return summary.
 ```
+
+   If the user included `--no-spawn` in their arguments, append to the agent prompt: `Skip Step 11b (do not spawn vendor profiles or tech notes).`
 
 3. **Report the result**: When the agent completes, relay its summary to the user.
 
@@ -49,6 +51,12 @@ If the Task tool is unavailable or the user prefers inline execution, fall back 
 6. Write to `projects/{project-dir}/ARC-{PROJECT_ID}-RSCH-v1.0.md` using Write tool
 7. Show summary only (not full document)
 
+### Flags
+
+| Flag | Effect |
+|------|--------|
+| `--no-spawn` | Skip knowledge compounding — produce the research document only, without spawning vendor profiles or tech notes. Useful for quick research or when you do not want additional files created. |
+
 ### Output
 
 The agent writes the full research document to file and returns a summary including:
@@ -57,7 +65,17 @@ The agent writes the full research document to file and returns a summary includ
 - 3-year TCO range
 - Requirements coverage
 - Top vendor shortlist
+- Spawned vendor profiles and tech notes (unless `--no-spawn` was used)
 - Next steps (`/arckit:wardley`, `/arckit:sobc`, `/arckit:sow`)
+
+#### Spawned Knowledge
+
+In addition to the main research document, the agent creates standalone files for reusable knowledge:
+
+- **Vendor profiles** at `projects/{project}/vendors/{vendor-slug}-profile.md` — one per vendor evaluated in depth (3+ data points)
+- **Tech notes** at `projects/{project}/tech-notes/{topic-slug}.md` — one per significant technology finding (2+ substantive facts)
+
+Existing profiles and notes are updated rather than duplicated. A `## Spawned Knowledge` section is appended to the research document listing everything created or updated. See the [Knowledge Compounding Guide](../../docs/guides/knowledge-compounding.md) for details.
 
 ## Integration with Other Commands
 
@@ -67,3 +85,5 @@ The agent writes the full research document to file and returns a summary includ
 - **Output**: Feeds into `/arckit:sobc` (Economic Case TCO data)
 - **Output**: Feeds into `/arckit:sow` (RFP vendor requirements)
 - **Output**: Feeds into `/arckit:hld-review` (validates technology choices)
+- **Output**: Spawns `vendors/{slug}-profile.md` (reusable vendor knowledge)
+- **Output**: Spawns `tech-notes/{slug}.md` (reusable technology knowledge)

--- a/arckit-plugin/templates/tech-note-template.md
+++ b/arckit-plugin/templates/tech-note-template.md
@@ -1,0 +1,17 @@
+# Tech Note: {TOPIC}
+
+## Document Control
+| Field | Value |
+|-------|-------|
+| Topic | {TOPIC} |
+| Last Updated | {DATE} |
+| Source Research | {RESEARCH_DOC_ID} |
+
+## Summary
+{One-paragraph overview}
+
+## Key Findings
+{Bulleted findings from research}
+
+## Relevance to Projects
+{Which projects benefit from this knowledge}

--- a/arckit-plugin/templates/vendor-profile-template.md
+++ b/arckit-plugin/templates/vendor-profile-template.md
@@ -1,0 +1,32 @@
+# Vendor Profile: {VENDOR_NAME}
+
+## Document Control
+| Field | Value |
+|-------|-------|
+| Vendor | {VENDOR_NAME} |
+| Last Researched | {DATE} |
+| Source Research | {RESEARCH_DOC_ID} |
+| Confidence | {high/medium/low} |
+
+## Overview
+{One-paragraph vendor summary}
+
+## Products & Services
+{Relevant product lines}
+
+## Pricing Model
+{Pricing structure — CAPEX/OPEX/subscription}
+
+## UK Government Presence
+- G-Cloud listed: {yes/no/unknown}
+- DOS listed: {yes/no/unknown}
+- UK data centres: {yes/no/details}
+
+## Strengths
+{Bulleted strengths}
+
+## Weaknesses
+{Bulleted weaknesses}
+
+## Projects Referenced In
+{List of ArcKit projects where this vendor was evaluated}

--- a/docs/guides/knowledge-compounding.md
+++ b/docs/guides/knowledge-compounding.md
@@ -1,0 +1,133 @@
+# Knowledge Compounding Guide
+
+`/arckit.research` automatically extracts reusable knowledge from research output into standalone vendor profiles and tech notes.
+
+> **Compound Knowledge Pattern**: One research document contains findings about vendors and technologies that persist beyond the project that discovered them. By extracting these into standalone files, future projects can find and reference existing knowledge instead of re-researching from scratch.
+
+---
+
+## Why Knowledge Compounding Matters
+
+Research is expensive — each run performs dozens of web searches, fetches vendor pricing pages, and cross-references compliance data. Without compounding, this knowledge is locked inside a single research document and invisible to future projects.
+
+**The problem:** Project A researches AWS, Stripe, and Auth0 in depth. Six months later, Project B needs payment processing research. Without compounding, Project B starts from zero.
+
+**The solution:** Project A's research spawns `vendors/stripe-profile.md` with pricing, compliance, and strengths/weaknesses. When Project B runs research, the existing profile provides a head start — the agent updates it with fresh data rather than rebuilding from nothing.
+
+---
+
+## What Gets Spawned
+
+### Vendor Profiles
+
+Created when a vendor is evaluated with **3 or more data points** (e.g., pricing, features, compliance, reviews, UK Government presence).
+
+**Location:** `projects/{project}/vendors/{vendor-slug}-profile.md`
+
+**Contains:**
+- Vendor overview and product lines
+- Pricing model (CAPEX/OPEX/subscription)
+- UK Government presence (G-Cloud, DOS, UK data centres)
+- Strengths and weaknesses
+- Projects where the vendor has been evaluated
+
+**Examples:**
+- `vendors/aws-profile.md`
+- `vendors/stripe-profile.md`
+- `vendors/auth0-profile.md`
+
+### Tech Notes
+
+Created when a technology, protocol, or standard is researched with **2 or more substantive facts**.
+
+**Location:** `projects/{project}/tech-notes/{topic-slug}.md`
+
+**Contains:**
+- Summary of the technology or standard
+- Key findings from research
+- Relevance to current and future projects
+
+**Examples:**
+- `tech-notes/event-driven-architecture.md`
+- `tech-notes/pci-dss-compliance.md`
+- `tech-notes/graphql-vs-rest.md`
+
+---
+
+## Directory Structure
+
+After research with spawning enabled, a project directory looks like this:
+
+```
+projects/001-my-project/
+├── ARC-001-REQ-v1.0.md          # Requirements (input)
+├── ARC-001-RSCH-v1.0.md         # Research findings (main output)
+├── vendors/                      # Spawned vendor profiles
+│   ├── aws-profile.md
+│   ├── stripe-profile.md
+│   └── auth0-profile.md
+└── tech-notes/                   # Spawned tech notes
+    ├── event-driven-architecture.md
+    └── pci-dss-compliance.md
+```
+
+---
+
+## Deduplication
+
+The research agent always checks for existing files before creating new ones. It uses filename glob patterns to find matches:
+
+- `projects/{project}/vendors/*{vendor-name}*`
+- `projects/{project}/tech-notes/*{topic}*`
+
+**When a match is found**, the agent reads the existing file, merges in new findings, and updates the date fields. It does not overwrite existing content — it appends or refines.
+
+**When no match is found**, the agent creates a new file from the appropriate template.
+
+---
+
+## Source Traceability
+
+Every spawned file includes a `Source Research` field in its Document Control table linking back to the research document that created it:
+
+```markdown
+| Source Research | ARC-001-RSCH-v1.0 |
+```
+
+The main research document includes a `## Spawned Knowledge` section at the end listing all vendor profiles and tech notes that were created or updated during that research run.
+
+---
+
+## Skipping Knowledge Spawning
+
+Use the `--no-spawn` flag to produce only the main research document without creating additional files:
+
+```bash
+/arckit.research Research options for authentication --no-spawn
+```
+
+**When to skip:**
+- Quick exploratory research where you do not want to pollute the project with standalone files
+- Re-running research purely to refresh the main document
+- Projects where you prefer to manage vendor and technology notes manually
+
+---
+
+## Confidence Levels
+
+Vendor profiles include a confidence indicator based on the depth of research:
+
+| Confidence | Criteria |
+|------------|----------|
+| **high** | 5+ data points gathered (pricing, features, compliance, reviews, case studies) |
+| **medium** | 3–4 data points gathered |
+| **low** | Fewer than 3 data points (profile created for completeness but needs enrichment) |
+
+---
+
+## Follow-on Actions
+
+- Review spawned profiles and notes for accuracy before sharing
+- Reference vendor profiles from `/arckit:evaluate` scoring summaries
+- Use tech notes as input for `/arckit:adr` when making technology decisions
+- Update profiles manually when you learn new information outside of research runs


### PR DESCRIPTION
## Summary
- Introduces compound knowledge pattern to research workflow
- New Step 11b: spawn vendor profiles (3+ data points) and tech notes (2+ facts) from research
- Deduplication via glob patterns with deterministic slug generation
- Explicit merge rules for updating existing profiles (append-only, date-stamped)
- New `--no-spawn` flag to skip spawning
- New templates: `vendor-profile-template.md`, `tech-note-template.md`
- Guide at `docs/guides/knowledge-compounding.md`

## Motivation
Research documents contain vendor and technology knowledge that persists beyond the project. This extracts it into standalone, reusable notes for future projects.

## Test plan
- [ ] Run `/arckit:research` and verify vendor profiles spawned
- [ ] Verify tech notes spawned for significant findings
- [ ] Verify `## Spawned Knowledge` section in research output
- [ ] Run with `--no-spawn` and verify no spawning
- [ ] Run twice and verify deduplication (update, not duplicate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)