### PR TITLE
feat: hook-aware converter for cross-platform hook dependencies

### DIFF
--- a/arckit-claude/commands-standalone/pages.md
+++ b/arckit-claude/commands-standalone/pages.md
@@ -1,0 +1,568 @@
+---
+description: Generate documentation site with governance dashboard, document viewer, and Mermaid diagram support
+allowed-tools: Read, Write, Glob, Grep
+argument-hint: "<project ID or 'all', e.g. '001', 'all'>"
+---
+
+# ArcKit: Documentation Site Generator
+
+You are an expert web developer helping generate a documentation site that displays all ArcKit project documents with full Mermaid diagram rendering support.
+
+## What is the Pages Generator?
+
+The Pages Generator creates a `docs/index.html` file that:
+
+- **Dashboard** with KPI cards, donut charts, coverage bars, and governance checklist
+- **Displays** all ArcKit artifacts in a navigable web interface
+- **Renders** Mermaid diagrams inline
+- **Organizes** documents by project with sidebar navigation
+- **Follows** GOV.UK Design System styling
+- **Works** with any static hosting provider (GitHub Pages, Netlify, Vercel, S3, etc.)
+
+## Your Task
+
+**User Request**: $ARGUMENTS
+
+Generate a documentation site for this ArcKit repository.
+
+## Step 0: Determine Repository Info
+
+Determine the repository name and URL:
+
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
+
+## Step 1: Discover Repository Structure
+
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
+
+### 1.1 Guides (Command Documentation)
+
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `${CLAUDE_PLUGIN_ROOT}/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
+
+**Guide Categories** (based on filename):
+
+| Category | Guide Files |
+|----------|-------------|
+| Discovery | requirements, stakeholders, stakeholder-analysis, research, datascout |
+| Planning | sobc, business-case, plan, roadmap, backlog, strategy |
+| Architecture | principles, adr, diagram, wardley, data-model, hld-review, dld-review, design-review, platform-design, data-mesh-contract, c4-layout-science |
+| Governance | risk, risk-management, traceability, principles-compliance, analyze, artifact-health, data-quality-framework, knowledge-compounding |
+| Compliance | tcop, secure, mod-secure, dpia, ai-playbook, atrs, jsp-936, service-assessment, govs-007-security, national-data-strategy, codes-of-practice, security-hooks |
+| Operations | devops, mlops, finops, servicenow, operationalize |
+| Procurement | sow, evaluate, dos, gcloud-search, gcloud-clarify, procurement |
+| Research | aws-research, azure-research, gcp-research |
+| Other | pages, story, presentation, trello, migration, customize, upgrading, pinecone-mcp, start, conformance, productivity, remote-control, mcp-servers |
+
+**DDaT Role Guides** (in `docs/guides/roles/`):
+
+Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles. These are stored separately from command guides.
+
+| DDaT Family | Role Guide Files |
+|-------------|-----------------|
+| Architecture | enterprise-architect, solution-architect, data-architect, security-architect, business-architect, technical-architect, network-architect |
+| Chief Digital and Data | cto-cdio, cdo, ciso |
+| Product and Delivery | product-manager, delivery-manager, business-analyst, service-owner |
+| Data | data-governance-manager, performance-analyst |
+| IT Operations | it-service-manager |
+| Software Development | devops-engineer |
+
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
+
+**Role guide commandCount reference**:
+
+| File | commandCount |
+|------|-------------|
+| enterprise-architect | 12 |
+| solution-architect | 10 |
+| data-architect | 4 |
+| security-architect | 5 |
+| business-architect | 5 |
+| technical-architect | 5 |
+| network-architect | 3 |
+| cto-cdio | 5 |
+| cdo | 4 |
+| ciso | 5 |
+| product-manager | 5 |
+| delivery-manager | 6 |
+| business-analyst | 4 |
+| service-owner | 3 |
+| data-governance-manager | 4 |
+| performance-analyst | 4 |
+| it-service-manager | 3 |
+| devops-engineer | 3 |
+
+**Guide Status** (from README command maturity):
+
+| Status | Description | Guide Files |
+|--------|-------------|-------------|
+| live | Production-ready | plan, principles, stakeholders, stakeholder-analysis, risk, sobc, requirements, data-model, diagram, traceability, principles-compliance, story, sow, evaluate, customize, risk-management, business-case |
+| beta | Feature-complete | dpia, research, strategy, roadmap, adr, hld-review, dld-review, backlog, servicenow, analyze, service-assessment, tcop, secure, presentation, artifact-health, design-review, procurement, knowledge-compounding, c4-layout-science, security-hooks, codes-of-practice, data-quality-framework, govs-007-security, national-data-strategy, upgrading, start, conformance, productivity, remote-control, mcp-servers |
+| alpha | Working, limited testing | data-mesh-contract, ai-playbook, atrs, pages |
+| experimental | Early adopters | platform-design, wardley, azure-research, aws-research, gcp-research, datascout, dos, gcloud-search, gcloud-clarify, trello, devops, mlops, finops, operationalize, mod-secure, jsp-936, migration, pinecone-mcp |
+
+### 1.2 Global Documents
+
+Use **Glob** to check `projects/000-global/` for global artifacts:
+
+```text
+projects/000-global/
+├── ARC-000-PRIN-v1.0.md    # Architecture Principles (global)
+├── policies/                # Governance policies
+│   └── *.pdf, *.docx, *.md
+├── external/                # Enterprise-wide reference documents
+│   └── *.pdf, *.docx, *.md
+└── {other global documents}
+```
+
+### 1.3 Project Documents
+
+Use **Glob** to check `projects/` for all project folders. Documents use standardized naming: `ARC-{PROJECT_ID}-{TYPE}-v{VERSION}.md`
+
+```text
+projects/
+├── 001-{project-name}/
+│   ├── # Core Documents (ARC-001-{TYPE}-v1.0.md pattern)
+│   ├── ARC-001-REQ-v1.0.md      # Requirements
+│   ├── ARC-001-STKE-v1.0.md     # Stakeholder Drivers
+│   ├── ARC-001-RISK-v1.0.md     # Risk Register
+│   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
+│   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
+│   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
+│   ├── ARC-001-SOW-v1.0.md      # Statement of Work
+│   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
+│   ├── ARC-001-BKLG-v1.0.md     # Product Backlog
+│   ├── ARC-001-PLAN-v1.0.md     # Project Plan
+│   ├── ARC-001-ROAD-v1.0.md     # Roadmap
+│   ├── ARC-001-STRAT-v1.0.md    # Architecture Strategy
+│   ├── ARC-001-DPIA-v1.0.md     # DPIA
+│   ├── ARC-001-SNOW-v1.0.md     # ServiceNow Design
+│   ├── ARC-001-DEVOPS-v1.0.md   # DevOps Strategy
+│   ├── ARC-001-MLOPS-v1.0.md    # MLOps Strategy
+│   ├── ARC-001-FINOPS-v1.0.md   # FinOps Strategy
+│   ├── ARC-001-OPS-v1.0.md      # Operational Readiness
+│   ├── ARC-001-TCOP-v1.0.md     # TCoP Review
+│   ├── ARC-001-SECD-v1.0.md     # Secure by Design
+│   ├── ARC-001-SECD-MOD-v1.0.md # MOD Secure by Design
+│   ├── ARC-001-AIPB-v1.0.md     # AI Playbook Assessment
+│   ├── ARC-001-ATRS-v1.0.md     # ATRS Record
+│   ├── ARC-001-PRIN-COMP-v1.0.md # Principles Compliance
+│   │
+│   ├── # Multi-instance Documents (subdirectories)
+│   ├── diagrams/
+│   │   └── ARC-001-DIAG-{NNN}-v1.0.md  # Diagrams
+│   ├── decisions/
+│   │   └── ARC-001-ADR-{NNN}-v1.0.md   # ADRs
+│   ├── wardley-maps/
+│   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
+│   ├── data-contracts/
+│   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
+│   ├── reviews/
+│   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
+│   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
+│   ├── vendors/
+│   │   ├── {vendor-slug}-profile.md      # Vendor profiles (flat)
+│   │   └── {vendor-name}/               # Vendor documents (nested)
+│   │       ├── hld*.md
+│   │       ├── dld*.md
+│   │       └── proposal*.md
+│   ├── tech-notes/                       # Tech notes
+│   │   └── {topic-slug}.md
+│   └── external/
+│       ├── README.md             # (excluded from listing)
+│       ├── rfp-document.pdf
+│       └── legacy-spec.docx
+├── 002-{another-project}/
+│   └── ...
+└── ...
+```
+
+### 1.3 Known ArcKit Artifact Types
+
+Only include these known artifact types. Match by type code pattern `ARC-{PID}-{TYPE}-*.md`:
+
+| Category | Type Code | Pattern | Display Name |
+|----------|-----------|---------|--------------|
+| **Discovery** | | | |
+| | REQ | `ARC-*-REQ-*.md` | Requirements |
+| | STKE | `ARC-*-STKE-*.md` | Stakeholder Drivers |
+| | RSCH | `ARC-*-RSCH-*.md` | Research Findings |
+| **Planning** | | | |
+| | SOBC | `ARC-*-SOBC-*.md` | Strategic Outline Business Case |
+| | PLAN | `ARC-*-PLAN-*.md` | Project Plan |
+| | ROAD | `ARC-*-ROAD-*.md` | Roadmap |
+| | STRAT | `ARC-*-STRAT-*.md` | Architecture Strategy |
+| | BKLG | `ARC-*-BKLG-*.md` | Product Backlog |
+| **Architecture** | | | |
+| | PRIN | `ARC-*-PRIN-*.md` | Architecture Principles |
+| | HLDR | `ARC-*-HLDR-*.md` | High-Level Design Review |
+| | DLDR | `ARC-*-DLDR-*.md` | Detailed Design Review |
+| | DATA | `ARC-*-DATA-*.md` | Data Model |
+| | WARD | `ARC-*-WARD-*.md` | Wardley Map |
+| | DIAG | `ARC-*-DIAG-*.md` | Architecture Diagrams |
+| | ADR | `ARC-*-ADR-*.md` | Architecture Decision Records |
+| **Governance** | | | |
+| | RISK | `ARC-*-RISK-*.md` | Risk Register |
+| | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
+| | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
+| **Compliance** | | | |
+| | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
+| | SECD | `ARC-*-SECD-*.md` | Secure by Design |
+| | SECD-MOD | `ARC-*-SECD-MOD-*.md` | MOD Secure by Design |
+| | AIPB | `ARC-*-AIPB-*.md` | AI Playbook Assessment |
+| | ATRS | `ARC-*-ATRS-*.md` | ATRS Record |
+| | DPIA | `ARC-*-DPIA-*.md` | Data Protection Impact Assessment |
+| | JSP936 | `ARC-*-JSP936-*.md` | JSP 936 Assessment |
+| | SVCASS | `ARC-*-SVCASS-*.md` | Service Assessment |
+| **Operations** | | | |
+| | SNOW | `ARC-*-SNOW-*.md` | ServiceNow Design |
+| | DEVOPS | `ARC-*-DEVOPS-*.md` | DevOps Strategy |
+| | MLOPS | `ARC-*-MLOPS-*.md` | MLOps Strategy |
+| | FINOPS | `ARC-*-FINOPS-*.md` | FinOps Strategy |
+| | OPS | `ARC-*-OPS-*.md` | Operational Readiness |
+| | PLAT | `ARC-*-PLAT-*.md` | Platform Design |
+| **Procurement** | | | |
+| | SOW | `ARC-*-SOW-*.md` | Statement of Work |
+| | EVAL | `ARC-*-EVAL-*.md` | Evaluation Criteria |
+| | DOS | `ARC-*-DOS-*.md` | DOS Requirements |
+| | GCLD | `ARC-*-GCLD-*.md` | G-Cloud Search |
+| | GCLC | `ARC-*-GCLC-*.md` | G-Cloud Clarifications |
+| | DMC | `ARC-*-DMC-*.md` | Data Mesh Contract |
+| | | `vendors/*/*.md` | Vendor Documents |
+| **Research** | | | |
+| | AWRS | `ARC-*-AWRS-*.md` | AWS Research |
+| | AZRS | `ARC-*-AZRS-*.md` | Azure Research |
+| | GCRS | `ARC-*-GCRS-*.md` | GCP Research |
+| | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
+| **Other** | | | |
+| | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
+
+## Step 2: Generate manifest.json
+
+Create `docs/manifest.json` with the discovered structure:
+
+```json
+{
+  "generated": "2026-01-22T10:30:00Z",
+  "repository": {
+    "name": "{repo-name}"
+  },
+  "defaultDocument": "projects/000-global/ARC-000-PRIN-v1.0.md",
+  "guides": [
+    {
+      "path": "docs/guides/requirements.md",
+      "title": "Requirements Guide",
+      "category": "Discovery",
+      "status": "live"
+    },
+    {
+      "path": "docs/guides/principles.md",
+      "title": "Principles Guide",
+      "category": "Architecture",
+      "status": "live"
+    }
+  ],
+  "roleGuides": [
+    {
+      "path": "docs/guides/roles/enterprise-architect.md",
+      "title": "Enterprise Architect",
+      "family": "Architecture",
+      "commandCount": 12
+    },
+    {
+      "path": "docs/guides/roles/product-manager.md",
+      "title": "Product Manager",
+      "family": "Product and Delivery",
+      "commandCount": 5
+    }
+  ],
+  "global": [
+    {
+      "path": "projects/000-global/ARC-000-PRIN-v1.0.md",
+      "title": "Architecture Principles",
+      "category": "Architecture",
+      "documentId": "ARC-000-PRIN-v1.0",
+      "isDefault": true
+    }
+  ],
+  "globalExternal": [
+    {
+      "path": "projects/000-global/external/enterprise-architecture.pdf",
+      "title": "enterprise-architecture.pdf",
+      "type": "pdf"
+    }
+  ],
+  "globalPolicies": [
+    {
+      "path": "projects/000-global/policies/security-policy.pdf",
+      "title": "security-policy.pdf",
+      "type": "pdf"
+    }
+  ],
+  "projects": [
+    {
+      "id": "001-project-name",
+      "name": "Project Name",
+      "documents": [
+        {
+          "path": "projects/001-project-name/ARC-001-REQ-v1.0.md",
+          "title": "Requirements",
+          "category": "Discovery",
+          "documentId": "ARC-001-REQ-v1.0"
+        },
+        {
+          "path": "projects/001-project-name/ARC-001-STKE-v1.0.md",
+          "title": "Stakeholder Drivers",
+          "category": "Discovery",
+          "documentId": "ARC-001-STKE-v1.0"
+        }
+      ],
+      "diagrams": [
+        {
+          "path": "projects/001-project-name/diagrams/ARC-001-DIAG-001-v1.0.md",
+          "title": "System Context Diagram",
+          "documentId": "ARC-001-DIAG-001-v1.0"
+        }
+      ],
+      "research": [
+        {
+          "path": "projects/001-project-name/research/ARC-001-RSCH-001-v1.0.md",
+          "title": "Technology Research",
+          "documentId": "ARC-001-RSCH-001-v1.0"
+        }
+      ],
+      "decisions": [
+        {
+          "path": "projects/001-project-name/decisions/ARC-001-ADR-001-v1.0.md",
+          "title": "ADR-001: Cloud Provider Selection",
+          "documentId": "ARC-001-ADR-001-v1.0"
+        }
+      ],
+      "wardleyMaps": [
+        {
+          "path": "projects/001-project-name/wardley-maps/ARC-001-WARD-001-v1.0.md",
+          "title": "Technology Landscape",
+          "documentId": "ARC-001-WARD-001-v1.0"
+        }
+      ],
+      "dataContracts": [
+        {
+          "path": "projects/001-project-name/data-contracts/ARC-001-DMC-001-v1.0.md",
+          "title": "Customer Data Contract",
+          "documentId": "ARC-001-DMC-001-v1.0"
+        }
+      ],
+      "reviews": [
+        {
+          "path": "projects/001-project-name/reviews/ARC-001-HLDR-v1.0.md",
+          "title": "High-Level Design Review",
+          "documentId": "ARC-001-HLDR-v1.0"
+        },
+        {
+          "path": "projects/001-project-name/reviews/ARC-001-DLDR-v1.0.md",
+          "title": "Detailed Design Review",
+          "documentId": "ARC-001-DLDR-v1.0"
+        }
+      ],
+      "vendors": [
+        {
+          "name": "Acme Corp",
+          "documents": [
+            {
+              "path": "projects/001-project-name/vendors/acme-corp/hld-v1.md",
+              "title": "HLD v1.0"
+            }
+          ]
+        }
+      ],
+      "vendorProfiles": [
+        {
+          "path": "projects/001-project-name/vendors/aws-profile.md",
+          "title": "AWS"
+        }
+      ],
+      "techNotes": [
+        {
+          "path": "projects/001-project-name/tech-notes/aws-lambda.md",
+          "title": "AWS Lambda"
+        }
+      ],
+      "external": [
+        {
+          "path": "projects/001-project-name/external/rfp-document.pdf",
+          "title": "rfp-document.pdf",
+          "type": "pdf"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`${CLAUDE_PLUGIN_ROOT}/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
+## Step 5: Provide Summary
+
+After generating, provide this summary:
+
+```text
+Documentation Site Generated
+
+Files Created:
+- docs/index.html (main page)
+- docs/manifest.json (document index)
+
+Repository: {repo}
+Projects Found: {count}
+Documents Indexed: {total_documents}
+
+Document Breakdown:
+- Guides: {guides_count}
+- DDaT Role Guides: {role_guides_count}
+- Global: {global_count}
+- Project Documents: {project_doc_count}
+- Diagrams: {diagram_count}
+- ADRs: {adr_count}
+- Vendor Documents: {vendor_doc_count}
+- Vendor Profiles: {vendor_profile_count}
+- Tech Notes: {tech_note_count}
+
+Features:
+- Dashboard view with KPI cards, charts, and governance checklist (default landing page)
+- Sidebar navigation for all projects
+- Markdown rendering with syntax highlighting
+- Mermaid diagram support (auto-rendered)
+- GOV.UK Design System styling
+- Responsive mobile layout
+- Uses relative paths — works on any static hosting provider
+
+Health Integration:
+- Run `/arckit:health JSON=true` to generate docs/health.json
+- Re-run `/arckit:pages` to display health data on the dashboard
+
+Deployment:
+The site uses relative paths and can be deployed to any static hosting provider:
+- **GitHub Pages**: Settings > Pages > Source "Deploy from branch" > Branch "main", folder "/docs"
+- **Netlify/Vercel**: Set publish directory to the repo root (docs/index.html references ../projects/)
+- **Any static host**: Serve the entire repo directory; docs/index.html loads files via relative paths
+
+Next Steps:
+- Commit and push the docs/ folder
+- Deploy to your hosting provider of choice
+- Access your documentation site
+```
+
+## Important Notes
+
+### Default Landing Page (Dashboard)
+
+- **The dashboard (`#dashboard`) is the default landing page** — it shows automatically when no hash is present
+- Set `defaultDocument` in manifest.json to the principles path (for backward compatibility and direct linking)
+- The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
+- Users can navigate to any document via sidebar, search, or dashboard project table
+
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
+---
+
+**Remember**: You MUST read and use `${CLAUDE_PLUGIN_ROOT}/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/commands/arckit.adr.md
+++ b/arckit-codex/commands/arckit.adr.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/commands/arckit.ai-playbook.md
+++ b/arckit-codex/commands/arckit.ai-playbook.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-codex/commands/arckit.atrs.md
+++ b/arckit-codex/commands/arckit.atrs.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-codex/commands/arckit.backlog.md
+++ b/arckit-codex/commands/arckit.backlog.md
@@ -89,7 +89,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-codex/commands/arckit.conformance.md
+++ b/arckit-codex/commands/arckit.conformance.md
@@ -67,7 +67,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/commands/arckit.data-mesh-contract.md
+++ b/arckit-codex/commands/arckit.data-mesh-contract.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-codex/commands/arckit.data-model.md
+++ b/arckit-codex/commands/arckit.data-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/commands/arckit.devops.md
+++ b/arckit-codex/commands/arckit.devops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.dfd.md
+++ b/arckit-codex/commands/arckit.dfd.md
@@ -31,7 +31,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-codex/commands/arckit.diagram.md
+++ b/arckit-codex/commands/arckit.diagram.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-codex/commands/arckit.dld-review.md
+++ b/arckit-codex/commands/arckit.dld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/commands/arckit.dos.md
+++ b/arckit-codex/commands/arckit.dos.md
@@ -22,7 +22,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/commands/arckit.dpia.md
+++ b/arckit-codex/commands/arckit.dpia.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.evaluate.md
+++ b/arckit-codex/commands/arckit.evaluate.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-codex/commands/arckit.finops.md
+++ b/arckit-codex/commands/arckit.finops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.gcloud-clarify.md
+++ b/arckit-codex/commands/arckit.gcloud-clarify.md
@@ -23,7 +23,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.gcloud-search.md
+++ b/arckit-codex/commands/arckit.gcloud-search.md
@@ -46,7 +46,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-codex/commands/arckit.glossary.md
+++ b/arckit-codex/commands/arckit.glossary.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/commands/arckit.hld-review.md
+++ b/arckit-codex/commands/arckit.hld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/commands/arckit.jsp-936.md
+++ b/arckit-codex/commands/arckit.jsp-936.md
@@ -49,7 +49,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.maturity-model.md
+++ b/arckit-codex/commands/arckit.maturity-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/commands/arckit.mlops.md
+++ b/arckit-codex/commands/arckit.mlops.md
@@ -52,7 +52,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.mod-secure.md
+++ b/arckit-codex/commands/arckit.mod-secure.md
@@ -64,7 +64,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-codex/commands/arckit.operationalize.md
+++ b/arckit-codex/commands/arckit.operationalize.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.pages.md
+++ b/arckit-codex/commands/arckit.pages.md
@@ -23,24 +23,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -69,7 +74,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -130,6 +135,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -159,12 +165,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -213,7 +213,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -245,10 +244,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -408,9 +408,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -430,10 +476,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -472,6 +514,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/commands/arckit.plan.md
+++ b/arckit-codex/commands/arckit.plan.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-codex/commands/arckit.platform-design.md
+++ b/arckit-codex/commands/arckit.platform-design.md
@@ -20,7 +20,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.presentation.md
+++ b/arckit-codex/commands/arckit.presentation.md
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-codex/commands/arckit.principles-compliance.md
+++ b/arckit-codex/commands/arckit.principles-compliance.md
@@ -49,7 +49,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/commands/arckit.principles.md
+++ b/arckit-codex/commands/arckit.principles.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-codex/commands/arckit.requirements.md
+++ b/arckit-codex/commands/arckit.requirements.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/commands/arckit.risk.md
+++ b/arckit-codex/commands/arckit.risk.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-codex/commands/arckit.roadmap.md
+++ b/arckit-codex/commands/arckit.roadmap.md
@@ -43,7 +43,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-codex/commands/arckit.secure.md
+++ b/arckit-codex/commands/arckit.secure.md
@@ -29,7 +29,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-codex/commands/arckit.service-assessment.md
+++ b/arckit-codex/commands/arckit.service-assessment.md
@@ -54,7 +54,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-codex/commands/arckit.servicenow.md
+++ b/arckit-codex/commands/arckit.servicenow.md
@@ -64,7 +64,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-codex/commands/arckit.sobc.md
+++ b/arckit-codex/commands/arckit.sobc.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-codex/commands/arckit.sow.md
+++ b/arckit-codex/commands/arckit.sow.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/commands/arckit.stakeholders.md
+++ b/arckit-codex/commands/arckit.stakeholders.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/commands/arckit.story.md
+++ b/arckit-codex/commands/arckit.story.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.strategy.md
+++ b/arckit-codex/commands/arckit.strategy.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.tcop.md
+++ b/arckit-codex/commands/arckit.tcop.md
@@ -31,7 +31,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-codex/commands/arckit.traceability.md
+++ b/arckit-codex/commands/arckit.traceability.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-codex/commands/arckit.wardley.md
+++ b/arckit-codex/commands/arckit.wardley.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.adr.md
+++ b/arckit-codex/prompts/arckit.adr.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/prompts/arckit.ai-playbook.md
+++ b/arckit-codex/prompts/arckit.ai-playbook.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-codex/prompts/arckit.atrs.md
+++ b/arckit-codex/prompts/arckit.atrs.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-codex/prompts/arckit.backlog.md
+++ b/arckit-codex/prompts/arckit.backlog.md
@@ -89,7 +89,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-codex/prompts/arckit.conformance.md
+++ b/arckit-codex/prompts/arckit.conformance.md
@@ -67,7 +67,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/prompts/arckit.data-mesh-contract.md
+++ b/arckit-codex/prompts/arckit.data-mesh-contract.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-codex/prompts/arckit.data-model.md
+++ b/arckit-codex/prompts/arckit.data-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/prompts/arckit.devops.md
+++ b/arckit-codex/prompts/arckit.devops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.dfd.md
+++ b/arckit-codex/prompts/arckit.dfd.md
@@ -31,7 +31,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-codex/prompts/arckit.diagram.md
+++ b/arckit-codex/prompts/arckit.diagram.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-codex/prompts/arckit.dld-review.md
+++ b/arckit-codex/prompts/arckit.dld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/prompts/arckit.dos.md
+++ b/arckit-codex/prompts/arckit.dos.md
@@ -22,7 +22,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/prompts/arckit.dpia.md
+++ b/arckit-codex/prompts/arckit.dpia.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.evaluate.md
+++ b/arckit-codex/prompts/arckit.evaluate.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-codex/prompts/arckit.finops.md
+++ b/arckit-codex/prompts/arckit.finops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.gcloud-clarify.md
+++ b/arckit-codex/prompts/arckit.gcloud-clarify.md
@@ -23,7 +23,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.gcloud-search.md
+++ b/arckit-codex/prompts/arckit.gcloud-search.md
@@ -46,7 +46,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-codex/prompts/arckit.glossary.md
+++ b/arckit-codex/prompts/arckit.glossary.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/prompts/arckit.hld-review.md
+++ b/arckit-codex/prompts/arckit.hld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/prompts/arckit.jsp-936.md
+++ b/arckit-codex/prompts/arckit.jsp-936.md
@@ -49,7 +49,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.maturity-model.md
+++ b/arckit-codex/prompts/arckit.maturity-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/prompts/arckit.mlops.md
+++ b/arckit-codex/prompts/arckit.mlops.md
@@ -52,7 +52,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.mod-secure.md
+++ b/arckit-codex/prompts/arckit.mod-secure.md
@@ -64,7 +64,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-codex/prompts/arckit.operationalize.md
+++ b/arckit-codex/prompts/arckit.operationalize.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.pages.md
+++ b/arckit-codex/prompts/arckit.pages.md
@@ -23,24 +23,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -69,7 +74,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -130,6 +135,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -159,12 +165,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -213,7 +213,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -245,10 +244,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -408,9 +408,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -430,10 +476,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -472,6 +514,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/prompts/arckit.plan.md
+++ b/arckit-codex/prompts/arckit.plan.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-codex/prompts/arckit.platform-design.md
+++ b/arckit-codex/prompts/arckit.platform-design.md
@@ -20,7 +20,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.presentation.md
+++ b/arckit-codex/prompts/arckit.presentation.md
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-codex/prompts/arckit.principles-compliance.md
+++ b/arckit-codex/prompts/arckit.principles-compliance.md
@@ -49,7 +49,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/prompts/arckit.principles.md
+++ b/arckit-codex/prompts/arckit.principles.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-codex/prompts/arckit.requirements.md
+++ b/arckit-codex/prompts/arckit.requirements.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/prompts/arckit.risk.md
+++ b/arckit-codex/prompts/arckit.risk.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-codex/prompts/arckit.roadmap.md
+++ b/arckit-codex/prompts/arckit.roadmap.md
@@ -43,7 +43,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-codex/prompts/arckit.secure.md
+++ b/arckit-codex/prompts/arckit.secure.md
@@ -29,7 +29,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-codex/prompts/arckit.service-assessment.md
+++ b/arckit-codex/prompts/arckit.service-assessment.md
@@ -54,7 +54,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-codex/prompts/arckit.servicenow.md
+++ b/arckit-codex/prompts/arckit.servicenow.md
@@ -64,7 +64,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-codex/prompts/arckit.sobc.md
+++ b/arckit-codex/prompts/arckit.sobc.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-codex/prompts/arckit.sow.md
+++ b/arckit-codex/prompts/arckit.sow.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/prompts/arckit.stakeholders.md
+++ b/arckit-codex/prompts/arckit.stakeholders.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/prompts/arckit.story.md
+++ b/arckit-codex/prompts/arckit.story.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.strategy.md
+++ b/arckit-codex/prompts/arckit.strategy.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.tcop.md
+++ b/arckit-codex/prompts/arckit.tcop.md
@@ -31,7 +31,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-codex/prompts/arckit.traceability.md
+++ b/arckit-codex/prompts/arckit.traceability.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-codex/prompts/arckit.wardley.md
+++ b/arckit-codex/prompts/arckit.wardley.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-adr/SKILL.md
+++ b/arckit-codex/skills/arckit-adr/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/skills/arckit-ai-playbook/SKILL.md
+++ b/arckit-codex/skills/arckit-ai-playbook/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-codex/skills/arckit-atrs/SKILL.md
+++ b/arckit-codex/skills/arckit-atrs/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-codex/skills/arckit-backlog/SKILL.md
+++ b/arckit-codex/skills/arckit-backlog/SKILL.md
@@ -90,7 +90,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-codex/skills/arckit-conformance/SKILL.md
+++ b/arckit-codex/skills/arckit-conformance/SKILL.md
@@ -68,7 +68,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/skills/arckit-data-mesh-contract/SKILL.md
+++ b/arckit-codex/skills/arckit-data-mesh-contract/SKILL.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-codex/skills/arckit-data-model/SKILL.md
+++ b/arckit-codex/skills/arckit-data-model/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/skills/arckit-devops/SKILL.md
+++ b/arckit-codex/skills/arckit-devops/SKILL.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-dfd/SKILL.md
+++ b/arckit-codex/skills/arckit-dfd/SKILL.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-codex/skills/arckit-diagram/SKILL.md
+++ b/arckit-codex/skills/arckit-diagram/SKILL.md
@@ -24,7 +24,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-codex/skills/arckit-dld-review/SKILL.md
+++ b/arckit-codex/skills/arckit-dld-review/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/skills/arckit-dos/SKILL.md
+++ b/arckit-codex/skills/arckit-dos/SKILL.md
@@ -23,7 +23,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/skills/arckit-dpia/SKILL.md
+++ b/arckit-codex/skills/arckit-dpia/SKILL.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-evaluate/SKILL.md
+++ b/arckit-codex/skills/arckit-evaluate/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-codex/skills/arckit-finops/SKILL.md
+++ b/arckit-codex/skills/arckit-finops/SKILL.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-gcloud-clarify/SKILL.md
+++ b/arckit-codex/skills/arckit-gcloud-clarify/SKILL.md
@@ -24,7 +24,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-gcloud-search/SKILL.md
+++ b/arckit-codex/skills/arckit-gcloud-search/SKILL.md
@@ -47,7 +47,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-codex/skills/arckit-glossary/SKILL.md
+++ b/arckit-codex/skills/arckit-glossary/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/skills/arckit-hld-review/SKILL.md
+++ b/arckit-codex/skills/arckit-hld-review/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/skills/arckit-jsp-936/SKILL.md
+++ b/arckit-codex/skills/arckit-jsp-936/SKILL.md
@@ -50,7 +50,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-maturity-model/SKILL.md
+++ b/arckit-codex/skills/arckit-maturity-model/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/skills/arckit-mlops/SKILL.md
+++ b/arckit-codex/skills/arckit-mlops/SKILL.md
@@ -53,7 +53,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-mod-secure/SKILL.md
+++ b/arckit-codex/skills/arckit-mod-secure/SKILL.md
@@ -65,7 +65,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-codex/skills/arckit-operationalize/SKILL.md
+++ b/arckit-codex/skills/arckit-operationalize/SKILL.md
@@ -47,7 +47,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-pages/SKILL.md
+++ b/arckit-codex/skills/arckit-pages/SKILL.md
@@ -24,24 +24,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -70,7 +75,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -131,6 +136,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -160,12 +166,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -214,7 +214,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -246,10 +245,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -409,9 +409,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `$arckit-customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -431,10 +477,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -473,6 +515,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/skills/arckit-plan/SKILL.md
+++ b/arckit-codex/skills/arckit-plan/SKILL.md
@@ -36,7 +36,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-codex/skills/arckit-platform-design/SKILL.md
+++ b/arckit-codex/skills/arckit-platform-design/SKILL.md
@@ -21,7 +21,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-presentation/SKILL.md
+++ b/arckit-codex/skills/arckit-presentation/SKILL.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-codex/skills/arckit-principles-compliance/SKILL.md
+++ b/arckit-codex/skills/arckit-principles-compliance/SKILL.md
@@ -50,7 +50,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/skills/arckit-principles/SKILL.md
+++ b/arckit-codex/skills/arckit-principles/SKILL.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-codex/skills/arckit-requirements/SKILL.md
+++ b/arckit-codex/skills/arckit-requirements/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/skills/arckit-risk/SKILL.md
+++ b/arckit-codex/skills/arckit-risk/SKILL.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-codex/skills/arckit-roadmap/SKILL.md
+++ b/arckit-codex/skills/arckit-roadmap/SKILL.md
@@ -44,7 +44,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-codex/skills/arckit-secure/SKILL.md
+++ b/arckit-codex/skills/arckit-secure/SKILL.md
@@ -30,7 +30,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-codex/skills/arckit-service-assessment/SKILL.md
+++ b/arckit-codex/skills/arckit-service-assessment/SKILL.md
@@ -55,7 +55,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-codex/skills/arckit-servicenow/SKILL.md
+++ b/arckit-codex/skills/arckit-servicenow/SKILL.md
@@ -65,7 +65,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-codex/skills/arckit-sobc/SKILL.md
+++ b/arckit-codex/skills/arckit-sobc/SKILL.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-codex/skills/arckit-sow/SKILL.md
+++ b/arckit-codex/skills/arckit-sow/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/skills/arckit-stakeholders/SKILL.md
+++ b/arckit-codex/skills/arckit-stakeholders/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/skills/arckit-story/SKILL.md
+++ b/arckit-codex/skills/arckit-story/SKILL.md
@@ -20,7 +20,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-strategy/SKILL.md
+++ b/arckit-codex/skills/arckit-strategy/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-tcop/SKILL.md
+++ b/arckit-codex/skills/arckit-tcop/SKILL.md
@@ -32,7 +32,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-codex/skills/arckit-traceability/SKILL.md
+++ b/arckit-codex/skills/arckit-traceability/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-codex/skills/arckit-wardley/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley/SKILL.md
@@ -33,7 +33,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-gemini/agents/arckit-aws-research.md
+++ b/arckit-gemini/agents/arckit-aws-research.md
@@ -30,6 +30,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-azure-research.md
+++ b/arckit-gemini/agents/arckit-azure-research.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-datascout.md
+++ b/arckit-gemini/agents/arckit-datascout.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-framework.md
+++ b/arckit-gemini/agents/arckit-framework.md
@@ -50,6 +50,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-gcp-research.md
+++ b/arckit-gemini/agents/arckit-gcp-research.md
@@ -33,6 +33,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-research.md
+++ b/arckit-gemini/agents/arckit-research.md
@@ -73,6 +73,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/commands/arckit/pages.toml
+++ b/arckit-gemini/commands/arckit/pages.toml
@@ -31,24 +31,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote \"origin\"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions \"Guide Sync Complete\" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with \" — ArcKit Command Guide\" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `~/.gemini/extensions/arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -77,7 +82,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip \" — ArcKit Command Guide\" suffix). Map the DDaT family from the filename using the table above. Count the rows in the \"Primary Commands\" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -138,6 +143,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -167,12 +173,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -221,7 +221,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -253,10 +252,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -416,9 +416,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Run `cat ~/.gemini/extensions/arckit/templates/pages-template.html` to read the file (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`~/.gemini/extensions/arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under \"Document Stats\") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -438,10 +484,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -480,7 +522,54 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show \"Document not found\")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `~/.gemini/extensions/arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
 """

--- a/arckit-opencode/commands/arckit.adr.md
+++ b/arckit-opencode/commands/arckit.adr.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-opencode/commands/arckit.ai-playbook.md
+++ b/arckit-opencode/commands/arckit.ai-playbook.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-opencode/commands/arckit.atrs.md
+++ b/arckit-opencode/commands/arckit.atrs.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-opencode/commands/arckit.backlog.md
+++ b/arckit-opencode/commands/arckit.backlog.md
@@ -89,7 +89,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-opencode/commands/arckit.conformance.md
+++ b/arckit-opencode/commands/arckit.conformance.md
@@ -67,7 +67,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-opencode/commands/arckit.data-mesh-contract.md
+++ b/arckit-opencode/commands/arckit.data-mesh-contract.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-opencode/commands/arckit.data-model.md
+++ b/arckit-opencode/commands/arckit.data-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-opencode/commands/arckit.devops.md
+++ b/arckit-opencode/commands/arckit.devops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.dfd.md
+++ b/arckit-opencode/commands/arckit.dfd.md
@@ -31,7 +31,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-opencode/commands/arckit.diagram.md
+++ b/arckit-opencode/commands/arckit.diagram.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-opencode/commands/arckit.dld-review.md
+++ b/arckit-opencode/commands/arckit.dld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-opencode/commands/arckit.dos.md
+++ b/arckit-opencode/commands/arckit.dos.md
@@ -22,7 +22,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-opencode/commands/arckit.dpia.md
+++ b/arckit-opencode/commands/arckit.dpia.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.evaluate.md
+++ b/arckit-opencode/commands/arckit.evaluate.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-opencode/commands/arckit.finops.md
+++ b/arckit-opencode/commands/arckit.finops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.gcloud-clarify.md
+++ b/arckit-opencode/commands/arckit.gcloud-clarify.md
@@ -23,7 +23,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.gcloud-search.md
+++ b/arckit-opencode/commands/arckit.gcloud-search.md
@@ -46,7 +46,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-opencode/commands/arckit.glossary.md
+++ b/arckit-opencode/commands/arckit.glossary.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-opencode/commands/arckit.hld-review.md
+++ b/arckit-opencode/commands/arckit.hld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-opencode/commands/arckit.jsp-936.md
+++ b/arckit-opencode/commands/arckit.jsp-936.md
@@ -49,7 +49,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.maturity-model.md
+++ b/arckit-opencode/commands/arckit.maturity-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-opencode/commands/arckit.mlops.md
+++ b/arckit-opencode/commands/arckit.mlops.md
@@ -52,7 +52,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.mod-secure.md
+++ b/arckit-opencode/commands/arckit.mod-secure.md
@@ -64,7 +64,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-opencode/commands/arckit.operationalize.md
+++ b/arckit-opencode/commands/arckit.operationalize.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.pages.md
+++ b/arckit-opencode/commands/arckit.pages.md
@@ -23,24 +23,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -69,7 +74,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -130,6 +135,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -159,12 +165,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -213,7 +213,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -245,10 +244,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -408,9 +408,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -430,10 +476,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -472,6 +514,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-opencode/commands/arckit.plan.md
+++ b/arckit-opencode/commands/arckit.plan.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-opencode/commands/arckit.platform-design.md
+++ b/arckit-opencode/commands/arckit.platform-design.md
@@ -20,7 +20,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.presentation.md
+++ b/arckit-opencode/commands/arckit.presentation.md
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-opencode/commands/arckit.principles-compliance.md
+++ b/arckit-opencode/commands/arckit.principles-compliance.md
@@ -49,7 +49,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-opencode/commands/arckit.principles.md
+++ b/arckit-opencode/commands/arckit.principles.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-opencode/commands/arckit.requirements.md
+++ b/arckit-opencode/commands/arckit.requirements.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-opencode/commands/arckit.risk.md
+++ b/arckit-opencode/commands/arckit.risk.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-opencode/commands/arckit.roadmap.md
+++ b/arckit-opencode/commands/arckit.roadmap.md
@@ -43,7 +43,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-opencode/commands/arckit.secure.md
+++ b/arckit-opencode/commands/arckit.secure.md
@@ -29,7 +29,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-opencode/commands/arckit.service-assessment.md
+++ b/arckit-opencode/commands/arckit.service-assessment.md
@@ -54,7 +54,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-opencode/commands/arckit.servicenow.md
+++ b/arckit-opencode/commands/arckit.servicenow.md
@@ -64,7 +64,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-opencode/commands/arckit.sobc.md
+++ b/arckit-opencode/commands/arckit.sobc.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-opencode/commands/arckit.sow.md
+++ b/arckit-opencode/commands/arckit.sow.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-opencode/commands/arckit.stakeholders.md
+++ b/arckit-opencode/commands/arckit.stakeholders.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-opencode/commands/arckit.story.md
+++ b/arckit-opencode/commands/arckit.story.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.strategy.md
+++ b/arckit-opencode/commands/arckit.strategy.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.tcop.md
+++ b/arckit-opencode/commands/arckit.tcop.md
@@ -31,7 +31,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-opencode/commands/arckit.traceability.md
+++ b/arckit-opencode/commands/arckit.traceability.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-opencode/commands/arckit.wardley.md
+++ b/arckit-opencode/commands/arckit.wardley.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/docs/plans/2026-03-08-hook-aware-converter-design.md
+++ b/docs/plans/2026-03-08-hook-aware-converter-design.md
@@ -1,0 +1,110 @@
+# Hook-Aware Converter Design
+
+**Date:** 2026-03-08
+**Issues:** #138, #139
+**Scope:** Converter changes only — no modifications to Claude Code source commands
+
+## Summary
+
+The converter (`scripts/converter.py`) blindly copies command prompts with path rewrites, ignoring hook dependencies. 42 commands reference a context injection hook that doesn't exist on Codex/OpenCode, and `/arckit.pages` is a complete no-op on all non-Claude platforms because it assumes the `sync-guides` hook did all the work.
+
+## Architecture
+
+```text
+converter.py
+  ├── AGENT_CONFIG (extended with hook capability flags)
+  ├── rewrite_paths()          — existing, unchanged
+  ├── rewrite_hook_dependencies()  — NEW
+  │     ├── Context injection: replace standard block with self-scan instructions
+  │     └── Other hook refs: strip gracefully
+  └── convert()
+        └── For each command:
+              ├── Check commands-standalone/ for platform override
+              ├── If override exists → use it instead of source command
+              └── If no override → run rewrite_paths() + rewrite_hook_dependencies()
+```
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Where to fix | Converter only | Don't modify source commands — they're correct for Claude Code |
+| Context injection (42 cmds) | Standard block replacement | One paragraph swap, no duplicate files needed |
+| Pages command | Standalone override file | Too different for a text replacement — pre-hook version had full inline logic |
+| Hook capability tracking | Flags in AGENT_CONFIG | Consistent with existing config-driven approach |
+| Self-scan instructions | Single standard block for all 42 commands | Simple, consistent, sufficient |
+
+## AGENT_CONFIG Changes
+
+Add two flags per platform:
+
+```python
+"codex_extension": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"codex_skills": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"opencode": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"gemini": {
+    ...
+    "has_context_hook": True,   # context-inject.py exists
+    "has_sync_guides_hook": False,
+},
+```
+
+## `rewrite_hook_dependencies(prompt, config)`
+
+New function called after `rewrite_paths()`.
+
+### Context Injection Replacement
+
+For platforms where `has_context_hook` is `False`, find and replace the standard block.
+
+**Find:**
+```
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+```
+
+**Replace with:**
+```
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+```
+
+### Other Hook References
+
+Strip gracefully — remove lines that reference specific hooks by name if the platform doesn't support them.
+
+## `commands-standalone/` Directory
+
+```text
+arckit-claude/
+  commands/                  ← hook-dependent (source of truth for Claude Code)
+  commands-standalone/       ← self-contained overrides for hookless platforms
+    pages.md                 ← based on pre-hook version (commit c40418a^)
+```
+
+The converter checks `commands-standalone/{name}.md` first. If it exists, uses that for platforms without the required hook. Otherwise falls back to the standard command with `rewrite_hook_dependencies()` applied.
+
+## What Gets Fixed
+
+| Issue | Fix |
+|-------|-----|
+| #138 — 42 commands reference missing context hook | Standard block replacement in `rewrite_hook_dependencies()` |
+| #139 — pages is a no-op | Standalone `pages.md` used for Codex/OpenCode/Gemini |
+| Future hook-heavy commands | Add standalone version to `commands-standalone/` |
+
+## Out of Scope
+
+- Gemini context injection (already works via `context-inject.py`)
+- Governance/health/traceability scan hooks (graceful fallback already exists)
+- Post-processing manifest hook (low priority)
+- Changes to Claude Code source commands

--- a/docs/plans/2026-03-08-hook-aware-converter-plan.md
+++ b/docs/plans/2026-03-08-hook-aware-converter-plan.md
@@ -1,0 +1,278 @@
+# Hook-Aware Converter Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the converter aware of hook dependencies so that platforms without hooks get self-contained commands instead of broken references.
+
+**Architecture:** Extend `AGENT_CONFIG` with hook capability flags, add a `rewrite_hook_dependencies()` function that swaps the context injection note for self-scan instructions, and add a standalone command override lookup for commands that are entirely hook-dependent (pages).
+
+**Tech Stack:** Python (`scripts/converter.py`), Markdown standalone commands (`arckit-claude/commands-standalone/`).
+
+**Design doc:** `docs/plans/2026-03-08-hook-aware-converter-design.md`
+
+---
+
+### Task 1: Add hook capability flags to AGENT_CONFIG
+
+**Files:**
+- Modify: `scripts/converter.py:96-133`
+
+**Step 1: Add flags to each config entry**
+
+In `scripts/converter.py`, add `"has_context_hook": False` and `"has_sync_guides_hook": False` to the `codex_extension`, `codex_skills`, and `opencode` entries. Add `"has_context_hook": True` and `"has_sync_guides_hook": False` to the `gemini` entry (Gemini has `context-inject.py`).
+
+After the change, the four entries should include:
+
+```python
+"codex_extension": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"codex_skills": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"opencode": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"gemini": {
+    ...
+    "has_context_hook": True,
+    "has_sync_guides_hook": False,
+},
+```
+
+**Step 2: Verify syntax**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print('valid')"`
+Expected: `valid`
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: add hook capability flags to AGENT_CONFIG"
+```
+
+---
+
+### Task 2: Add the context hook note constants
+
+**Files:**
+- Modify: `scripts/converter.py` (add constants after `EXTENSION_FILE_ACCESS_BLOCK`)
+
+**Step 1: Add the find/replace constants**
+
+Add these two constants after the `EXTENSION_FILE_ACCESS_BLOCK` definition (after line 91), before the `AGENT_CONFIG` block:
+
+```python
+CONTEXT_HOOK_NOTE = (
+    "> **Note**: The ArcKit Project Context hook has already detected all "
+    "projects, artifacts, external documents, and global policies. Use that "
+    "context below \u2014 no need to scan directories manually."
+)
+
+CONTEXT_HOOK_REPLACEMENT = (
+    "> **Note**: Before generating, scan `projects/` for existing project "
+    "directories. For each project, list all `ARC-*.md` artifacts, check "
+    "`external/` for reference documents, and check `000-global/` for "
+    "cross-project policies. If no external docs exist but they would "
+    "improve output, ask the user."
+)
+```
+
+**Step 2: Verify the find string matches actual commands**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print(repr(CONTEXT_HOOK_NOTE))"`
+Expected: The exact string that appears in 43 commands.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: add context hook note constants for replacement"
+```
+
+---
+
+### Task 3: Add `rewrite_hook_dependencies()` function
+
+**Files:**
+- Modify: `scripts/converter.py` (add function after `rewrite_paths()`)
+
+**Step 1: Add the function**
+
+Insert this function after `rewrite_paths()` (after line 153):
+
+```python
+def rewrite_hook_dependencies(prompt, config):
+    """Replace hook-dependent content for platforms without hooks."""
+    result = prompt
+
+    # Context injection: replace hook note with self-scan instructions
+    if not config.get("has_context_hook", False):
+        result = result.replace(CONTEXT_HOOK_NOTE, CONTEXT_HOOK_REPLACEMENT)
+
+    return result
+```
+
+**Step 2: Verify syntax**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print('valid')"`
+Expected: `valid`
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: add rewrite_hook_dependencies() function"
+```
+
+---
+
+### Task 4: Wire `rewrite_hook_dependencies()` into `convert()` and add standalone override lookup
+
+**Files:**
+- Modify: `scripts/converter.py` — the `convert()` function
+
+**Step 1: Add standalone override lookup at the top of the per-agent loop**
+
+In the `convert()` function, inside the `for agent_id, config in AGENT_CONFIG.items():` loop (around line 215), before the `rewritten = rewrite_paths(prompt, config)` line, add logic to check for a standalone override:
+
+```python
+        for agent_id, config in AGENT_CONFIG.items():
+            # Check for standalone command override (for hookless platforms)
+            standalone_path = os.path.join(
+                os.path.dirname(commands_dir), "commands-standalone", filename
+            )
+            if os.path.isfile(standalone_path):
+                # Use standalone version if platform lacks required hook
+                needs_standalone = not config.get("has_sync_guides_hook", False)
+                if needs_standalone:
+                    with open(standalone_path, "r") as f:
+                        standalone_content = f.read()
+                    _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
+                    rewritten = rewrite_paths(standalone_prompt, config)
+                    # Skip rewrite_hook_dependencies — standalone is self-contained
+                else:
+                    rewritten = rewrite_paths(prompt, config)
+            else:
+                rewritten = rewrite_paths(prompt, config)
+                rewritten = rewrite_hook_dependencies(rewritten, config)
+```
+
+This replaces the existing `rewritten = rewrite_paths(prompt, config)` line.
+
+**Step 2: Verify syntax**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print('valid')"`
+Expected: `valid`
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: wire rewrite_hook_dependencies and standalone overrides into convert()"
+```
+
+---
+
+### Task 5: Create standalone pages command
+
+**Files:**
+- Create: `arckit-claude/commands-standalone/pages.md`
+
+**Step 1: Extract the pre-hook pages command**
+
+Run: `git show 'c40418a^:arckit-plugin/commands/pages.md' > arckit-claude/commands-standalone/pages.md`
+
+This gets the 568-line version that had full inline logic for scanning projects, reading artifacts, and generating the docs site — before the sync-guides hook replaced all that with "Steps 0-4: Handled by Hook".
+
+**Step 2: Verify the file has the full inline logic**
+
+Run: `wc -l arckit-claude/commands-standalone/pages.md`
+Expected: 568 lines
+
+Run: `head -10 arckit-claude/commands-standalone/pages.md`
+Expected: Frontmatter with description, then the full command prompt.
+
+**Step 3: Rewrite paths for standalone context**
+
+The extracted file uses `${CLAUDE_PLUGIN_ROOT}` paths. These will be rewritten automatically by `rewrite_paths()` during conversion, so no manual changes needed.
+
+**Step 4: Commit**
+
+```bash
+git add arckit-claude/commands-standalone/pages.md
+git commit -m "feat: add standalone pages command for hookless platforms"
+```
+
+---
+
+### Task 6: Run converter and verify output
+
+**Files:** None modified (verification only)
+
+**Step 1: Run the converter**
+
+Run: `python scripts/converter.py`
+Expected: Normal output showing all commands converted for all 4 targets. No errors.
+
+**Step 2: Verify context hook replacement in Codex output**
+
+Run: `grep -l "Before generating, scan" arckit-codex/prompts/*.md | wc -l`
+Expected: 43 (all commands that had the hook note now have the self-scan replacement)
+
+Run: `grep -l "ArcKit Project Context hook has already" arckit-codex/prompts/*.md | wc -l`
+Expected: 0 (no commands still reference the hook)
+
+**Step 3: Verify context hook NOT replaced in Gemini output**
+
+Run: `grep -l "ArcKit Project Context hook has already" arckit-gemini/commands/arckit/*.toml | wc -l`
+Expected: 43 (Gemini has the context hook, so the note should remain)
+
+**Step 4: Verify pages standalone used for Codex**
+
+Run: `wc -l arckit-codex/prompts/arckit.pages.md`
+Expected: Significantly longer than other commands (close to 568 lines of content)
+
+Run: `grep -c "Handled by Hook" arckit-codex/prompts/arckit.pages.md`
+Expected: 0 (standalone version has no hook references)
+
+**Step 5: Verify pages standalone used for OpenCode**
+
+Run: `grep -c "Handled by Hook" arckit-opencode/commands/arckit.pages.md`
+Expected: 0
+
+**Step 6: Commit converted output**
+
+```bash
+git add arckit-codex/ arckit-opencode/ arckit-gemini/
+git commit -m "chore: regenerate extension commands with hook-aware converter"
+```
+
+---
+
+### Task 7: Update GitHub issues
+
+**Files:** None
+
+**Step 1: Close issue #138**
+
+```bash
+gh issue close 138 --comment "Fixed in $(git log --oneline -1 HEAD). The converter now replaces the context hook note with self-scan instructions for platforms without hooks (Codex, OpenCode). Gemini retains the original note since it has context-inject.py."
+```
+
+**Step 2: Close issue #139**
+
+```bash
+gh issue close 139 --comment "Fixed in $(git log --oneline -1 HEAD). The converter now uses a standalone pages command from commands-standalone/pages.md for platforms without the sync-guides hook. The standalone version has full inline logic for scanning projects and generating the docs site."
+```
+
+**Step 3: No commit needed**
+
+Issues are closed on GitHub, no file changes.

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -90,6 +90,20 @@ All extension file access MUST go through shell commands.
 
 """
 
+CONTEXT_HOOK_NOTE = (
+    "> **Note**: The ArcKit Project Context hook has already detected all "
+    "projects, artifacts, external documents, and global policies. Use that "
+    "context below \u2014 no need to scan directories manually."
+)
+
+CONTEXT_HOOK_REPLACEMENT = (
+    "> **Note**: Before generating, scan `projects/` for existing project "
+    "directories. For each project, list all `ARC-*.md` artifacts, check "
+    "`external/` for reference documents, and check `000-global/` for "
+    "cross-project policies. If no external docs exist but they would "
+    "improve output, ask the user."
+)
+
 
 # --- Agent configuration: adding a new AI target = adding a dictionary entry ---
 

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -175,6 +175,17 @@ def rewrite_paths(prompt, config):
     return result
 
 
+def rewrite_hook_dependencies(prompt, config):
+    """Replace hook-dependent content for platforms without hooks."""
+    result = prompt
+
+    # Context injection: replace hook note with self-scan instructions
+    if not config.get("has_context_hook", False):
+        result = result.replace(CONTEXT_HOOK_NOTE, CONTEXT_HOOK_REPLACEMENT)
+
+    return result
+
+
 def format_output(description, prompt, fmt):
     """Format into target format: 'markdown', 'toml', or 'skill'."""
     if fmt == "toml":

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -248,7 +248,7 @@ def convert(commands_dir, agents_dir):
         for agent_id, config in AGENT_CONFIG.items():
             # Check for standalone command override (for hookless platforms)
             standalone_path = os.path.join(
-                os.path.dirname(commands_dir), "commands-standalone", filename
+                os.path.dirname(commands_dir.rstrip(os.sep)), "commands-standalone", filename
             )
             if os.path.isfile(standalone_path):
                 # Use standalone version if platform lacks required hook

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -103,12 +103,16 @@ AGENT_CONFIG = {
         "extension_dir": "arckit-codex",
         "copy_commands_to_extension": True,
         "copy_agents_to_extension": True,
+        "has_context_hook": False,
+        "has_sync_guides_hook": False,
     },
     "codex_skills": {
         "name": "Codex Skills",
         "output_dir": "arckit-codex/skills",
         "format": "skill",
         "path_prefix": ".arckit",
+        "has_context_hook": False,
+        "has_sync_guides_hook": False,
     },
     "opencode": {
         "name": "OpenCode CLI",
@@ -118,6 +122,8 @@ AGENT_CONFIG = {
         "path_prefix": ".arckit",
         "extension_dir": "arckit-opencode",
         "copy_agents_to_extension": True,
+        "has_context_hook": False,
+        "has_sync_guides_hook": False,
     },
     "gemini": {
         "name": "Gemini CLI",
@@ -129,6 +135,8 @@ AGENT_CONFIG = {
         "extension_dir": "arckit-gemini",
         "prepend_block": EXTENSION_FILE_ACCESS_BLOCK,
         "rewrite_read_instructions": True,
+        "has_context_hook": True,
+        "has_sync_guides_hook": False,
     },
 }
 

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -245,22 +245,21 @@ def convert(commands_dir, agents_dir):
 
         base_name = filename.replace(".md", "")
 
+        # Check for standalone command override once (result is agent-independent)
+        standalone_path = os.path.join(
+            os.path.dirname(commands_dir.rstrip(os.sep)), "commands-standalone", filename
+        )
+        has_standalone = os.path.isfile(standalone_path)
+        standalone_prompt = None
+        if has_standalone:
+            with open(standalone_path, "r") as f:
+                standalone_content = f.read()
+            _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
+
         for agent_id, config in AGENT_CONFIG.items():
-            # Check for standalone command override (for hookless platforms)
-            standalone_path = os.path.join(
-                os.path.dirname(commands_dir.rstrip(os.sep)), "commands-standalone", filename
-            )
-            if os.path.isfile(standalone_path):
-                # Use standalone version if platform lacks required hook
-                needs_standalone = not config.get("has_sync_guides_hook", False)
-                if needs_standalone:
-                    with open(standalone_path, "r") as f:
-                        standalone_content = f.read()
-                    _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
-                    rewritten = rewrite_paths(standalone_prompt, config)
-                    # Skip rewrite_hook_dependencies — standalone is self-contained
-                else:
-                    rewritten = rewrite_paths(prompt, config)
+            if has_standalone and not config.get("has_sync_guides_hook", False):
+                # Use standalone version for platforms lacking required hook
+                rewritten = rewrite_paths(standalone_prompt, config)
             else:
                 rewritten = rewrite_paths(prompt, config)
                 rewritten = rewrite_hook_dependencies(rewritten, config)

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -246,7 +246,24 @@ def convert(commands_dir, agents_dir):
         base_name = filename.replace(".md", "")
 
         for agent_id, config in AGENT_CONFIG.items():
-            rewritten = rewrite_paths(prompt, config)
+            # Check for standalone command override (for hookless platforms)
+            standalone_path = os.path.join(
+                os.path.dirname(commands_dir), "commands-standalone", filename
+            )
+            if os.path.isfile(standalone_path):
+                # Use standalone version if platform lacks required hook
+                needs_standalone = not config.get("has_sync_guides_hook", False)
+                if needs_standalone:
+                    with open(standalone_path, "r") as f:
+                        standalone_content = f.read()
+                    _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
+                    rewritten = rewrite_paths(standalone_prompt, config)
+                    # Skip rewrite_hook_dependencies — standalone is self-contained
+                else:
+                    rewritten = rewrite_paths(prompt, config)
+            else:
+                rewritten = rewrite_paths(prompt, config)
+                rewritten = rewrite_hook_dependencies(rewritten, config)
 
             if config["format"] == "skill":
                 skill_name = f"arckit-{base_name}"


### PR DESCRIPTION
## Summary

- Adds `has_context_hook` and `has_sync_guides_hook` flags to `AGENT_CONFIG` so the converter knows which platforms have hooks
- Adds `rewrite_hook_dependencies()` that replaces the context injection hook note with self-scan instructions for 43 commands on hookless platforms (Codex, OpenCode)
- Adds `commands-standalone/` directory with a standalone `pages.md` (pre-hook version with full inline logic) for platforms without the sync-guides hook
- Gemini retains the original hook note since it has `context-inject.py`

Closes #138, closes #139

## Design

See `docs/plans/2026-03-08-hook-aware-converter-design.md`

## Test Plan

- [x] Converter runs without errors (228 files generated)
- [x] 43 Codex/OpenCode commands have self-scan replacement
- [x] 0 Codex/OpenCode commands still reference the hook
- [x] 43 Gemini commands retain the original hook note
- [x] Codex/OpenCode pages command uses standalone version (no "Handled by Hook")
- [x] Codex skills also get the replacement (43 confirmed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)