### PR TITLE
feat: add architecture-workflow process skill

### DIFF
--- a/arckit-plugin/commands/start.md
+++ b/arckit-plugin/commands/start.md
@@ -1,12 +1,11 @@
 ---
-description: Get oriented with ArcKit — check project status, explore available commands, and choose your next step
+description: Get oriented with ArcKit — guided project onboarding, workflow selection, and command recommendations
 argument-hint: "[workflow focus, e.g. 'new project', 'procurement', 'governance review']"
-tags: [start, onboarding, getting-started, welcome, help, overview, guide]
 ---
 
-# ArcKit: Onboarding & Navigation
+# ArcKit: Project Onboarding
 
-You are providing a **guided onboarding and navigation experience** for ArcKit. This is a console-only diagnostic command — do NOT create a file. Your output is a navigation aid, not a governance artifact.
+Use the **architecture-workflow** skill to guide this user through project onboarding and workflow selection.
 
 ## User Input
 
@@ -14,175 +13,9 @@ You are providing a **guided onboarding and navigation experience** for ArcKit. 
 $ARGUMENTS
 ```
 
----
+## Instructions
 
-## Process
-
-### Step 1: Welcome Banner
-
-Use the ArcKit version from context (provided by the SessionStart hook), then display:
-
-```text
-ArcKit — Enterprise Architecture Governance Toolkit
-Version X.Y.Z | 53 commands | Plugin mode
-
-Your AI-powered assistant for architecture governance, vendor procurement,
-and compliance — all driven by templates and traceability.
-```
-
-Replace `X.Y.Z` with the actual version from context.
-
-### Step 2: Detect Project State
-
-Use the **ArcKit Project Context** (above) to get the project inventory. Display a compact summary:
-
-```text
-Projects
---------
-🟢 [001] project-name (N artifacts)
-🟠 [002] another-project (N artifacts)
-
-Global foundations:
-  ✓ Architecture Principles (ARC-000-PRIN-v1.0.md)
-  ✗ No policies directory
-  ✗ No external reference documents
-```
-
-**Completeness heuristic** — estimate project completeness based on artifact types present:
-
-- 0-24%: Only stakeholders/principles/requirements
-- 25-49%: Has research, data-model, or ADRs
-- 50-74%: Has design reviews, SOW, or evaluations
-- 75-100%: Has traceability, governance analysis, conformance
-
-**If no `projects/` directory exists**, show:
-
-```text
-No project structure found. Run /arckit:init to create your first project.
-```
-
-**If `list-projects.sh` is not available**, fall back to manually checking for `projects/` directory.
-
-> **Note**: The ArcKit Project Context hook may have already detected projects and artifacts. Use that context when available rather than scanning manually.
-
-### Step 3: Check Connected Tools
-
-Check which MCP tools are available by listing available tools. Look for:
-
-- **AWS Knowledge** — tools with `aws` in the name (enables `/arckit:aws-research`)
-- **Microsoft Learn** — tools with `microsoft` in the name (enables `/arckit:azure-research`)
-- **Google Developer** — tools with `google` in the name (enables `/arckit:gcp-research`)
-
-Report which are connected:
-
-```text
-Connected Tools
----------------
-✓ AWS Knowledge — AWS service research and architecture patterns
-✓ Microsoft Learn — Azure and Microsoft documentation
-✗ Google Developer — not connected (GCP research available via web search fallback)
-```
-
-Only show this section if at least one cloud research MCP is detected. If none are connected, skip this section entirely.
-
-### Step 4: Show Command Decision Tree
-
-If the user provided `$ARGUMENTS` with a specific focus area (e.g., "procurement", "new project", "governance"), skip directly to the relevant section of the tree and expand it with more detail.
-
-Otherwise, show the full navigation tree:
-
-```text
-What are you working on?
-
-Starting a new project
-├── No project structure?     → /arckit:init
-├── Need principles first?    → /arckit:principles (global, required by most commands)
-├── Planning phases & gates?  → /arckit:plan
-└── Ready to scope?           → /arckit:stakeholders → /arckit:requirements
-
-Architecture decisions
-├── Technology research?      → /arckit:research (build vs buy, market scan)
-├── Cloud service research?   → /arckit:aws-research, /arckit:azure-research, /arckit:gcp-research
-├── Data architecture?        → /arckit:data-model → /arckit:datascout
-├── Platform strategy?        → /arckit:platform-design → /arckit:wardley
-└── Record a decision?        → /arckit:adr
-
-Procurement & evaluation
-├── Statement of work / RFP?  → /arckit:sow
-├── G-Cloud services?         → /arckit:gcloud-search → /arckit:gcloud-clarify
-├── Digital Outcomes?          → /arckit:dos
-└── Evaluate vendors?         → /arckit:evaluate
-
-Quality & governance
-├── Artifact health scan?     → /arckit:health
-├── Governance analysis?      → /arckit:analyze
-├── Architecture conformance? → /arckit:conformance
-├── Principles compliance?    → /arckit:principles-compliance
-└── Traceability matrix?      → /arckit:traceability
-
-UK Government compliance
-├── GDS Service Standard?     → /arckit:service-assessment
-├── Technology Code of Practice? → /arckit:tcop
-├── Secure by Design?         → /arckit:secure
-├── AI Playbook?              → /arckit:ai-playbook
-└── MOD Secure by Design?     → /arckit:mod-secure
-
-Reporting & publishing
-├── Project narrative?        → /arckit:story
-├── MARP presentation?        → /arckit:presentation
-└── GitHub Pages site?        → /arckit:pages
-```
-
-### Step 5: Context-Aware Recommendations
-
-Based on what was detected in Step 2, provide 3-5 specific **suggested next steps**. Use this decision logic:
-
-| Project State | Recommendations |
-|---|---|
-| No `projects/` directory | "Run `/arckit:init` to create your project structure" |
-| No principles (no `000-global/ARC-000-PRIN-*`) | "Run `/arckit:principles` — this is required by most downstream commands" |
-| Project at 0-24% completeness | Suggest: `/arckit:stakeholders` → `/arckit:requirements` → `/arckit:risk` (the standard opening sequence) |
-| Project at 25-49% completeness | Suggest: `/arckit:research`, `/arckit:data-model`, or `/arckit:adr` based on what artifact types are missing |
-| Project at 50-74% completeness | Suggest: `/arckit:sow`, `/arckit:evaluate`, or design review commands based on what's missing |
-| Project at 75-100% completeness | Suggest: governance commands (`/arckit:health`, `/arckit:analyze`, `/arckit:conformance`, `/arckit:traceability`) |
-| Multiple projects | Highlight which project needs the most attention (fewest artifacts relative to others) |
-
-Format as a numbered list:
-
-```text
-Suggested next steps
---------------------
-1. Run /arckit:principles to establish architecture principles (required by most commands)
-2. Run /arckit:stakeholders to analyze stakeholder drivers and goals
-3. Run /arckit:requirements to create your requirements specification
-```
-
-### Step 6: Conversational Entry Points
-
-Present three conversational entry points to help the user choose their path:
-
-```text
-How can I help today?
-
-1. "I'm starting a new project"
-   → I'll guide you through init → principles → stakeholders → requirements
-
-2. "I need to make an architecture decision"
-   → I'll help with research, ADRs, and design reviews
-
-3. "I want to review existing work"
-   → I'll run health checks, governance analysis, and compliance scans
-```
-
-### Step 7: Wait for Response
-
-Wait for user input and route to the appropriate command or workflow based on their response. If they choose one of the three entry points, begin guiding them through that workflow.
-
----
-
-## Important Notes
-
-- **Console output only** — do NOT create a file. This is a navigation aid, not a governance artifact.
-- **Use the ArcKit Project Context hook** — the hook has already detected projects and artifacts; use that data rather than scanning directories manually where possible.
-- If `list-projects.sh` is not available (e.g., running outside plugin context), fall back to manually checking for `projects/` directory.
-- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` to prevent markdown renderers from interpreting them as HTML tags.
+1. Follow the architecture-workflow skill process exactly
+2. If the user provided `$ARGUMENTS` with a specific focus (e.g., "procurement", "governance review"), use that as context during triage — it may let you skip some questions
+3. The skill will detect project state, ask adaptive questions, and present a tailored command plan
+4. Do NOT run any commands — only present the recommended plan for the user to execute

