### PR TITLE
feat: vendor scoring with structured storage and audit trail

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "58 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "59 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.0.2",
       "author": {
         "name": "TractorJuice"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "57 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "58 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.0.2",
       "author": {
         "name": "TractorJuice"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+- `/arckit.score` command for structured vendor scoring with JSON storage, comparison, sensitivity analysis, and audit trail
 
 ## [4.0.2] - 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+
 ## [4.0.2] - 2026-03-08
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 59 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Five distribution formats** exist side-by-side in this repo:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 57 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Five distribution formats** exist side-by-side in this repo:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 58 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 59 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 58 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 59 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -760,7 +760,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Codex / OpenCode |
 |---------|:-----------:|:----------:|:----------------:|
-| 58 slash commands | ✅ | ✅ | ✅ |
+| 59 slash commands | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | — |
@@ -887,7 +887,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 58 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 59 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -982,6 +982,7 @@ These commands use [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | `/arckit.gcloud-search` | Find G-Cloud services on UK Digital Marketplace with live search and comparison | [v3](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-GCLD-v1.0.md) [v14](https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-GCLD-v1.0.md) | 🟣 Experimental |
 | `/arckit.gcloud-clarify` | Analyze G-Cloud service gaps and generate supplier clarification questions | — | 🟣 Experimental |
 | `/arckit.evaluate` | Create vendor evaluation framework and score vendor proposals | [v1](https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/ARC-001-EVAL-v1.0.md) [v2](https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-EVAL-v1.0.md) [v3/001](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-EVAL-v1.0.md) [v3/002](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-EVAL-v1.0.md) [v3/003](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/003-peripherals-update-upgrade/ARC-003-EVAL-v1.0.md) [v3/005](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/005-cloud-pki/ARC-005-EVAL-v1.0.md) [v6](https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/ARC-001-EVAL-v1.0.md) | 🟢 Live |
+| `/arckit.score` | Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail | — | 🔵 Beta |
 
 ### Design & Architecture
 
@@ -1155,7 +1156,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 58×58 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 59×59 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 57 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 58 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 57 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 58 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -760,7 +760,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Codex / OpenCode |
 |---------|:-----------:|:----------:|:----------------:|
-| 57 slash commands | ✅ | ✅ | ✅ |
+| 58 slash commands | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | — |
@@ -887,7 +887,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 57 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 58 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -1014,6 +1014,7 @@ These commands use [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | `/arckit.presentation` | Generate MARP slide deck from project artifacts for governance boards and stakeholder briefings | — | 🔵 Beta |
 | `/arckit.conformance` | Assess architecture conformance — ADR decision implementation, cross-decision consistency, architecture drift, technical debt, and custom constraint rules | — | 🔵 Beta |
 | `/arckit.health` | Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift | — | 🔵 Beta |
+| `/arckit.search` | Search across all project artifacts by keyword, document type, or requirement ID | — | 🔵 Beta |
 | `/arckit.customize` | Copy templates to `.arckit/templates-custom/` for customization (preserved across updates) | — | 🟢 Live |
 | `/arckit.maturity-model` | Generate capability maturity model with current-state assessment, target-state definition, and improvement roadmap | — | 🔵 Beta |
 | `/arckit.template-builder` | Create new document templates through interactive interview — generates community-origin templates, guides, and optional shareable bundles | — | 🟠 Alpha |
@@ -1154,7 +1155,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 57×57 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 58×58 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 59 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 57 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 58 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 59 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 58 | Slash commands for architecture artifacts |
+| Commands | 59 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 57 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 58 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 57 | Slash commands for architecture artifacts |
+| Commands | 58 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/commands/score.md
+++ b/arckit-claude/commands/score.md
@@ -1,0 +1,160 @@
+---
+description: Score vendor proposals against evaluation criteria with persistent structured storage
+argument-hint: "<action> <args>, e.g. 'vendor Acme --project=001', 'compare --project=001', 'audit --project=001'"
+tags: [vendor, scoring, evaluation, procurement, comparison, audit]
+handoffs:
+  - command: evaluate
+    description: Create or update evaluation framework before scoring
+    condition: "No EVAL artifact exists for the project"
+  - command: sow
+    description: Generate Statement of Work for selected vendor
+    condition: "Vendor selection complete, ready for procurement"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal

--- a/arckit-claude/commands/search.md
+++ b/arckit-claude/commands/search.md
@@ -1,0 +1,78 @@
+---
+description: Search across all project artifacts by keyword, document type, or requirement ID
+argument-hint: "<query, e.g. 'PostgreSQL', 'data residency', '--type=ADR', '--project=001'>"
+tags: [search, find, query, lookup, discover]
+handoffs:
+  - command: health
+    description: Check artifact health after finding relevant documents
+    condition: "Search revealed potentially stale artifacts"
+  - command: traceability
+    description: Trace requirements found in search results
+    condition: "Search included requirement IDs"
+  - command: impact
+    description: Analyse impact of changes to found documents
+    condition: "User wants to understand change blast radius"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/score.md
+++ b/arckit-claude/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/arckit-claude/docs/guides/search.md
+++ b/arckit-claude/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -105,6 +105,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-arc-filename.mjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+            "timeout": 5
           }
         ]
       },
@@ -102,16 +107,6 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/secret-file-scanner.mjs",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
             "timeout": 5
           }
         ]

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -68,6 +68,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "/arckit:search",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/search-scan.mjs",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/arckit-claude/hooks/score-validator.mjs
+++ b/arckit-claude/hooks/score-validator.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * ArcKit PreToolUse (Write) Hook — Score Validator
+ *
+ * Validates scores.json files before they are written to ensure
+ * data integrity of vendor scoring records.
+ *
+ * Checks:
+ *   - Valid JSON structure with required fields
+ *   - Score values are 0-3
+ *   - Weights sum to approximately 1.0
+ *
+ * Hook Type: PreToolUse
+ * Matcher: Write
+ * Input (stdin):  JSON { tool_name, tool_input: { file_path, content }, ... }
+ * Output (stdout): JSON with decision (allow/block)
+ */
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+// --- Read stdin ---
+let raw = '';
+try {
+  raw = readFileSync(0, 'utf8');
+} catch {
+  process.exit(0);
+}
+if (!raw || !raw.trim()) process.exit(0);
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+// --- Early exit: only validate scores.json files ---
+const filePath = (data.tool_input || {}).file_path || '';
+if (!filePath.endsWith('/scores.json') && basename(filePath) !== 'scores.json') {
+  process.exit(0);
+}
+if (!filePath.includes('/vendors/')) process.exit(0);
+
+const content = (data.tool_input || {}).content || '';
+if (!content) process.exit(0);
+
+// --- Validate JSON ---
+let scores;
+try {
+  scores = JSON.parse(content);
+} catch (e) {
+  console.log(JSON.stringify({
+    decision: 'block',
+    reason: `Invalid JSON in scores.json: ${e.message}`,
+  }));
+  process.exit(0);
+}
+
+const warnings = [];
+
+// --- Validate required top-level fields ---
+if (!scores.projectId) warnings.push('Missing required field: projectId');
+if (!scores.criteria || !Array.isArray(scores.criteria)) {
+  warnings.push('Missing or invalid field: criteria (must be an array)');
+}
+if (!scores.vendors || typeof scores.vendors !== 'object') {
+  warnings.push('Missing or invalid field: vendors (must be an object)');
+}
+
+// --- Validate criteria weights ---
+if (Array.isArray(scores.criteria) && scores.criteria.length > 0) {
+  const weightSum = scores.criteria.reduce((sum, c) => sum + (c.weight || 0), 0);
+  if (Math.abs(weightSum - 1.0) > 0.01) {
+    warnings.push(`Criteria weights sum to ${weightSum.toFixed(3)} (expected ~1.0)`);
+  }
+
+  // Check each criterion has required fields
+  for (const c of scores.criteria) {
+    if (!c.id) warnings.push(`Criterion missing id field`);
+    if (!c.name) warnings.push(`Criterion ${c.id || '?'} missing name field`);
+    if (typeof c.weight !== 'number') warnings.push(`Criterion ${c.id || '?'} missing numeric weight`);
+  }
+}
+
+// --- Validate vendor scores ---
+if (scores.vendors && typeof scores.vendors === 'object') {
+  const criteriaIds = new Set((scores.criteria || []).map(c => c.id));
+
+  for (const [vendorKey, vendor] of Object.entries(scores.vendors)) {
+    if (!vendor.displayName) warnings.push(`Vendor '${vendorKey}' missing displayName`);
+    if (!Array.isArray(vendor.scores)) {
+      warnings.push(`Vendor '${vendorKey}' missing scores array`);
+      continue;
+    }
+
+    for (const s of vendor.scores) {
+      if (typeof s.score !== 'number' || s.score < 0 || s.score > 3) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: score ${s.score} out of range (must be 0-3)`);
+      }
+      if (s.criterionId && !criteriaIds.has(s.criterionId)) {
+        warnings.push(`Vendor '${vendorKey}' references unknown criterion: ${s.criterionId}`);
+      }
+    }
+  }
+}
+
+// --- Output ---
+if (warnings.length > 0) {
+  // Allow but warn — don't block data writes
+  console.log(JSON.stringify({
+    decision: 'allow',
+    reason: `Score validation warnings:\n${warnings.map(w => `- ${w}`).join('\n')}`,
+  }));
+} else {
+  // Clean pass
+  process.exit(0);
+}

--- a/arckit-claude/hooks/score-validator.mjs
+++ b/arckit-claude/hooks/score-validator.mjs
@@ -16,24 +16,10 @@
  * Output (stdout): JSON with decision (allow/block)
  */
 
-import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
+import { parseHookInput } from './hook-utils.mjs';
 
-// --- Read stdin ---
-let raw = '';
-try {
-  raw = readFileSync(0, 'utf8');
-} catch {
-  process.exit(0);
-}
-if (!raw || !raw.trim()) process.exit(0);
-
-let data;
-try {
-  data = JSON.parse(raw);
-} catch {
-  process.exit(0);
-}
+const data = parseHookInput();
 
 // --- Early exit: only validate scores.json files ---
 const filePath = (data.tool_input || {}).file_path || '';
@@ -97,6 +83,9 @@ if (scores.vendors && typeof scores.vendors === 'object') {
     for (const s of vendor.scores) {
       if (typeof s.score !== 'number' || s.score < 0 || s.score > 3) {
         warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: score ${s.score} out of range (must be 0-3)`);
+      }
+      if (!s.evidence || !s.evidence.trim()) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: missing evidence (every score must cite supporting evidence)`);
       }
       if (s.criterionId && !criteriaIds.has(s.criterionId)) {
         warnings.push(`Vendor '${vendorKey}' references unknown criterion: ${s.criterionId}`);

--- a/arckit-claude/hooks/search-scan.mjs
+++ b/arckit-claude/hooks/search-scan.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Search Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:search commands.
+ * Scans all projects for ARC-*.md files and builds a search-ready index
+ * with document metadata and content previews.
+ *
+ * Hook Type: UserPromptSubmit (sync)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing search index
+ */
+
+import { join } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  parseHookInput,
+} from './hook-utils.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const text = prompt.replace(/^\/arckit[.:]+search\s*/i, '');
+  return text.trim();
+}
+
+// ── Content preview extraction ──
+
+function extractPreview(content, maxLen = 500) {
+  // Skip document control table and revision history
+  const lines = content.split('\n');
+  let inTable = false;
+  let pastControl = false;
+  const previewLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip leading headings and tables (doc control area)
+    if (!pastControl) {
+      if (trimmed.startsWith('|') || trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('---')) {
+        if (trimmed.startsWith('|')) inTable = true;
+        else if (inTable && !trimmed.startsWith('|')) {
+          inTable = false;
+          pastControl = true;
+        }
+        continue;
+      }
+      pastControl = true;
+    }
+
+    if (pastControl && trimmed) {
+      previewLines.push(trimmed);
+    }
+
+    if (previewLines.join(' ').length >= maxLen) break;
+  }
+
+  return previewLines.join(' ').substring(0, maxLen);
+}
+
+// ── Title extraction ──
+
+function extractTitle(content) {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1].trim() : null;
+}
+
+// ── Artifact scanning ──
+
+function scanProject(projectDir, projectName) {
+  const artifacts = [];
+
+  function scanDir(dir, relPrefix) {
+    if (!isDir(dir)) return;
+    for (const f of listDir(dir)) {
+      const fp = join(dir, f);
+      if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+
+      const content = readText(fp);
+      if (!content) continue;
+
+      const docType = extractDocType(f);
+      const version = extractVersion(f);
+      const fields = extractDocControlFields(content);
+      const title = extractTitle(content) || fields['Document Title'] || f;
+      const reqIds = [...extractRequirementIds(content)];
+      const preview = extractPreview(content);
+      const relPath = relPrefix ? `${relPrefix}/${f}` : f;
+
+      artifacts.push({
+        filename: f,
+        relPath,
+        project: projectName,
+        docType,
+        version,
+        title,
+        status: fields['Status'] || '',
+        owner: fields['Owner'] || fields['Document Owner'] || '',
+        reqIds,
+        preview,
+        controlFields: Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('; '),
+      });
+    }
+  }
+
+  // Root level
+  scanDir(projectDir, null);
+
+  // Subdirectories
+  for (const subdir of ['decisions', 'diagrams', 'wardley-maps', 'data-contracts', 'reviews', 'research']) {
+    scanDir(join(projectDir, subdir), subdir);
+  }
+
+  // Vendor directories
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vendorDir = join(vendorsDir, vendor);
+      if (!isDir(vendorDir)) continue;
+      scanDir(vendorDir, `vendors/${vendor}`);
+      scanDir(join(vendorDir, 'reviews'), `vendors/${vendor}/reviews`);
+    }
+  }
+
+  return artifacts;
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+// Guard: only fire for /arckit:search
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+search\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Search across all project artifacts/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+const query = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Discover and scan all projects
+const allArtifacts = [];
+const projectDirs = listDir(projectsDir)
+  .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+for (const projectName of projectDirs) {
+  const projectDir = join(projectsDir, projectName);
+  const artifacts = scanProject(projectDir, projectName);
+  allArtifacts.push(...artifacts);
+}
+
+// Build output
+const lines = [];
+lines.push('## Search Pre-processor Complete (hook)');
+lines.push('');
+lines.push(`**Indexed ${allArtifacts.length} artifacts across ${projectDirs.length} project(s).**`);
+lines.push('');
+lines.push(`**User query:** ${query || '(no query provided)'}`);
+lines.push('');
+lines.push('### SEARCH INDEX (JSON)');
+lines.push('');
+lines.push('```json');
+lines.push(JSON.stringify(allArtifacts, null, 2));
+lines.push('```');
+lines.push('');
+lines.push('### Instructions');
+lines.push('- Parse the query for keywords, --type=XXX, --project=NNN, --id=XX-NNN filters');
+lines.push('- Score results: title match=10, control fields=5, preview=3, filename=2');
+lines.push('- Output ranked table with top result preview');
+lines.push('- If no results, suggest broadening the search');
+
+const message = lines.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/arckit-codex/README.md
+++ b/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 62 skills (58 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- 63 skills (59 commands + 4 reference skills, auto-discovered by Codex)
 - `.codex/agents/` -- 6 agent configs (research, datascout, cloud providers, framework)
 - `.codex/config.toml` -- MCP servers and agent roles
 - `.arckit/templates/` -- document templates
@@ -58,7 +58,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 58 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes all 59 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -75,7 +75,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 58 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+All 59 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -219,7 +219,7 @@ arckit-codex/
 ├── README.md              # This file
 ├── VERSION                # Extension version (tracks plugin)
 ├── config.toml            # MCP servers + agent configuration
-├── skills/                # 62 skills (58 commands + 4 reference)
+├── skills/                # 63 skills (59 commands + 4 reference)
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
@@ -230,7 +230,7 @@ arckit-codex/
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 58 prompts (deprecated, use skills instead)
+├── prompts/               # 59 prompts (deprecated, use skills instead)
 ├── agents/                # 6 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -243,7 +243,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v3.1.2 (58 commands, 4 reference skills)**
+**Current Release: v3.1.2 (59 commands, 4 reference skills)**
 
 ---
 

--- a/arckit-codex/README.md
+++ b/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 61 skills (57 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- 62 skills (58 commands + 4 reference skills, auto-discovered by Codex)
 - `.codex/agents/` -- 6 agent configs (research, datascout, cloud providers, framework)
 - `.codex/config.toml` -- MCP servers and agent roles
 - `.arckit/templates/` -- document templates
@@ -58,7 +58,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 57 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes all 58 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -75,7 +75,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 57 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+All 58 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -219,7 +219,7 @@ arckit-codex/
 ├── README.md              # This file
 ├── VERSION                # Extension version (tracks plugin)
 ├── config.toml            # MCP servers + agent configuration
-├── skills/                # 61 skills (57 commands + 4 reference)
+├── skills/                # 62 skills (58 commands + 4 reference)
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
@@ -230,7 +230,7 @@ arckit-codex/
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 57 prompts (deprecated, use skills instead)
+├── prompts/               # 58 prompts (deprecated, use skills instead)
 ├── agents/                # 6 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -243,7 +243,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v3.1.2 (57 commands, 4 reference skills)**
+**Current Release: v3.1.2 (58 commands, 4 reference skills)**
 
 ---
 

--- a/arckit-codex/commands/arckit.score.md
+++ b/arckit-codex/commands/arckit.score.md
@@ -1,0 +1,159 @@
+---
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `/arckit:sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-codex/commands/arckit.search.md
+++ b/arckit-codex/commands/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/score.md
+++ b/arckit-codex/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/arckit-codex/docs/guides/search.md
+++ b/arckit-codex/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/prompts/arckit.score.md
+++ b/arckit-codex/prompts/arckit.score.md
@@ -1,0 +1,159 @@
+---
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `/arckit:sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-codex/prompts/arckit.search.md
+++ b/arckit-codex/prompts/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/skills/arckit-score/SKILL.md
+++ b/arckit-codex/skills/arckit-score/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: arckit-score
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `$arckit-evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: $arckit-score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  $arckit-score vendor "Acme Cloud" --project=001
+  $arckit-score compare --project=001
+  $arckit-score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `$arckit-sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-codex/skills/arckit-score/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-score/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-search/SKILL.md
+++ b/arckit-codex/skills/arckit-search/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: arckit-search
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: $arckit-search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     $arckit-search PostgreSQL
+     $arckit-search "data residency" --type=ADR
+     $arckit-search --id=BR-003
+     $arckit-search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `$arckit-traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `$arckit-impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/skills/arckit-search/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-search/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 59 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 57 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 58 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 59 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 58 Commands
+## All 59 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 57 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 58 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 57 Commands
+## All 58 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 59 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 57 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-opencode/commands/arckit.score.md
+++ b/arckit-opencode/commands/arckit.score.md
@@ -1,0 +1,159 @@
+---
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `/arckit:sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-opencode/commands/arckit.search.md
+++ b/arckit-opencode/commands/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/score.md
+++ b/arckit-opencode/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/arckit-opencode/docs/guides/search.md
+++ b/arckit-opencode/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -161,6 +161,9 @@ Most procurement commands require ARC-*-REQ-*.md:
   - Note: Requirements recommended for search context but not mandatory
 - **gcloud-clarify** → Depends on: requirements (M), gcloud-search (M)
 - **evaluate** → Depends on: requirements (M), sow (M), principles (R), research (R), gcloud-clarify (R)
+- **score** → Depends on: evaluate (M), requirements (M)
+  - Note: Structured vendor scoring with JSON storage, comparison, and audit trail
+  - Integrates with evaluate criteria; scores stored in `projects/{id}/vendors/scores.json`
 
 ### Tier 6: Design Reviews (Depends on Design Documents + Requirements)
 
@@ -350,11 +353,21 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 - **ArcKit Version**: 1.5.0
 - **Matrix Date**: 2026-02-25
-- **Commands Documented**: 58
+- **Commands Documented**: 59
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
 - **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-08 - Added Vendor Scoring Command
+
+- **Added**: `/arckit.score` command (59th ArcKit command) for structured vendor scoring with JSON storage, comparison, and audit trail
+- **Added**: score row and column to dependency matrix
+- **Updated**: Tier 5 Procurement to include score command
+- **Dependencies**: evaluate (M), requirements (M)
+- **Consumed by**: sow (O), pages (R)
+- **Updated**: Commands Documented count from 58 to 59
+- **Note**: First command to use structured JSON output instead of Markdown; includes PreToolUse validator hook for scores.json integrity
 
 ### 2026-03-08 - Added Project Search Command
 

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -350,11 +350,18 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 - **ArcKit Version**: 1.5.0
 - **Matrix Date**: 2026-02-25
-- **Commands Documented**: 57
+- **Commands Documented**: 58
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-08 - Added Project Search Command
+
+- **Added**: `/arckit.search` command (58th ArcKit command) for keyword, type, and requirement ID search across all project artifacts
+- **Not in matrix**: Diagnostic/query command with console-only output — no dependencies and no outputs consumed by other commands
+- **Updated**: Commands Documented count from 57 to 58
+- **Note**: Uses UserPromptSubmit pre-processing hook (`search-scan.mjs`) to index artifacts before search
 
 ### 2026-03-08 - Added DFD Command to Matrix
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,8 +202,9 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.framework` | [framework.md](guides/framework.md) | ✅ Complete |
 | `/arckit.glossary` | [glossary.md](guides/glossary.md) | ✅ Complete |
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
+| `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
 
-**Coverage**: 58/58 commands documented (100%)
+**Coverage**: 59/59 commands documented (100%)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,13 +196,14 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.customize` | [customize.md](guides/customize.md) | ✅ Complete |
 | `/arckit.presentation` | [presentation.md](guides/presentation.md) | ✅ Complete |
 | `/arckit.health` | [artifact-health.md](guides/artifact-health.md) | ✅ Complete |
+| `/arckit.search` | [search.md](guides/search.md) | ✅ Complete |
 | `/arckit.start` | [start.md](guides/start.md) | ✅ Complete |
 | `/arckit.template-builder` | [template-builder.md](guides/template-builder.md) | ✅ Complete |
 | `/arckit.framework` | [framework.md](guides/framework.md) | ✅ Complete |
 | `/arckit.glossary` | [glossary.md](guides/glossary.md) | ✅ Complete |
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
 
-**Coverage**: 57/57 commands documented (100%)
+**Coverage**: 58/58 commands documented (100%)
 
 ---
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">58 AI Commands</span>
+            <span class="app-page-hero__stat">59 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">59 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">58</span> of 58 commands
+                Showing <span id="visible-count">59</span> of 59 commands
             </div>
         </div>
 
@@ -951,6 +951,13 @@
                             <a href="https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/ARC-001-EVAL-v1.0.md" title="Patent">v6</a>
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="procurement">
+                        <td><code>/arckit.score</code></td>
+                        <td class="description">Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail</td>
+                        <td>Procurement</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
 
                     <!-- Design & Architecture -->

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">57 AI Commands</span>
+            <span class="app-page-hero__stat">58 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">57 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">57</span> of 57 commands
+                Showing <span id="visible-count">58</span> of 58 commands
             </div>
         </div>
 
@@ -1244,6 +1244,13 @@
                         <td><code>/arckit.health</code></td>
                         <td class="description">Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift</td>
                         <td>Quality & Governance</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="governance">
+                        <td><code>/arckit.search</code></td>
+                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
+                        <td>Quality &amp; Governance</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -377,7 +377,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 58 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 59 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -417,7 +417,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 58 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 59 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -465,7 +465,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 59 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -515,7 +515,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 59 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -577,7 +577,7 @@ opencode</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 58 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 59 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -377,7 +377,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 57 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 58 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -417,7 +417,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 57 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 58 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -465,7 +465,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 57 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -515,7 +515,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 57 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -577,7 +577,7 @@ opencode</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 57 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 58 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/score.md
+++ b/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 59 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "59 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">58</div>
+                    <div class="app-stat-number">59</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">58 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">59 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 58 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 59 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -488,7 +488,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 58 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 59 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 57 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "57 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">57</div>
+                    <div class="app-stat-number">58</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">57 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">58 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 57 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 58 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -488,7 +488,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 57 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 58 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/docs/plans/2026-03-08-pr143-search-completion-design.md
+++ b/docs/plans/2026-03-08-pr143-search-completion-design.md
@@ -1,0 +1,35 @@
+# Design: Make PR 143 (Project Search) Merge-Ready
+
+**Date**: 2026-03-08
+**PR**: #143 — feat: project search command with pre-processing hook
+**Branch**: `feat/project-search`
+
+## Context
+
+PR 143 adds `/arckit:search` — keyword, type, and requirement ID search across all project artifacts. The core implementation (hook, command, guide) is solid and follows established patterns. This design covers the missing deliverables needed to make the PR merge-ready.
+
+## Approach
+
+Check out `feat/project-search`, add missing items per the "Adding a New Slash Command" checklist, commit, push.
+
+## Work Items
+
+1. **Run `scripts/converter.py`** — generates Codex skills, OpenCode commands, and Gemini extension TOML. Converter handles path rewriting and format conversion automatically.
+
+2. **Update `docs/DEPENDENCY-MATRIX.md`** — add `search` row. Search has no hard prerequisites but benefits from existing project artifacts.
+
+3. **Update `docs/index.html`** — add search to the command listing.
+
+4. **Update `README.md`** — bump command count from 57 to 58, add search to the command table.
+
+5. **Update `CHANGELOG.md`** — add entry under next version section.
+
+6. **Copy guide to plugin** — ensure `docs/guides/search.md` is also at `arckit-claude/guides/search.md`.
+
+## Out of Scope
+
+- No changes to `search-scan.mjs` (working, follows patterns)
+- No changes to `search.md` command (well-structured with proper handoffs)
+- No changes to `hooks.json` (correctly registered)
+- No template file needed (search is a query command, doesn't generate documents)
+- `extractPreview` edge case left as-is (matches existing hook patterns)

--- a/docs/plans/2026-03-08-pr143-search-completion-plan.md
+++ b/docs/plans/2026-03-08-pr143-search-completion-plan.md
@@ -1,0 +1,255 @@
+# PR 143 Search Command Completion — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make PR 143 (`feat/project-search`) merge-ready by adding missing deliverables per the "Adding a New Slash Command" checklist.
+
+**Architecture:** The core search implementation (hook, command, guide) is already written and solid. This plan only adds the surrounding documentation, converter output, and plugin guide copy that the checklist requires.
+
+**Tech Stack:** Python (converter), Markdown (docs), HTML (commands.html, index.html), Git
+
+---
+
+### Task 1: Check out the PR branch
+
+**Files:**
+- No file changes
+
+**Step 1: Fetch and check out the branch**
+
+Run: `git fetch origin feat/project-search && git checkout feat/project-search`
+Expected: Branch checked out successfully
+
+**Step 2: Verify PR files exist**
+
+Run: `ls arckit-claude/commands/search.md arckit-claude/hooks/search-scan.mjs docs/guides/search.md`
+Expected: All 3 files listed
+
+---
+
+### Task 2: Copy guide to plugin directory
+
+**Files:**
+- Copy: `docs/guides/search.md` → `arckit-claude/guides/search.md`
+
+**Step 1: Copy the guide**
+
+Run: `cp docs/guides/search.md arckit-claude/guides/search.md`
+Expected: File copied
+
+**Step 2: Verify the copy**
+
+Run: `diff docs/guides/search.md arckit-claude/guides/search.md`
+Expected: No differences
+
+---
+
+### Task 3: Run the converter
+
+**Files:**
+- Generated: `arckit-codex/skills/arckit-search/SKILL.md`
+- Generated: `arckit-opencode/commands/arckit.search.md`
+- Generated: `arckit-gemini/commands/arckit/search.toml`
+- Generated: `.codex/prompts/arckit.search.md` (Codex CLI format)
+- Generated: `.opencode/commands/arckit.search.md` (OpenCode CLI format)
+
+**Step 1: Run converter**
+
+Run: `python scripts/converter.py`
+Expected: Converter runs without errors, outputs summary of converted commands
+
+**Step 2: Verify search files were generated**
+
+Run: `ls arckit-codex/skills/arckit-search/SKILL.md arckit-opencode/commands/arckit.search.md arckit-gemini/commands/arckit/search.toml`
+Expected: All 3 extension files exist
+
+---
+
+### Task 4: Update DEPENDENCY-MATRIX.md
+
+**Files:**
+- Modify: `docs/DEPENDENCY-MATRIX.md`
+
+Search is a **diagnostic/utility command** — it queries existing artifacts but produces no output consumed by other commands. It has no mandatory dependencies. Per the existing pattern (health, customize, template-builder, start, init), it should NOT be added to the DSM table but noted in the utility exclusion list.
+
+**Step 1: Update the Version section**
+
+In `docs/DEPENDENCY-MATRIX.md`, update:
+
+```markdown
+- **Commands Documented**: 57
+```
+
+to:
+
+```markdown
+- **Commands Documented**: 58
+```
+
+**Step 2: Add search to the utility command exclusion note**
+
+Update the note at line ~355:
+
+```markdown
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+```
+
+to:
+
+```markdown
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+```
+
+**Step 3: Add changelog entry**
+
+Add to the Changelog section at the top (after the DFD entry):
+
+```markdown
+### 2026-03-08 - Added Project Search Command
+
+- **Added**: `/arckit.search` command (58th ArcKit command) for keyword, type, and requirement ID search across all project artifacts
+- **Not in matrix**: Diagnostic/query command with console-only output — no dependencies and no outputs consumed by other commands
+- **Updated**: Commands Documented count from 57 to 58
+- **Note**: Uses UserPromptSubmit pre-processing hook (`search-scan.mjs`) to index artifacts before search
+```
+
+---
+
+### Task 5: Update README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Bump command count**
+
+Find all instances of "57 commands" or "57 " (in context of command counts) and update to 58. Key locations:
+
+- Line 43: `all 57 commands` → `all 58 commands`
+- Any other "57" references in the command count context
+
+**Step 2: Add search to the Quality & Governance command table**
+
+In the Quality & Governance table (around line 1016, after the `/arckit.health` row), add:
+
+```markdown
+| `/arckit.search` | Search across all project artifacts by keyword, document type, or requirement ID | — | 🔵 Beta |
+```
+
+---
+
+### Task 6: Update docs/commands.html
+
+**Files:**
+- Modify: `docs/commands.html`
+
+**Step 1: Bump command count in heading**
+
+Update line ~515:
+
+```html
+<h2 class="govuk-heading-l">57 ArcKit AI Commands</h2>
+```
+
+to:
+
+```html
+<h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
+```
+
+**Step 2: Add search command row**
+
+In the Diagnostics section (after the `/arckit.health` row, around line 1247), add:
+
+```html
+                    <tr data-status="beta" data-category="governance">
+                        <td><code>/arckit.search</code></td>
+                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
+                        <td>Quality & Governance</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+```
+
+---
+
+### Task 7: Update docs/index.html
+
+**Files:**
+- Modify: `docs/index.html`
+
+**Step 1: Bump command count**
+
+Update all "57" references in meta descriptions and content to "58":
+
+- Line 7: `meta name="description"` — `57 AI-assisted commands` → `58 AI-assisted commands`
+- Line 11: `og:description` — same change
+- Line 18: `twitter:description` — same change
+- Line 315: JSON-LD description — same change
+- Line 392: body text — `57 AI-assisted commands` → `58 AI-assisted commands`
+
+---
+
+### Task 8: Update CHANGELOG.md
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Step 1: Add entry under [Unreleased]**
+
+After the `## [Unreleased]` heading (line 8), add:
+
+```markdown
+
+### Added
+
+- `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+```
+
+---
+
+### Task 9: Commit and push
+
+**Files:**
+- No new files
+
+**Step 1: Stage all changes**
+
+Run: `git add arckit-claude/guides/search.md arckit-codex/ arckit-opencode/ arckit-gemini/ .codex/ .opencode/ docs/DEPENDENCY-MATRIX.md docs/commands.html docs/index.html README.md CHANGELOG.md`
+Expected: Files staged
+
+**Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: complete search command deliverables for merge readiness
+
+- Run converter to generate Codex/OpenCode/Gemini extension formats
+- Copy guide to plugin directory (arckit-claude/guides/)
+- Update DEPENDENCY-MATRIX.md (58 commands, utility exclusion note)
+- Update README.md (command count, Quality & Governance table)
+- Update commands.html and index.html (command count, table row)
+- Update CHANGELOG.md with search command entry
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Step 3: Push**
+
+Run: `git push origin feat/project-search`
+Expected: Push succeeds
+
+---
+
+### Task 10: Verify
+
+**Step 1: Confirm PR is updated**
+
+Run: `gh pr view 143 --json commits --jq '.commits | length'`
+Expected: 2 (original + our commit)
+
+**Step 2: Run markdownlint on changed files**
+
+Run: `npx markdownlint-cli2 "docs/DEPENDENCY-MATRIX.md" "CHANGELOG.md" "README.md"`
+Expected: No errors

--- a/docs/plans/2026-03-08-pr145-vendor-scoring-design.md
+++ b/docs/plans/2026-03-08-pr145-vendor-scoring-design.md
@@ -1,0 +1,38 @@
+# Design: Make PR 145 (Vendor Scoring) Merge-Ready
+
+**Date**: 2026-03-08
+**PR**: #145 — feat: vendor scoring with structured storage and audit trail
+**Branch**: `feat/vendor-scoring` (based on `feat/project-search` for 58→59 count)
+
+## Context
+
+PR 145 adds `/arckit:score` — vendor scoring with structured JSON storage, side-by-side comparison, sensitivity analysis, and audit trail. Includes a PreToolUse validator hook for scores.json integrity. Core code is solid; needs code fixes from review and missing deliverables.
+
+## Code Fixes
+
+1. **`score-validator.mjs`**: Replace manual stdin parsing (lines 22-38) with `parseHookInput()` from `hook-utils.mjs`
+2. **`score-validator.mjs`**: Add `evidence` non-empty validation — warn if empty string, don't block
+3. **`hooks.json`**: Merge score-validator into existing `"matcher": "Write"` PreToolUse block (line 75) instead of creating a duplicate matcher block
+
+## Missing Deliverables
+
+4. **Run `scripts/converter.py`** — generate Codex skills, OpenCode commands, Gemini TOML
+5. **Copy guide** — `docs/guides/score.md` → `arckit-claude/docs/guides/score.md`
+6. **Update `docs/DEPENDENCY-MATRIX.md`**:
+   - Add `score` row and column to DSM (Tier 5 Procurement)
+   - Dependencies: evaluate (M), requirements (M)
+   - Consumed by: sow (O), pages (R)
+   - Update count 58→59
+   - Add changelog entry
+7. **Update `README.md`** — count 58→59, add score to Procurement table
+8. **Update `docs/commands.html`** — count 58→59, add table row
+9. **Update `docs/index.html`** — count 58→59 in meta descriptions
+10. **Update `CHANGELOG.md`** — add entry under [Unreleased]
+11. **Update all extension/plugin/guide 58→59** (same sweep as PR 146)
+12. **Update `CLAUDE.md`** — count 58→59
+
+## Out of Scope
+
+- No changes to `score.md` command (well-structured)
+- No template file (outputs JSON, not markdown)
+- Guide content unchanged (clear with good examples)

--- a/docs/plans/2026-03-08-pr145-vendor-scoring-plan.md
+++ b/docs/plans/2026-03-08-pr145-vendor-scoring-plan.md
@@ -1,0 +1,312 @@
+# PR 145 Vendor Scoring Completion — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make PR 145 (`feat/vendor-scoring`) merge-ready by fixing review issues and adding missing deliverables.
+
+**Architecture:** Cherry-pick PR 145's commit onto `feat/project-search` (which has 58 commands), fix code issues in score-validator.mjs, fix hooks.json structure, then add all missing documentation and converter output for 58→59 count.
+
+**Tech Stack:** Node.js/ESM (hook fixes), Python (converter), Markdown/HTML (docs), Git
+
+---
+
+### Task 1: Create branch and cherry-pick PR 145
+
+**Files:**
+- No file changes
+
+**Step 1: Create branch from feat/project-search**
+
+Run: `git checkout feat/project-search && git checkout -b feat/vendor-scoring`
+Expected: New branch created
+
+**Step 2: Cherry-pick PR 145's commit**
+
+Run: `gh pr view 145 --json commits --jq '.commits[0].oid'`
+Then: `git fetch origin pull/145/head:pr-145-temp && git cherry-pick <SHA>`
+Expected: Commit applied (may need conflict resolution on hooks.json)
+
+**Step 3: If hooks.json conflicts, resolve**
+
+Our `feat/project-search` branch already has the search hook entry. The PR 145 diff adds a new Write matcher block under PreToolUse. Take both changes, but we'll restructure the hooks.json in the next task.
+
+---
+
+### Task 2: Fix score-validator.mjs — use parseHookInput()
+
+**Files:**
+- Modify: `arckit-claude/hooks/score-validator.mjs`
+
+**Step 1: Replace manual stdin parsing with parseHookInput()**
+
+Replace lines 18-38 (the manual stdin read + JSON parse) with:
+
+```javascript
+import { basename } from 'node:path';
+import { isDir, isFile, parseHookInput } from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+const data = parseHookInput();
+```
+
+Remove the `import { readFileSync } from 'node:fs';` line since `parseHookInput()` handles it.
+
+**Step 2: Add evidence non-empty validation**
+
+In the vendor scores validation loop (after the score range check), add:
+
+```javascript
+      if (!s.evidence || !s.evidence.trim()) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: missing evidence (every score must cite supporting evidence)`);
+      }
+```
+
+**Step 3: Verify ESM imports work**
+
+Run: `node -e "import('./arckit-claude/hooks/score-validator.mjs')" 2>&1 || echo "Import check done"`
+Expected: No syntax errors
+
+---
+
+### Task 3: Fix hooks.json — merge into existing Write block
+
+**Files:**
+- Modify: `arckit-claude/hooks/hooks.json`
+
+**Step 1: Remove the duplicate Write matcher block**
+
+PR 145 adds a separate `"matcher": "Write"` block under PreToolUse. Instead, add `score-validator.mjs` to the **existing** `"matcher": "Write"` block (the one with `validate-arc-filename.mjs`).
+
+The existing PreToolUse Write block should become:
+
+```json
+{
+  "matcher": "Write",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-arc-filename.mjs",
+      "timeout": 5
+    },
+    {
+      "type": "command",
+      "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+Remove the duplicate standalone Write matcher block that PR 145 added.
+
+**Step 2: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('arckit-claude/hooks/hooks.json','utf8')); console.log('Valid JSON')"`
+Expected: "Valid JSON"
+
+---
+
+### Task 4: Copy guide to plugin directory
+
+**Files:**
+- Copy: `docs/guides/score.md` → `arckit-claude/docs/guides/score.md`
+
+**Step 1: Copy and verify**
+
+Run: `cp docs/guides/score.md arckit-claude/docs/guides/score.md && diff docs/guides/score.md arckit-claude/docs/guides/score.md`
+Expected: No differences
+
+---
+
+### Task 5: Run converter
+
+**Files:**
+- Generated: `arckit-codex/skills/arckit-score/SKILL.md` (and agents/openai.yaml)
+- Generated: `arckit-opencode/commands/arckit.score.md`
+- Generated: `arckit-gemini/commands/arckit/score.toml`
+
+**Step 1: Run converter**
+
+Run: `python scripts/converter.py`
+Expected: Converter runs without errors
+
+**Step 2: Verify score files generated**
+
+Run: `ls arckit-codex/skills/arckit-score/SKILL.md arckit-opencode/commands/arckit.score.md arckit-gemini/commands/arckit/score.toml`
+Expected: All 3 exist
+
+---
+
+### Task 6: Update all documentation (58→59)
+
+**Files:**
+- Modify: `docs/DEPENDENCY-MATRIX.md`
+- Modify: `README.md`
+- Modify: `docs/commands.html`
+- Modify: `docs/index.html`
+- Modify: `docs/README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `CLAUDE.md`
+- Modify: All extension/plugin/guide files with "58" command counts
+
+**Step 1: DEPENDENCY-MATRIX.md**
+
+a) Update "Commands Documented: 58" → "Commands Documented: 59"
+
+b) Add score to the Tier 5 Procurement section description:
+```markdown
+- **score** → Depends on: evaluate (M), requirements (M)
+  - Note: Structured vendor scoring with JSON storage, comparison, and audit trail
+  - Integrates with evaluate criteria; scores stored in `projects/{id}/vendors/scores.json`
+```
+
+c) Add changelog entry at top of Changelog section:
+```markdown
+### 2026-03-08 - Added Vendor Scoring Command
+
+- **Added**: `/arckit.score` command (59th ArcKit command) for structured vendor scoring with JSON storage, comparison, and audit trail
+- **Added**: score row and column to dependency matrix
+- **Updated**: Tier 5 Procurement to include score command
+- **Dependencies**: evaluate (M), requirements (M)
+- **Consumed by**: sow (O), pages (R)
+- **Updated**: Commands Documented count from 58 to 59
+- **Note**: First command to use structured JSON output instead of Markdown; includes PreToolUse validator hook for scores.json integrity
+```
+
+**Step 2: README.md**
+
+a) Update all "58" command count references to "59"
+
+b) Add score row to Procurement table (after `/arckit.evaluate`):
+```markdown
+| `/arckit.score` | Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail | — | 🔵 Beta |
+```
+
+**Step 3: docs/commands.html**
+
+a) Update "58 ArcKit AI Commands" → "59 ArcKit AI Commands" in heading and all meta/count references
+
+b) Add score row in Procurement section (after evaluate row):
+```html
+                    <tr data-status="beta" data-category="procurement">
+                        <td><code>/arckit.score</code></td>
+                        <td class="description">Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail</td>
+                        <td>Procurement</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+```
+
+**Step 4: docs/index.html**
+
+Update all "58" meta description and body text references to "59"
+
+**Step 5: docs/README.md**
+
+a) Add to documentation coverage table:
+```markdown
+| `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
+```
+
+b) Update "58/58 commands documented" → "59/59 commands documented"
+
+**Step 6: CHANGELOG.md**
+
+Add under [Unreleased] → Added:
+```markdown
+- `/arckit.score` command for structured vendor scoring with JSON storage, comparison, sensitivity analysis, and audit trail
+```
+
+**Step 7: CLAUDE.md**
+
+Update "58 slash commands" → "59 slash commands"
+
+**Step 8: Sweep all "58" command count references to "59"**
+
+Same pattern as PR 146's sweep — update all extension READMEs, plugin files, guides, marketplace.json, getting-started.html, etc.
+
+---
+
+### Task 7: Commit and push
+
+**Step 1: Stage all changes**
+
+Run: `git add -A` (then verify no sensitive files with `git diff --cached --name-only`)
+
+**Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: vendor scoring with structured storage and audit trail
+
+Cherry-picked from PR #145 with fixes:
+- Use parseHookInput() instead of manual stdin parsing
+- Add evidence non-empty validation to score-validator
+- Merge score-validator into existing Write matcher block (not duplicate)
+- Run converter for Codex/OpenCode/Gemini extension formats
+- Copy guide to plugin directory
+- Update DEPENDENCY-MATRIX.md (59 commands, Tier 5 Procurement entry)
+- Update all docs and command counts (58→59)
+- Add CHANGELOG entry
+
+Supersedes #145.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Step 3: Push**
+
+Run: `git push -u origin feat/vendor-scoring`
+
+---
+
+### Task 8: Create PR and verify
+
+**Step 1: Create PR**
+
+```bash
+gh pr create --base main --head feat/vendor-scoring --title "feat: vendor scoring with structured storage and audit trail" --body "$(cat <<'EOF'
+## Summary
+
+Adds `/arckit:score` for persistent, auditable vendor scoring — completing the procurement workflow chain (`evaluate → score → compare → sow`).
+
+Cherry-picked from #145 with code fixes and complete documentation.
+
+### Code fixes from review
+- Use `parseHookInput()` from hook-utils.mjs (consistent with all other hooks)
+- Add `evidence` non-empty validation to score-validator
+- Merge score-validator into existing Write matcher block (was duplicate)
+
+### Deliverables added
+- Converter output for Codex/OpenCode/Gemini extensions
+- Guide copied to plugin directory
+- DEPENDENCY-MATRIX entry (Tier 5 Procurement, depends on evaluate (M))
+- Command counts 58→59 across all docs, extensions, and manifests
+- CHANGELOG entry
+
+Supersedes #145 (fork PR).
+
+## Test plan
+
+- [ ] JSON validation of hooks.json
+- [ ] ESM import validation of score-validator.mjs
+- [ ] Score a vendor and verify scores.json structure
+- [ ] Compare sub-action with 2+ vendors
+- [ ] Validator catches out-of-range scores and missing evidence
+- [ ] Converter output validates
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 2: Comment on PR 145**
+
+Run: `gh pr comment 145 --body "Superseded by #<NEW_PR> ..."`
+
+**Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 "docs/DEPENDENCY-MATRIX.md" "CHANGELOG.md" "README.md" "docs/README.md"`
+Expected: 0 errors

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -401,7 +401,7 @@ python scripts/converter.py
 #   Codex Skills: arckit-claude/commands/plan.md -> arckit-codex/skills/arckit-plan/
 #   Gemini:       arckit-claude/commands/plan.md -> arckit-gemini/commands/arckit/plan.toml
 #   ...
-# Generated 58 Codex CLI + 58 Codex Skills + 58 OpenCode + 58 Gemini = 290 total files.
+# Generated 59 Codex CLI + 59 Codex Skills + 59 OpenCode + 59 Gemini = 295 total files.
 ```
 
 **Use Cases**:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -401,7 +401,7 @@ python scripts/converter.py
 #   Codex Skills: arckit-claude/commands/plan.md -> arckit-codex/skills/arckit-plan/
 #   Gemini:       arckit-claude/commands/plan.md -> arckit-gemini/commands/arckit/plan.toml
 #   ...
-# Generated 57 Codex CLI + 57 Codex Skills + 57 OpenCode + 57 Gemini = 285 total files.
+# Generated 58 Codex CLI + 58 Codex Skills + 58 OpenCode + 58 Gemini = 290 total files.
 ```
 
 **Use Cases**:


### PR DESCRIPTION
## Summary

Adds `/arckit:score` for persistent, auditable vendor scoring — completing the procurement workflow chain (`evaluate → score → compare → sow`).

Cherry-picked from #145 with code fixes and complete documentation.

### Code fixes from review
- Use `parseHookInput()` from hook-utils.mjs (consistent with all other hooks)
- Add `evidence` non-empty validation to score-validator
- Merge score-validator into existing Write matcher block (was creating a duplicate)

### Deliverables added
- Converter output for Codex/OpenCode/Gemini extensions
- Guide copied to plugin directory
- DEPENDENCY-MATRIX entry (Tier 5 Procurement, depends on evaluate (M), requirements (M))
- Command counts 58→59 across all docs, extensions, and manifests
- CHANGELOG entry

Supersedes #145 (fork PR). Depends on #146 (search command) merging first.

## Test plan

- [ ] JSON validation of hooks.json
- [ ] ESM import validation of score-validator.mjs
- [ ] Score a vendor and verify scores.json structure
- [ ] Compare sub-action with 2+ vendors
- [ ] Validator catches out-of-range scores and missing evidence
- [ ] Converter output validates for Codex/OpenCode/Gemini

🤖 Generated with [Claude Code](https://claude.com/claude-code)