### PR TITLE
feat: project search command with pre-processing hook

### DIFF
--- a/arckit-claude/commands/search.md
+++ b/arckit-claude/commands/search.md
@@ -1,0 +1,78 @@
+---
+description: Search across all project artifacts by keyword, document type, or requirement ID
+argument-hint: "<query, e.g. 'PostgreSQL', 'data residency', '--type=ADR', '--project=001'>"
+tags: [search, find, query, lookup, discover]
+handoffs:
+  - command: health
+    description: Check artifact health after finding relevant documents
+    condition: "Search revealed potentially stale artifacts"
+  - command: traceability
+    description: Trace requirements found in search results
+    condition: "Search included requirement IDs"
+  - command: impact
+    description: Analyse impact of changes to found documents
+    condition: "User wants to understand change blast radius"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -68,6 +68,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "/arckit:search",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/search-scan.mjs",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/arckit-claude/hooks/search-scan.mjs
+++ b/arckit-claude/hooks/search-scan.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Search Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:search commands.
+ * Scans all projects for ARC-*.md files and builds a search-ready index
+ * with document metadata and content previews.
+ *
+ * Hook Type: UserPromptSubmit (sync)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing search index
+ */
+
+import { join } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  parseHookInput,
+} from './hook-utils.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const text = prompt.replace(/^\/arckit[.:]+search\s*/i, '');
+  return text.trim();
+}
+
+// ── Content preview extraction ──
+
+function extractPreview(content, maxLen = 500) {
+  // Skip document control table and revision history
+  const lines = content.split('\n');
+  let inTable = false;
+  let pastControl = false;
+  const previewLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip leading headings and tables (doc control area)
+    if (!pastControl) {
+      if (trimmed.startsWith('|') || trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('---')) {
+        if (trimmed.startsWith('|')) inTable = true;
+        else if (inTable && !trimmed.startsWith('|')) {
+          inTable = false;
+          pastControl = true;
+        }
+        continue;
+      }
+      pastControl = true;
+    }
+
+    if (pastControl && trimmed) {
+      previewLines.push(trimmed);
+    }
+
+    if (previewLines.join(' ').length >= maxLen) break;
+  }
+
+  return previewLines.join(' ').substring(0, maxLen);
+}
+
+// ── Title extraction ──
+
+function extractTitle(content) {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1].trim() : null;
+}
+
+// ── Artifact scanning ──
+
+function scanProject(projectDir, projectName) {
+  const artifacts = [];
+
+  function scanDir(dir, relPrefix) {
+    if (!isDir(dir)) return;
+    for (const f of listDir(dir)) {
+      const fp = join(dir, f);
+      if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+
+      const content = readText(fp);
+      if (!content) continue;
+
+      const docType = extractDocType(f);
+      const version = extractVersion(f);
+      const fields = extractDocControlFields(content);
+      const title = extractTitle(content) || fields['Document Title'] || f;
+      const reqIds = [...extractRequirementIds(content)];
+      const preview = extractPreview(content);
+      const relPath = relPrefix ? `${relPrefix}/${f}` : f;
+
+      artifacts.push({
+        filename: f,
+        relPath,
+        project: projectName,
+        docType,
+        version,
+        title,
+        status: fields['Status'] || '',
+        owner: fields['Owner'] || fields['Document Owner'] || '',
+        reqIds,
+        preview,
+        controlFields: Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('; '),
+      });
+    }
+  }
+
+  // Root level
+  scanDir(projectDir, null);
+
+  // Subdirectories
+  for (const subdir of ['decisions', 'diagrams', 'wardley-maps', 'data-contracts', 'reviews', 'research']) {
+    scanDir(join(projectDir, subdir), subdir);
+  }
+
+  // Vendor directories
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vendorDir = join(vendorsDir, vendor);
+      if (!isDir(vendorDir)) continue;
+      scanDir(vendorDir, `vendors/${vendor}`);
+      scanDir(join(vendorDir, 'reviews'), `vendors/${vendor}/reviews`);
+    }
+  }
+
+  return artifacts;
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+// Guard: only fire for /arckit:search
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+search\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Search across all project artifacts/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+const query = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Discover and scan all projects
+const allArtifacts = [];
+const projectDirs = listDir(projectsDir)
+  .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+for (const projectName of projectDirs) {
+  const projectDir = join(projectsDir, projectName);
+  const artifacts = scanProject(projectDir, projectName);
+  allArtifacts.push(...artifacts);
+}
+
+// Build output
+const lines = [];
+lines.push('## Search Pre-processor Complete (hook)');
+lines.push('');
+lines.push(`**Indexed ${allArtifacts.length} artifacts across ${projectDirs.length} project(s).**`);
+lines.push('');
+lines.push(`**User query:** ${query || '(no query provided)'}`);
+lines.push('');
+lines.push('### SEARCH INDEX (JSON)');
+lines.push('');
+lines.push('```json');
+lines.push(JSON.stringify(allArtifacts, null, 2));
+lines.push('```');
+lines.push('');
+lines.push('### Instructions');
+lines.push('- Parse the query for keywords, --type=XXX, --project=NNN, --id=XX-NNN filters');
+lines.push('- Score results: title match=10, control fields=5, preview=3, filename=2');
+lines.push('- Output ranked table with top result preview');
+lines.push('- If no results, suggest broadening the search');
+
+const message = lines.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`


### PR DESCRIPTION
## Summary

Adds `/arckit:search` — keyword, type, and requirement ID search across all project artifacts. Fills the gap of having no search capability across 34+ document types.

- **search-scan.mjs** — UserPromptSubmit hook that indexes all ARC documents (metadata, content preview, requirement IDs)
- **search.md** — Command with ranked results, filter syntax, and handoffs
- Supports `--type=ADR`, `--project=001`, `--id=BR-003` filters and combinations
- Scoring: title match (10pts), control fields (5pts), content (3pts), filename (2pts)

## Files Changed

| File | Change |
|------|--------|
| `arckit-claude/hooks/search-scan.mjs` | New — UserPromptSubmit pre-processing hook |
| `arckit-claude/commands/search.md` | New — search command |
| `arckit-claude/hooks/hooks.json` | Register search hook |
| `docs/guides/search.md` | New — usage guide |

## Design Decisions

- **No persistent index** — scans fresh on each invocation for accuracy. Projects typically have <100 documents, so scan time is negligible.
- **Hook does I/O, command does reasoning** — follows the pattern established by health-scan.mjs and traceability-scan.mjs
- **Content preview** — extracts first 500 chars after document control table, giving Claude enough context to rank and excerpt results

## Test plan

- [x] JSON validation of hooks.json
- [x] ESM import validation
- [ ] Search in a project with multiple document types
- [ ] Filter by type, project, and requirement ID
- [ ] Empty query shows usage help

🤖 Generated with [Claude Code](https://claude.com/claude-code)