--- a/arckit-plugin/skills/architecture-workflow/SKILL.md
+++ b/arckit-plugin/skills/architecture-workflow/SKILL.md
@@ -1,0 +1,218 @@
+---
+name: architecture-workflow
+description: "This skill should be used when the user asks how to start an architecture project, which ArcKit commands to run, what order to run commands in, what's the right workflow path, how to begin with ArcKit, project onboarding, getting started, which commands do I need, recommend commands for my project, architecture governance workflow, command sequence, what's next after this command. Triggers: start a project, which commands should I run, what's next, how do I begin, recommend a workflow, onboard my project, getting started with arckit, project setup, arckit start, arckit workflow, what commands are available, guide me through, help me plan my architecture, new project setup, what order, command sequence, next steps."
+---
+
+# Architecture Workflow
+
+A process skill that guides users through ArcKit project onboarding by asking adaptive-depth questions and recommending a tailored command sequence. This skill replaces the old inline `/arckit:start` logic with a structured, question-driven methodology.
+
+<HARD-GATE>
+Do NOT run any `/arckit:*` commands during this process. Your only output is a recommended command plan. The user decides when and what to execute. This applies regardless of how simple the project seems.
+</HARD-GATE>
+
+## Anti-Patterns
+
+### "I already know what I need"
+
+Even experienced architects benefit from the triage. It catches blind spots — missing compliance requirements, forgotten dependencies, stakeholder gaps. The triage is fast (3-4 questions). Skip it and you risk generating artifacts in the wrong order or missing mandatory prerequisites.
+
+### "Just run everything"
+
+A 30-command sequence helps nobody. The skill's job is to recommend the *right* commands for *this* project, in the *right* order. Every project is different — a compliance review needs 6 commands, not 30.
+
+## Process
+
+Follow these steps in order. Ask questions one at a time using AskUserQuestion. Prefer multiple-choice options.
+
+### Step 1: Detect Project State
+
+Automatically check the project context (no questions needed):
+
+- Check if `projects/` directory exists and count projects
+- Check for principles document (`ARC-000-PRIN-*`)
+- Count existing artifacts per project
+- Use ArcKit Project Context from the SessionStart hook if available
+
+Based on findings, determine:
+
+- **New project**: No `projects/` directory or empty — recommend starting from scratch
+- **Early stage**: Projects exist but few artifacts (0-24% complete) — recommend next foundation steps
+- **Mid stage**: Has requirements, some design artifacts (25-74%) — recommend design and procurement steps
+- **Late stage**: Has most artifacts (75-100%) — recommend quality, compliance, and reporting steps
+
+Display a brief status summary before asking questions:
+
+```text
+Project State: [1 project found, 4 artifacts, ~20% complete]
+```
+
+Or:
+
+```text
+Project State: No project structure found. Starting fresh.
+```
+
+### Step 2: Triage Questions
+
+Ask these questions one at a time. Each uses AskUserQuestion with multiple-choice options.
+
+**Question 1 — Sector:**
+
+- UK Government (civilian departments)
+- Defence (MOD, defence contractors)
+- Public sector (non-UK)
+- Private sector
+
+**Question 2 — Project Type:**
+
+- New system build
+- System migration or modernization
+- Procurement / vendor selection
+- Data platform or analytics
+- AI/ML system
+- Strategy or governance review only
+
+**Question 3 — Current Stage:**
+
+- Just starting (no artifacts yet)
+- Have stakeholders and/or requirements
+- Have design artifacts (data model, research, diagrams)
+- Need compliance review of existing work
+
+**Question 4 — Primary Goal:**
+
+- Full governance lifecycle (end-to-end)
+- Specific deliverable (e.g., just requirements, just SOBC)
+- Compliance check (assess existing work)
+- Quick prototype documentation (minimum viable)
+
+### Step 3: Deep Questions (Complex Projects Only)
+
+Only ask these if the project triggers complexity:
+
+- Sector is UK Government or Defence
+- Project type is AI/ML
+- Primary goal is full governance lifecycle
+
+Ask one at a time:
+
+**Q5 — Compliance Frameworks** (multiple select):
+
+- GDS Service Standard
+- Technology Code of Practice (TCoP)
+- NCSC Cyber Assessment Framework
+- AI Playbook
+- JSP 440 / MOD Secure by Design
+- JSP 936 / MOD AI Assurance
+- None / not sure
+
+**Q6 — Procurement** (if applicable):
+
+- G-Cloud (Digital Marketplace)
+- Digital Outcomes and Specialists (DOS)
+- Open tender / framework agreement
+- No procurement needed
+
+**Q7 — Strategic Analysis:**
+
+- Yes, need Wardley Maps and strategic positioning
+- Yes, need platform design (multi-sided platform)
+- No, straightforward technology choices
+
+**Q8 — Timeline Pressure:**
+
+- Weeks (urgent, minimum viable only)
+- Months (standard delivery)
+- Quarters (major programme, full governance)
+
+### Step 4: Present Tailored Plan
+
+Based on the answers, select the appropriate path and present the plan.
+
+#### Decision Logic
+
+**Base path selection:**
+
+| Sector Answer | Base Path |
+|---------------|-----------|
+| Private sector or Public sector (non-UK) | [standard-path.md](references/standard-path.md) |
+| UK Government | [uk-gov-path.md](references/uk-gov-path.md) |
+| Defence | [defence-path.md](references/defence-path.md) |
+
+**Modifiers (applied on top of base path):**
+
+| Condition | Modifier |
+|-----------|----------|
+| Project type = AI/ML | Apply [ai-ml-path.md](references/ai-ml-path.md) |
+| Project type = Data platform | Apply [data-path.md](references/data-path.md) |
+| Both AI/ML and Data | Apply both modifiers |
+
+**Scope adjustments:**
+
+| Goal | Adjustment |
+|------|------------|
+| Full governance lifecycle | Show full path from base + modifiers |
+| Specific deliverable | Show only the relevant phase |
+| Compliance check | Show only compliance phase from base path |
+| Quick prototype documentation | Show minimum viable path from base path |
+
+| Stage | Adjustment |
+|-------|------------|
+| Just starting | Show full path (or scoped path) |
+| Have stakeholders/requirements | Skip Phases 1-2, start from Phase 3 |
+| Have design artifacts | Skip to Phase 4 (Procurement) or Phase 5 (Design Reviews) |
+| Need compliance review | Skip to compliance phase |
+
+| Timeline | Adjustment |
+|----------|------------|
+| Weeks | Show minimum viable path only |
+| Months | Show full path, note optional commands |
+| Quarters | Show full path with all optional additions |
+
+#### Plan Output Format
+
+Present the plan as a numbered list grouped by phase:
+
+```text
+Recommended Command Sequence
+=============================
+
+Based on: [UK Government] + [AI/ML] project, starting fresh, full lifecycle
+
+Phase 1: Foundation
+  1. /arckit:principles — Governance foundation (GDS + TCoP aligned)
+  2. /arckit:stakeholders — Map DDaT roles, SROs, policy owners
+  3. /arckit:risk — HMG Orange Book risk methodology
+
+Phase 2: Business Justification
+  4. /arckit:sobc — HM Treasury Green Book 5-case model
+  5. /arckit:requirements — Central artifact for all downstream work
+
+Phase 3: Design & Analysis
+  6. /arckit:datascout — Discover UK Gov open data sources
+  7. /arckit:data-model — Data architecture with GDPR considerations
+  ...
+
+[Total: N commands across M phases]
+[Estimated duration: X-Y months]
+
+Run commands in order. Each command will guide you through its process.
+```
+
+After presenting the plan, ask if they want to adjust anything or if they're ready to begin.
+
+## Key Principles
+
+- **One question at a time** — do not overwhelm with multiple questions per message
+- **Multiple choice preferred** — easier to answer than open-ended
+- **Adaptive depth** — simple projects get 4 questions, complex get 8
+- **Scaled output** — minimum viable = 5 commands, full lifecycle = 25-30
+- **No commands executed** — only present the plan, user drives execution
+- **Reference existing artifacts** — skip phases where artifacts already exist
+
+## ArcKit Integration
+
+This skill is invoked by the `/arckit:start` command, which delegates project onboarding to this skill. Users can also trigger it by asking about getting started, command sequences, or workflow recommendations.
+
+For the detailed command dependency matrix, see `DEPENDENCY-MATRIX.md` in the project root. For visual workflow diagrams, see `WORKFLOW-DIAGRAMS.md`.

--- a/arckit-plugin/skills/architecture-workflow/references/ai-ml-path.md
+++ b/arckit-plugin/skills/architecture-workflow/references/ai-ml-path.md
@@ -1,0 +1,91 @@
+# AI/ML Project Path Modifier
+
+## When This Modifier Applies
+
+This is not a standalone path. Apply these additions to whichever base path matches the project sector (standard, UK Government, or Defence).
+
+- Project includes AI or machine learning components
+- Algorithmic decision-making systems
+- Natural language processing or computer vision
+- Predictive analytics or recommendation engines
+- Any system requiring model training, serving, or monitoring
+
+## Additional Commands
+
+### Design and Analysis Phase
+
+Add to the base path's Design and Analysis phase:
+
+| Command | Rationale | Insert After |
+|---------|-----------|-------------|
+| `/arckit:datascout` | Discover training data sources, validate data quality | Before data-model (if not already in base path) |
+
+### Operations Phase
+
+Add to the base path's Operations phase:
+
+| Command | Rationale | Insert After |
+|---------|-----------|-------------|
+| `/arckit:mlops` | ML model lifecycle: training pipelines, model registry, serving, monitoring, drift detection | After `/arckit:devops` |
+
+### Compliance Phase
+
+Which compliance commands to add depends on the base path:
+
+#### UK Government Base Path
+
+| Command | Rationale | Insert After |
+|---------|-----------|-------------|
+| `/arckit:ai-playbook` | UK Government AI Playbook compliance (10 principles) | After `/arckit:tcop` |
+| `/arckit:atrs` | Algorithmic Transparency Recording Standard (mandatory for public-facing algorithmic systems) | After `/arckit:ai-playbook` |
+
+#### Defence Base Path
+
+| Command | Rationale | Insert After |
+|---------|-----------|-------------|
+| `/arckit:jsp-936` | MOD AI Assurance (JSP 936) — risk classification and approval pathway | After `/arckit:mod-secure` |
+
+#### Standard Base Path
+
+| Command | Rationale | Insert After |
+|---------|-----------|-------------|
+| `/arckit:ai-playbook` | AI Playbook principles are good practice even outside UK Government | Optional, after quality checks |
+
+## Critical Gates
+
+### UK Government AI Projects
+
+- AI Playbook compliance required before Beta
+- ATRS publication required before Live
+- DPIA mandatory if AI processes personal data
+
+### Defence AI Projects
+
+- JSP 936 risk classification determines approval pathway:
+  - **Critical**: 2PUS/Ministerial approval
+  - **Severe/Major**: Defence-Level JROC/IAC approval
+  - **Moderate/Minor**: TLB-Level approval
+- MOD Secure by Design required before Beta
+- JSP 936 approval required before Beta
+
+### Standard AI Projects
+
+- No mandatory compliance gates
+- AI Playbook principles recommended as best practice
+- DPIA recommended if processing personal data
+
+## Key Considerations
+
+- **Model governance**: Establish model risk management framework early (during requirements phase)
+- **Training data**: Use `/arckit:datascout` to identify and evaluate training data sources
+- **Bias and fairness**: Address in requirements (NFR-AI-xxx) and validate in ai-playbook assessment
+- **Explainability**: Document explainability approach in ADRs
+- **Monitoring**: MLOps must include model drift detection and retraining triggers
+
+## Duration Impact
+
+AI/ML components typically add:
+
+- **2-4 weeks** for mlops planning
+- **2-4 weeks** for AI compliance assessments (ai-playbook, atrs, jsp-936)
+- **Ongoing** model monitoring and retraining cycles post-deployment

