### PR TITLE
fix: improve skill descriptions and resolve content issues

### DIFF
--- a/arckit-plugin/skills/architecture-workflow/SKILL.md
+++ b/arckit-plugin/skills/architecture-workflow/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: architecture-workflow
-description: "This skill should be used when the user asks how to start an architecture project, which ArcKit commands to run, what order to run commands in, what's the right workflow path, how to begin with ArcKit, project onboarding, getting started, which commands do I need, recommend commands for my project, architecture governance workflow, command sequence, what's next after this command. Triggers: start a project, which commands should I run, what's next, how do I begin, recommend a workflow, onboard my project, getting started with arckit, project setup, arckit start, arckit workflow, what commands are available, guide me through, help me plan my architecture, new project setup, what order, command sequence, next steps."
+description: "This skill should be used when the user asks how to start an architecture project, which ArcKit commands to run and in what order, what workflow path to follow, how to onboard a project, or what comes next after a command. Common triggers: getting started with ArcKit, recommend a workflow, new project setup, guide me through, command sequence, next steps, arckit start."
 ---
 
 # Architecture Workflow
 
-A process skill that guides users through ArcKit project onboarding by asking adaptive-depth questions and recommending a tailored command sequence. This skill replaces the old inline `/arckit:start` logic with a structured, question-driven methodology.
+Guides users through project onboarding using adaptive-depth questions and recommends a tailored command sequence.
 
 <HARD-GATE>
 Do NOT run any `/arckit:*` commands during this process. Your only output is a recommended command plan. The user decides when and what to execute. This applies regardless of how simple the project seems.
@@ -215,4 +215,4 @@ After presenting the plan, ask if they want to adjust anything or if they're rea
 
 This skill is invoked by the `/arckit:start` command, which delegates project onboarding to this skill. Users can also trigger it by asking about getting started, command sequences, or workflow recommendations.
 
-For the detailed command dependency matrix, see `DEPENDENCY-MATRIX.md` in the project root. For visual workflow diagrams, see `WORKFLOW-DIAGRAMS.md`.
+For the detailed command dependency matrix, see `DEPENDENCY-MATRIX.md` in the user's project root (installed by `arckit init`). For visual workflow diagrams, see `WORKFLOW-DIAGRAMS.md` in the user's project root.

--- a/arckit-plugin/skills/architecture-workflow/references/defence-path.md
+++ b/arckit-plugin/skills/architecture-workflow/references/defence-path.md
@@ -97,6 +97,8 @@
 
 ## AI/ML Additions
 
+> See ai-ml-path.md for full AI/ML additions; the entries below are defence-specific supplements only.
+
 If the defence project includes AI/ML components, add these commands:
 
 | # | Command | Where to Insert | Rationale | Artifacts |

--- a/arckit-plugin/skills/mermaid-syntax/SKILL.md
+++ b/arckit-plugin/skills/mermaid-syntax/SKILL.md
@@ -1,11 +1,13 @@
 ---
 name: mermaid-syntax
