### PR TITLE
feat: session-learner hook with auto-memory integration

### DIFF
--- a/arckit-claude/hooks/arckit-session.mjs
+++ b/arckit-claude/hooks/arckit-session.mjs
@@ -110,6 +110,21 @@ if (isDir(projectsDir)) {
   }
 }
 
+// Surface recent session history if available
+const sessionsFile = join(cwd, '.arckit', 'memory', 'sessions.md');
+if (isFile(sessionsFile)) {
+  const sessionsContent = readText(sessionsFile);
+  if (sessionsContent) {
+    // Extract last 3 session entries for context
+    const sections = sessionsContent.split(/\n(?=### \d{4}-\d{2}-\d{2})/);
+    const recentSessions = sections.slice(1, 4); // skip header, take 3
+    if (recentSessions.length > 0) {
+      context += '\n\n## Recent Sessions\n';
+      context += recentSessions.join('\n');
+    }
+  }
+}
+
 // Output additionalContext
 const output = {
   hookSpecificOutput: {

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "ArcKit hooks: session init, project context injection, filename enforcement, MCP tool auto-allow, and security protection (file protection, secret detection, secret file scanning)",
+  "description": "ArcKit hooks: session init, session learner, project context injection, filename enforcement, MCP tool auto-allow, and security protection (file protection, secret detection, secret file scanning)",
   "hooks": {
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-learner.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": ".*",

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -1,0 +1,148 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Stop Hook — Session Learner
+ *
+ * Fires when a session ends (Stop event). Analyses recent git commits
+ * to build a session summary and appends it to .arckit/memory/sessions.md.
+ *
+ * The summary captures:
+ *   - Which artifact types were created or modified
+ *   - Session classification (governance, research, procurement, review, general)
+ *   - Commit summaries for context
+ *
+ * Designed to complement Claude Code's built-in auto-memory. Auto-memory
+ * captures what Claude decides to remember; this hook captures what actually
+ * happened (git commits, artifact types) without relying on Claude's judgement.
+ *
+ * Hook Type: Stop (Notification)
+ * Input (stdin):  JSON with session_id, cwd, etc.
+ * Output (stdout): empty (notification hook, no output required)
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { isDir, isFile, readText, parseHookInput } from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+const data = parseHookInput();
+const cwd = data.cwd || '.';
+
+// Only proceed if we're in a project with .arckit directory
+if (!isDir(join(cwd, '.arckit'))) {
+  process.exit(0);
+}
+
+// Collect recent git activity (last 2 hours)
+let commits = '';
+try {
+  commits = execFileSync('git', ['log', '--since=2 hours ago', '--oneline', '--no-merges'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+if (!commits) process.exit(0);
+
+const commitLines = commits.split('\n').filter(Boolean);
+const commitCount = commitLines.length;
+
+// Detect changed files from recent commits
+let changedFiles = '';
+try {
+  changedFiles = execFileSync('git', ['log', '--since=2 hours ago', '--no-merges', '--name-only', '--pretty=format:'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  }).trim();
+} catch {
+  changedFiles = '';
+}
+
+const files = [...new Set(changedFiles.split('\n').filter(Boolean))];
+
+// Detect artifact types from filenames using DOC_TYPES config
+const detectedTypes = new Set();
+for (const f of files) {
+  for (const [code, info] of Object.entries(DOC_TYPES)) {
+    if (f.includes(`-${code}-`) || f.includes(`-${code}.`)) {
+      detectedTypes.add(`${info.name} (${info.category})`);
+    }
+  }
+}
+
+// Classify session type from DOC_TYPES categories
+function classifySession(types) {
+  const typeArr = [...types];
+  const categories = typeArr.map(t => {
+    const match = t.match(/\((.+)\)$/);
+    return match ? match[1] : '';
+  });
+
+  if (categories.includes('Compliance') || categories.includes('Governance')) return 'governance';
+  if (categories.includes('Research')) return 'research';
+  if (categories.includes('Procurement')) return 'procurement';
+  if (typeArr.some(t => t.includes('Review'))) return 'review';
+  return 'general';
+}
+
+const sessionType = classifySession(detectedTypes);
+
+// Extract commit message summaries (strip hashes)
+const commitSummaries = commitLines.map(line => {
+  const spaceIdx = line.indexOf(' ');
+  return spaceIdx > 0 ? line.substring(spaceIdx + 1) : line;
+});
+
+// Build markdown entry
+const now = new Date();
+const dateStr = now.toISOString().substring(0, 10);
+const timeStr = now.toISOString().substring(11, 16);
+const artifactList = [...detectedTypes].join(', ') || 'none detected';
+
+let entry = `\n### ${dateStr} ${timeStr} — ${sessionType}\n\n`;
+entry += `- **Commits:** ${commitCount} | **Files changed:** ${files.length}\n`;
+entry += `- **Artifacts:** ${artifactList}\n`;
+
+if (commitSummaries.length > 0) {
+  entry += '- **Summary:**\n';
+  for (const s of commitSummaries.slice(0, 8)) {
+    entry += `  - ${s}\n`;
+  }
+}
+
+// Ensure memory directory and file exist
+const memoryDir = join(cwd, '.arckit', 'memory');
+mkdirSync(memoryDir, { recursive: true });
+
+const sessionsFile = join(memoryDir, 'sessions.md');
+
+// Read existing content or create with header
+let existing = '';
+if (isFile(sessionsFile)) {
+  existing = readText(sessionsFile) || '';
+}
+
+if (!existing.trim()) {
+  existing = '# Session Log\n\nAutomated session summaries captured by the ArcKit session-learner hook.\n';
+}
+
+// Append new entry and trim to last 30 sessions
+const sections = existing.split(/\n(?=### \d{4}-\d{2}-\d{2})/);
+const header = sections[0];
+const entries = sections.slice(1);
+
+// Add new entry at the start (most recent first)
+entries.unshift(entry.trimStart());
+
+// Keep last 30 sessions
+const trimmed = entries.slice(0, 30);
+
+const output = header.trimEnd() + '\n' + trimmed.map(e => '\n' + e).join('');
+
+writeFileSync(sessionsFile, output);
+
+process.exit(0);

--- a/docs/guides/session-memory.md
+++ b/docs/guides/session-memory.md
@@ -1,0 +1,80 @@
+# Session Memory
+
+ArcKit includes automated session capture that records what happened during each Claude Code session. This complements Claude Code's built-in auto-memory by tracking the *actual work done* (git commits, artifact types) rather than relying on what Claude decides to remember.
+
+## How It Works
+
+```
+Session N ends
+  └── session-learner.mjs (Stop hook) analyses recent git commits
+       └── appends summary to .arckit/memory/sessions.md
+
+Session N+1 starts
+  └── arckit-session.mjs (SessionStart hook) reads sessions.md
+       └── surfaces last 3 sessions as context
+```
+
+The Stop hook fires automatically when a session ends. No configuration needed beyond installing the ArcKit plugin.
+
+## What Gets Captured
+
+Each session entry includes:
+
+- **Session classification** — governance, research, procurement, review, or general (auto-detected from artifact types)
+- **Commit count and files changed** — quantitative measure of session activity
+- **Artifact types** — which ArcKit document types (ADR, HLDR, WARD, etc.) were created or modified
+- **Commit summaries** — up to 8 commit messages for context
+
+## Session Classification
+
+Sessions are classified by the dominant category of artifacts touched:
+
+| Classification | Triggered by |
+|---|---|
+| `governance` | Compliance or Governance artifacts (TCOP, SECD, DPIA, RISK, TRAC, etc.) |
+| `research` | Research artifacts (RSCH, AWRS, AZRS, GCRS) |
+| `procurement` | Procurement artifacts (SOW, EVAL, DOS, GCLD, VEND) |
+| `review` | Review artifacts (HLDR, DLDR, SVCASS) |
+| `general` | Everything else |
+
+## Storage
+
+Session history is stored in `.arckit/memory/sessions.md` — a rolling log of the last 30 sessions. This file can be committed to git for team visibility, or added to `.gitignore` for individual use.
+
+### Example Entry
+
+```markdown
+### 2026-03-08 14:30 — governance
+
+- **Commits:** 4 | **Files changed:** 7
+- **Artifacts:** Secure by Design (Compliance), Architecture Decision Records (Architecture)
+- **Summary:**
+  - feat: add SECD assessment for cloud migration
+  - docs: update ADR-003 with security review outcome
+  - fix: correct risk rating in RISK register
+  - chore: update traceability matrix
+```
+
+## Relationship to Auto-Memory
+
+| Feature | Claude Auto-Memory | Session Learner |
+|---|---|---|
+| **What it captures** | What Claude decides is important | What actually happened (git commits) |
+| **Trigger** | Automatic (Claude's judgement) | Deterministic (Stop hook on every session) |
+| **Storage** | `~/.claude/projects/<project>/memory/` (machine-local) | `.arckit/memory/sessions.md` (in-repo) |
+| **Team sharing** | Not shareable | Committable to git |
+| **Content** | Freeform insights, preferences | Structured session summaries |
+
+The two systems are complementary, not competing. Auto-memory captures *insights*; session-learner captures *activity*.
+
+## Troubleshooting
+
+**No sessions.md created after ending a session:**
+- Check that `.arckit/` directory exists in your project root
+- Verify there were git commits in the last 2 hours
+- Check hook registration: `hooks.json` should include a `Stop` event
+
+**Session classification seems wrong:**
+- Classification is based on artifact type codes in filenames (e.g., `ARC-001-SECD-v1.md`)
+- Non-ARC files don't contribute to classification
+- Sessions with no detected ARC artifacts default to `general`


### PR DESCRIPTION
## Summary

Replaces #104 (MCP memory server approach) with a lightweight session-learner that writes to markdown instead. Per the review feedback: the MCP server layer is now redundant given Claude Code's built-in auto-memory. This PR keeps the unique value — automated git-based session capture — while dropping all external dependencies.

- **`session-learner.mjs`** (Stop hook): Analyses recent git commits, detects ARC artifact types, classifies sessions (governance/research/procurement/review/general), appends structured markdown entries to `.arckit/memory/sessions.md`
- **`arckit-session.mjs`** enhancement: Surfaces last 3 session entries on session start as context
- **No MCP server, no extra processes, no competing memory systems**

## Architecture

```
Session N ends
  └── session-learner.mjs (Stop hook) analyses git commits
       └── appends structured entry to .arckit/memory/sessions.md

Session N+1 starts
  └── arckit-session.mjs reads sessions.md
       └── surfaces last 3 sessions as context
```

## Relationship to auto-memory

| Feature | Claude Auto-Memory | Session Learner |
|---|---|---|
| What it captures | What Claude decides is important | What actually happened (git commits) |
| Trigger | Automatic (Claude's judgement) | Deterministic (Stop hook) |
| Storage | Machine-local (`~/.claude/`) | In-repo (`.arckit/memory/`) |
| Team sharing | Not shareable | Committable to git |

The two are complementary — auto-memory captures insights, session-learner captures activity.

## Files Changed

| File | Change |
|------|--------|
| `arckit-claude/hooks/session-learner.mjs` | New — Stop hook |
| `arckit-claude/hooks/arckit-session.mjs` | Enhanced — surfaces session history on start |
| `arckit-claude/hooks/hooks.json` | Add Stop hook registration |
| `docs/guides/session-memory.md` | New — comprehensive guide |

## Test plan

- [x] Start a session in a project with `.arckit/` — verify no errors from session hook
- [x] Simulated Stop hook with real git history — `sessions.md` created with correct structure
- [x] Simulated SessionStart — last session surfaced in context output
- [x] JSON validation of hooks.json
- [x] ESM import validation of session-learner.mjs
- [ ] End-to-end test across two real sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)