--- a/arckit-plugin/skills/architecture-workflow/references/data-path.md
+++ b/arckit-plugin/skills/architecture-workflow/references/data-path.md
@@ -1,0 +1,78 @@
+# Data Platform Path Modifier
+
+## When This Modifier Applies
+
+This is not a standalone path. Apply these additions to whichever base path matches the project sector (standard, UK Government, or Defence).
+
+- Data platform or data lake/lakehouse projects
+- Data mesh architecture implementations
+- Analytics or business intelligence platforms
+- Data marketplace or data sharing initiatives
+- Projects with significant data integration requirements
+- Open data publishing platforms
+
+## Additional Commands
+
+### Design and Analysis Phase
+
+Add or promote these commands in the base path's Design and Analysis phase:
+
+| Command | Rationale | Insert After |
+|---------|-----------|-------------|
+| `/arckit:datascout` | Discover external data sources: APIs, datasets, open data portals, commercial providers | Before data-model |
+| `/arckit:data-model` | Comprehensive data architecture with entity relationships, schemas, governance | After datascout (promote to mandatory if not already) |
+| `/arckit:dpia` | Data Protection Impact Assessment — mandatory if processing personal data | After data-model |
+| `/arckit:data-mesh-contract` | Federated data product contracts for mesh architectures | After data-model |
+| `/arckit:platform-design` | Multi-sided platform strategy using Platform Design Toolkit (PDT) | After requirements, before data-model |
+
+### Cloud-Specific Research
+
+If the data platform targets a specific cloud provider, add the relevant research command:
+
+| Command | When to Use | Rationale |
+|---------|-------------|-----------|
+| `/arckit:aws-research` | AWS-hosted data platform | S3, Glue, Athena, Redshift, Lake Formation research via AWS Knowledge MCP |
+| `/arckit:azure-research` | Azure-hosted data platform | ADLS, Synapse, Fabric, Purview research via Microsoft Learn MCP |
+| `/arckit:gcp-research` | GCP-hosted data platform | BigQuery, Dataflow, Dataplex research via Google Developer MCP |
+
+Insert cloud research commands after `/arckit:research` in the Design and Analysis phase. These require their respective MCP servers to be connected.
+
+## UK Government Data Considerations
+
+For UK Government data projects, these additional factors apply:
+
+- **TCoP Point 10**: Make better use of data — `/arckit:datascout` prioritizes UK Gov open data sources
+- **GDPR/DPA 2018**: DPIA mandatory for personal data processing
+- **Open Standards**: Use open data formats where possible
+- **Cross-government sharing**: Consider API standards and data sharing agreements
+
+## Key Considerations
+
+- **Data governance**: Establish ownership, quality standards, and access controls early (requirements phase)
+- **Data lineage**: Use `/arckit:traceability` to map data requirements (DR-xxx) through to implementation
+- **Schema evolution**: Document versioning strategy in ADRs
+- **Data quality**: Define quality metrics and monitoring in `/arckit:operationalize`
+- **Data contracts**: Use `/arckit:data-mesh-contract` for producer-consumer agreements in mesh architectures
+
+## Recommended Sequence for Data-Heavy Projects
+
+When data is the primary focus, reorder the Design and Analysis phase:
+
+1. `/arckit:datascout` — discover what data is available
+2. `/arckit:platform-design` — design the platform ecosystem
+3. `/arckit:data-model` — model the data architecture
+4. `/arckit:data-mesh-contract` — define data product contracts
+5. `/arckit:dpia` — assess data protection impact
+6. `/arckit:research` — research technology options for the data platform
+7. Cloud research (`aws-research`, `azure-research`, or `gcp-research`)
+8. `/arckit:wardley` — map data component evolution
+
+## Duration Impact
+
+Data platform focus typically adds:
+
+- **1-2 weeks** for datascout and data source evaluation
+- **2-3 weeks** for comprehensive data modeling
+- **1-2 weeks** for data mesh contracts (if applicable)
+- **1 week** for DPIA (if personal data)
+- **1-2 weeks** for platform design (if multi-sided platform)

--- a/arckit-plugin/skills/architecture-workflow/references/defence-path.md
+++ b/arckit-plugin/skills/architecture-workflow/references/defence-path.md
@@ -1,0 +1,146 @@
+# Defence Project Path
+
+## When This Path Applies
+
+- Ministry of Defence (MOD) projects
+- Defence contractors working on MOD programmes
+- Projects subject to JSP 440 (Defence Manual of Security)
+- IAMM (Information Assurance Maturity Model) applies
+- Digital Outcomes and Specialists (DOS) procurement likely
+- Security clearance requirements for team
+
+## Compliance Frameworks
+
+- JSP 440 (Defence Manual of Security)
+- IAMM (Information Assurance Maturity Model)
+- MOD Secure by Design
+- Technology Code of Practice (TCoP)
+- JSP 936 (MOD AI Assurance) — if AI/ML components
+- Green Book / Orange Book (HM Treasury)
+
+## Phased Command Sequence
+
+### Phase 1: Foundation (Mandatory)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 1 | `/arckit:principles` | Governance foundation — must align with MOD architecture standards | ARC-000-PRIN-v1.0.md |
+| 2 | `/arckit:stakeholders` | Map DDaT roles, SROs, security officers, DG/2* sponsors | ARC-{PID}-STKE-v1.0.md |
+| 3 | `/arckit:risk` | MOD risk methodology with security classification | ARC-{PID}-RISK-v1.0.md |
+
+### Phase 2: Business Justification
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 4 | `/arckit:sobc` | HM Treasury Green Book SOBC with defence-specific considerations | ARC-{PID}-SOBC-v1.0.md |
+| 5 | `/arckit:requirements` | Requirements with security and interoperability constraints | ARC-{PID}-REQ-v1.0.md |
+
+### Phase 3: Design and Analysis
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 6 | `/arckit:datascout` | Discover data sources within MOD and cross-government | ARC-{PID}-DSCT-v1.0.md |
+| 7 | `/arckit:data-model` | Data architecture with classification levels | ARC-{PID}-DMOD-v1.0.md |
+| 8 | `/arckit:dpia` | Data Protection Impact Assessment | ARC-{PID}-DPIA-v1.0.md |
+| 9 | `/arckit:research` | Technology research with defence supplier focus | ARC-{PID}-RES-v1.0.md |
+| 10 | `/arckit:wardley` | Strategic positioning for defence capabilities | ARC-{PID}-WARD-001-v1.0.md |
+| 11 | `/arckit:roadmap` | Multi-year roadmap aligned to defence planning rounds | ARC-{PID}-ROAD-v1.0.md |
+| 12 | `/arckit:diagram` | Architecture diagrams (C4, sequence, DFD) | ARC-{PID}-DIAG-001-v1.0.md |
+
+### Phase 4: Procurement (DOS)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 13 | `/arckit:dos` | Digital Outcomes and Specialists opportunity | ARC-{PID}-DOS-v1.0.md |
+| 14 | `/arckit:sow` | Statement of work for procurement | ARC-{PID}-SOW-v1.0.md |
+| 15 | `/arckit:evaluate` | Vendor evaluation with security vetting requirements | ARC-{PID}-EVAL-v1.0.md |
+
+### Phase 5: Design Reviews
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 16 | `/arckit:hld-review` | HLD review against MOD architecture standards | ARC-{PID}-HLDR-v1.0.md |
+| 17 | `/arckit:dld-review` | DLD review with security architecture focus | ARC-{PID}-DLDR-v1.0.md |
+| 18 | `/arckit:adr` | Architecture Decision Records | ARC-{PID}-ADR-001-v1.0.md |
+
+### Phase 6: Implementation
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 19 | `/arckit:backlog` | Product backlog from requirements and design | ARC-{PID}-BKLG-v1.0.md |
+
+### Phase 7: Operations and Quality
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 20 | `/arckit:devops` | CI/CD with secure pipeline requirements | ARC-{PID}-DVOP-v1.0.md |
+| 21 | `/arckit:operationalize` | Operational readiness with MOD service management | ARC-{PID}-OPS-v1.0.md |
+| 22 | `/arckit:traceability` | End-to-end traceability matrix | ARC-{PID}-TRACE-v1.0.md |
+
+### Phase 8: Compliance (Defence Specific)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 23 | `/arckit:tcop` | Technology Code of Practice assessment | ARC-{PID}-TCOP-v1.0.md |
+| 24 | `/arckit:mod-secure` | MOD Secure by Design (JSP 440, IAMM) | ARC-{PID}-MSEC-v1.0.md |
+| 25 | `/arckit:principles-compliance` | Principles adherence | ARC-{PID}-PCOMP-v1.0.md |
+| 26 | `/arckit:conformance` | ADR conformance checking | ARC-{PID}-CONF-v1.0.md |
+| 27 | `/arckit:analyze` | Deep governance analysis | ARC-{PID}-ANAL-v1.0.md |
+| 28 | `/arckit:service-assessment` | Service assessment readiness | ARC-{PID}-SA-v1.0.md |
+
+### Phase 9: Reporting
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 29 | `/arckit:story` | Project narrative for governance boards | ARC-{PID}-STORY-v1.0.md |
+| 30 | `/arckit:pages` | GitHub Pages documentation site | docs/index.html |
+
+## AI/ML Additions
+
+If the defence project includes AI/ML components, add these commands:
+
+| # | Command | Where to Insert | Rationale | Artifacts |
+|---|---------|-----------------|-----------|-----------|
+| — | `/arckit:mlops` | Phase 7, after devops | ML model lifecycle, training pipelines | ARC-{PID}-MLOP-v1.0.md |
+| — | `/arckit:jsp-936` | Phase 8, after mod-secure | MOD AI Assurance (JSP 936) | ARC-{PID}-JSP936-v1.0.md |
+
+### Critical Gates for AI Projects
+
+- JSP 936 risk classification determines approval pathway:
+  - **Critical**: 2PUS/Ministerial approval
+  - **Severe/Major**: Defence-Level JROC/IAC approval
+  - **Moderate/Minor**: TLB-Level approval
+
+## Optional Commands
+
+| Command | When to Add | Phase |
+|---------|-------------|-------|
+| `/arckit:strategy` | Executive strategy synthesis needed | After Phase 3 |
+| `/arckit:platform-design` | Defence platform or shared service | Phase 3 |
+| `/arckit:data-mesh-contract` | Federated data products across TLBs | Phase 3 |
+| `/arckit:gcloud-search` | G-Cloud procurement (alternative to DOS) | Phase 4 |
+| `/arckit:finops` | Cloud cost management | Phase 7 |
+| `/arckit:servicenow` | ServiceNow CMDB integration | Phase 7 |
+| `/arckit:presentation` | Governance board slide deck | Phase 9 |
+
+## Minimum Viable Path
+
+For initial security assessment preparation:
+
+1. `/arckit:principles`
+2. `/arckit:stakeholders`
+3. `/arckit:requirements`
+4. `/arckit:risk`
+5. `/arckit:mod-secure`
+
+## Duration
+
+- **Non-AI projects**: 12-24 months
+- **AI projects**: 18-36 months
+- **Minimum viable**: 3-6 weeks
+
+## Critical Gates
+
+- MOD Secure by Design (JSP 440, IAMM) required before Beta
+- Security clearances required for all team members
+- JSP 936 AI assurance required before Beta (AI projects only)

