### PR TITLE
feat: vendor scoring with structured storage and audit trail

### DIFF
--- a/arckit-claude/commands/score.md
+++ b/arckit-claude/commands/score.md
@@ -1,0 +1,160 @@
+---
+description: Score vendor proposals against evaluation criteria with persistent structured storage
+argument-hint: "<action> <args>, e.g. 'vendor Acme --project=001', 'compare --project=001', 'audit --project=001'"
+tags: [vendor, scoring, evaluation, procurement, comparison, audit]
+handoffs:
+  - command: evaluate
+    description: Create or update evaluation framework before scoring
+    condition: "No EVAL artifact exists for the project"
+  - command: sow
+    description: Generate Statement of Work for selected vendor
+    condition: "Vendor selection complete, ready for procurement"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -95,6 +95,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/arckit-claude/hooks/score-validator.mjs
+++ b/arckit-claude/hooks/score-validator.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * ArcKit PreToolUse (Write) Hook — Score Validator
+ *
+ * Validates scores.json files before they are written to ensure
+ * data integrity of vendor scoring records.
+ *
+ * Checks:
+ *   - Valid JSON structure with required fields
+ *   - Score values are 0-3
+ *   - Weights sum to approximately 1.0
+ *
+ * Hook Type: PreToolUse
+ * Matcher: Write
+ * Input (stdin):  JSON { tool_name, tool_input: { file_path, content }, ... }
+ * Output (stdout): JSON with decision (allow/block)
+ */
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+// --- Read stdin ---
+let raw = '';
+try {
+  raw = readFileSync(0, 'utf8');
+} catch {
+  process.exit(0);
+}
+if (!raw || !raw.trim()) process.exit(0);
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+// --- Early exit: only validate scores.json files ---
+const filePath = (data.tool_input || {}).file_path || '';
+if (!filePath.endsWith('/scores.json') && basename(filePath) !== 'scores.json') {
+  process.exit(0);
+}
+if (!filePath.includes('/vendors/')) process.exit(0);
+
+const content = (data.tool_input || {}).content || '';
+if (!content) process.exit(0);
+
+// --- Validate JSON ---
+let scores;
+try {
+  scores = JSON.parse(content);
+} catch (e) {
+  console.log(JSON.stringify({
+    decision: 'block',
+    reason: `Invalid JSON in scores.json: ${e.message}`,
+  }));
+  process.exit(0);
+}
+
+const warnings = [];
+
+// --- Validate required top-level fields ---
+if (!scores.projectId) warnings.push('Missing required field: projectId');
+if (!scores.criteria || !Array.isArray(scores.criteria)) {
+  warnings.push('Missing or invalid field: criteria (must be an array)');
+}
+if (!scores.vendors || typeof scores.vendors !== 'object') {
+  warnings.push('Missing or invalid field: vendors (must be an object)');
+}
+
+// --- Validate criteria weights ---
+if (Array.isArray(scores.criteria) && scores.criteria.length > 0) {
+  const weightSum = scores.criteria.reduce((sum, c) => sum + (c.weight || 0), 0);
+  if (Math.abs(weightSum - 1.0) > 0.01) {
+    warnings.push(`Criteria weights sum to ${weightSum.toFixed(3)} (expected ~1.0)`);
+  }
+
+  // Check each criterion has required fields
+  for (const c of scores.criteria) {
+    if (!c.id) warnings.push(`Criterion missing id field`);
+    if (!c.name) warnings.push(`Criterion ${c.id || '?'} missing name field`);
+    if (typeof c.weight !== 'number') warnings.push(`Criterion ${c.id || '?'} missing numeric weight`);
+  }
+}
+
+// --- Validate vendor scores ---
+if (scores.vendors && typeof scores.vendors === 'object') {
+  const criteriaIds = new Set((scores.criteria || []).map(c => c.id));
+
+  for (const [vendorKey, vendor] of Object.entries(scores.vendors)) {
+    if (!vendor.displayName) warnings.push(`Vendor '${vendorKey}' missing displayName`);
+    if (!Array.isArray(vendor.scores)) {
+      warnings.push(`Vendor '${vendorKey}' missing scores array`);
+      continue;
+    }
+
+    for (const s of vendor.scores) {
+      if (typeof s.score !== 'number' || s.score < 0 || s.score > 3) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: score ${s.score} out of range (must be 0-3)`);
+      }
+      if (s.criterionId && !criteriaIds.has(s.criterionId)) {
+        warnings.push(`Vendor '${vendorKey}' references unknown criterion: ${s.criterionId}`);
+      }
+    }
+  }
+}
+
+// --- Output ---
+if (warnings.length > 0) {
+  // Allow but warn — don't block data writes
+  console.log(JSON.stringify({
+    decision: 'allow',
+    reason: `Score validation warnings:\n${warnings.map(w => `- ${w}`).join('\n')}`,
+  }));
+} else {
+  // Clean pass
+  process.exit(0);
+}

--- a/docs/guides/score.md
+++ b/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged


### PR DESCRIPTION
## Summary

Adds `/arckit:score` for persistent, auditable vendor scoring — completing the procurement workflow chain (`evaluate → score → compare → sow`).

- **score vendor** — Score against EVAL criteria using 0-3 rubric with evidence
- **compare** — Side-by-side weighted comparison with sensitivity analysis
- **audit** — Chronological scoring history for governance
- **score-validator.mjs** — PreToolUse hook validates scores.json integrity

Scores stored in `projects/{id}/vendors/scores.json` for structured querying and team sharing.

## Files Changed

| File | Change |
|------|--------|
| `arckit-claude/commands/score.md` | New — scoring command (3 sub-actions) |
| `arckit-claude/hooks/score-validator.mjs` | New — PreToolUse validator for scores.json |
| `arckit-claude/hooks/hooks.json` | Register validator hook |
| `docs/guides/score.md` | New — usage guide |

## Scoring Format

```json
{
  "projectId": "001",
  "criteria": [{ "id": "C-001", "name": "Technical Capability", "weight": 0.25 }],
  "vendors": {
    "acme-cloud": {
      "scores": [{ "criterionId": "C-001", "score": 3, "evidence": "..." }],
      "totalWeighted": 2.45
    }
  }
}
```

## Design Decisions

- **Structured JSON, not markdown** — enables querying, comparison, and audit without parsing prose
- **Evidence is mandatory** — every score must cite supporting evidence from the vendor proposal
- **Validator is advisory** — warns on invalid scores/weights but allows writes (architects can fix issues)
- **Integrates with /arckit:evaluate** — reads criteria from the EVAL artifact

## Test plan

- [x] JSON validation of hooks.json
- [x] ESM import validation
- [ ] Score a vendor and verify scores.json structure
- [ ] Score a second vendor and verify append (not overwrite)
- [ ] Compare sub-action with 2+ vendors
- [ ] Validator catches out-of-range scores

🤖 Generated with [Claude Code](https://claude.com/claude-code)