### PR TITLE
fix(gemini): remove settings block that requires system keychain

### DIFF
--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -23,14 +23,6 @@
       }
     }
   },
-  "settings": [
-    {
-      "name": "Google API Key",
-      "description": "Optional. Required for /arckit:gcp-research. Get one at https://makersuite.google.com/app/apikey",
-      "envVar": "GOOGLE_API_KEY",
-      "sensitive": true
-    }
-  ],
   "themes": [
     {
       "name": "arckit",


### PR DESCRIPTION
## Summary
- Removes the `settings` block with `"sensitive": true` from `gemini-extension.json`
- This block required a system keychain to store the Google API Key, which isn't available in GitHub Codespaces
- Without a keychain, the entire extension fails to load with "Keychain is not available"
- Users can still set `GOOGLE_API_KEY` via environment variable as documented in the README

## Test plan
- [ ] Install extension in a codespace: `gemini extensions install https://github.com/tractorjuice/arckit-gemini`
- [ ] Verify `gemini extensions list` shows the extension without errors
- [ ] Verify `/arckit:gcp-research` still works when `GOOGLE_API_KEY` is set via env var

🤖 Generated with [Claude Code](https://claude.com/claude-code)