### PR TITLE
feat: project search command with pre-processing hook

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "57 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "58 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.0.2",
       "author": {
         "name": "TractorJuice"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+
 ## [4.0.2] - 2026-03-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 57 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Five distribution formats** exist side-by-side in this repo:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 57 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 58 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 57 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 58 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -760,7 +760,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Codex / OpenCode |
 |---------|:-----------:|:----------:|:----------------:|
-| 57 slash commands | ✅ | ✅ | ✅ |
+| 58 slash commands | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | — |
@@ -887,7 +887,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 57 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 58 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -1014,6 +1014,7 @@ These commands use [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | `/arckit.presentation` | Generate MARP slide deck from project artifacts for governance boards and stakeholder briefings | — | 🔵 Beta |
 | `/arckit.conformance` | Assess architecture conformance — ADR decision implementation, cross-decision consistency, architecture drift, technical debt, and custom constraint rules | — | 🔵 Beta |
 | `/arckit.health` | Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift | — | 🔵 Beta |
+| `/arckit.search` | Search across all project artifacts by keyword, document type, or requirement ID | — | 🔵 Beta |
 | `/arckit.customize` | Copy templates to `.arckit/templates-custom/` for customization (preserved across updates) | — | 🟢 Live |
 | `/arckit.maturity-model` | Generate capability maturity model with current-state assessment, target-state definition, and improvement roadmap | — | 🔵 Beta |
 | `/arckit.template-builder` | Create new document templates through interactive interview — generates community-origin templates, guides, and optional shareable bundles | — | 🟠 Alpha |
@@ -1154,7 +1155,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 57×57 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 58×58 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 57 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 57 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 58 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 57 | Slash commands for architecture artifacts |
+| Commands | 58 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/commands/search.md
+++ b/arckit-claude/commands/search.md
@@ -1,0 +1,78 @@
+---
+description: Search across all project artifacts by keyword, document type, or requirement ID
+argument-hint: "<query, e.g. 'PostgreSQL', 'data residency', '--type=ADR', '--project=001'>"
+tags: [search, find, query, lookup, discover]
+handoffs:
+  - command: health
+    description: Check artifact health after finding relevant documents
+    condition: "Search revealed potentially stale artifacts"
+  - command: traceability
+    description: Trace requirements found in search results
+    condition: "Search included requirement IDs"
+  - command: impact
+    description: Analyse impact of changes to found documents
+    condition: "User wants to understand change blast radius"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/search.md
+++ b/arckit-claude/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -68,6 +68,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "/arckit:search",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/search-scan.mjs",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/arckit-claude/hooks/search-scan.mjs
+++ b/arckit-claude/hooks/search-scan.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Search Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:search commands.
+ * Scans all projects for ARC-*.md files and builds a search-ready index
+ * with document metadata and content previews.
+ *
+ * Hook Type: UserPromptSubmit (sync)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing search index
+ */
+
+import { join } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  parseHookInput,
+} from './hook-utils.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const text = prompt.replace(/^\/arckit[.:]+search\s*/i, '');
+  return text.trim();
+}
+
+// ── Content preview extraction ──
+
+function extractPreview(content, maxLen = 500) {
+  // Skip document control table and revision history
+  const lines = content.split('\n');
+  let inTable = false;
+  let pastControl = false;
+  const previewLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip leading headings and tables (doc control area)
+    if (!pastControl) {
+      if (trimmed.startsWith('|') || trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('---')) {
+        if (trimmed.startsWith('|')) inTable = true;
+        else if (inTable && !trimmed.startsWith('|')) {
+          inTable = false;
+          pastControl = true;
+        }
+        continue;
+      }
+      pastControl = true;
+    }
+
+    if (pastControl && trimmed) {
+      previewLines.push(trimmed);
+    }
+
+    if (previewLines.join(' ').length >= maxLen) break;
+  }
+
+  return previewLines.join(' ').substring(0, maxLen);
+}
+
+// ── Title extraction ──
+
+function extractTitle(content) {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1].trim() : null;
+}
+
+// ── Artifact scanning ──
+
+function scanProject(projectDir, projectName) {
+  const artifacts = [];
+
+  function scanDir(dir, relPrefix) {
+    if (!isDir(dir)) return;
+    for (const f of listDir(dir)) {
+      const fp = join(dir, f);
+      if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+
+      const content = readText(fp);
+      if (!content) continue;
+
+      const docType = extractDocType(f);
+      const version = extractVersion(f);
+      const fields = extractDocControlFields(content);
+      const title = extractTitle(content) || fields['Document Title'] || f;
+      const reqIds = [...extractRequirementIds(content)];
+      const preview = extractPreview(content);
+      const relPath = relPrefix ? `${relPrefix}/${f}` : f;
+
+      artifacts.push({
+        filename: f,
+        relPath,
+        project: projectName,
+        docType,
+        version,
+        title,
+        status: fields['Status'] || '',
+        owner: fields['Owner'] || fields['Document Owner'] || '',
+        reqIds,
+        preview,
+        controlFields: Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('; '),
+      });
+    }
+  }
+
+  // Root level
+  scanDir(projectDir, null);
+
+  // Subdirectories
+  for (const subdir of ['decisions', 'diagrams', 'wardley-maps', 'data-contracts', 'reviews', 'research']) {
+    scanDir(join(projectDir, subdir), subdir);
+  }
+
+  // Vendor directories
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vendorDir = join(vendorsDir, vendor);
+      if (!isDir(vendorDir)) continue;
+      scanDir(vendorDir, `vendors/${vendor}`);
+      scanDir(join(vendorDir, 'reviews'), `vendors/${vendor}/reviews`);
+    }
+  }
+
+  return artifacts;
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+// Guard: only fire for /arckit:search
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+search\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Search across all project artifacts/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+const query = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Discover and scan all projects
+const allArtifacts = [];
+const projectDirs = listDir(projectsDir)
+  .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+for (const projectName of projectDirs) {
+  const projectDir = join(projectsDir, projectName);
+  const artifacts = scanProject(projectDir, projectName);
+  allArtifacts.push(...artifacts);
+}
+
+// Build output
+const lines = [];
+lines.push('## Search Pre-processor Complete (hook)');
+lines.push('');
+lines.push(`**Indexed ${allArtifacts.length} artifacts across ${projectDirs.length} project(s).**`);
+lines.push('');
+lines.push(`**User query:** ${query || '(no query provided)'}`);
+lines.push('');
+lines.push('### SEARCH INDEX (JSON)');
+lines.push('');
+lines.push('```json');
+lines.push(JSON.stringify(allArtifacts, null, 2));
+lines.push('```');
+lines.push('');
+lines.push('### Instructions');
+lines.push('- Parse the query for keywords, --type=XXX, --project=NNN, --id=XX-NNN filters');
+lines.push('- Score results: title match=10, control fields=5, preview=3, filename=2');
+lines.push('- Output ranked table with top result preview');
+lines.push('- If no results, suggest broadening the search');
+
+const message = lines.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/arckit-codex/README.md
+++ b/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 61 skills (57 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- 62 skills (58 commands + 4 reference skills, auto-discovered by Codex)
 - `.codex/agents/` -- 6 agent configs (research, datascout, cloud providers, framework)
 - `.codex/config.toml` -- MCP servers and agent roles
 - `.arckit/templates/` -- document templates
@@ -58,7 +58,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 57 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes all 58 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -75,7 +75,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 57 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+All 58 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -219,7 +219,7 @@ arckit-codex/
 ├── README.md              # This file
 ├── VERSION                # Extension version (tracks plugin)
 ├── config.toml            # MCP servers + agent configuration
-├── skills/                # 61 skills (57 commands + 4 reference)
+├── skills/                # 62 skills (58 commands + 4 reference)
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
@@ -230,7 +230,7 @@ arckit-codex/
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 57 prompts (deprecated, use skills instead)
+├── prompts/               # 58 prompts (deprecated, use skills instead)
 ├── agents/                # 6 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -243,7 +243,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v3.1.2 (57 commands, 4 reference skills)**
+**Current Release: v3.1.2 (58 commands, 4 reference skills)**
 
 ---
 

--- a/arckit-codex/commands/arckit.search.md
+++ b/arckit-codex/commands/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/search.md
+++ b/arckit-codex/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/prompts/arckit.search.md
+++ b/arckit-codex/prompts/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/skills/arckit-search/SKILL.md
+++ b/arckit-codex/skills/arckit-search/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: arckit-search
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: $arckit-search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     $arckit-search PostgreSQL
+     $arckit-search "data residency" --type=ADR
+     $arckit-search --id=BR-003
+     $arckit-search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `$arckit-traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `$arckit-impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/skills/arckit-search/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-search/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 57 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 57 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 58 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 57 Commands
+## All 58 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 57 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-opencode/commands/arckit.search.md
+++ b/arckit-opencode/commands/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/search.md
+++ b/arckit-opencode/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -350,11 +350,18 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 - **ArcKit Version**: 1.5.0
 - **Matrix Date**: 2026-02-25
-- **Commands Documented**: 57
+- **Commands Documented**: 58
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-08 - Added Project Search Command
+
+- **Added**: `/arckit.search` command (58th ArcKit command) for keyword, type, and requirement ID search across all project artifacts
+- **Not in matrix**: Diagnostic/query command with console-only output — no dependencies and no outputs consumed by other commands
+- **Updated**: Commands Documented count from 57 to 58
+- **Note**: Uses UserPromptSubmit pre-processing hook (`search-scan.mjs`) to index artifacts before search
 
 ### 2026-03-08 - Added DFD Command to Matrix
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,13 +196,14 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.customize` | [customize.md](guides/customize.md) | ✅ Complete |
 | `/arckit.presentation` | [presentation.md](guides/presentation.md) | ✅ Complete |
 | `/arckit.health` | [artifact-health.md](guides/artifact-health.md) | ✅ Complete |
+| `/arckit.search` | [search.md](guides/search.md) | ✅ Complete |
 | `/arckit.start` | [start.md](guides/start.md) | ✅ Complete |
 | `/arckit.template-builder` | [template-builder.md](guides/template-builder.md) | ✅ Complete |
 | `/arckit.framework` | [framework.md](guides/framework.md) | ✅ Complete |
 | `/arckit.glossary` | [glossary.md](guides/glossary.md) | ✅ Complete |
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
 
-**Coverage**: 57/57 commands documented (100%)
+**Coverage**: 58/58 commands documented (100%)
 
 ---
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">57 AI Commands</span>
+            <span class="app-page-hero__stat">58 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">57 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">57</span> of 57 commands
+                Showing <span id="visible-count">58</span> of 58 commands
             </div>
         </div>
 
@@ -1244,6 +1244,13 @@
                         <td><code>/arckit.health</code></td>
                         <td class="description">Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift</td>
                         <td>Quality & Governance</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="governance">
+                        <td><code>/arckit.search</code></td>
+                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
+                        <td>Quality &amp; Governance</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -377,7 +377,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 57 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 58 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -417,7 +417,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 57 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 58 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -465,7 +465,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 57 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -515,7 +515,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 57 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -577,7 +577,7 @@ opencode</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 57 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 58 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 57 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "57 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">57</div>
+                    <div class="app-stat-number">58</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">57 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">58 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 57 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 58 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -488,7 +488,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 57 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 58 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -401,7 +401,7 @@ python scripts/converter.py
 #   Codex Skills: arckit-claude/commands/plan.md -> arckit-codex/skills/arckit-plan/
 #   Gemini:       arckit-claude/commands/plan.md -> arckit-gemini/commands/arckit/plan.toml
 #   ...
-# Generated 57 Codex CLI + 57 Codex Skills + 57 OpenCode + 57 Gemini = 285 total files.
+# Generated 58 Codex CLI + 58 Codex Skills + 58 OpenCode + 58 Gemini = 290 total files.
 ```
 
 **Use Cases**:


### PR DESCRIPTION
## Summary

Adds `/arckit:search` — keyword, type, and requirement ID search across all project artifacts. Fills the gap of having no search capability across 34+ document types.

- **search-scan.mjs** — UserPromptSubmit hook that indexes all ARC documents (metadata, content preview, requirement IDs)
- **search.md** — Command with ranked results, filter syntax, and handoffs
- Supports `--type=ADR`, `--project=001`, `--id=BR-003` filters and combinations
- Scoring: title match (10pts), control fields (5pts), content (3pts), filename (2pts)
- Converter output for Codex, OpenCode, and Gemini extensions
- All documentation updated (58 commands across README, commands.html, index.html, DEPENDENCY-MATRIX, CHANGELOG, guides, extension READMEs)

Supersedes #143 (fork PR — original code preserved, doc completions added).

## Files Changed

| Area | Files |
|------|-------|
| Command | `arckit-claude/commands/search.md` |
| Hook | `arckit-claude/hooks/search-scan.mjs`, `hooks.json` |
| Guide | `docs/guides/search.md`, `arckit-claude/docs/guides/search.md` |
| Extensions | `arckit-codex/skills/arckit-search/`, `arckit-opencode/commands/`, `arckit-gemini/commands/` |
| Docs | README.md, CLAUDE.md, CHANGELOG.md, DEPENDENCY-MATRIX.md, commands.html, index.html, getting-started.html, docs/README.md |
| Counts | 57→58 across all READMEs, guides, meta descriptions, plugin.json, marketplace.json, gemini-extension.json |

## Design Decisions

- **No persistent index** — scans fresh on each invocation for accuracy
- **Hook does I/O, command does reasoning** — follows health-scan/traceability-scan pattern
- **Diagnostic command** — console-only output, not in dependency matrix (same as health, customize)

## Test plan

- [ ] JSON validation of hooks.json
- [ ] ESM import validation of search-scan.mjs
- [ ] Search in a project with multiple document types
- [ ] Filter by type, project, and requirement ID
- [ ] Empty query shows usage help
- [ ] Converter output validates for Codex/OpenCode/Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)