--- a/arckit-plugin/skills/architecture-workflow/references/standard-path.md
+++ b/arckit-plugin/skills/architecture-workflow/references/standard-path.md
@@ -1,0 +1,104 @@
+# Standard Project Path
+
+## When This Path Applies
+
+- Private sector projects
+- Non-UK government public sector
+- No AI/ML components
+- No specific compliance framework requirements
+
+## Phased Command Sequence
+
+### Phase 1: Foundation (Mandatory)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 1 | `/arckit:principles` | Governance foundation — 21 downstream commands depend on this | ARC-000-PRIN-v1.0.md |
+| 2 | `/arckit:stakeholders` | Identify who cares and what they need — drives everything downstream | ARC-{PID}-STKE-v1.0.md |
+| 3 | `/arckit:risk` | Identify what could go wrong before committing resources | ARC-{PID}-RISK-v1.0.md |
+
+### Phase 2: Business Justification
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 4 | `/arckit:sobc` | Justify the investment before detailed technical work | ARC-{PID}-SOBC-v1.0.md |
+| 5 | `/arckit:requirements` | Central artifact — 38 commands depend on this | ARC-{PID}-REQ-v1.0.md |
+
+### Phase 3: Design and Analysis
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 6 | `/arckit:data-model` | Define data structures from DR-xxx requirements | ARC-{PID}-DMOD-v1.0.md |
+| 7 | `/arckit:research` | Technology options, build vs buy, vendor landscape | ARC-{PID}-RES-v1.0.md |
+| 8 | `/arckit:wardley` | Strategic positioning and evolution analysis | ARC-{PID}-WARD-001-v1.0.md |
+| 9 | `/arckit:roadmap` | Multi-year timeline from strategy analysis | ARC-{PID}-ROAD-v1.0.md |
+| 10 | `/arckit:diagram` | Architecture diagrams (C4, DFD, sequence) | ARC-{PID}-DIAG-001-v1.0.md |
+
+### Phase 4: Procurement (If Applicable)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 11 | `/arckit:sow` | Statement of work / RFP for vendors | ARC-{PID}-SOW-v1.0.md |
+| 12 | `/arckit:evaluate` | Vendor evaluation framework and scoring | ARC-{PID}-EVAL-v1.0.md |
+
+### Phase 5: Design Reviews
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 13 | `/arckit:hld-review` | Validate high-level design against requirements | ARC-{PID}-HLDR-v1.0.md |
+| 14 | `/arckit:dld-review` | Validate detailed design | ARC-{PID}-DLDR-v1.0.md |
+| 15 | `/arckit:adr` | Record key architecture decisions | ARC-{PID}-ADR-001-v1.0.md |
+
+### Phase 6: Implementation
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 16 | `/arckit:backlog` | Product backlog from requirements and design | ARC-{PID}-BKLG-v1.0.md |
+| 17 | `/arckit:trello` | Export backlog to Trello (optional) | Trello board |
+
+### Phase 7: Operations and Quality
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 18 | `/arckit:devops` | CI/CD, IaC, container orchestration strategy | ARC-{PID}-DVOP-v1.0.md |
+| 19 | `/arckit:operationalize` | Operational readiness, SRE, runbooks | ARC-{PID}-OPS-v1.0.md |
+| 20 | `/arckit:traceability` | End-to-end traceability matrix | ARC-{PID}-TRACE-v1.0.md |
+| 21 | `/arckit:principles-compliance` | Principles adherence assessment | ARC-{PID}-PCOMP-v1.0.md |
+| 22 | `/arckit:conformance` | ADR conformance checking | ARC-{PID}-CONF-v1.0.md |
+| 23 | `/arckit:analyze` | Deep governance analysis | ARC-{PID}-ANAL-v1.0.md |
+
+### Phase 8: Reporting
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 24 | `/arckit:story` | Comprehensive project narrative | ARC-{PID}-STORY-v1.0.md |
+| 25 | `/arckit:pages` | GitHub Pages documentation site | docs/index.html |
+
+## Optional Commands
+
+These can be added at the appropriate phase if needed:
+
+| Command | When to Add | Phase |
+|---------|-------------|-------|
+| `/arckit:strategy` | Executive strategy synthesis needed | After Phase 3 |
+| `/arckit:platform-design` | Multi-sided platform or marketplace | Phase 3 |
+| `/arckit:datascout` | External data sources needed | Phase 3, before data-model |
+| `/arckit:dpia` | Personal data is processed | Phase 3, after data-model |
+| `/arckit:finops` | Cloud cost management needed | Phase 7 |
+| `/arckit:servicenow` | ServiceNow CMDB integration | Phase 7 |
+| `/arckit:presentation` | Governance board slide deck | Phase 8 |
+
+## Minimum Viable Path
+
+For quick prototype documentation or proof of concept:
+
+1. `/arckit:principles`
+2. `/arckit:stakeholders`
+3. `/arckit:requirements`
+4. `/arckit:research`
+5. `/arckit:diagram`
+
+## Duration
+
+- **Full path**: 4-8 months
+- **Minimum viable**: 1-2 weeks

