### PR TITLE
feat: add dynamic version badge to main GitHub Pages site

### DIFF
--- a/docs/heroes.css
+++ b/docs/heroes.css
@@ -89,6 +89,33 @@
 .app-page-hero__title       { animation-delay: 0.09s; }
 .app-page-hero__description { animation-delay: 0.14s; }
 
+/* Version badge */
+.app-page-hero__version {
+    display: inline-block;
+    margin-top: 0.75rem;
+    padding: 0.25rem 0.75rem;
+    font-size: 0.8125rem;
+    font-weight: 700;
+    color: #fff;
+    background: rgba(255, 255, 255, 0.18);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    border-radius: 2px;
+    animation: heroReveal 0.45s ease-out 0.19s both;
+}
+
+.app-page-hero__version:empty {
+    display: none;
+}
+
+.app-page-hero__version a {
+    color: #fff;
+    text-decoration: none;
+}
+
+.app-page-hero__version a:hover {
+    text-decoration: underline;
+}
+
 /* ============================================================
    Responsive
    ============================================================ */

--- a/docs/index.html
+++ b/docs/index.html
@@ -359,6 +359,7 @@
             <span class="app-page-hero__stat">Enterprise Architecture Toolkit</span>
             <h1 class="app-page-hero__title">ArcKit</h1>
             <p class="app-page-hero__description">Transform architecture chaos into systematic, audit-ready governance.</p>
+            <p class="app-page-hero__version" id="hero-version"></p>
         </div>
     </div>
 
@@ -526,7 +527,7 @@
                 <div class="govuk-grid-column-two-thirds">
                     <h2 class="govuk-heading-m">ArcKit</h2>
                     <p class="govuk-body">Enterprise Architecture Governance & Vendor Procurement Toolkit</p>
-                    <p class="govuk-body">Version 4.0.0 - March 2026</p>
+                    <p class="govuk-body" id="footer-version"></p>
                 </div>
 
                 <div class="govuk-grid-column-one-third">
@@ -554,5 +555,26 @@
         initAll()
     </script>
 <script src="theme.js"></script>
+    <script>
+        (function() {
+            fetch('https://api.github.com/repos/tractorjuice/arc-kit/releases/latest')
+                .then(function(r) { return r.json(); })
+                .then(function(d) {
+                    if (!d.tag_name) return;
+                    var ver = d.tag_name.replace(/^v/, '');
+                    var date = d.published_at ? new Date(d.published_at).toLocaleDateString('en-GB', { month: 'long', year: 'numeric' }) : '';
+                    var hero = document.getElementById('hero-version');
+                    if (hero) {
+                        var link = document.createElement('a');
+                        link.href = d.html_url;
+                        link.textContent = 'v' + ver;
+                        hero.appendChild(link);
+                    }
+                    var footer = document.getElementById('footer-version');
+                    if (footer) footer.textContent = 'Version ' + ver + (date ? ' \u2014 ' + date : '');
+                })
+                .catch(function() {});
+        })();
+    </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary

- Fetch latest release version from GitHub API (`/repos/tractorjuice/arc-kit/releases/latest`) and display dynamically
- Hero section shows a clickable version badge linking to the release page
- Footer shows "Version X.Y.Z — Month Year" (replaces hardcoded `Version 4.0.0 - March 2026`)
- Version elements hidden when API is unavailable (graceful degradation)
- Reverts accidental hardcoded version added to getting-started.html footer

## Test plan

- [ ] Verify version badge appears in hero section with correct version number
- [ ] Verify clicking badge links to the GitHub release page
- [ ] Verify footer shows version with date
- [ ] Verify dark mode renders badge correctly
- [ ] Verify page loads gracefully when GitHub API is rate-limited

🤖 Generated with [Claude Code](https://claude.com/claude-code)