### PR TITLE
feat: impact analysis — reverse dependency tracing

### DIFF
--- a/arckit-claude/commands/impact.md
+++ b/arckit-claude/commands/impact.md
@@ -1,0 +1,89 @@
+---
+description: Analyse the blast radius of a change to a requirement, decision, or design document
+argument-hint: "<document ID or requirement ID, e.g. 'ARC-001-REQ', 'BR-003', 'ADR-002'>"
+tags: [impact, change, blast-radius, dependency, traceability, governance]
+handoffs:
+  - command: traceability
+    description: Update traceability matrix after impact assessment
+    condition: "Impact analysis revealed traceability gaps"
+  - command: health
+    description: Check health of impacted artifacts
+    condition: "Impacted documents may be stale"
+  - command: conformance
+    description: Re-assess conformance after changes
+    condition: "Impact includes architecture design documents"
+---
+
+# Impact Analysis
+
+You are helping an enterprise architect understand the blast radius of a change to an existing requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Impact hook has already built a dependency graph from all project artifacts and provided it as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the query** to identify the change source:
+   - **ARC document ID** (e.g., `ARC-001-REQ`, `ARC-001-ADR-003`) → find all documents that reference it
+   - **Requirement ID** (e.g., `BR-003`, `NFR-SEC-001`) → find all documents containing that requirement ID
+   - **Document type + project** (e.g., `ADR --project=001`) → show all dependencies of ADRs in that project
+   - **Plain text** → search node titles and suggest the most likely target
+
+2. **Perform reverse traversal** using the dependency graph:
+   - **Level 0**: The changed document itself
+   - **Level 1**: Documents that directly reference it (via cross-references or shared requirement IDs)
+   - **Level 2**: Documents that reference Level 1 documents
+   - Continue until no more references found (max depth 5)
+
+3. **Classify impact severity** using the `severity` field from the graph nodes:
+   - **HIGH**: Compliance/Governance documents (TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF) — may need formal re-assessment
+   - **MEDIUM**: Architecture documents (HLDR, DLDR, ADR, DATA, DIAG, PLAT) — may need design updates
+   - **LOW**: Planning/Other documents (PLAN, ROAD, BKLG, SOBC, OPS, PRES) — review recommended
+
+4. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Impact Analysis: BR-003 (Data Residency Requirement)
+
+   ### Change Source
+   - **Requirement:** BR-003 — "All customer data must reside within UK data centres"
+   - **Defined in:** ARC-001-REQ-v2.0 (projects/001-payments/)
+
+   ### Impact Chain
+
+   | Level | Document | Type | Impact | Action Needed |
+   |-------|----------|------|--------|---------------|
+   | 1 | ARC-001-ADR-002-v1.0 | ADR | MEDIUM | Review cloud provider decision |
+   | 1 | ARC-001-HLDR-v1.0 | HLDR | MEDIUM | Update deployment architecture |
+   | 2 | ARC-001-SECD-v1.0 | SECD | HIGH | Re-assess data protection controls |
+   | 2 | ARC-001-DPIA-v1.0 | DPIA | HIGH | Re-run DPIA assessment |
+   | 3 | ARC-001-OPS-v1.0 | OPS | LOW | Check operational procedures |
+
+   ### Summary
+   - **Total impacted:** 5 documents
+   - **HIGH severity:** 2 (compliance re-assessment needed)
+   - **MEDIUM severity:** 2 (design updates needed)
+   - **LOW severity:** 1 (review recommended)
+
+   ### Recommended Actions
+   1. Re-run `/arckit:secure` to update Secure by Design assessment
+   2. Re-run `/arckit:dpia` to update Data Protection Impact Assessment
+   3. Review ADR-002 decision rationale against updated requirement
+   ```
+
+5. **Recommend specific `/arckit:` commands** for HIGH severity impacts:
+   - SECD impacted → `/arckit:secure`
+   - DPIA impacted → `/arckit:dpia`
+   - TCOP impacted → `/arckit:tcop`
+   - HLDR impacted → `/arckit:hld-review`
+   - RISK impacted → `/arckit:risk`
+   - TRAC impacted → `/arckit:traceability`
+
+6. **If no impacts found**, report that the document has no downstream dependencies. Note this may indicate a traceability gap — suggest running `/arckit:traceability` to check coverage.
+
+7. **If the query matches multiple documents**, list them and ask the user to specify which one to analyse.

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -68,6 +68,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "/arckit:impact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/impact-scan.mjs",
+            "timeout": 20
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/arckit-claude/hooks/impact-scan.mjs
+++ b/arckit-claude/hooks/impact-scan.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Impact Analysis Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:impact commands.
+ * Builds a dependency graph from cross-references between ARC documents,
+ * enabling reverse traversal to determine the blast radius of changes.
+ *
+ * Hook Type: UserPromptSubmit (sync)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing dependency graph
+ */
+
+import { join } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  parseHookInput,
+} from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const text = prompt.replace(/^\/arckit[.:]+impact\s*/i, '');
+  return text.trim();
+}
+
+// ── Title extraction ──
+
+function extractTitle(content) {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1].trim() : null;
+}
+
+// ── Severity classification by doc type category ──
+
+function classifySeverity(docType) {
+  const info = DOC_TYPES[docType];
+  if (!info) return 'LOW';
+  const cat = info.category;
+  if (cat === 'Compliance' || cat === 'Governance') return 'HIGH';
+  if (cat === 'Architecture') return 'MEDIUM';
+  return 'LOW';
+}
+
+// ── Artifact scanning ──
+
+function scanAllArtifacts(projectsDir) {
+  const nodes = {};   // docId -> { type, project, path, title, status }
+  const edges = [];   // { from, to, type }
+  const reqIndex = {}; // reqId -> [docIds]
+
+  const projectDirs = listDir(projectsDir)
+    .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+  for (const projectName of projectDirs) {
+    const projectDir = join(projectsDir, projectName);
+    scanProjectDir(projectDir, projectName, nodes, edges, reqIndex);
+  }
+
+  return { nodes, edges, reqIndex, projects: projectDirs };
+}
+
+function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) {
+  const dirsToScan = [
+    { dir: projectDir, prefix: '' },
+    { dir: join(projectDir, 'decisions'), prefix: 'decisions/' },
+    { dir: join(projectDir, 'diagrams'), prefix: 'diagrams/' },
+    { dir: join(projectDir, 'wardley-maps'), prefix: 'wardley-maps/' },
+    { dir: join(projectDir, 'data-contracts'), prefix: 'data-contracts/' },
+    { dir: join(projectDir, 'reviews'), prefix: 'reviews/' },
+    { dir: join(projectDir, 'research'), prefix: 'research/' },
+  ];
+
+  // Also scan vendor directories
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vd = join(vendorsDir, vendor);
+      if (isDir(vd)) {
+        dirsToScan.push({ dir: vd, prefix: `vendors/${vendor}/` });
+        const vrd = join(vd, 'reviews');
+        if (isDir(vrd)) {
+          dirsToScan.push({ dir: vrd, prefix: `vendors/${vendor}/reviews/` });
+        }
+      }
+    }
+  }
+
+  for (const { dir, prefix } of dirsToScan) {
+    if (!isDir(dir)) continue;
+    for (const f of listDir(dir)) {
+      if (!f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+      const fp = join(dir, f);
+      if (!isFile(fp)) continue;
+
+      const content = readText(fp);
+      if (!content) continue;
+
+      const docType = extractDocType(f);
+      const version = extractVersion(f);
+      const fields = extractDocControlFields(content);
+      const title = extractTitle(content) || fields['Document Title'] || f;
+      const status = fields['Status'] || '';
+
+      // Build a short document ID (without version for matching)
+      const shortId = f.replace(/-v[\d.]+\.md$/, '');
+      const fullId = f.replace(/\.md$/, '');
+
+      nodes[fullId] = {
+        type: docType,
+        project: projectName,
+        path: `projects/${projectName}/${prefix}${f}`,
+        title,
+        status,
+        severity: classifySeverity(docType),
+      };
+
+      // Extract requirement IDs referenced in this document
+      const reqIds = extractRequirementIds(content);
+      for (const reqId of reqIds) {
+        if (!reqIndex[reqId]) reqIndex[reqId] = [];
+        if (!reqIndex[reqId].includes(fullId)) {
+          reqIndex[reqId].push(fullId);
+        }
+      }
+
+      // Extract cross-references to other ARC documents
+      const ARC_REF_RE = /\bARC-(\d{3})-([A-Z][\w-]*?)(?:-(\d{3}))?(?:-v[\d.]+)?(?:\.md)?\b/g;
+      let match;
+      while ((match = ARC_REF_RE.exec(content)) !== null) {
+        const refStr = match[0].replace(/\.md$/, '');
+        // Build a normalized reference ID
+        const refShort = refStr.replace(/-v[\d.]+$/, '');
+        if (refShort !== shortId) {
+          edges.push({ from: fullId, to: refShort, type: 'references' });
+        }
+      }
+    }
+  }
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+// Guard: only fire for /arckit:impact
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+impact\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Analyse the blast radius/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+const query = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Build dependency graph
+const { nodes, edges, reqIndex, projects } = scanAllArtifacts(projectsDir);
+
+const nodeCount = Object.keys(nodes).length;
+const edgeCount = edges.length;
+const reqCount = Object.keys(reqIndex).length;
+
+// Build output
+const lines = [];
+lines.push('## Impact Pre-processor Complete (hook)');
+lines.push('');
+lines.push(`**Dependency graph built: ${nodeCount} documents, ${edgeCount} cross-references, ${reqCount} requirement IDs across ${projects.length} project(s).**`);
+lines.push('');
+lines.push(`**User query:** ${query || '(no query provided)'}`);
+lines.push('');
+lines.push('### DEPENDENCY GRAPH (JSON)');
+lines.push('');
+lines.push('```json');
+lines.push(JSON.stringify({ nodes, edges, reqIndex }, null, 2));
+lines.push('```');
+lines.push('');
+lines.push('### Impact Severity Classification');
+lines.push('| Category | Severity | Document Types |');
+lines.push('|----------|----------|---------------|');
+lines.push('| Compliance/Governance | HIGH | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF |');
+lines.push('| Architecture | MEDIUM | HLDR, DLDR, ADR, DATA, DIAG, PLAT |');
+lines.push('| Planning/Other | LOW | PLAN, ROAD, BKLG, SOBC, OPS, PRES |');
+lines.push('');
+lines.push('### Instructions');
+lines.push('- Parse query: ARC document ID, requirement ID (e.g. BR-003), or type+project');
+lines.push('- Perform reverse traversal through edges (max depth 5)');
+lines.push('- Classify impact severity using node severity field');
+lines.push('- Output impact chain table, summary counts, and recommended actions');
+lines.push('- Suggest specific /arckit commands to re-run for HIGH severity impacts');
+
+const message = lines.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/docs/guides/impact.md
+++ b/docs/guides/impact.md
@@ -1,0 +1,68 @@
+# Impact Analysis
+
+Analyse the blast radius of a change to a requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability (`/arckit:traceability`).
+
+## Usage
+
+```
+/arckit:impact <document ID or requirement ID>
+```
+
+## Examples
+
+```bash
+# Impact of changing a requirement
+/arckit:impact BR-003
+/arckit:impact NFR-SEC-001
+
+# Impact of changing a document
+/arckit:impact ARC-001-REQ
+/arckit:impact ARC-001-ADR-002
+
+# Show all dependencies for a document type in a project
+/arckit:impact ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook builds a dependency graph on invocation:
+
+1. Scans all ARC-\*.md files across all projects
+2. Extracts cross-references between documents (ARC-NNN-TYPE patterns)
+3. Maps requirement IDs to the documents that contain them
+4. Classifies each document's impact severity by type category
+
+The command then performs reverse traversal through the graph to find all downstream dependencies.
+
+## Impact Severity
+
+| Severity | Category | Document Types | Action |
+|----------|----------|---------------|--------|
+| **HIGH** | Compliance/Governance | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF | Formal re-assessment likely needed |
+| **MEDIUM** | Architecture | HLDR, DLDR, ADR, DATA, DIAG, PLAT | Design updates may be needed |
+| **LOW** | Planning/Other | PLAN, ROAD, BKLG, SOBC, OPS, PRES | Review recommended |
+
+## Traversal Depth
+
+The analysis traces dependencies up to 5 levels deep:
+
+- **Level 0**: The changed document itself
+- **Level 1**: Documents that directly reference it
+- **Level 2**: Documents that reference Level 1 documents
+- **Level 3-5**: Further indirect dependencies
+
+## When to Use
+
+- **Before changing a requirement** — understand what other documents will be affected
+- **Before updating an ADR** — check if compliance documents reference it
+- **After a design review** — trace what else needs updating when conditions are imposed
+- **During change governance** — document the full impact chain for approval boards
+
+## Relationship to Traceability
+
+| Command | Direction | Question |
+|---------|-----------|----------|
+| `/arckit:traceability` | Forward | "Are my requirements covered by design decisions?" |
+| `/arckit:impact` | Reverse | "If I change this requirement, what breaks?" |
+
+Use traceability to check coverage. Use impact to assess change risk.


### PR DESCRIPTION
## Summary

Adds `/arckit:impact` for change blast radius analysis. Given a document or requirement ID, traces all downstream dependencies and classifies impact severity. The reverse complement of `/arckit:traceability`.

- **impact-scan.mjs** — UserPromptSubmit hook that builds a dependency graph (nodes, edges, requirement index)
- **impact.md** — Command with reverse traversal (max depth 5) and severity classification
- Severity: HIGH (compliance/governance), MEDIUM (architecture), LOW (planning)
- Recommends specific `/arckit:` commands to re-run for impacted documents

## Files Changed

| File | Change |
|------|--------|
| `arckit-claude/hooks/impact-scan.mjs` | New — dependency graph builder |
| `arckit-claude/commands/impact.md` | New — impact analysis command |
| `arckit-claude/hooks/hooks.json` | Register impact hook |
| `docs/guides/impact.md` | New — usage guide |

## Architecture

```
/arckit:impact BR-003
  └── impact-scan.mjs builds dependency graph (all ARC docs)
       └── Command performs reverse traversal from BR-003
            └── Level 1: ADR-002 (references BR-003) → MEDIUM
            └── Level 2: SECD (references ADR-002) → HIGH
            └── Level 2: DPIA (references ADR-002) → HIGH
```

## Design Decisions

- **Builds on existing extractors** — uses `extractRequirementIds`, `extractDocType`, `extractDocControlFields` from `hook-utils.mjs`
- **Severity from DOC_TYPES categories** — uses the `category` field from `doc-types.mjs` rather than hardcoding
- **Cross-project aware** — scans all projects, so cross-project dependencies are captured

## Test plan

- [x] JSON validation of hooks.json
- [x] ESM import validation
- [ ] Impact analysis on a requirement ID referenced across multiple document types
- [ ] Impact analysis on an ARC document ID
- [ ] Verify severity classification matches DOC_TYPES categories

🤖 Generated with [Claude Code](https://claude.com/claude-code)