--- a/arckit-plugin/skills/architecture-workflow/references/uk-gov-path.md
+++ b/arckit-plugin/skills/architecture-workflow/references/uk-gov-path.md
@@ -1,0 +1,125 @@
+# UK Government Project Path
+
+## When This Path Applies
+
+- UK Government civilian departments (non-MOD)
+- Projects subject to GDS Service Standard
+- Projects subject to Technology Code of Practice (TCoP)
+- NCSC Cyber Assessment Framework applies
+- G-Cloud or Digital Outcomes procurement likely
+
+## Compliance Frameworks
+
+- GDS Service Standard (14 points)
+- Technology Code of Practice (TCoP)
+- NCSC Cyber Assessment Framework (CAF)
+- Secure by Design (civilian)
+- Green Book / Orange Book (HM Treasury)
+
+## Phased Command Sequence
+
+### Phase 1: Foundation (Mandatory)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 1 | `/arckit:principles` | Governance foundation — must align with GDS and TCoP | ARC-000-PRIN-v1.0.md |
+| 2 | `/arckit:stakeholders` | Map DDaT roles, SROs, policy owners | ARC-{PID}-STKE-v1.0.md |
+| 3 | `/arckit:risk` | HMG Orange Book risk methodology | ARC-{PID}-RISK-v1.0.md |
+
+### Phase 2: Business Justification
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 4 | `/arckit:sobc` | HM Treasury Green Book SOBC with 5-case model | ARC-{PID}-SOBC-v1.0.md |
+| 5 | `/arckit:requirements` | Requirements aligned to GDS service standard | ARC-{PID}-REQ-v1.0.md |
+
+### Phase 3: Design and Analysis
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 6 | `/arckit:datascout` | Discover UK Gov open data sources (TCoP Point 10) | ARC-{PID}-DSCT-v1.0.md |
+| 7 | `/arckit:data-model` | Data architecture with GDPR/DPA considerations | ARC-{PID}-DMOD-v1.0.md |
+| 8 | `/arckit:dpia` | Data Protection Impact Assessment (mandatory for personal data) | ARC-{PID}-DPIA-v1.0.md |
+| 9 | `/arckit:research` | Technology research with Crown Commercial focus | ARC-{PID}-RES-v1.0.md |
+| 10 | `/arckit:wardley` | Strategic positioning for GaaP components | ARC-{PID}-WARD-001-v1.0.md |
+| 11 | `/arckit:roadmap` | Roadmap aligned to spending review cycles | ARC-{PID}-ROAD-v1.0.md |
+| 12 | `/arckit:diagram` | Architecture diagrams (C4, sequence, DFD) | ARC-{PID}-DIAG-001-v1.0.md |
+
+### Phase 4: Procurement (G-Cloud / DOS)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 13 | `/arckit:gcloud-search` | Search Digital Marketplace for G-Cloud services | Console output |
+| 14 | `/arckit:gcloud-clarify` | Generate clarification questions for shortlisted services | ARC-{PID}-GCLR-v1.0.md |
+| 15 | `/arckit:sow` | Statement of work for procurement | ARC-{PID}-SOW-v1.0.md |
+| 16 | `/arckit:evaluate` | Vendor evaluation with value-for-money assessment | ARC-{PID}-EVAL-v1.0.md |
+
+### Phase 5: Design Reviews
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 17 | `/arckit:hld-review` | HLD review against GDS patterns | ARC-{PID}-HLDR-v1.0.md |
+| 18 | `/arckit:dld-review` | DLD review for security and performance | ARC-{PID}-DLDR-v1.0.md |
+| 19 | `/arckit:adr` | Architecture Decision Records | ARC-{PID}-ADR-001-v1.0.md |
+
+### Phase 6: Implementation
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 20 | `/arckit:backlog` | Product backlog from requirements and design | ARC-{PID}-BKLG-v1.0.md |
+
+### Phase 7: Operations and Quality
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 21 | `/arckit:devops` | CI/CD aligned to GDS technology standards | ARC-{PID}-DVOP-v1.0.md |
+| 22 | `/arckit:operationalize` | Operational readiness, service desk integration | ARC-{PID}-OPS-v1.0.md |
+| 23 | `/arckit:traceability` | End-to-end traceability matrix | ARC-{PID}-TRACE-v1.0.md |
+
+### Phase 8: Compliance (UK Government Specific)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 24 | `/arckit:tcop` | Technology Code of Practice assessment | ARC-{PID}-TCOP-v1.0.md |
+| 25 | `/arckit:secure` | Secure by Design assessment (NCSC CAF) | ARC-{PID}-SEC-v1.0.md |
+| 26 | `/arckit:principles-compliance` | Principles adherence | ARC-{PID}-PCOMP-v1.0.md |
+| 27 | `/arckit:conformance` | ADR conformance checking | ARC-{PID}-CONF-v1.0.md |
+| 28 | `/arckit:analyze` | Deep governance analysis | ARC-{PID}-ANAL-v1.0.md |
+| 29 | `/arckit:service-assessment` | GDS Service Assessment readiness | ARC-{PID}-SA-v1.0.md |
+
+### Phase 9: Reporting
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 30 | `/arckit:story` | Project narrative for governance boards | ARC-{PID}-STORY-v1.0.md |
+| 31 | `/arckit:pages` | GitHub Pages documentation site | docs/index.html |
+
+## Optional Commands
+
+These can be added at the appropriate phase if needed:
+
+| Command | When to Add | Phase |
+|---------|-------------|-------|
+| `/arckit:strategy` | Executive strategy synthesis needed | After Phase 3 |
+| `/arckit:platform-design` | Government as a Platform (GaaP) service | Phase 3 |
+| `/arckit:data-mesh-contract` | Federated data products | Phase 3, after data-model |
+| `/arckit:dos` | Digital Outcomes and Specialists procurement | Phase 4 (alternative to G-Cloud) |
+| `/arckit:finops` | Cloud cost management | Phase 7 |
+| `/arckit:servicenow` | ServiceNow CMDB integration | Phase 7 |
+| `/arckit:presentation` | Governance board slide deck | Phase 9 |
+
+## Minimum Viable Path
+
+For Alpha assessment preparation:
+
+1. `/arckit:principles`
+2. `/arckit:stakeholders`
+3. `/arckit:requirements`
+4. `/arckit:research`
+5. `/arckit:tcop`
+6. `/arckit:secure`
+
+## Duration
+
+- **Full path**: 6-12 months
+- **Minimum viable**: 2-4 weeks

