### PR TITLE
feat: session-learner hook with timestamp tracking

### DIFF
--- a/arckit-claude/hooks/arckit-session.mjs
+++ b/arckit-claude/hooks/arckit-session.mjs
@@ -110,6 +110,21 @@ if (isDir(projectsDir)) {
   }
 }
 
+// Surface recent session history if available
+const sessionsFile = join(cwd, '.arckit', 'memory', 'sessions.md');
+if (isFile(sessionsFile)) {
+  const sessionsContent = readText(sessionsFile);
+  if (sessionsContent) {
+    // Extract last 3 session entries for context
+    const sections = sessionsContent.split(/\n(?=### \d{4}-\d{2}-\d{2})/);
+    const recentSessions = sections.slice(1, 4); // skip header, take 3
+    if (recentSessions.length > 0) {
+      context += '\n\n## Recent Sessions\n';
+      context += recentSessions.join('\n');
+    }
+  }
+}
+
 // Output additionalContext
 const output = {
   hookSpecificOutput: {

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "ArcKit hooks: session init, project context injection, filename enforcement, MCP tool auto-allow, and security protection (file protection, secret detection, secret file scanning)",
+  "description": "ArcKit hooks: session init, session learner, project context injection, filename enforcement, MCP tool auto-allow, and security protection (file protection, secret detection, secret file scanning)",
   "hooks": {
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-learner.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": ".*",

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -68,12 +68,24 @@ try {
 
 const files = [...new Set(changedFiles.split('\n').filter(Boolean))];
 
-// Detect artifact types from filenames using DOC_TYPES config
-const detectedTypes = new Set();
+// Detect artifact types from filenames, grouped by project number
+// projectArtifacts: Map<projectNum, Map<category, Set<typeName>>>
+const projectArtifacts = new Map();
+const allCategories = new Set();
+
 for (const f of files) {
+  // Extract project number from ARC filename (e.g., ARC-001-REQ-v1.0.md → 001)
+  const projMatch = f.match(/ARC-(\d{3})-/);
+  if (!projMatch) continue;
+  const projNum = projMatch[1];
+
   for (const [code, info] of Object.entries(DOC_TYPES)) {
     if (f.includes(`-${code}-`) || f.includes(`-${code}.`)) {
-      detectedTypes.add(`${info.name} (${info.category})`);
+      if (!projectArtifacts.has(projNum)) projectArtifacts.set(projNum, new Map());
+      const projMap = projectArtifacts.get(projNum);
+      if (!projMap.has(info.category)) projMap.set(info.category, new Set());
+      projMap.get(info.category).add(info.name);
+      allCategories.add(info.category);
     }
   }
 }
@@ -84,19 +96,14 @@ const CATEGORY_PRIORITY = [
   'Architecture', 'Planning', 'Discovery', 'Operations',
 ];
 
-function classifySession(types) {
-  const categories = new Set();
-  for (const t of types) {
-    const match = t.match(/\((.+)\)$/);
-    if (match) categories.add(match[1]);
-  }
+function classifySession(categories) {
   for (const cat of CATEGORY_PRIORITY) {
     if (categories.has(cat)) return cat.toLowerCase();
   }
   return 'general';
 }
 
-const sessionType = classifySession(detectedTypes);
+const sessionType = classifySession(allCategories);
 
 // Extract commit message summaries (strip hashes)
 const commitSummaries = commitLines.map(line => {
@@ -108,11 +115,22 @@ const commitSummaries = commitLines.map(line => {
 const now = new Date();
 const dateStr = now.toISOString().substring(0, 10);
 const timeStr = now.toISOString().substring(11, 16);
-const artifactList = [...detectedTypes].join(', ') || 'none detected';
 
 let entry = `### ${dateStr} ${timeStr} — ${sessionType}\n\n`;
 entry += `- **Commits:** ${commitCount} | **Files changed:** ${files.length}\n`;
-entry += `- **Artifacts:** ${artifactList}\n`;
+
+if (projectArtifacts.size > 0) {
+  entry += '- **Artifacts:**\n';
+  for (const [projNum, catMap] of [...projectArtifacts.entries()].sort()) {
+    const parts = [];
+    for (const [category, names] of catMap) {
+      parts.push(`${category}: ${[...names].join(', ')}`);
+    }
+    entry += `  - [${projNum}] ${parts.join(' | ')}\n`;
+  }
+} else {
+  entry += '- **Artifacts:** none detected\n';
+}
 
 if (commitSummaries.length > 0) {
   entry += '- **Summary:**\n';

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Stop Hook — Session Learner
+ *
+ * Fires when a session ends (Stop event). Analyses recent git commits
+ * to build a session summary and appends it to .arckit/memory/sessions.md.
+ *
+ * Uses timestamp tracking (.arckit/memory/.last-session) to capture
+ * exactly the commits from this session — no overlap, no gaps.
+ *
+ * Hook Type: Stop (Notification)
+ * Input (stdin):  JSON with session_id, cwd, etc.
+ * Output (stdout): empty (notification hook, no output required)
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { isDir, isFile, readText, parseHookInput } from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+const data = parseHookInput();
+const cwd = data.cwd || '.';
+
+// Only proceed if we're in a project with .arckit directory
+if (!isDir(join(cwd, '.arckit'))) {
+  process.exit(0);
+}
+
+// Read last-session timestamp for --since boundary
+const memoryDir = join(cwd, '.arckit', 'memory');
+const lastSessionFile = join(memoryDir, '.last-session');
+let sinceArg = '4 hours ago'; // first-run fallback
+
+if (isFile(lastSessionFile)) {
+  const ts = readText(lastSessionFile)?.trim();
+  if (ts) sinceArg = ts;
+}
+
+// Collect git commits since last session
+let commits = '';
+try {
+  commits = execFileSync('git', ['log', `--since=${sinceArg}`, '--oneline', '--no-merges'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+if (!commits) process.exit(0);
+
+const commitLines = commits.split('\n').filter(Boolean);
+const commitCount = commitLines.length;
+
+// Detect changed files from recent commits
+let changedFiles = '';
+try {
+  changedFiles = execFileSync('git', ['log', `--since=${sinceArg}`, '--no-merges', '--name-only', '--pretty=format:'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  }).trim();
+} catch {
+  changedFiles = '';
+}
+
+const files = [...new Set(changedFiles.split('\n').filter(Boolean))];
+
+// Detect artifact types from filenames using DOC_TYPES config
+const detectedTypes = new Set();
+for (const f of files) {
+  for (const [code, info] of Object.entries(DOC_TYPES)) {
+    if (f.includes(`-${code}-`) || f.includes(`-${code}.`)) {
+      detectedTypes.add(`${info.name} (${info.category})`);
+    }
+  }
+}
+
+// Classify session by dominant DOC_TYPES category (priority order)
+const CATEGORY_PRIORITY = [
+  'Compliance', 'Governance', 'Research', 'Procurement',
+  'Architecture', 'Planning', 'Discovery', 'Operations',
+];
+
+function classifySession(types) {
+  const categories = new Set();
+  for (const t of types) {
+    const match = t.match(/\((.+)\)$/);
+    if (match) categories.add(match[1]);
+  }
+  for (const cat of CATEGORY_PRIORITY) {
+    if (categories.has(cat)) return cat.toLowerCase();
+  }
+  return 'general';
+}
+
+const sessionType = classifySession(detectedTypes);
+
+// Extract commit message summaries (strip hashes)
+const commitSummaries = commitLines.map(line => {
+  const spaceIdx = line.indexOf(' ');
+  return spaceIdx > 0 ? line.substring(spaceIdx + 1) : line;
+});
+
+// Build markdown entry
+const now = new Date();
+const dateStr = now.toISOString().substring(0, 10);
+const timeStr = now.toISOString().substring(11, 16);
+const artifactList = [...detectedTypes].join(', ') || 'none detected';
+
+let entry = `### ${dateStr} ${timeStr} — ${sessionType}\n\n`;
+entry += `- **Commits:** ${commitCount} | **Files changed:** ${files.length}\n`;
+entry += `- **Artifacts:** ${artifactList}\n`;
+
+if (commitSummaries.length > 0) {
+  entry += '- **Summary:**\n';
+  for (const s of commitSummaries.slice(0, 8)) {
+    entry += `  - ${s}\n`;
+  }
+}
+
+// Ensure memory directory exists
+mkdirSync(memoryDir, { recursive: true });
+
+const sessionsFile = join(memoryDir, 'sessions.md');
+
+// Read existing content or create with header
+let existing = '';
+if (isFile(sessionsFile)) {
+  existing = readText(sessionsFile) || '';
+}
+
+if (!existing.trim()) {
+  existing = '# Session Log\n\nAutomated session summaries captured by the ArcKit session-learner hook.\n';
+}
+
+// Split into header + entries, prepend new entry, trim to 30
+const sections = existing.split(/\n(?=### \d{4}-\d{2}-\d{2})/);
+const header = sections[0];
+const entries = sections.slice(1);
+
+entries.unshift(entry);
+
+const trimmed = entries.slice(0, 30);
+const output = header.trimEnd() + '\n\n' + trimmed.join('\n');
+
+writeFileSync(sessionsFile, output);
+
+// Write timestamp for next session boundary
+writeFileSync(lastSessionFile, now.toISOString());
+
+process.exit(0);

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -144,7 +144,7 @@ const entries = sections.slice(1);
 entries.unshift(entry);
 
 const trimmed = entries.slice(0, 30);
-const output = header.trimEnd() + '\n\n' + trimmed.join('\n');
+const output = header.trimEnd() + '\n\n' + trimmed.join('\n') + '\n';
 
 writeFileSync(sessionsFile, output);
 

--- a/arckit-gemini/agents/arckit-aws-research.md
+++ b/arckit-gemini/agents/arckit-aws-research.md
@@ -30,6 +30,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-azure-research.md
+++ b/arckit-gemini/agents/arckit-azure-research.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-datascout.md
+++ b/arckit-gemini/agents/arckit-datascout.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-framework.md
+++ b/arckit-gemini/agents/arckit-framework.md
@@ -50,6 +50,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-gcp-research.md
+++ b/arckit-gemini/agents/arckit-gcp-research.md
@@ -33,6 +33,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-research.md
+++ b/arckit-gemini/agents/arckit-research.md
@@ -73,6 +73,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@ See the [full index](guides/roles/README.md) for details.
 
 ## 🔧 Technical Guides
 
+- [Session Memory](guides/session-memory.md) - Automated cross-session activity tracking
 - [Upgrading ArcKit](guides/upgrading.md) - Upgrade the CLI and update existing projects
 - [Token Limits Solutions](TOKEN-LIMITS.md) - Handling large projects with AI token limits
 - [File Migration](guides/migration.md) - Migrate legacy filenames to Document ID convention

--- a/docs/guides/session-memory.md
+++ b/docs/guides/session-memory.md
@@ -1,0 +1,96 @@
+# Session Memory
+
+ArcKit includes automated session capture that records what happened during each Claude Code session. This complements Claude Code's built-in auto-memory by tracking the *actual work done* (git commits, artifact types) rather than relying on what Claude decides to remember.
+
+## How It Works
+
+```text
+Session N ends
+  └── session-learner.mjs (Stop hook) analyses recent git commits
+       └── appends summary to .arckit/memory/sessions.md
+
+Session N+1 starts
+  └── arckit-session.mjs (SessionStart hook) reads sessions.md
+       └── surfaces last 3 sessions as context
+```
+
+The Stop hook fires automatically when a session ends. No configuration needed beyond installing the ArcKit plugin.
+
+## What Gets Captured
+
+Each session entry includes:
+
+- **Session classification** — compliance, governance, research, procurement, architecture, planning, discovery, operations, or general (auto-detected from artifact types)
+- **Commit count and files changed** — quantitative measure of session activity
+- **Artifact types** — which ArcKit document types (ADR, HLDR, WARD, etc.) were created or modified
+- **Commit summaries** — up to 8 commit messages for context
+
+## Session Classification
+
+Sessions are classified by the highest-priority category of artifacts touched:
+
+| Priority | Classification | Triggered by category |
+|---|---|---|
+| 1 | `compliance` | Compliance artifacts (TCOP, SECD, DPIA, JSP936, SVCASS, etc.) |
+| 2 | `governance` | Governance artifacts (RISK, TRAC, PRIN-COMP, CONF, etc.) |
+| 3 | `research` | Cloud research artifacts (AWRS, AZRS, GCRS) |
+| 4 | `procurement` | Procurement artifacts (SOW, EVAL, DOS, GCLD, VEND, etc.) |
+| 5 | `architecture` | Architecture artifacts (ADR, HLDR, DLDR, DIAG, WARD, etc.) |
+| 6 | `planning` | Planning artifacts (SOBC, PLAN, ROAD, STRAT, BKLG) |
+| 7 | `discovery` | Discovery artifacts (REQ, STKE, RSCH, DSCT) |
+| 8 | `operations` | Operations artifacts (SNOW, DEVOPS, MLOPS, FINOPS, OPS) |
+| 9 | `general` | No ARC artifacts or Other category only |
+
+## Timestamp Tracking
+
+The session-learner uses timestamp-based tracking to capture exactly the commits from each session:
+
+- Timestamp stored in `.arckit/memory/.last-session`
+- Each session captures commits since the previous session ended
+- First run uses `--since=4 hours ago` as a bootstrap
+- No overlap between sessions, no missed commits
+
+## Storage
+
+Session history is stored in `.arckit/memory/sessions.md` — a rolling log of the last 30 sessions. This file is committed to git by default for team visibility.
+
+### Example Entry
+
+```markdown
+### 2026-03-08 14:30 — governance
+
+- **Commits:** 4 | **Files changed:** 7
+- **Artifacts:** Risk Register (Governance), Architecture Decision Records (Architecture)
+- **Summary:**
+  - feat: add SECD assessment for cloud migration
+  - docs: update ADR-003 with security review outcome
+  - fix: correct risk rating in RISK register
+  - chore: update traceability matrix
+```
+
+## Relationship to Auto-Memory
+
+| Feature | Claude Auto-Memory | Session Learner |
+|---|---|---|
+| **What it captures** | What Claude decides is important | What actually happened (git commits) |
+| **Trigger** | Automatic (Claude's judgement) | Deterministic (Stop hook on every session) |
+| **Storage** | `~/.claude/projects/<project>/memory/` (machine-local) | `.arckit/memory/sessions.md` (in-repo) |
+| **Team sharing** | Not shareable | Committed to git |
+| **Content** | Freeform insights, preferences | Structured session summaries |
+
+The two systems are complementary, not competing. Auto-memory captures *insights*; session-learner captures *activity*.
+
+## Troubleshooting
+
+**No sessions.md created after ending a session:**
+
+- Check that `.arckit/` directory exists in your project root
+- Verify there were git commits since the last recorded session (or within 4 hours on first run)
+- Check hook registration: `hooks.json` should include a `Stop` event
+
+**Session classification seems wrong:**
+
+- Classification is based on artifact type codes in filenames (e.g., `ARC-001-SECD-v1.md`)
+- Non-ARC files don't contribute to classification
+- Sessions with no detected ARC artifacts default to `general`
+- When multiple categories are present, the highest-priority one wins (compliance > governance > research > ...)

--- a/docs/guides/session-memory.md
+++ b/docs/guides/session-memory.md
@@ -60,13 +60,17 @@ Session history is stored in `.arckit/memory/sessions.md` — a rolling log of t
 ### 2026-03-08 14:30 — governance
 
 - **Commits:** 4 | **Files changed:** 7
-- **Artifacts:** Risk Register (Governance), Architecture Decision Records (Architecture)
+- **Artifacts:**
+  - [001] Governance: Risk Register | Architecture: Architecture Decision Records
+  - [002] Compliance: Secure by Design
 - **Summary:**
   - feat: add SECD assessment for cloud migration
   - docs: update ADR-003 with security review outcome
   - fix: correct risk rating in RISK register
   - chore: update traceability matrix
 ```
+
+Artifacts are grouped by project number (e.g., `[001]`) and organized by category, making it easy to see which projects were active and what type of work was done.
 
 ## Relationship to Auto-Memory
 

--- a/docs/plans/2026-03-08-hook-aware-converter-design.md
+++ b/docs/plans/2026-03-08-hook-aware-converter-design.md
@@ -1,0 +1,110 @@
+# Hook-Aware Converter Design
+
+**Date:** 2026-03-08
+**Issues:** #138, #139
+**Scope:** Converter changes only — no modifications to Claude Code source commands
+
+## Summary
+
+The converter (`scripts/converter.py`) blindly copies command prompts with path rewrites, ignoring hook dependencies. 42 commands reference a context injection hook that doesn't exist on Codex/OpenCode, and `/arckit.pages` is a complete no-op on all non-Claude platforms because it assumes the `sync-guides` hook did all the work.
+
+## Architecture
+
+```text
+converter.py
+  ├── AGENT_CONFIG (extended with hook capability flags)
+  ├── rewrite_paths()          — existing, unchanged
+  ├── rewrite_hook_dependencies()  — NEW
+  │     ├── Context injection: replace standard block with self-scan instructions
+  │     └── Other hook refs: strip gracefully
+  └── convert()
+        └── For each command:
+              ├── Check commands-standalone/ for platform override
+              ├── If override exists → use it instead of source command
+              └── If no override → run rewrite_paths() + rewrite_hook_dependencies()
+```
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Where to fix | Converter only | Don't modify source commands — they're correct for Claude Code |
+| Context injection (42 cmds) | Standard block replacement | One paragraph swap, no duplicate files needed |
+| Pages command | Standalone override file | Too different for a text replacement — pre-hook version had full inline logic |
+| Hook capability tracking | Flags in AGENT_CONFIG | Consistent with existing config-driven approach |
+| Self-scan instructions | Single standard block for all 42 commands | Simple, consistent, sufficient |
+
+## AGENT_CONFIG Changes
+
+Add two flags per platform:
+
+```python
+"codex_extension": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"codex_skills": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"opencode": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"gemini": {
+    ...
+    "has_context_hook": True,   # context-inject.py exists
+    "has_sync_guides_hook": False,
+},
+```
+
+## `rewrite_hook_dependencies(prompt, config)`
+
+New function called after `rewrite_paths()`.
+
+### Context Injection Replacement
+
+For platforms where `has_context_hook` is `False`, find and replace the standard block.
+
+**Find:**
+```
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+```
+
+**Replace with:**
+```
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+```
+
+### Other Hook References
+
+Strip gracefully — remove lines that reference specific hooks by name if the platform doesn't support them.
+
+## `commands-standalone/` Directory
+
+```text
+arckit-claude/
+  commands/                  ← hook-dependent (source of truth for Claude Code)
+  commands-standalone/       ← self-contained overrides for hookless platforms
+    pages.md                 ← based on pre-hook version (commit c40418a^)
+```
+
+The converter checks `commands-standalone/{name}.md` first. If it exists, uses that for platforms without the required hook. Otherwise falls back to the standard command with `rewrite_hook_dependencies()` applied.
+
+## What Gets Fixed
+
+| Issue | Fix |
+|-------|-----|
+| #138 — 42 commands reference missing context hook | Standard block replacement in `rewrite_hook_dependencies()` |
+| #139 — pages is a no-op | Standalone `pages.md` used for Codex/OpenCode/Gemini |
+| Future hook-heavy commands | Add standalone version to `commands-standalone/` |
+
+## Out of Scope
+
+- Gemini context injection (already works via `context-inject.py`)
+- Governance/health/traceability scan hooks (graceful fallback already exists)
+- Post-processing manifest hook (low priority)
+- Changes to Claude Code source commands


### PR DESCRIPTION
## Summary

Replaces PR #136 approach with a clean implementation incorporating all review feedback:

- **`session-learner.mjs`** (Stop hook): Analyses git commits since last recorded timestamp, detects ARC artifact types grouped by project number and category, classifies sessions (compliance/governance/research/procurement/architecture/planning/discovery/operations/general), appends structured markdown entries to `.arckit/memory/sessions.md`
- **`arckit-session.mjs`** enhancement: Surfaces last 3 session entries on session start as context
- **Timestamp tracking** via `.arckit/memory/.last-session` — eliminates the 2-hour window heuristic, no overlap or gaps between sessions
- **Claude Code only** — Gemini/Codex/OpenCode lack Stop hooks

### Key differences from #136
- Timestamp-based tracking instead of `--since=2 hours ago`
- Session classification uses all 9 DOC_TYPES categories with priority order
- Artifacts grouped by project number and category (e.g., `[001] Governance: Risk Register | Architecture: ADR`)
- Committed to git by default for team visibility

### Example session entry

```markdown
### 2026-03-08 14:30 — compliance

- **Commits:** 4 | **Files changed:** 7
- **Artifacts:**
  - [001] Governance: Risk Register | Architecture: Architecture Decision Records
  - [002] Compliance: Secure by Design
- **Summary:**
  - feat: add SECD assessment for cloud migration
  - docs: update ADR-003 with security review outcome
```

## Files Changed

| File | Change |
|------|--------|
| `arckit-claude/hooks/session-learner.mjs` | New — Stop hook |
| `arckit-claude/hooks/arckit-session.mjs` | Enhanced — surfaces session history on start |
| `arckit-claude/hooks/hooks.json` | Add Stop hook registration |
| `docs/guides/session-memory.md` | New — comprehensive guide |
| `docs/README.md` | Add session-memory guide to index |
| `docs/plans/2026-03-08-session-learner-*.md` | Design doc and implementation plan |

## Test plan

- [x] Syntax validation (`node --check`) for all JS files
- [x] JSON validation for hooks.json
- [x] Simulated Stop hook — `sessions.md` created with correct structure
- [x] Simulated SessionStart — recent sessions surfaced in context output
- [x] Timestamp tracking — second run produces no duplicates
- [x] Artifact grouping — project numbers and categories correctly extracted
- [x] Session classification — highest-priority category wins
- [x] Test with real ARC artifacts across multiple projects
- [ ] End-to-end test across two real sessions

Closes #136

🤖 Generated with [Claude Code](https://claude.com/claude-code)