### PR TITLE
fix(gemini): restore MCP servers, keep settings block removed

### DIFF
--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -9,6 +9,18 @@
     },
     "microsoft-learn": {
       "httpUrl": "https://learn.microsoft.com/api/mcp"
+    },
+    "google-developer-knowledge": {
+      "httpUrl": "https://developerknowledge.googleapis.com/mcp",
+      "headers": {
+        "X-Goog-Api-Key": "${GOOGLE_API_KEY}"
+      }
+    },
+    "datacommons-mcp": {
+      "httpUrl": "https://api.datacommons.org/mcp",
+      "headers": {
+        "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
     }
   },
   "themes": [


### PR DESCRIPTION
## Summary
- Restores `google-developer-knowledge` and `datacommons-mcp` MCP servers with their API key headers
- Keeps the `settings` block removed — that was the actual cause of the "Keychain is not available" error during install
- Version 4.0.1

## Test plan
- [ ] Manual clone: `git clone https://github.com/tractorjuice/arckit-gemini ~/.gemini/extensions/arckit`
- [ ] Verify `gemini extensions list` shows all 4 MCP servers
- [ ] No keychain errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)