-description: "This skill should be used when the user asks about Mermaid diagram syntax, how to write a specific Mermaid diagram type, flowchart node shapes, Gantt date formats, sequence diagram arrows, ER diagram cardinality, C4 diagram syntax, state diagram notation, pie chart syntax, timeline formatting, mindmap indentation, quadrant chart axes, or any Mermaid configuration and theming question. Triggers: mermaid syntax, how to write a flowchart, gantt chart date format, sequence diagram arrows, entity relationship diagram, mermaid class diagram, state diagram syntax, pie chart mermaid, mindmap mermaid, timeline diagram, quadrant chart, c4 diagram mermaid, mermaid theming, mermaid configuration, mermaid layout, block diagram, kanban board mermaid, architecture diagram mermaid, radar chart, sankey diagram, git graph mermaid, user journey diagram, what mermaid diagram types are available, mermaid node shapes, mermaid edge labels, mermaid styling."
+description: "This skill should be used when the user asks about Mermaid diagram syntax, how to write a specific Mermaid diagram type (flowchart, sequence, class, state, ER, Gantt, pie, mindmap, timeline, git graph, quadrant, C4, sankey, XY chart, block, packet, kanban, architecture, radar, treemap, user journey, ZenUML), Mermaid node shapes, edge labels, styling, configuration, theming, layout options, or troubleshooting Mermaid rendering errors and syntax gotchas."
 ---
 
 # Mermaid Syntax Reference
 
 A comprehensive reference for all 23 Mermaid diagram types plus configuration and theming. This skill provides official Mermaid syntax documentation sourced from the [mermaid-skill](https://github.com/WH-2099/mermaid-skill) project (auto-synced from upstream Mermaid docs).
+
+To look up syntax for a specific diagram type, identify the type from the table below and read the corresponding reference file.
 
 ## Supported Diagram Types
 

--- a/arckit-plugin/skills/plantuml-syntax/SKILL.md
+++ b/arckit-plugin/skills/plantuml-syntax/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plantuml-syntax
-description: "This skill should be used when the user asks about PlantUML diagram syntax, C4-PlantUML library, PlantUML sequence diagrams, component diagrams, deployment diagrams, class diagrams, state diagrams, activity diagrams, ER diagrams, use case diagrams, PlantUML skinparams, themes, layout hints, Rel_Down, Rel_Right, Lay_Right, Lay_Down, or PlantUML directional hints. Triggers: plantuml syntax, C4-PlantUML, plantuml sequence diagram, plantuml class diagram, plantuml component diagram, plantuml deployment diagram, plantuml ER diagram, plantuml layout, plantuml skinparams, plantuml themes, plantuml icons, plantuml styling, Rel_Down vs Lay_Right, plantuml layout conflicts, plantuml activity diagram, plantuml state diagram, plantuml use case diagram, plantuml common errors."
+description: "This skill should be used when the user asks about PlantUML syntax for any diagram type including C4-PlantUML, sequence, class, activity, state, ER, component, deployment, or use case diagrams. Also applies when troubleshooting PlantUML rendering errors, fixing layout conflicts between Rel_Down and Lay_Right, styling with skinparams or themes, or asking about C4 directional relationships and tier-based layout patterns."
 ---
 
 # PlantUML Syntax Reference
@@ -21,6 +21,7 @@ Select the appropriate diagram type and read the corresponding reference file:
 | ER Diagram | [er-diagrams.md](references/er-diagrams.md) | — |
 | Component Diagram | [component-diagrams.md](references/component-diagrams.md) | — |
 | Use Case Diagram | [use-case-diagrams.md](references/use-case-diagrams.md) | — |
+| Deployment Diagram | [deployment-diagrams.md](references/deployment-diagrams.md) | — |
 
 ## Styling & Errors
 
@@ -57,7 +58,7 @@ These are the most common PlantUML syntax errors encountered when generating dia
 | Missing element declaration | Relationship references an undeclared element ID | Declare ALL elements before ANY relationships |
 | Spaces in element IDs | Parser fails on IDs with spaces or special characters | Use camelCase or underscores: `paymentApi`, `payment_api` |
 | Nested boundaries without content | Empty boundaries may cause rendering errors | Ensure every boundary contains at least one element |
-| `\n` in descriptions | Literal `\n` appears instead of line break | Use `\n` for line breaks in element descriptions (PlantUML handles this natively) |
+| `\n` in descriptions | Expects literal `\n` text but PlantUML renders it as a line break | This is expected behavior — PlantUML interprets `\n` as line breaks natively. Use `\\n` if literal text is needed |
 
 ## ArcKit Integration
 

--- a/arckit-plugin/skills/plantuml-syntax/references/c4-plantuml.md
+++ b/arckit-plugin/skills/plantuml-syntax/references/c4-plantuml.md
@@ -41,7 +41,7 @@ Every C4-PlantUML diagram must include the appropriate library file. Use one inc
 | `Person_Ext(alias, label, description)` | An external person | alias, label, description |
 | `System(alias, label, description)` | The system being described | alias, label, description |
 | `System_Ext(alias, label, description)` | An external system | alias, label, description |
-| `SystemDb(alias, label, description)` | An external database system | alias, label, description |
+| `SystemDb(alias, label, description)` | A database system | alias, label, description |
 | `SystemDb_Ext(alias, label, description)` | An external database system | alias, label, description |
 | `SystemQueue(alias, label, description)` | A queue system | alias, label, description |
 | `SystemQueue_Ext(alias, label, description)` | An external queue system | alias, label, description |

--- a/arckit-plugin/skills/plantuml-syntax/references/deployment-diagrams.md
+++ b/arckit-plugin/skills/plantuml-syntax/references/deployment-diagrams.md
@@ -1,0 +1,110 @@
+# PlantUML Deployment Diagrams
+
+Deployment diagrams model the physical architecture of a system — nodes, devices, artifacts, and their relationships.
+
+## Core Elements
+
+| Element | Syntax | Description |
+|---------|--------|-------------|
+| Node | `node "Name" { }` | Generic processing node |
+| Device | `device "Name" { }` | Physical device (server, phone) |
+| Artifact | `artifact "Name"` | Deployable unit (JAR, WAR, binary) |
+| Database | `database "Name"` | Database instance |
+| Cloud | `cloud "Name" { }` | Cloud environment |
+| Folder | `folder "Name" { }` | Logical grouping |
+| Frame | `frame "Name" { }` | Named frame boundary |
+| Package | `package "Name" { }` | Package grouping |
+| Queue | `queue "Name"` | Message queue |
+| Stack | `stack "Name"` | Stack of elements |
+| Storage | `storage "Name"` | Storage device |
+| File | `file "Name"` | File artifact |
+
+## Nesting
+
+Nodes and containers can be nested to show deployment topology:
+
+```plantuml
+@startuml
+node "Production Server" {
+  node "Docker Host" {
+    artifact "web-app.war"
+    artifact "api-service.jar"
+  }
+  database "PostgreSQL" as db
+}
+@enduml
+```
+
+## Relationships
+
+| Syntax | Description |
+|--------|-------------|
+| `A -- B` | Solid line (association) |
+| `A --> B` | Arrow |
+| `A ..> B` | Dashed arrow (dependency) |
+| `A -- B : label` | Association with label |
+| `A --> B : "HTTPS"` | Arrow with protocol label |
+
+## Aliases
+
+Assign aliases for cleaner relationship definitions:
+
+```plantuml
+node "Web Server" as web
+node "App Server" as app
+database "Database" as db
+
+web --> app : "REST API"
+app --> db : "JDBC"
+```
+
+## Styling
+
+| Skinparam | Example |
+|-----------|---------|
+| `skinparam node` | `skinparam node { BackgroundColor LightBlue }` |
+| `skinparam database` | `skinparam database { BackgroundColor LightGreen }` |
+| `skinparam artifact` | `skinparam artifact { BackgroundColor LightYellow }` |
+| Individual color | `node "Name" #LightBlue` |
+
+## Complete Worked Example
+
+```plantuml
+@startuml
+skinparam node {
+  BackgroundColor #E8F4FD
+  BorderColor #2196F3
+}
+skinparam database {
+  BackgroundColor #E8F5E9
+  BorderColor #4CAF50
+}
+
+cloud "AWS Cloud" as aws {
+  node "ALB" as alb
+
+  node "ECS Cluster" as ecs {
+    artifact "web-frontend" as web
+    artifact "api-service" as api
+    artifact "worker-service" as worker
+  }
+
+  database "RDS PostgreSQL" as rds
+  queue "SQS Queue" as sqs
+  storage "S3 Bucket" as s3
+}
+
+node "User Browser" as browser
+
+browser --> alb : "HTTPS"
+alb --> web : "HTTP:3000"
+web --> api : "HTTP:8080"
+api --> rds : "JDBC:5432"
+api --> sqs : "AWS SDK"
+sqs --> worker : "Poll"
+worker --> rds : "JDBC:5432"
+worker --> s3 : "AWS SDK"
+@enduml
+```
+
+This example shows a typical AWS deployment with load balancer, ECS containers, RDS database, SQS queue, and S3 storage.

--- a/arckit-plugin/skills/wardley-mapping/SKILL.md
+++ b/arckit-plugin/skills/wardley-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wardley-mapping
-description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, or competitive landscape. Covers creating maps, gameplay patterns, doctrine, build vs. buy, inertia, and quantitative analysis. Triggers: create a wardley map, map our value chain, what evolution stage is this component, should we build or buy, assess doctrine maturity, analyze competitive landscape, where should we invest vs outsource, score evolution, calculate ubiquity, quantitative positioning, evolution formula, differentiation pressure, commodity leverage, weak signal detection, readiness score."
+description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, gameplay patterns, doctrine, build vs. buy decisions, inertia analysis, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
 ---
 
 # Wardley Mapping
@@ -117,14 +117,9 @@ Use AskUserQuestion to confirm priorities with the user before finalizing recomm
 
 When the user asks for numeric precision, scoring, or data-driven positioning, apply the mathematical models from [references/mathematical-models.md](references/mathematical-models.md):
 
-1. **Evolution Scoring** — Score each component's Ubiquity (0-1) and Certainty (0-1), then calculate `E(c) = (U + C) / 2` to get a precise X-axis position. Use the rubrics in [references/evolution-stages.md](references/evolution-stages.md) for scoring guidance.
-
-2. **Decision Metrics** — For each component, calculate:
-   - **Differentiation Pressure**: `D(v) = visibility × (1 - evolution)` — high means invest to differentiate
-   - **Commodity Leverage**: `K(v) = (1 - visibility) × evolution` — high means outsource/consume
-   - **Dependency Risk**: `R(a,b) = visibility(a) × (1 - evolution(b))` — high means critical dependency on immature component
-
-3. **Weak Signal Detection** — When the user asks whether a component is about to transition stages, assess the four readiness factors (Concept, Technology, Suitability, Attitude) and calculate `R(t) = C × T × S × A`. A score above 0.7 signals imminent transition.
+1. **Evolution Scoring** — Calculate precise X-axis positions using Ubiquity and Certainty scores
+2. **Decision Metrics** — Differentiation Pressure, Commodity Leverage, and Dependency Risk
+3. **Weak Signal Detection** — Assess readiness factors to predict stage transitions
 
 Present results as a table alongside the qualitative analysis — the numbers should confirm or challenge the intuitive positioning, not replace it.
 

--- a/arckit-plugin/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-plugin/skills/wardley-mapping/references/climatic-patterns.md
@@ -1,6 +1,6 @@
 # Climatic Patterns
 
-External forces that affect the landscape over which you have no choice.
+External forces that affect the landscape, outside organizational control.
 
 ## Economic Patterns
 
@@ -24,7 +24,7 @@ pattern:
 ```yaml
 pattern:
   name: "Characteristics Change"
-  description: "How you manage a component changes with its evolution"
+  description: "How a component is managed changes with its evolution"
 
   changes:
     genesis:

--- a/arckit-plugin/skills/wardley-mapping/references/evolution-stages.md
+++ b/arckit-plugin/skills/wardley-mapping/references/evolution-stages.md
@@ -83,42 +83,7 @@ evolution_stages:
 
 ## Numeric Scoring
 
-For precise positioning, score a component on two dimensions — **Ubiquity** (how widespread) and **Certainty** (how standardized) — each on a 0.0 to 1.0 scale, then average them:
-
-```
-Evolution Score = (Ubiquity + Certainty) / 2
-```
-
-### Ubiquity Scale
-
-| Score | Label | Markers |
-|-------|-------|---------|
-| 0.0 - 0.2 | Rare/Novel | Only a few organizations; no established market |
-| 0.2 - 0.4 | Emerging | Early adopters; limited vendor options |
-| 0.4 - 0.6 | Common | Multiple vendors; analyst coverage; most large orgs aware |
-| 0.6 - 0.8 | Widespread | Industry standard; assumed capability |
-| 0.8 - 1.0 | Universal | Everywhere; pay-per-use available; not adopting is unusual |
-
-### Certainty Scale
-
-| Score | Label | Markers |
-|-------|-------|---------|
-| 0.0 - 0.2 | Undefined | No established practices; high variation |
-| 0.2 - 0.4 | Emerging | Some patterns forming; vendor-specific approaches |
-| 0.4 - 0.6 | Accepted | Recognized methodologies; training courses available |
-| 0.6 - 0.8 | Well-defined | Industry standards; compliance frameworks |
-| 0.8 - 1.0 | Standardized | ISO/formal standards; commoditized operations |
-
-### Score-to-Stage Mapping
-
-| Evolution Score | Stage |
-|----------------|-------|
-| 0.00 - 0.25 | Genesis |
-| 0.25 - 0.50 | Custom-Built |
-| 0.50 - 0.75 | Product |
-| 0.75 - 1.00 | Commodity |
-
-For detailed formulas (sigmoid variant, decision metrics, weak signals), see [Mathematical Models](mathematical-models.md).
+For quantitative evolution scoring rubrics (Ubiquity Scale, Certainty Scale, Score-to-Stage Mapping) and decision metrics, see [Mathematical Models](mathematical-models.md).
 
 ## Positioning Criteria
 


### PR DESCRIPTION
## Summary

- **All 4 skills**: Trimmed redundant `Triggers:` keyword lists from descriptions (all now <500 chars)
- **mermaid-syntax**: Added imperative instruction at top of body
- **plantuml-syntax**: Fixed circular `\n` gotcha, fixed `SystemDb` description, added `deployment-diagrams.md` reference
- **architecture-workflow**: Removed internal changelog line, fixed file path references for plugin context, added AI/ML cross-reference in defence-path
- **wardley-mapping**: Deduplicated scoring content between evolution-stages and mathematical-models, slimmed Step 6 formulas, fixed second-person in climatic-patterns

## Test plan

- [ ] Verify skill triggers still match expected user queries
- [ ] Check new `deployment-diagrams.md` renders correctly
- [ ] Confirm `evolution-stages.md` pointer to `mathematical-models.md` works
- [ ] Validate description lengths are under 500 characters

🤖 Generated with [Claude Code](https://claude.com/claude-code)