--- a/docs/plans/2026-03-05-architecture-workflow-skill-design.md
+++ b/docs/plans/2026-03-05-architecture-workflow-skill-design.md
@@ -1,0 +1,153 @@
+# Architecture Workflow Skill Design
+
+**Date**: 2026-03-05
+**Status**: Approved
+**Author**: Claude + User
+
+## Problem
+
+ArcKit has 53 commands, 5 documented workflow paths, and a dependency matrix — but no skill-level guidance for new users. Users don't know which commands to run or in what order. The existing `/arckit:start` command provides some navigation but lacks the structured, question-driven methodology that process skills (like the Claude Code brainstorming skill) offer.
+
+## Decision
+
+Create a new **process skill** called `architecture-workflow` that replaces `/arckit:start` with an adaptive-depth, question-driven onboarding experience. The skill asks questions to understand the project, then presents a tailored command sequence as a plan.
+
+## Approach
+
+**Skill + reference files** (Approach B) — consistent with existing ArcKit skill patterns (wardley-mapping, mermaid-syntax, plantuml-syntax).
+
+## Skill Identity
+
+- **Name**: `architecture-workflow`
+- **Location**: `arckit-plugin/skills/architecture-workflow/`
+- **Replaces**: `/arckit:start` (command becomes thin wrapper delegating to skill)
+
+## File Structure
+
+```text
+arckit-plugin/skills/architecture-workflow/
+├── SKILL.md                           # Process methodology + question flow
+└── references/
+    ├── standard-path.md               # Non-government, non-AI projects
+    ├── uk-gov-path.md                 # UK Government (GDS + TCoP)
+    ├── defence-path.md                # MOD/Defence (JSP 440 + MOD Secure)
+    ├── ai-ml-path.md                  # AI/ML projects (AI Playbook + MLOps)
+    └── data-path.md                   # Data platforms (Data Mesh + DataScout)
+```
+
+## Process Flow
+
+```text
+┌─────────────────────────────┐
+│ 1. DETECT PROJECT STATE     │  Check for existing artifacts
+│    (automatic, no questions)│  (projects/, .arckit/, principles)
+└──────────────┬──────────────┘
+               ▼
+┌─────────────────────────────┐
+│ 2. TRIAGE (3-4 questions)   │  Sector, project type,
+│    Everyone gets these      │  what stage, goals
+└──────────────┬──────────────┘
+               ▼
+        ┌──────┴──────┐
+        │  Complex?   │
+        └──┬──────┬───┘
+       no  │      │  yes
+           ▼      ▼
+┌──────────┐  ┌──────────────────┐
+│ SHORT    │  │ 3. DEEP QUESTIONS│
+│ PATH     │  │   (4-8 more)     │
+│ (3-5     │  │   Compliance,    │
+│ commands)│  │   stakeholders,  │
+└────┬─────┘  │   constraints    │
+     │        └────────┬─────────┘
+     │                 │
+     ▼                 ▼
+┌─────────────────────────────┐
+│ 4. PRESENT TAILORED PLAN    │  Numbered command sequence
+│    with rationale per step  │  with why each matters
+└─────────────────────────────┘
+```
+
+### Step 1: Detect Project State (Automatic)
+
+- Check if `projects/` exists, count existing artifacts
+- Check if `.arckit/` is set up
+- Check if principles document exists
+- Determines "start from scratch" vs "continue from where you left off"
+
+### Step 2: Triage Questions (Everyone, One at a Time)
+
+1. **Sector**: UK Government / Defence / Public sector (non-UK) / Private sector
+2. **Project type**: New system build / System migration / Procurement / Data platform / AI/ML / Strategy only
+3. **Current stage**: Just starting / Have requirements / Have design / Need compliance review
+4. **Primary goal**: Full governance lifecycle / Specific deliverable / Compliance check / Quick prototype documentation
+
+### Step 3: Deep Questions (Complex Projects Only)
+
+Triggered by: UK Gov, Defence, AI/ML, or "full governance lifecycle" selections.
+
+- Do you have existing stakeholder analysis?
+- What compliance frameworks apply? (GDS, TCoP, NCSC CAF, AI Playbook, JSP 440)
+- Is there procurement involved? (G-Cloud, DOS)
+- Do you need Wardley Maps / strategic analysis?
+- What's the timeline pressure?
+
+### Step 4: Present Tailored Plan
+
+- Numbered list of recommended commands in execution order
+- Each entry: command name, one-line rationale, estimated artifacts produced
+- Grouped by phase (Foundation, Analysis, Design, Procurement, Implementation, Compliance)
+- User drives execution from here
+
+## /arckit:start Replacement Strategy
+
+The `/arckit:start` command becomes a thin wrapper:
+
+```markdown
+---
+description: Start a new architecture project with guided workflow selection
+---
+Use the architecture-workflow skill to guide this user through project onboarding.
+```
+
+Users can still type `/arckit:start` but get the skill's structured methodology.
+
+## Patterns Borrowed from Brainstorming Skill
+
+| Pattern | Application |
+|---------|-------------|
+| Hard gate | Do NOT run commands, only present the plan |
+| Anti-patterns | "I already know what I need" / "Just run everything" |
+| One question at a time | All questions via individual `AskUserQuestion` calls |
+| Multiple choice preferred | All questions use options with "Other" available |
+| Adaptive depth | Simple = 3-5 commands, complex = 10-15+ |
+| Scaled sections | Plan output scales with project complexity |
+| Checklist with tasks | Task tracking for: detect, triage, deep, present |
+
+## Intentional Differences from Brainstorming
+
+- **No design doc output** — presents command sequence in conversation only
+- **No skill chaining** — terminates with presented plan, user drives from there
+- **No incremental section approval** — plan presented as a whole (it's a list, not a document)
+
+## SKILL.md Specifications
+
+~200-250 lines containing:
+
+- Frontmatter with comprehensive trigger description
+- Process overview
+- Question definitions with multiple-choice options
+- Decision logic mapping triage answers to path reference files
+- Plan output format
+- Hard gate and anti-patterns
+
+## Reference File Specifications
+
+Each ~80-120 lines containing:
+
+- Path description and when it applies
+- Phased command sequence (Foundation, Analysis, Design, etc.)
+- Per-command rationale
+- Optional vs mandatory commands for the path
+- Compliance requirements specific to the path
+- Example output plan

--- a/docs/plans/2026-03-05-architecture-workflow-skill.md
+++ b/docs/plans/2026-03-05-architecture-workflow-skill.md
@@ -1,0 +1,562 @@
+# Architecture Workflow Skill Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a process skill that replaces `/arckit:start` with an adaptive-depth, question-driven onboarding experience that recommends tailored command sequences.
+
+**Architecture:** A new `architecture-workflow` skill in `arckit-plugin/skills/` with a SKILL.md (process methodology + question flow) and 5 reference files (one per workflow path). The existing `/arckit:start` command becomes a thin wrapper delegating to the skill.
+
+**Tech Stack:** Claude Code plugin skills (Markdown with YAML frontmatter), AskUserQuestion tool for interactive questions.
+
+---
+
+### Task 1: Create skill directory structure
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/SKILL.md` (placeholder)
+- Create: `arckit-plugin/skills/architecture-workflow/references/` (directory)
+
+**Step 1: Create the directories**
+
+Run: `mkdir -p arckit-plugin/skills/architecture-workflow/references`
+
+**Step 2: Verify structure**
+
+Run: `ls -la arckit-plugin/skills/architecture-workflow/`
+Expected: Empty directory with `references/` subdirectory
+
+**Step 3: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/
+git commit -m "chore: scaffold architecture-workflow skill directory"
+```
+
+---
+
+### Task 2: Create the standard-path reference file
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/references/standard-path.md`
+- Reference: `WORKFLOW-DIAGRAMS.md` lines 18-113 (Standard Project Path)
+- Reference: `DEPENDENCY-MATRIX.md` lines 225-231 (Standard critical path)
+
+**Step 1: Write the reference file**
+
+```markdown
+# Standard Project Path
+
+## When This Path Applies
+
+- Private sector projects
+- Non-UK government public sector
+- No AI/ML components
+- No specific compliance framework requirements
+
+## Phased Command Sequence
+
+### Phase 1: Foundation (Mandatory)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 1 | `/arckit:principles` | Governance foundation — 21 downstream commands depend on this | ARC-000-PRIN-v1.0.md |
+| 2 | `/arckit:stakeholders` | Identify who cares and what they need — drives everything downstream | ARC-{PID}-STKE-v1.0.md |
+| 3 | `/arckit:risk` | Identify what could go wrong before committing resources | ARC-{PID}-RISK-v1.0.md |
+
+### Phase 2: Business Justification
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 4 | `/arckit:sobc` | Justify the investment before detailed technical work | ARC-{PID}-SOBC-v1.0.md |
+| 5 | `/arckit:requirements` | Central artifact — 38 commands depend on this | ARC-{PID}-REQ-v1.0.md |
+
+### Phase 3: Design & Analysis
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 6 | `/arckit:data-model` | Define data structures from DR-xxx requirements | ARC-{PID}-DMOD-v1.0.md |
+| 7 | `/arckit:research` | Technology options, build vs buy, vendor landscape | ARC-{PID}-RES-v1.0.md |
+| 8 | `/arckit:wardley` | Strategic positioning and evolution analysis | ARC-{PID}-WARD-001-v1.0.md |
+| 9 | `/arckit:roadmap` | Multi-year timeline from strategy analysis | ARC-{PID}-ROAD-v1.0.md |
+| 10 | `/arckit:diagram` | Architecture diagrams (C4, DFD, sequence) | ARC-{PID}-DIAG-001-v1.0.md |
+
+### Phase 4: Procurement (If Applicable)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 11 | `/arckit:sow` | Statement of work / RFP for vendors | ARC-{PID}-SOW-v1.0.md |
+| 12 | `/arckit:evaluate` | Vendor evaluation framework and scoring | ARC-{PID}-EVAL-v1.0.md |
+
+### Phase 5: Design Reviews
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 13 | `/arckit:hld-review` | Validate high-level design against requirements | ARC-{PID}-HLDR-v1.0.md |
+| 14 | `/arckit:dld-review` | Validate detailed design | ARC-{PID}-DLDR-v1.0.md |
+| 15 | `/arckit:adr` | Record key architecture decisions | ARC-{PID}-ADR-001-v1.0.md |
+
+### Phase 6: Implementation
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 16 | `/arckit:backlog` | Product backlog from requirements + design | ARC-{PID}-BKLG-v1.0.md |
+| 17 | `/arckit:trello` | Export backlog to Trello (optional) | Trello board |
+
+### Phase 7: Operations & Quality
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 18 | `/arckit:devops` | CI/CD, IaC, container orchestration strategy | ARC-{PID}-DVOP-v1.0.md |
+| 19 | `/arckit:operationalize` | Operational readiness, SRE, runbooks | ARC-{PID}-OPS-v1.0.md |
+| 20 | `/arckit:traceability` | End-to-end traceability matrix | ARC-{PID}-TRACE-v1.0.md |
+| 21 | `/arckit:principles-compliance` | Principles adherence assessment | ARC-{PID}-PCOMP-v1.0.md |
+| 22 | `/arckit:conformance` | ADR conformance checking | ARC-{PID}-CONF-v1.0.md |
+| 23 | `/arckit:analyze` | Deep governance analysis | ARC-{PID}-ANAL-v1.0.md |
+
+### Phase 8: Reporting
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 24 | `/arckit:story` | Comprehensive project narrative | ARC-{PID}-STORY-v1.0.md |
+| 25 | `/arckit:pages` | GitHub Pages documentation site | docs/index.html |
+
+## Minimum Viable Path
+
+For quick prototype documentation or proof of concept:
+
+1. `/arckit:principles` → 2. `/arckit:stakeholders` → 3. `/arckit:requirements` → 4. `/arckit:research` → 5. `/arckit:diagram`
+
+## Duration
+
+- **Full path**: 4-8 months
+- **Minimum viable**: 1-2 weeks
+```
+
+**Step 2: Verify file renders correctly**
+
+Run: `wc -l arckit-plugin/skills/architecture-workflow/references/standard-path.md`
+Expected: ~90-100 lines
+
+**Step 3: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/references/standard-path.md
+git commit -m "feat: add standard-path reference for architecture-workflow skill"
+```
+
+---
+
+### Task 3: Create the uk-gov-path reference file
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/references/uk-gov-path.md`
+- Reference: `WORKFLOW-DIAGRAMS.md` lines 116-224 (UK Government Path)
+- Reference: `DEPENDENCY-MATRIX.md` lines 236-240 (UK Gov critical path)
+
+**Step 1: Write the reference file**
+
+```markdown
+# UK Government Project Path
+
+## When This Path Applies
+
+- UK Government civilian departments (non-MOD)
+- Projects subject to GDS Service Standard
+- Projects subject to Technology Code of Practice (TCoP)
+- NCSC Cyber Assessment Framework applies
+- G-Cloud or Digital Outcomes procurement likely
+
+## Compliance Frameworks
+
+- GDS Service Standard (14 points)
+- Technology Code of Practice (TCoP)
+- NCSC Cyber Assessment Framework (CAF)
+- Secure by Design (civilian)
+- Green Book / Orange Book (HM Treasury)
+
+## Phased Command Sequence
+
+### Phase 1: Foundation (Mandatory)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 1 | `/arckit:principles` | Governance foundation — must align with GDS and TCoP | ARC-000-PRIN-v1.0.md |
+| 2 | `/arckit:stakeholders` | Map DDaT roles, SROs, policy owners | ARC-{PID}-STKE-v1.0.md |
+| 3 | `/arckit:risk` | HMG Orange Book risk methodology | ARC-{PID}-RISK-v1.0.md |
+
+### Phase 2: Business Justification
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 4 | `/arckit:sobc` | HM Treasury Green Book SOBC with 5-case model | ARC-{PID}-SOBC-v1.0.md |
+| 5 | `/arckit:requirements` | Requirements aligned to GDS service standard | ARC-{PID}-REQ-v1.0.md |
+
+### Phase 3: Design & Analysis
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 6 | `/arckit:datascout` | Discover UK Gov open data sources (TCoP Point 10) | ARC-{PID}-DSCT-v1.0.md |
+| 7 | `/arckit:data-model` | Data architecture with GDPR/DPA considerations | ARC-{PID}-DMOD-v1.0.md |
+| 8 | `/arckit:dpia` | Data Protection Impact Assessment (mandatory for personal data) | ARC-{PID}-DPIA-v1.0.md |
+| 9 | `/arckit:research` | Technology research with Crown Commercial focus | ARC-{PID}-RES-v1.0.md |
+| 10 | `/arckit:wardley` | Strategic positioning for GaaP components | ARC-{PID}-WARD-001-v1.0.md |
+| 11 | `/arckit:roadmap` | Roadmap aligned to spending review cycles | ARC-{PID}-ROAD-v1.0.md |
+| 12 | `/arckit:diagram` | Architecture diagrams (C4, sequence, DFD) | ARC-{PID}-DIAG-001-v1.0.md |
+
+### Phase 4: Procurement (G-Cloud / DOS)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 13 | `/arckit:gcloud-search` | Search Digital Marketplace for G-Cloud services | Console output |
+| 14 | `/arckit:gcloud-clarify` | Generate clarification questions for shortlisted services | ARC-{PID}-GCLR-v1.0.md |
+| 15 | `/arckit:sow` | Statement of work for procurement | ARC-{PID}-SOW-v1.0.md |
+| 16 | `/arckit:evaluate` | Vendor evaluation with value-for-money assessment | ARC-{PID}-EVAL-v1.0.md |
+
+### Phase 5: Design Reviews
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 17 | `/arckit:hld-review` | HLD review against GDS patterns | ARC-{PID}-HLDR-v1.0.md |
+| 18 | `/arckit:dld-review` | DLD review for security and performance | ARC-{PID}-DLDR-v1.0.md |
+| 19 | `/arckit:adr` | Architecture Decision Records | ARC-{PID}-ADR-001-v1.0.md |
+
+### Phase 6: Implementation
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 20 | `/arckit:backlog` | Product backlog from requirements + design | ARC-{PID}-BKLG-v1.0.md |
+
+### Phase 7: Operations & Quality
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 21 | `/arckit:devops` | CI/CD aligned to GDS technology standards | ARC-{PID}-DVOP-v1.0.md |
+| 22 | `/arckit:operationalize` | Operational readiness, service desk integration | ARC-{PID}-OPS-v1.0.md |
+| 23 | `/arckit:traceability` | End-to-end traceability matrix | ARC-{PID}-TRACE-v1.0.md |
+
+### Phase 8: Compliance (UK Government Specific)
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 24 | `/arckit:tcop` | Technology Code of Practice assessment | ARC-{PID}-TCOP-v1.0.md |
+| 25 | `/arckit:secure` | Secure by Design assessment (NCSC CAF) | ARC-{PID}-SEC-v1.0.md |
+| 26 | `/arckit:principles-compliance` | Principles adherence | ARC-{PID}-PCOMP-v1.0.md |
+| 27 | `/arckit:conformance` | ADR conformance checking | ARC-{PID}-CONF-v1.0.md |
+| 28 | `/arckit:analyze` | Deep governance analysis | ARC-{PID}-ANAL-v1.0.md |
+| 29 | `/arckit:service-assessment` | GDS Service Assessment readiness | ARC-{PID}-SA-v1.0.md |
+
+### Phase 9: Reporting
+
+| # | Command | Rationale | Artifacts |
+|---|---------|-----------|-----------|
+| 30 | `/arckit:story` | Project narrative for governance boards | ARC-{PID}-STORY-v1.0.md |
+| 31 | `/arckit:pages` | GitHub Pages documentation site | docs/index.html |
+
+## Minimum Viable Path
+
+For Alpha assessment preparation:
+
+1. `/arckit:principles` → 2. `/arckit:stakeholders` → 3. `/arckit:requirements` → 4. `/arckit:research` → 5. `/arckit:tcop` → 6. `/arckit:secure`
+
+## Duration
+
+- **Full path**: 6-12 months
+- **Minimum viable**: 2-4 weeks
+```
+
+**Step 2: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/references/uk-gov-path.md
+git commit -m "feat: add uk-gov-path reference for architecture-workflow skill"
+```
+
+---
+
+### Task 4: Create the defence-path reference file
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/references/defence-path.md`
+- Reference: `WORKFLOW-DIAGRAMS.md` lines 349-461 (MOD Defence Path)
+- Reference: `DEPENDENCY-MATRIX.md` lines 262-276 (MOD critical paths)
+
+**Step 1: Write the reference file**
+
+Content follows the same table structure as uk-gov-path but with these differences:
+- Procurement uses `/arckit:dos` (Digital Outcomes and Specialists) instead of G-Cloud
+- Compliance adds `/arckit:mod-secure` (JSP 440, IAMM) instead of civilian `/arckit:secure`
+- If AI/ML is involved, adds `/arckit:jsp-936` (MOD AI Assurance) and `/arckit:mlops`
+- Security clearance notes added
+- Duration: 12-24 months (non-AI) or 18-36 months (AI)
+- Critical gates: MOD Secure by Design required before Beta, JSP 936 for AI
+
+Key differences from UK Gov path:
+- Phase 4 uses DOS procurement: `/arckit:dos` → `/arckit:evaluate`
+- Phase 8 compliance: `/arckit:tcop` → `/arckit:mod-secure` → `/arckit:principles-compliance` → `/arckit:conformance` → `/arckit:analyze` → `/arckit:service-assessment`
+- If AI: Add `/arckit:jsp-936` after mod-secure, add `/arckit:mlops` in operations
+
+**Step 2: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/references/defence-path.md
+git commit -m "feat: add defence-path reference for architecture-workflow skill"
+```
+
+---
+
+### Task 5: Create the ai-ml-path reference file
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/references/ai-ml-path.md`
+- Reference: `WORKFLOW-DIAGRAMS.md` lines 227-346 (UK Gov AI Path)
+- Reference: `DEPENDENCY-MATRIX.md` lines 251-258 (UK Gov AI critical path)
+
+**Step 1: Write the reference file**
+
+Content adds AI-specific commands to whichever base path applies:
+- `/arckit:ai-playbook` — AI Playbook compliance (UK Gov)
+- `/arckit:atrs` — Algorithmic Transparency Recording Standard
+- `/arckit:mlops` — ML model lifecycle, training pipelines, serving
+- `/arckit:jsp-936` — MOD AI Assurance (Defence only)
+- Additional considerations: model governance, bias assessment, explainability
+
+This reference is a **modifier** — it specifies which additional commands to add and where they slot in, depending on whether base path is standard, UK Gov, or Defence.
+
+**Step 2: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/references/ai-ml-path.md
+git commit -m "feat: add ai-ml-path reference for architecture-workflow skill"
+```
+
+---
+
+### Task 6: Create the data-path reference file
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/references/data-path.md`
+
+**Step 1: Write the reference file**
+
+Content adds data-focused commands to whichever base path applies:
+- `/arckit:datascout` — Discover external data sources (APIs, datasets, open data)
+- `/arckit:data-model` — Comprehensive data architecture
+- `/arckit:data-mesh-contract` — Federated data product contracts
+- `/arckit:dpia` — Data Protection Impact Assessment
+- `/arckit:platform-design` — Multi-sided platform strategy (data marketplaces)
+- Cloud-specific research: `/arckit:aws-research`, `/arckit:azure-research`, `/arckit:gcp-research`
+
+This reference is a **modifier** like ai-ml-path — specifies additions and where they slot into the base path.
+
+**Step 2: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/references/data-path.md
+git commit -m "feat: add data-path reference for architecture-workflow skill"
+```
+
+---
+
+### Task 7: Create the SKILL.md
+
+**Files:**
+- Create: `arckit-plugin/skills/architecture-workflow/SKILL.md`
+- Reference: `arckit-plugin/skills/wardley-mapping/SKILL.md` (for frontmatter pattern)
+- Reference: `arckit-plugin/commands/start.md` (for project detection logic)
+- Reference: Design doc at `docs/plans/2026-03-05-architecture-workflow-skill-design.md`
+
+**Step 1: Write the SKILL.md**
+
+The skill must contain:
+
+1. **YAML Frontmatter** with `name: architecture-workflow` and comprehensive `description` trigger text (see design doc)
+
+2. **Overview** — one paragraph explaining what this skill does
+
+3. **Hard Gate** — `<HARD-GATE>` block: Do NOT run any `/arckit:*` commands. Only present the recommended plan.
+
+4. **Anti-Patterns** — "I already know what I need" and "Just run everything"
+
+5. **Process** with 4 steps:
+
+   **Step 1: Detect Project State** (automatic, no questions)
+   - Check for `projects/` directory
+   - Check for principles document (`ARC-000-PRIN-*`)
+   - Count existing artifacts per project
+   - Use ArcKit Project Context from hooks if available
+   - Determine: new project vs continue existing
+
+   **Step 2: Triage Questions** (one at a time via AskUserQuestion)
+   - Q1 Sector: UK Government / Defence / Public sector (non-UK) / Private sector
+   - Q2 Project type: New system build / System migration / Procurement / Data platform / AI/ML / Strategy only
+   - Q3 Current stage: Just starting / Have requirements / Have design / Need compliance review
+   - Q4 Primary goal: Full governance lifecycle / Specific deliverable / Compliance check / Quick prototype documentation
+
+   **Step 3: Deep Questions** (only if complex — UK Gov, Defence, AI/ML, or full lifecycle)
+   - Existing stakeholder analysis?
+   - Compliance frameworks? (multiple choice: GDS, TCoP, NCSC CAF, AI Playbook, JSP 440)
+   - Procurement involvement? (G-Cloud, DOS, open tender, none)
+   - Strategic analysis needed? (Wardley Maps, platform design)
+   - Timeline pressure? (weeks, months, quarters)
+
+   **Step 4: Present Tailored Plan**
+   - Select base path reference: standard-path, uk-gov-path, or defence-path
+   - Apply modifiers: ai-ml-path and/or data-path if applicable
+   - Adjust for current stage (skip completed phases)
+   - Present numbered command sequence grouped by phase
+   - Each entry: command name, one-line rationale
+   - Include "Minimum Viable Path" for quick starts
+
+6. **Decision Logic** — mapping from triage answers to reference files:
+   ```
+   Sector = Private/Non-UK → standard-path.md
+   Sector = UK Gov → uk-gov-path.md
+   Sector = Defence → defence-path.md
+   Project type = AI/ML → add ai-ml-path.md
+   Project type = Data platform → add data-path.md
+   Goal = Compliance check → show compliance phase only from relevant path
+   Goal = Quick prototype → show minimum viable path only
+   ```
+
+7. **Output Format** — example of what the presented plan looks like
+
+8. **ArcKit Integration** — note that `/arckit:start` delegates to this skill
+
+**Step 2: Verify the skill is well-formed**
+
+Run: `head -5 arckit-plugin/skills/architecture-workflow/SKILL.md`
+Expected: YAML frontmatter with `name: architecture-workflow`
+
+**Step 3: Commit**
+
+```bash
+git add arckit-plugin/skills/architecture-workflow/SKILL.md
+git commit -m "feat: add architecture-workflow process skill"
+```
+
+---
+
+### Task 8: Modify /arckit:start to delegate to skill
+
+**Files:**
+- Modify: `arckit-plugin/commands/start.md` (entire file — replace content)
+
+**Step 1: Read the current start.md to confirm contents**
+
+Run: `wc -l arckit-plugin/commands/start.md`
+Expected: 189 lines (the current full command)
+
+**Step 2: Replace with thin wrapper**
+
+The new `start.md` should be:
+
+```markdown
+---
+description: Get oriented with ArcKit — guided project onboarding, workflow selection, and command recommendations
+argument-hint: "[workflow focus, e.g. 'new project', 'procurement', 'governance review']"
+---
+
+# ArcKit: Project Onboarding
+
+Use the **architecture-workflow** skill to guide this user through project onboarding and workflow selection.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Instructions
+
+1. Follow the architecture-workflow skill process exactly
+2. If the user provided $ARGUMENTS with a specific focus (e.g., "procurement", "governance review"), use that as context during triage — it may let you skip some questions
+3. The skill will detect project state, ask adaptive questions, and present a tailored command plan
+4. Do NOT run any commands — only present the recommended plan for the user to execute
+```
+
+**Step 3: Verify the replacement**
+
+Run: `wc -l arckit-plugin/commands/start.md`
+Expected: ~18-20 lines (much shorter than 189)
+
+**Step 4: Commit**
+
+```bash
+git add arckit-plugin/commands/start.md
+git commit -m "refactor: make /arckit:start delegate to architecture-workflow skill"
+```
+
+---
+
+### Task 9: Update MEMORY.md skill count
+
+**Files:**
+- Modify: `/home/codespace/.claude/projects/-workspaces-arc-kit/memory/MEMORY.md`
+
+**Step 1: Update the Quick Reference line**
+
+Change the skill count from `2 skills` to `3 skills` and add `Architecture Workflow` to the list:
+
+```
+- **54 commands**, **5 agents**, **3 skills** (Wardley Mapping, Mermaid Syntax, PlantUML Syntax, Architecture Workflow), **18 DDaT role guides**
+```
+
+Wait — that's 4 skills now (wardley-mapping, mermaid-syntax, plantuml-syntax, architecture-workflow). Update accordingly.
+
+**Step 2: Commit**
+
+No git commit for memory files — they're outside the repo.
+
+---
+
+### Task 10: Test the skill end-to-end
+
+**Step 1: Verify skill auto-discovery**
+
+Open a test repo with the arckit plugin enabled and check that the skill appears in the available skills list. Type a message like "how do I start an architecture project" and verify the architecture-workflow skill triggers.
+
+**Step 2: Verify /arckit:start delegation**
+
+Run `/arckit:start` and verify it invokes the architecture-workflow skill rather than the old inline logic.
+
+**Step 3: Walk through the question flow**
+
+- Answer triage questions for each sector type
+- Verify correct path is selected
+- Verify plan output matches the reference file content
+- Verify deep questions only appear for complex projects
+
+**Step 4: Verify edge cases**
+
+- Empty project (no `projects/` directory)
+- Existing project with artifacts at different completeness levels
+- Specific $ARGUMENTS like "procurement" or "compliance review"
+
+**Step 5: Commit any fixes**
+
+```bash
+git add -A
+git commit -m "fix: address issues found during skill testing"
+```
+
+---
+
+## Summary
+
+| Task | Files | Type |
+|------|-------|------|
+| 1 | Directory scaffold | Create |
+| 2 | `references/standard-path.md` | Create (~100 lines) |
+| 3 | `references/uk-gov-path.md` | Create (~120 lines) |
+| 4 | `references/defence-path.md` | Create (~120 lines) |
+| 5 | `references/ai-ml-path.md` | Create (~80 lines) |
+| 6 | `references/data-path.md` | Create (~80 lines) |
+| 7 | `SKILL.md` | Create (~200-250 lines) |
+| 8 | `arckit-plugin/commands/start.md` | Modify (189 → ~20 lines) |
+| 9 | `MEMORY.md` | Modify (skill count) |
+| 10 | End-to-end testing | Test |
+
+**Total new content**: ~750-800 lines across 7 new files
+**Modified files**: 2 (start.md, MEMORY.md)
+**No converter run needed**: Skills are Claude Code plugin only
+**No template/guide needed**: This is a process skill, not a document-generating command


### PR DESCRIPTION
## Summary

- **New process skill** `architecture-workflow` that replaces inline `/arckit:start` with adaptive-depth, question-driven onboarding
- Asks triage questions (sector, project type, stage, goal) and recommends a tailored command sequence from 5 workflow paths
- Borrows patterns from Claude Code brainstorming skill: HARD-GATE, anti-patterns, one-question-at-a-time, adaptive depth

## Files

| File | Lines | Description |
|------|-------|-------------|
| `arckit-plugin/skills/architecture-workflow/SKILL.md` | 218 | Process methodology, question flow, decision logic |
| `references/standard-path.md` | 104 | Private sector, non-AI path |
| `references/uk-gov-path.md` | 125 | UK Government civilian path |
| `references/defence-path.md` | 146 | MOD/Defence path |
| `references/ai-ml-path.md` | 91 | AI/ML modifier (adds to any base) |
| `references/data-path.md` | 78 | Data platform modifier (adds to any base) |
| `arckit-plugin/commands/start.md` | 21 | Thin wrapper delegating to skill (was 189 lines) |
| `docs/plans/*.md` | 2 files | Design doc + implementation plan |

## Test plan

- [ ] Verify skill auto-discovery in a test repo with plugin enabled
- [ ] Run `/arckit:start` and confirm it delegates to the skill
- [ ] Walk through triage for each sector (standard, UK Gov, Defence)
- [ ] Verify deep questions only appear for complex projects
- [ ] Verify plan output matches reference file content
- [ ] Test with existing project (artifacts present) vs empty project

🤖 Generated with [Claude Code](https://claude.com/claude-code)