### PR TITLE
feat: search command + vendor scoring (daily 2026-03-08)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "58 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "59 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.0.2",
       "author": {
         "name": "TractorJuice"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "59 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "60 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.0.2",
       "author": {
         "name": "TractorJuice"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "57 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "58 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.0.2",
       "author": {
         "name": "TractorJuice"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+- `/arckit.score` command for structured vendor scoring with JSON storage, comparison, sensitivity analysis, and audit trail
 
 ## [4.0.2] - 2026-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+
 ## [4.0.2] - 2026-03-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
 - `/arckit.score` command for structured vendor scoring with JSON storage, comparison, sensitivity analysis, and audit trail
+- `/arckit.impact` command for blast radius analysis and reverse dependency tracing
 
 ## [4.0.2] - 2026-03-08
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 59 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Five distribution formats** exist side-by-side in this repo:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 57 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Five distribution formats** exist side-by-side in this repo:
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 59 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 60 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Five distribution formats** exist side-by-side in this repo:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 58 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 59 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 58 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 59 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -760,7 +760,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Codex / OpenCode |
 |---------|:-----------:|:----------:|:----------------:|
-| 58 slash commands | ✅ | ✅ | ✅ |
+| 59 slash commands | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | — |
@@ -887,7 +887,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 58 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 59 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -982,6 +982,7 @@ These commands use [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | `/arckit.gcloud-search` | Find G-Cloud services on UK Digital Marketplace with live search and comparison | [v3](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-GCLD-v1.0.md) [v14](https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-GCLD-v1.0.md) | 🟣 Experimental |
 | `/arckit.gcloud-clarify` | Analyze G-Cloud service gaps and generate supplier clarification questions | — | 🟣 Experimental |
 | `/arckit.evaluate` | Create vendor evaluation framework and score vendor proposals | [v1](https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/ARC-001-EVAL-v1.0.md) [v2](https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-EVAL-v1.0.md) [v3/001](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-EVAL-v1.0.md) [v3/002](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-EVAL-v1.0.md) [v3/003](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/003-peripherals-update-upgrade/ARC-003-EVAL-v1.0.md) [v3/005](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/005-cloud-pki/ARC-005-EVAL-v1.0.md) [v6](https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/ARC-001-EVAL-v1.0.md) | 🟢 Live |
+| `/arckit.score` | Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail | — | 🔵 Beta |
 
 ### Design & Architecture
 
@@ -1155,7 +1156,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 58×58 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 59×59 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 57 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 58 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 57 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 58 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -760,7 +760,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Codex / OpenCode |
 |---------|:-----------:|:----------:|:----------------:|
-| 57 slash commands | ✅ | ✅ | ✅ |
+| 58 slash commands | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | — |
@@ -887,7 +887,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 57 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 58 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -1014,6 +1014,7 @@ These commands use [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | `/arckit.presentation` | Generate MARP slide deck from project artifacts for governance boards and stakeholder briefings | — | 🔵 Beta |
 | `/arckit.conformance` | Assess architecture conformance — ADR decision implementation, cross-decision consistency, architecture drift, technical debt, and custom constraint rules | — | 🔵 Beta |
 | `/arckit.health` | Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift | — | 🔵 Beta |
+| `/arckit.search` | Search across all project artifacts by keyword, document type, or requirement ID | — | 🔵 Beta |
 | `/arckit.customize` | Copy templates to `.arckit/templates-custom/` for customization (preserved across updates) | — | 🟢 Live |
 | `/arckit.maturity-model` | Generate capability maturity model with current-state assessment, target-state definition, and improvement roadmap | — | 🔵 Beta |
 | `/arckit.template-builder` | Create new document templates through interactive interview — generates community-origin templates, guides, and optional shareable bundles | — | 🟠 Alpha |
@@ -1154,7 +1155,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 57×57 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 58×58 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 59 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 60 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 59 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 60 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -760,7 +760,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Codex / OpenCode |
 |---------|:-----------:|:----------:|:----------------:|
-| 59 slash commands | ✅ | ✅ | ✅ |
+| 60 slash commands | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | — |
@@ -887,7 +887,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 59 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 60 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -1015,6 +1015,7 @@ These commands use [Model Context Protocol (MCP)](https://modelcontextprotocol.i
 | `/arckit.presentation` | Generate MARP slide deck from project artifacts for governance boards and stakeholder briefings | — | 🔵 Beta |
 | `/arckit.conformance` | Assess architecture conformance — ADR decision implementation, cross-decision consistency, architecture drift, technical debt, and custom constraint rules | — | 🔵 Beta |
 | `/arckit.health` | Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift | — | 🔵 Beta |
+| `/arckit.impact` | Analyse blast radius of changes — reverse dependency tracing | — | 🟣 Experimental |
 | `/arckit.search` | Search across all project artifacts by keyword, document type, or requirement ID | — | 🔵 Beta |
 | `/arckit.customize` | Copy templates to `.arckit/templates-custom/` for customization (preserved across updates) | — | 🟢 Live |
 | `/arckit.maturity-model` | Generate capability maturity model with current-state assessment, target-state definition, and improvement roadmap | — | 🔵 Beta |
@@ -1156,7 +1157,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 59×59 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 60×60 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 59 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 59 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 60 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 57 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/arckit.impact` command for blast radius analysis and reverse dependency tracing
+- `impact-scan.mjs` hook for dependency graph pre-processing
+
 ## [4.0.2] - 2026-03-08
 
 ### Added

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 58 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 59 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 58 | Slash commands for architecture artifacts |
+| Commands | 59 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 59 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 60 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 59 | Slash commands for architecture artifacts |
+| Commands | 60 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 57 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 58 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 57 | Slash commands for architecture artifacts |
+| Commands | 58 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/commands-standalone/pages.md
+++ b/arckit-claude/commands-standalone/pages.md
@@ -1,0 +1,568 @@
+---
+description: Generate documentation site with governance dashboard, document viewer, and Mermaid diagram support
+allowed-tools: Read, Write, Glob, Grep
+argument-hint: "<project ID or 'all', e.g. '001', 'all'>"
+---
+
+# ArcKit: Documentation Site Generator
+
+You are an expert web developer helping generate a documentation site that displays all ArcKit project documents with full Mermaid diagram rendering support.
+
+## What is the Pages Generator?
+
+The Pages Generator creates a `docs/index.html` file that:
+
+- **Dashboard** with KPI cards, donut charts, coverage bars, and governance checklist
+- **Displays** all ArcKit artifacts in a navigable web interface
+- **Renders** Mermaid diagrams inline
+- **Organizes** documents by project with sidebar navigation
+- **Follows** GOV.UK Design System styling
+- **Works** with any static hosting provider (GitHub Pages, Netlify, Vercel, S3, etc.)
+
+## Your Task
+
+**User Request**: $ARGUMENTS
+
+Generate a documentation site for this ArcKit repository.
+
+## Step 0: Determine Repository Info
+
+Determine the repository name and URL:
+
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
+
+## Step 1: Discover Repository Structure
+
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
+
+### 1.1 Guides (Command Documentation)
+
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `${CLAUDE_PLUGIN_ROOT}/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
+
+**Guide Categories** (based on filename):
+
+| Category | Guide Files |
+|----------|-------------|
+| Discovery | requirements, stakeholders, stakeholder-analysis, research, datascout |
+| Planning | sobc, business-case, plan, roadmap, backlog, strategy |
+| Architecture | principles, adr, diagram, wardley, data-model, hld-review, dld-review, design-review, platform-design, data-mesh-contract, c4-layout-science |
+| Governance | risk, risk-management, traceability, principles-compliance, analyze, artifact-health, data-quality-framework, knowledge-compounding |
+| Compliance | tcop, secure, mod-secure, dpia, ai-playbook, atrs, jsp-936, service-assessment, govs-007-security, national-data-strategy, codes-of-practice, security-hooks |
+| Operations | devops, mlops, finops, servicenow, operationalize |
+| Procurement | sow, evaluate, dos, gcloud-search, gcloud-clarify, procurement |
+| Research | aws-research, azure-research, gcp-research |
+| Other | pages, story, presentation, trello, migration, customize, upgrading, pinecone-mcp, start, conformance, productivity, remote-control, mcp-servers |
+
+**DDaT Role Guides** (in `docs/guides/roles/`):
+
+Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles. These are stored separately from command guides.
+
+| DDaT Family | Role Guide Files |
+|-------------|-----------------|
+| Architecture | enterprise-architect, solution-architect, data-architect, security-architect, business-architect, technical-architect, network-architect |
+| Chief Digital and Data | cto-cdio, cdo, ciso |
+| Product and Delivery | product-manager, delivery-manager, business-analyst, service-owner |
+| Data | data-governance-manager, performance-analyst |
+| IT Operations | it-service-manager |
+| Software Development | devops-engineer |
+
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
+
+**Role guide commandCount reference**:
+
+| File | commandCount |
+|------|-------------|
+| enterprise-architect | 12 |
+| solution-architect | 10 |
+| data-architect | 4 |
+| security-architect | 5 |
+| business-architect | 5 |
+| technical-architect | 5 |
+| network-architect | 3 |
+| cto-cdio | 5 |
+| cdo | 4 |
+| ciso | 5 |
+| product-manager | 5 |
+| delivery-manager | 6 |
+| business-analyst | 4 |
+| service-owner | 3 |
+| data-governance-manager | 4 |
+| performance-analyst | 4 |
+| it-service-manager | 3 |
+| devops-engineer | 3 |
+
+**Guide Status** (from README command maturity):
+
+| Status | Description | Guide Files |
+|--------|-------------|-------------|
+| live | Production-ready | plan, principles, stakeholders, stakeholder-analysis, risk, sobc, requirements, data-model, diagram, traceability, principles-compliance, story, sow, evaluate, customize, risk-management, business-case |
+| beta | Feature-complete | dpia, research, strategy, roadmap, adr, hld-review, dld-review, backlog, servicenow, analyze, service-assessment, tcop, secure, presentation, artifact-health, design-review, procurement, knowledge-compounding, c4-layout-science, security-hooks, codes-of-practice, data-quality-framework, govs-007-security, national-data-strategy, upgrading, start, conformance, productivity, remote-control, mcp-servers |
+| alpha | Working, limited testing | data-mesh-contract, ai-playbook, atrs, pages |
+| experimental | Early adopters | platform-design, wardley, azure-research, aws-research, gcp-research, datascout, dos, gcloud-search, gcloud-clarify, trello, devops, mlops, finops, operationalize, mod-secure, jsp-936, migration, pinecone-mcp |
+
+### 1.2 Global Documents
+
+Use **Glob** to check `projects/000-global/` for global artifacts:
+
+```text
+projects/000-global/
+├── ARC-000-PRIN-v1.0.md    # Architecture Principles (global)
+├── policies/                # Governance policies
+│   └── *.pdf, *.docx, *.md
+├── external/                # Enterprise-wide reference documents
+│   └── *.pdf, *.docx, *.md
+└── {other global documents}
+```
+
+### 1.3 Project Documents
+
+Use **Glob** to check `projects/` for all project folders. Documents use standardized naming: `ARC-{PROJECT_ID}-{TYPE}-v{VERSION}.md`
+
+```text
+projects/
+├── 001-{project-name}/
+│   ├── # Core Documents (ARC-001-{TYPE}-v1.0.md pattern)
+│   ├── ARC-001-REQ-v1.0.md      # Requirements
+│   ├── ARC-001-STKE-v1.0.md     # Stakeholder Drivers
+│   ├── ARC-001-RISK-v1.0.md     # Risk Register
+│   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
+│   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
+│   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
+│   ├── ARC-001-SOW-v1.0.md      # Statement of Work
+│   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
+│   ├── ARC-001-BKLG-v1.0.md     # Product Backlog
+│   ├── ARC-001-PLAN-v1.0.md     # Project Plan
+│   ├── ARC-001-ROAD-v1.0.md     # Roadmap
+│   ├── ARC-001-STRAT-v1.0.md    # Architecture Strategy
+│   ├── ARC-001-DPIA-v1.0.md     # DPIA
+│   ├── ARC-001-SNOW-v1.0.md     # ServiceNow Design
+│   ├── ARC-001-DEVOPS-v1.0.md   # DevOps Strategy
+│   ├── ARC-001-MLOPS-v1.0.md    # MLOps Strategy
+│   ├── ARC-001-FINOPS-v1.0.md   # FinOps Strategy
+│   ├── ARC-001-OPS-v1.0.md      # Operational Readiness
+│   ├── ARC-001-TCOP-v1.0.md     # TCoP Review
+│   ├── ARC-001-SECD-v1.0.md     # Secure by Design
+│   ├── ARC-001-SECD-MOD-v1.0.md # MOD Secure by Design
+│   ├── ARC-001-AIPB-v1.0.md     # AI Playbook Assessment
+│   ├── ARC-001-ATRS-v1.0.md     # ATRS Record
+│   ├── ARC-001-PRIN-COMP-v1.0.md # Principles Compliance
+│   │
+│   ├── # Multi-instance Documents (subdirectories)
+│   ├── diagrams/
+│   │   └── ARC-001-DIAG-{NNN}-v1.0.md  # Diagrams
+│   ├── decisions/
+│   │   └── ARC-001-ADR-{NNN}-v1.0.md   # ADRs
+│   ├── wardley-maps/
+│   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
+│   ├── data-contracts/
+│   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
+│   ├── reviews/
+│   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
+│   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
+│   ├── vendors/
+│   │   ├── {vendor-slug}-profile.md      # Vendor profiles (flat)
+│   │   └── {vendor-name}/               # Vendor documents (nested)
+│   │       ├── hld*.md
+│   │       ├── dld*.md
+│   │       └── proposal*.md
+│   ├── tech-notes/                       # Tech notes
+│   │   └── {topic-slug}.md
+│   └── external/
+│       ├── README.md             # (excluded from listing)
+│       ├── rfp-document.pdf
+│       └── legacy-spec.docx
+├── 002-{another-project}/
+│   └── ...
+└── ...
+```
+
+### 1.3 Known ArcKit Artifact Types
+
+Only include these known artifact types. Match by type code pattern `ARC-{PID}-{TYPE}-*.md`:
+
+| Category | Type Code | Pattern | Display Name |
+|----------|-----------|---------|--------------|
+| **Discovery** | | | |
+| | REQ | `ARC-*-REQ-*.md` | Requirements |
+| | STKE | `ARC-*-STKE-*.md` | Stakeholder Drivers |
+| | RSCH | `ARC-*-RSCH-*.md` | Research Findings |
+| **Planning** | | | |
+| | SOBC | `ARC-*-SOBC-*.md` | Strategic Outline Business Case |
+| | PLAN | `ARC-*-PLAN-*.md` | Project Plan |
+| | ROAD | `ARC-*-ROAD-*.md` | Roadmap |
+| | STRAT | `ARC-*-STRAT-*.md` | Architecture Strategy |
+| | BKLG | `ARC-*-BKLG-*.md` | Product Backlog |
+| **Architecture** | | | |
+| | PRIN | `ARC-*-PRIN-*.md` | Architecture Principles |
+| | HLDR | `ARC-*-HLDR-*.md` | High-Level Design Review |
+| | DLDR | `ARC-*-DLDR-*.md` | Detailed Design Review |
+| | DATA | `ARC-*-DATA-*.md` | Data Model |
+| | WARD | `ARC-*-WARD-*.md` | Wardley Map |
+| | DIAG | `ARC-*-DIAG-*.md` | Architecture Diagrams |
+| | ADR | `ARC-*-ADR-*.md` | Architecture Decision Records |
+| **Governance** | | | |
+| | RISK | `ARC-*-RISK-*.md` | Risk Register |
+| | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
+| | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
+| **Compliance** | | | |
+| | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
+| | SECD | `ARC-*-SECD-*.md` | Secure by Design |
+| | SECD-MOD | `ARC-*-SECD-MOD-*.md` | MOD Secure by Design |
+| | AIPB | `ARC-*-AIPB-*.md` | AI Playbook Assessment |
+| | ATRS | `ARC-*-ATRS-*.md` | ATRS Record |
+| | DPIA | `ARC-*-DPIA-*.md` | Data Protection Impact Assessment |
+| | JSP936 | `ARC-*-JSP936-*.md` | JSP 936 Assessment |
+| | SVCASS | `ARC-*-SVCASS-*.md` | Service Assessment |
+| **Operations** | | | |
+| | SNOW | `ARC-*-SNOW-*.md` | ServiceNow Design |
+| | DEVOPS | `ARC-*-DEVOPS-*.md` | DevOps Strategy |
+| | MLOPS | `ARC-*-MLOPS-*.md` | MLOps Strategy |
+| | FINOPS | `ARC-*-FINOPS-*.md` | FinOps Strategy |
+| | OPS | `ARC-*-OPS-*.md` | Operational Readiness |
+| | PLAT | `ARC-*-PLAT-*.md` | Platform Design |
+| **Procurement** | | | |
+| | SOW | `ARC-*-SOW-*.md` | Statement of Work |
+| | EVAL | `ARC-*-EVAL-*.md` | Evaluation Criteria |
+| | DOS | `ARC-*-DOS-*.md` | DOS Requirements |
+| | GCLD | `ARC-*-GCLD-*.md` | G-Cloud Search |
+| | GCLC | `ARC-*-GCLC-*.md` | G-Cloud Clarifications |
+| | DMC | `ARC-*-DMC-*.md` | Data Mesh Contract |
+| | | `vendors/*/*.md` | Vendor Documents |
+| **Research** | | | |
+| | AWRS | `ARC-*-AWRS-*.md` | AWS Research |
+| | AZRS | `ARC-*-AZRS-*.md` | Azure Research |
+| | GCRS | `ARC-*-GCRS-*.md` | GCP Research |
+| | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
+| **Other** | | | |
+| | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
+
+## Step 2: Generate manifest.json
+
+Create `docs/manifest.json` with the discovered structure:
+
+```json
+{
+  "generated": "2026-01-22T10:30:00Z",
+  "repository": {
+    "name": "{repo-name}"
+  },
+  "defaultDocument": "projects/000-global/ARC-000-PRIN-v1.0.md",
+  "guides": [
+    {
+      "path": "docs/guides/requirements.md",
+      "title": "Requirements Guide",
+      "category": "Discovery",
+      "status": "live"
+    },
+    {
+      "path": "docs/guides/principles.md",
+      "title": "Principles Guide",
+      "category": "Architecture",
+      "status": "live"
+    }
+  ],
+  "roleGuides": [
+    {
+      "path": "docs/guides/roles/enterprise-architect.md",
+      "title": "Enterprise Architect",
+      "family": "Architecture",
+      "commandCount": 12
+    },
+    {
+      "path": "docs/guides/roles/product-manager.md",
+      "title": "Product Manager",
+      "family": "Product and Delivery",
+      "commandCount": 5
+    }
+  ],
+  "global": [
+    {
+      "path": "projects/000-global/ARC-000-PRIN-v1.0.md",
+      "title": "Architecture Principles",
+      "category": "Architecture",
+      "documentId": "ARC-000-PRIN-v1.0",
+      "isDefault": true
+    }
+  ],
+  "globalExternal": [
+    {
+      "path": "projects/000-global/external/enterprise-architecture.pdf",
+      "title": "enterprise-architecture.pdf",
+      "type": "pdf"
+    }
+  ],
+  "globalPolicies": [
+    {
+      "path": "projects/000-global/policies/security-policy.pdf",
+      "title": "security-policy.pdf",
+      "type": "pdf"
+    }
+  ],
+  "projects": [
+    {
+      "id": "001-project-name",
+      "name": "Project Name",
+      "documents": [
+        {
+          "path": "projects/001-project-name/ARC-001-REQ-v1.0.md",
+          "title": "Requirements",
+          "category": "Discovery",
+          "documentId": "ARC-001-REQ-v1.0"
+        },
+        {
+          "path": "projects/001-project-name/ARC-001-STKE-v1.0.md",
+          "title": "Stakeholder Drivers",
+          "category": "Discovery",
+          "documentId": "ARC-001-STKE-v1.0"
+        }
+      ],
+      "diagrams": [
+        {
+          "path": "projects/001-project-name/diagrams/ARC-001-DIAG-001-v1.0.md",
+          "title": "System Context Diagram",
+          "documentId": "ARC-001-DIAG-001-v1.0"
+        }
+      ],
+      "research": [
+        {
+          "path": "projects/001-project-name/research/ARC-001-RSCH-001-v1.0.md",
+          "title": "Technology Research",
+          "documentId": "ARC-001-RSCH-001-v1.0"
+        }
+      ],
+      "decisions": [
+        {
+          "path": "projects/001-project-name/decisions/ARC-001-ADR-001-v1.0.md",
+          "title": "ADR-001: Cloud Provider Selection",
+          "documentId": "ARC-001-ADR-001-v1.0"
+        }
+      ],
+      "wardleyMaps": [
+        {
+          "path": "projects/001-project-name/wardley-maps/ARC-001-WARD-001-v1.0.md",
+          "title": "Technology Landscape",
+          "documentId": "ARC-001-WARD-001-v1.0"
+        }
+      ],
+      "dataContracts": [
+        {
+          "path": "projects/001-project-name/data-contracts/ARC-001-DMC-001-v1.0.md",
+          "title": "Customer Data Contract",
+          "documentId": "ARC-001-DMC-001-v1.0"
+        }
+      ],
+      "reviews": [
+        {
+          "path": "projects/001-project-name/reviews/ARC-001-HLDR-v1.0.md",
+          "title": "High-Level Design Review",
+          "documentId": "ARC-001-HLDR-v1.0"
+        },
+        {
+          "path": "projects/001-project-name/reviews/ARC-001-DLDR-v1.0.md",
+          "title": "Detailed Design Review",
+          "documentId": "ARC-001-DLDR-v1.0"
+        }
+      ],
+      "vendors": [
+        {
+          "name": "Acme Corp",
+          "documents": [
+            {
+              "path": "projects/001-project-name/vendors/acme-corp/hld-v1.md",
+              "title": "HLD v1.0"
+            }
+          ]
+        }
+      ],
+      "vendorProfiles": [
+        {
+          "path": "projects/001-project-name/vendors/aws-profile.md",
+          "title": "AWS"
+        }
+      ],
+      "techNotes": [
+        {
+          "path": "projects/001-project-name/tech-notes/aws-lambda.md",
+          "title": "AWS Lambda"
+        }
+      ],
+      "external": [
+        {
+          "path": "projects/001-project-name/external/rfp-document.pdf",
+          "title": "rfp-document.pdf",
+          "type": "pdf"
+        }
+      ]
+    }
+  ]
+}
+```
+
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`${CLAUDE_PLUGIN_ROOT}/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
+## Step 5: Provide Summary
+
+After generating, provide this summary:
+
+```text
+Documentation Site Generated
+
+Files Created:
+- docs/index.html (main page)
+- docs/manifest.json (document index)
+
+Repository: {repo}
+Projects Found: {count}
+Documents Indexed: {total_documents}
+
+Document Breakdown:
+- Guides: {guides_count}
+- DDaT Role Guides: {role_guides_count}
+- Global: {global_count}
+- Project Documents: {project_doc_count}
+- Diagrams: {diagram_count}
+- ADRs: {adr_count}
+- Vendor Documents: {vendor_doc_count}
+- Vendor Profiles: {vendor_profile_count}
+- Tech Notes: {tech_note_count}
+
+Features:
+- Dashboard view with KPI cards, charts, and governance checklist (default landing page)
+- Sidebar navigation for all projects
+- Markdown rendering with syntax highlighting
+- Mermaid diagram support (auto-rendered)
+- GOV.UK Design System styling
+- Responsive mobile layout
+- Uses relative paths — works on any static hosting provider
+
+Health Integration:
+- Run `/arckit:health JSON=true` to generate docs/health.json
+- Re-run `/arckit:pages` to display health data on the dashboard
+
+Deployment:
+The site uses relative paths and can be deployed to any static hosting provider:
+- **GitHub Pages**: Settings > Pages > Source "Deploy from branch" > Branch "main", folder "/docs"
+- **Netlify/Vercel**: Set publish directory to the repo root (docs/index.html references ../projects/)
+- **Any static host**: Serve the entire repo directory; docs/index.html loads files via relative paths
+
+Next Steps:
+- Commit and push the docs/ folder
+- Deploy to your hosting provider of choice
+- Access your documentation site
+```
+
+## Important Notes
+
+### Default Landing Page (Dashboard)
+
+- **The dashboard (`#dashboard`) is the default landing page** — it shows automatically when no hash is present
+- Set `defaultDocument` in manifest.json to the principles path (for backward compatibility and direct linking)
+- The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
+- Users can navigate to any document via sidebar, search, or dashboard project table
+
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
+---
+
+**Remember**: You MUST read and use `${CLAUDE_PLUGIN_ROOT}/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-claude/commands/impact.md
+++ b/arckit-claude/commands/impact.md
@@ -1,0 +1,89 @@
+---
+description: Analyse the blast radius of a change to a requirement, decision, or design document
+argument-hint: "<document ID or requirement ID, e.g. 'ARC-001-REQ', 'BR-003', 'ADR-002'>"
+tags: [impact, change, blast-radius, dependency, traceability, governance]
+handoffs:
+  - command: traceability
+    description: Update traceability matrix after impact assessment
+    condition: "Impact analysis revealed traceability gaps"
+  - command: health
+    description: Check health of impacted artifacts
+    condition: "Impacted documents may be stale"
+  - command: conformance
+    description: Re-assess conformance after changes
+    condition: "Impact includes architecture design documents"
+---
+
+# Impact Analysis
+
+You are helping an enterprise architect understand the blast radius of a change to an existing requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Impact hook has already built a dependency graph from all project artifacts and provided it as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the query** to identify the change source:
+   - **ARC document ID** (e.g., `ARC-001-REQ`, `ARC-001-ADR-003`) → find all documents that reference it
+   - **Requirement ID** (e.g., `BR-003`, `NFR-SEC-001`) → find all documents containing that requirement ID
+   - **Document type + project** (e.g., `ADR --project=001`) → show all dependencies of ADRs in that project
+   - **Plain text** → search node titles and suggest the most likely target
+
+2. **Perform reverse traversal** using the dependency graph:
+   - **Level 0**: The changed document itself
+   - **Level 1**: Documents that directly reference it (via cross-references or shared requirement IDs)
+   - **Level 2**: Documents that reference Level 1 documents
+   - Continue until no more references found (max depth 5)
+
+3. **Classify impact severity** using the `severity` field from the graph nodes:
+   - **HIGH**: Compliance/Governance documents (TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF) — may need formal re-assessment
+   - **MEDIUM**: Architecture documents (HLDR, DLDR, ADR, DATA, DIAG, PLAT) — may need design updates
+   - **LOW**: Planning/Other documents (PLAN, ROAD, BKLG, SOBC, OPS, PRES) — review recommended
+
+4. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Impact Analysis: BR-003 (Data Residency Requirement)
+
+   ### Change Source
+   - **Requirement:** BR-003 — "All customer data must reside within UK data centres"
+   - **Defined in:** ARC-001-REQ-v2.0 (projects/001-payments/)
+
+   ### Impact Chain
+
+   | Level | Document | Type | Impact | Action Needed |
+   |-------|----------|------|--------|---------------|
+   | 1 | ARC-001-ADR-002-v1.0 | ADR | MEDIUM | Review cloud provider decision |
+   | 1 | ARC-001-HLDR-v1.0 | HLDR | MEDIUM | Update deployment architecture |
+   | 2 | ARC-001-SECD-v1.0 | SECD | HIGH | Re-assess data protection controls |
+   | 2 | ARC-001-DPIA-v1.0 | DPIA | HIGH | Re-run DPIA assessment |
+   | 3 | ARC-001-OPS-v1.0 | OPS | LOW | Check operational procedures |
+
+   ### Summary
+   - **Total impacted:** 5 documents
+   - **HIGH severity:** 2 (compliance re-assessment needed)
+   - **MEDIUM severity:** 2 (design updates needed)
+   - **LOW severity:** 1 (review recommended)
+
+   ### Recommended Actions
+   1. Re-run `/arckit:secure` to update Secure by Design assessment
+   2. Re-run `/arckit:dpia` to update Data Protection Impact Assessment
+   3. Review ADR-002 decision rationale against updated requirement
+   ```
+
+5. **Recommend specific `/arckit:` commands** for HIGH severity impacts:
+   - SECD impacted → `/arckit:secure`
+   - DPIA impacted → `/arckit:dpia`
+   - TCOP impacted → `/arckit:tcop`
+   - HLDR impacted → `/arckit:hld-review`
+   - RISK impacted → `/arckit:risk`
+   - TRAC impacted → `/arckit:traceability`
+
+6. **If no impacts found**, report that the document has no downstream dependencies. Note this may indicate a traceability gap — suggest running `/arckit:traceability` to check coverage.
+
+7. **If the query matches multiple documents**, list them and ask the user to specify which one to analyse.

--- a/arckit-claude/commands/score.md
+++ b/arckit-claude/commands/score.md
@@ -1,0 +1,160 @@
+---
+description: Score vendor proposals against evaluation criteria with persistent structured storage
+argument-hint: "<action> <args>, e.g. 'vendor Acme --project=001', 'compare --project=001', 'audit --project=001'"
+tags: [vendor, scoring, evaluation, procurement, comparison, audit]
+handoffs:
+  - command: evaluate
+    description: Create or update evaluation framework before scoring
+    condition: "No EVAL artifact exists for the project"
+  - command: sow
+    description: Generate Statement of Work for selected vendor
+    condition: "Vendor selection complete, ready for procurement"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal

--- a/arckit-claude/commands/score.md
+++ b/arckit-claude/commands/score.md
@@ -138,7 +138,7 @@ Show the scoring audit trail.
 
 If no recognised action, show usage:
 
-```
+```text
 Usage: /arckit:score <action> [options]
 
 Actions:

--- a/arckit-claude/commands/search.md
+++ b/arckit-claude/commands/search.md
@@ -1,0 +1,78 @@
+---
+description: Search across all project artifacts by keyword, document type, or requirement ID
+argument-hint: "<query, e.g. 'PostgreSQL', 'data residency', '--type=ADR', '--project=001'>"
+tags: [search, find, query, lookup, discover]
+handoffs:
+  - command: health
+    description: Check artifact health after finding relevant documents
+    condition: "Search revealed potentially stale artifacts"
+  - command: traceability
+    description: Trace requirements found in search results
+    condition: "Search included requirement IDs"
+  - command: impact
+    description: Analyse impact of changes to found documents
+    condition: "User wants to understand change blast radius"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```

--- a/arckit-claude/commands/search.md
+++ b/arckit-claude/commands/search.md
@@ -67,7 +67,8 @@ $ARGUMENTS
    - Trying alternative terms
 
 6. **If the query is empty**, show a usage summary:
-   ```
+
+   ```text
    Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 
    Examples:

--- a/arckit-claude/docs/guides/impact.md
+++ b/arckit-claude/docs/guides/impact.md
@@ -1,0 +1,68 @@
+# Impact Analysis
+
+Analyse the blast radius of a change to a requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability (`/arckit:traceability`).
+
+## Usage
+
+```bash
+/arckit:impact <document ID or requirement ID>
+```
+
+## Examples
+
+```bash
+# Impact of changing a requirement
+/arckit:impact BR-003
+/arckit:impact NFR-SEC-001
+
+# Impact of changing a document
+/arckit:impact ARC-001-REQ
+/arckit:impact ARC-001-ADR-002
+
+# Show all dependencies for a document type in a project
+/arckit:impact ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook builds a dependency graph on invocation:
+
+1. Scans all ARC-\*.md files across all projects
+2. Extracts cross-references between documents (ARC-NNN-TYPE patterns)
+3. Maps requirement IDs to the documents that contain them
+4. Classifies each document's impact severity by type category
+
+The command then performs reverse traversal through the graph to find all downstream dependencies.
+
+## Impact Severity
+
+| Severity | Category | Document Types | Action |
+|----------|----------|---------------|--------|
+| **HIGH** | Compliance/Governance | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF | Formal re-assessment likely needed |
+| **MEDIUM** | Architecture | HLDR, DLDR, ADR, DATA, DIAG, PLAT | Design updates may be needed |
+| **LOW** | Planning/Other | PLAN, ROAD, BKLG, SOBC, OPS, PRES | Review recommended |
+
+## Traversal Depth
+
+The analysis traces dependencies up to 5 levels deep:
+
+- **Level 0**: The changed document itself
+- **Level 1**: Documents that directly reference it
+- **Level 2**: Documents that reference Level 1 documents
+- **Level 3-5**: Further indirect dependencies
+
+## When to Use
+
+- **Before changing a requirement** — understand what other documents will be affected
+- **Before updating an ADR** — check if compliance documents reference it
+- **After a design review** — trace what else needs updating when conditions are imposed
+- **During change governance** — document the full impact chain for approval boards
+
+## Relationship to Traceability
+
+| Command | Direction | Question |
+|---------|-----------|----------|
+| `/arckit:traceability` | Forward | "Are my requirements covered by design decisions?" |
+| `/arckit:impact` | Reverse | "If I change this requirement, what breaks?" |
+
+Use traceability to check coverage. Use impact to assess change risk.

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 59 slash commands
+- **Commands**: 60 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 59 ArcKit commands and 6 research agents remain fully available
+- All 60 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/score.md
+++ b/arckit-claude/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/arckit-claude/docs/guides/score.md
+++ b/arckit-claude/docs/guides/score.md
@@ -4,7 +4,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Usage
 
-```
+```text
 /arckit:score vendor <name> --project=NNN    # Score a vendor
 /arckit:score compare --project=NNN          # Compare all scored vendors
 /arckit:score audit --project=NNN            # View scoring audit trail
@@ -12,7 +12,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Workflow
 
-```
+```text
 /arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
    (criteria)         (score each)             (decide)                  (procure)
 ```

--- a/arckit-claude/docs/guides/search.md
+++ b/arckit-claude/docs/guides/search.md
@@ -4,7 +4,7 @@ Search across all project artifacts by keyword, document type, or requirement ID
 
 ## Usage
 
-```
+```text
 /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 ```
 

--- a/arckit-claude/docs/guides/search.md
+++ b/arckit-claude/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 59 commands | Plugin mode
+Version 2.10.0 | 60 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/hooks/arckit-session.mjs
+++ b/arckit-claude/hooks/arckit-session.mjs
@@ -110,6 +110,21 @@ if (isDir(projectsDir)) {
   }
 }
 
+// Surface recent session history if available
+const sessionsFile = join(cwd, '.arckit', 'memory', 'sessions.md');
+if (isFile(sessionsFile)) {
+  const sessionsContent = readText(sessionsFile);
+  if (sessionsContent) {
+    // Extract last 3 session entries for context
+    const sections = sessionsContent.split(/\n(?=### \d{4}-\d{2}-\d{2})/);
+    const recentSessions = sections.slice(1, 4); // skip header, take 3
+    if (recentSessions.length > 0) {
+      context += '\n\n## Recent Sessions\n';
+      context += recentSessions.join('\n');
+    }
+  }
+}
+
 // Output additionalContext
 const output = {
   hookSpecificOutput: {

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -68,6 +68,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "/arckit:impact",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/impact-scan.mjs",
+            "timeout": 20
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -1,6 +1,18 @@
 {
-  "description": "ArcKit hooks: session init, project context injection, filename enforcement, MCP tool auto-allow, and security protection (file protection, secret detection, secret file scanning)",
+  "description": "ArcKit hooks: session init, session learner, project context injection, filename enforcement, MCP tool auto-allow, and security protection (file protection, secret detection, secret file scanning)",
   "hooks": {
+    "Stop": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/session-learner.mjs",
+            "timeout": 10
+          }
+        ]
+      }
+    ],
     "SessionStart": [
       {
         "matcher": ".*",

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -105,6 +105,16 @@
             "timeout": 5
           }
         ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -88,6 +88,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-arc-filename.mjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+            "timeout": 5
           }
         ]
       },
@@ -102,16 +107,6 @@
           {
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/secret-file-scanner.mjs",
-            "timeout": 5
-          }
-        ]
-      },
-      {
-        "matcher": "Write",
-        "hooks": [
-          {
-            "type": "command",
-            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
             "timeout": 5
           }
         ]

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -68,6 +68,16 @@
             "timeout": 30
           }
         ]
+      },
+      {
+        "matcher": "/arckit:search",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/search-scan.mjs",
+            "timeout": 15
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/arckit-claude/hooks/impact-scan.mjs
+++ b/arckit-claude/hooks/impact-scan.mjs
@@ -1,0 +1,208 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Impact Analysis Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:impact commands.
+ * Builds a dependency graph from cross-references between ARC documents,
+ * enabling reverse traversal to determine the blast radius of changes.
+ *
+ * Hook Type: UserPromptSubmit (sync)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing dependency graph
+ */
+
+import { join } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  parseHookInput,
+} from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const text = prompt.replace(/^\/arckit[.:]+impact\s*/i, '');
+  return text.trim();
+}
+
+// ── Title extraction ──
+
+function extractTitle(content) {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1].trim() : null;
+}
+
+// ── Severity classification by doc type category ──
+
+function classifySeverity(docType) {
+  const info = DOC_TYPES[docType];
+  if (!info) return 'LOW';
+  const cat = info.category;
+  if (cat === 'Compliance' || cat === 'Governance') return 'HIGH';
+  if (cat === 'Architecture') return 'MEDIUM';
+  return 'LOW';
+}
+
+// ── Artifact scanning ──
+
+function scanAllArtifacts(projectsDir) {
+  const nodes = {};   // docId -> { type, project, path, title, status }
+  const edges = [];   // { from, to, type }
+  const reqIndex = {}; // reqId -> [docIds]
+
+  const projectDirs = listDir(projectsDir)
+    .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+  for (const projectName of projectDirs) {
+    const projectDir = join(projectsDir, projectName);
+    scanProjectDir(projectDir, projectName, nodes, edges, reqIndex);
+  }
+
+  return { nodes, edges, reqIndex, projects: projectDirs };
+}
+
+function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) {
+  const dirsToScan = [
+    { dir: projectDir, prefix: '' },
+    { dir: join(projectDir, 'decisions'), prefix: 'decisions/' },
+    { dir: join(projectDir, 'diagrams'), prefix: 'diagrams/' },
+    { dir: join(projectDir, 'wardley-maps'), prefix: 'wardley-maps/' },
+    { dir: join(projectDir, 'data-contracts'), prefix: 'data-contracts/' },
+    { dir: join(projectDir, 'reviews'), prefix: 'reviews/' },
+    { dir: join(projectDir, 'research'), prefix: 'research/' },
+  ];
+
+  // Also scan vendor directories
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vd = join(vendorsDir, vendor);
+      if (isDir(vd)) {
+        dirsToScan.push({ dir: vd, prefix: `vendors/${vendor}/` });
+        const vrd = join(vd, 'reviews');
+        if (isDir(vrd)) {
+          dirsToScan.push({ dir: vrd, prefix: `vendors/${vendor}/reviews/` });
+        }
+      }
+    }
+  }
+
+  for (const { dir, prefix } of dirsToScan) {
+    if (!isDir(dir)) continue;
+    for (const f of listDir(dir)) {
+      if (!f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+      const fp = join(dir, f);
+      if (!isFile(fp)) continue;
+
+      const content = readText(fp);
+      if (!content) continue;
+
+      const docType = extractDocType(f);
+      const version = extractVersion(f);
+      const fields = extractDocControlFields(content);
+      const title = extractTitle(content) || fields['Document Title'] || f;
+      const status = fields['Status'] || '';
+
+      // Build a short document ID (without version for matching)
+      const shortId = f.replace(/-v[\d.]+\.md$/, '');
+      const fullId = f.replace(/\.md$/, '');
+
+      nodes[fullId] = {
+        type: docType,
+        project: projectName,
+        path: `projects/${projectName}/${prefix}${f}`,
+        title,
+        status,
+        severity: classifySeverity(docType),
+      };
+
+      // Extract requirement IDs referenced in this document
+      const reqIds = extractRequirementIds(content);
+      for (const reqId of reqIds) {
+        if (!reqIndex[reqId]) reqIndex[reqId] = [];
+        if (!reqIndex[reqId].includes(fullId)) {
+          reqIndex[reqId].push(fullId);
+        }
+      }
+
+      // Extract cross-references to other ARC documents
+      const ARC_REF_RE = /\bARC-(\d{3})-([A-Z][\w-]*?)(?:-(\d{3}))?(?:-v[\d.]+)?(?:\.md)?\b/g;
+      let match;
+      while ((match = ARC_REF_RE.exec(content)) !== null) {
+        const refStr = match[0].replace(/\.md$/, '');
+        // Build a normalized reference ID
+        const refShort = refStr.replace(/-v[\d.]+$/, '');
+        if (refShort !== shortId) {
+          edges.push({ from: fullId, to: refShort, type: 'references' });
+        }
+      }
+    }
+  }
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+// Guard: only fire for /arckit:impact
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+impact\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Analyse the blast radius/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+const query = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Build dependency graph
+const { nodes, edges, reqIndex, projects } = scanAllArtifacts(projectsDir);
+
+const nodeCount = Object.keys(nodes).length;
+const edgeCount = edges.length;
+const reqCount = Object.keys(reqIndex).length;
+
+// Build output
+const lines = [];
+lines.push('## Impact Pre-processor Complete (hook)');
+lines.push('');
+lines.push(`**Dependency graph built: ${nodeCount} documents, ${edgeCount} cross-references, ${reqCount} requirement IDs across ${projects.length} project(s).**`);
+lines.push('');
+lines.push(`**User query:** ${query || '(no query provided)'}`);
+lines.push('');
+lines.push('### DEPENDENCY GRAPH (JSON)');
+lines.push('');
+lines.push('```json');
+lines.push(JSON.stringify({ nodes, edges, reqIndex }, null, 2));
+lines.push('```');
+lines.push('');
+lines.push('### Impact Severity Classification');
+lines.push('| Category | Severity | Document Types |');
+lines.push('|----------|----------|---------------|');
+lines.push('| Compliance/Governance | HIGH | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF |');
+lines.push('| Architecture | MEDIUM | HLDR, DLDR, ADR, DATA, DIAG, PLAT |');
+lines.push('| Planning/Other | LOW | PLAN, ROAD, BKLG, SOBC, OPS, PRES |');
+lines.push('');
+lines.push('### Instructions');
+lines.push('- Parse query: ARC document ID, requirement ID (e.g. BR-003), or type+project');
+lines.push('- Perform reverse traversal through edges (max depth 5)');
+lines.push('- Classify impact severity using node severity field');
+lines.push('- Output impact chain table, summary counts, and recommended actions');
+lines.push('- Suggest specific /arckit commands to re-run for HIGH severity impacts');
+
+const message = lines.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/arckit-claude/hooks/score-validator.mjs
+++ b/arckit-claude/hooks/score-validator.mjs
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * ArcKit PreToolUse (Write) Hook — Score Validator
+ *
+ * Validates scores.json files before they are written to ensure
+ * data integrity of vendor scoring records.
+ *
+ * Checks:
+ *   - Valid JSON structure with required fields
+ *   - Score values are 0-3
+ *   - Weights sum to approximately 1.0
+ *
+ * Hook Type: PreToolUse
+ * Matcher: Write
+ * Input (stdin):  JSON { tool_name, tool_input: { file_path, content }, ... }
+ * Output (stdout): JSON with decision (allow/block)
+ */
+
+import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
+
+// --- Read stdin ---
+let raw = '';
+try {
+  raw = readFileSync(0, 'utf8');
+} catch {
+  process.exit(0);
+}
+if (!raw || !raw.trim()) process.exit(0);
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+// --- Early exit: only validate scores.json files ---
+const filePath = (data.tool_input || {}).file_path || '';
+if (!filePath.endsWith('/scores.json') && basename(filePath) !== 'scores.json') {
+  process.exit(0);
+}
+if (!filePath.includes('/vendors/')) process.exit(0);
+
+const content = (data.tool_input || {}).content || '';
+if (!content) process.exit(0);
+
+// --- Validate JSON ---
+let scores;
+try {
+  scores = JSON.parse(content);
+} catch (e) {
+  console.log(JSON.stringify({
+    decision: 'block',
+    reason: `Invalid JSON in scores.json: ${e.message}`,
+  }));
+  process.exit(0);
+}
+
+const warnings = [];
+
+// --- Validate required top-level fields ---
+if (!scores.projectId) warnings.push('Missing required field: projectId');
+if (!scores.criteria || !Array.isArray(scores.criteria)) {
+  warnings.push('Missing or invalid field: criteria (must be an array)');
+}
+if (!scores.vendors || typeof scores.vendors !== 'object') {
+  warnings.push('Missing or invalid field: vendors (must be an object)');
+}
+
+// --- Validate criteria weights ---
+if (Array.isArray(scores.criteria) && scores.criteria.length > 0) {
+  const weightSum = scores.criteria.reduce((sum, c) => sum + (c.weight || 0), 0);
+  if (Math.abs(weightSum - 1.0) > 0.01) {
+    warnings.push(`Criteria weights sum to ${weightSum.toFixed(3)} (expected ~1.0)`);
+  }
+
+  // Check each criterion has required fields
+  for (const c of scores.criteria) {
+    if (!c.id) warnings.push(`Criterion missing id field`);
+    if (!c.name) warnings.push(`Criterion ${c.id || '?'} missing name field`);
+    if (typeof c.weight !== 'number') warnings.push(`Criterion ${c.id || '?'} missing numeric weight`);
+  }
+}
+
+// --- Validate vendor scores ---
+if (scores.vendors && typeof scores.vendors === 'object') {
+  const criteriaIds = new Set((scores.criteria || []).map(c => c.id));
+
+  for (const [vendorKey, vendor] of Object.entries(scores.vendors)) {
+    if (!vendor.displayName) warnings.push(`Vendor '${vendorKey}' missing displayName`);
+    if (!Array.isArray(vendor.scores)) {
+      warnings.push(`Vendor '${vendorKey}' missing scores array`);
+      continue;
+    }
+
+    for (const s of vendor.scores) {
+      if (typeof s.score !== 'number' || s.score < 0 || s.score > 3) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: score ${s.score} out of range (must be 0-3)`);
+      }
+      if (s.criterionId && !criteriaIds.has(s.criterionId)) {
+        warnings.push(`Vendor '${vendorKey}' references unknown criterion: ${s.criterionId}`);
+      }
+    }
+  }
+}
+
+// --- Output ---
+if (warnings.length > 0) {
+  // Allow but warn — don't block data writes
+  console.log(JSON.stringify({
+    decision: 'allow',
+    reason: `Score validation warnings:\n${warnings.map(w => `- ${w}`).join('\n')}`,
+  }));
+} else {
+  // Clean pass
+  process.exit(0);
+}

--- a/arckit-claude/hooks/score-validator.mjs
+++ b/arckit-claude/hooks/score-validator.mjs
@@ -16,24 +16,10 @@
  * Output (stdout): JSON with decision (allow/block)
  */
 
-import { readFileSync } from 'node:fs';
 import { basename } from 'node:path';
+import { parseHookInput } from './hook-utils.mjs';
 
-// --- Read stdin ---
-let raw = '';
-try {
-  raw = readFileSync(0, 'utf8');
-} catch {
-  process.exit(0);
-}
-if (!raw || !raw.trim()) process.exit(0);
-
-let data;
-try {
-  data = JSON.parse(raw);
-} catch {
-  process.exit(0);
-}
+const data = parseHookInput();
 
 // --- Early exit: only validate scores.json files ---
 const filePath = (data.tool_input || {}).file_path || '';
@@ -97,6 +83,9 @@ if (scores.vendors && typeof scores.vendors === 'object') {
     for (const s of vendor.scores) {
       if (typeof s.score !== 'number' || s.score < 0 || s.score > 3) {
         warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: score ${s.score} out of range (must be 0-3)`);
+      }
+      if (!s.evidence || !s.evidence.trim()) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: missing evidence (every score must cite supporting evidence)`);
       }
       if (s.criterionId && !criteriaIds.has(s.criterionId)) {
         warnings.push(`Vendor '${vendorKey}' references unknown criterion: ${s.criterionId}`);

--- a/arckit-claude/hooks/search-scan.mjs
+++ b/arckit-claude/hooks/search-scan.mjs
@@ -1,0 +1,190 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Search Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:search commands.
+ * Scans all projects for ARC-*.md files and builds a search-ready index
+ * with document metadata and content previews.
+ *
+ * Hook Type: UserPromptSubmit (sync)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing search index
+ */
+
+import { join } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  parseHookInput,
+} from './hook-utils.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const text = prompt.replace(/^\/arckit[.:]+search\s*/i, '');
+  return text.trim();
+}
+
+// ── Content preview extraction ──
+
+function extractPreview(content, maxLen = 500) {
+  // Skip document control table and revision history
+  const lines = content.split('\n');
+  let inTable = false;
+  let pastControl = false;
+  const previewLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    // Skip leading headings and tables (doc control area)
+    if (!pastControl) {
+      if (trimmed.startsWith('|') || trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('---')) {
+        if (trimmed.startsWith('|')) inTable = true;
+        else if (inTable && !trimmed.startsWith('|')) {
+          inTable = false;
+          pastControl = true;
+        }
+        continue;
+      }
+      pastControl = true;
+    }
+
+    if (pastControl && trimmed) {
+      previewLines.push(trimmed);
+    }
+
+    if (previewLines.join(' ').length >= maxLen) break;
+  }
+
+  return previewLines.join(' ').substring(0, maxLen);
+}
+
+// ── Title extraction ──
+
+function extractTitle(content) {
+  const match = content.match(/^#\s+(.+)/m);
+  return match ? match[1].trim() : null;
+}
+
+// ── Artifact scanning ──
+
+function scanProject(projectDir, projectName) {
+  const artifacts = [];
+
+  function scanDir(dir, relPrefix) {
+    if (!isDir(dir)) return;
+    for (const f of listDir(dir)) {
+      const fp = join(dir, f);
+      if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+
+      const content = readText(fp);
+      if (!content) continue;
+
+      const docType = extractDocType(f);
+      const version = extractVersion(f);
+      const fields = extractDocControlFields(content);
+      const title = extractTitle(content) || fields['Document Title'] || f;
+      const reqIds = [...extractRequirementIds(content)];
+      const preview = extractPreview(content);
+      const relPath = relPrefix ? `${relPrefix}/${f}` : f;
+
+      artifacts.push({
+        filename: f,
+        relPath,
+        project: projectName,
+        docType,
+        version,
+        title,
+        status: fields['Status'] || '',
+        owner: fields['Owner'] || fields['Document Owner'] || '',
+        reqIds,
+        preview,
+        controlFields: Object.entries(fields).map(([k, v]) => `${k}: ${v}`).join('; '),
+      });
+    }
+  }
+
+  // Root level
+  scanDir(projectDir, null);
+
+  // Subdirectories
+  for (const subdir of ['decisions', 'diagrams', 'wardley-maps', 'data-contracts', 'reviews', 'research']) {
+    scanDir(join(projectDir, subdir), subdir);
+  }
+
+  // Vendor directories
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vendorDir = join(vendorsDir, vendor);
+      if (!isDir(vendorDir)) continue;
+      scanDir(vendorDir, `vendors/${vendor}`);
+      scanDir(join(vendorDir, 'reviews'), `vendors/${vendor}/reviews`);
+    }
+  }
+
+  return artifacts;
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+// Guard: only fire for /arckit:search
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+search\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Search across all project artifacts/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+const query = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Discover and scan all projects
+const allArtifacts = [];
+const projectDirs = listDir(projectsDir)
+  .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+for (const projectName of projectDirs) {
+  const projectDir = join(projectsDir, projectName);
+  const artifacts = scanProject(projectDir, projectName);
+  allArtifacts.push(...artifacts);
+}
+
+// Build output
+const lines = [];
+lines.push('## Search Pre-processor Complete (hook)');
+lines.push('');
+lines.push(`**Indexed ${allArtifacts.length} artifacts across ${projectDirs.length} project(s).**`);
+lines.push('');
+lines.push(`**User query:** ${query || '(no query provided)'}`);
+lines.push('');
+lines.push('### SEARCH INDEX (JSON)');
+lines.push('');
+lines.push('```json');
+lines.push(JSON.stringify(allArtifacts, null, 2));
+lines.push('```');
+lines.push('');
+lines.push('### Instructions');
+lines.push('- Parse the query for keywords, --type=XXX, --project=NNN, --id=XX-NNN filters');
+lines.push('- Score results: title match=10, control fields=5, preview=3, filename=2');
+lines.push('- Output ranked table with top result preview');
+lines.push('- If no results, suggest broadening the search');
+
+const message = lines.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -68,12 +68,24 @@ try {
 
 const files = [...new Set(changedFiles.split('\n').filter(Boolean))];
 
-// Detect artifact types from filenames using DOC_TYPES config
-const detectedTypes = new Set();
+// Detect artifact types from filenames, grouped by project number
+// projectArtifacts: Map<projectNum, Map<category, Set<typeName>>>
+const projectArtifacts = new Map();
+const allCategories = new Set();
+
 for (const f of files) {
+  // Extract project number from ARC filename (e.g., ARC-001-REQ-v1.0.md → 001)
+  const projMatch = f.match(/ARC-(\d{3})-/);
+  if (!projMatch) continue;
+  const projNum = projMatch[1];
+
   for (const [code, info] of Object.entries(DOC_TYPES)) {
     if (f.includes(`-${code}-`) || f.includes(`-${code}.`)) {
-      detectedTypes.add(`${info.name} (${info.category})`);
+      if (!projectArtifacts.has(projNum)) projectArtifacts.set(projNum, new Map());
+      const projMap = projectArtifacts.get(projNum);
+      if (!projMap.has(info.category)) projMap.set(info.category, new Set());
+      projMap.get(info.category).add(info.name);
+      allCategories.add(info.category);
     }
   }
 }
@@ -84,19 +96,14 @@ const CATEGORY_PRIORITY = [
   'Architecture', 'Planning', 'Discovery', 'Operations',
 ];
 
-function classifySession(types) {
-  const categories = new Set();
-  for (const t of types) {
-    const match = t.match(/\((.+)\)$/);
-    if (match) categories.add(match[1]);
-  }
+function classifySession(categories) {
   for (const cat of CATEGORY_PRIORITY) {
     if (categories.has(cat)) return cat.toLowerCase();
   }
   return 'general';
 }
 
-const sessionType = classifySession(detectedTypes);
+const sessionType = classifySession(allCategories);
 
 // Extract commit message summaries (strip hashes)
 const commitSummaries = commitLines.map(line => {
@@ -108,11 +115,22 @@ const commitSummaries = commitLines.map(line => {
 const now = new Date();
 const dateStr = now.toISOString().substring(0, 10);
 const timeStr = now.toISOString().substring(11, 16);
-const artifactList = [...detectedTypes].join(', ') || 'none detected';
 
 let entry = `### ${dateStr} ${timeStr} — ${sessionType}\n\n`;
 entry += `- **Commits:** ${commitCount} | **Files changed:** ${files.length}\n`;
-entry += `- **Artifacts:** ${artifactList}\n`;
+
+if (projectArtifacts.size > 0) {
+  entry += '- **Artifacts:**\n';
+  for (const [projNum, catMap] of [...projectArtifacts.entries()].sort()) {
+    const parts = [];
+    for (const [category, names] of catMap) {
+      parts.push(`${category}: ${[...names].join(', ')}`);
+    }
+    entry += `  - [${projNum}] ${parts.join(' | ')}\n`;
+  }
+} else {
+  entry += '- **Artifacts:** none detected\n';
+}
 
 if (commitSummaries.length > 0) {
   entry += '- **Summary:**\n';

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -1,0 +1,154 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Stop Hook — Session Learner
+ *
+ * Fires when a session ends (Stop event). Analyses recent git commits
+ * to build a session summary and appends it to .arckit/memory/sessions.md.
+ *
+ * Uses timestamp tracking (.arckit/memory/.last-session) to capture
+ * exactly the commits from this session — no overlap, no gaps.
+ *
+ * Hook Type: Stop (Notification)
+ * Input (stdin):  JSON with session_id, cwd, etc.
+ * Output (stdout): empty (notification hook, no output required)
+ */
+
+import { writeFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { execFileSync } from 'node:child_process';
+import { isDir, isFile, readText, parseHookInput } from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+const data = parseHookInput();
+const cwd = data.cwd || '.';
+
+// Only proceed if we're in a project with .arckit directory
+if (!isDir(join(cwd, '.arckit'))) {
+  process.exit(0);
+}
+
+// Read last-session timestamp for --since boundary
+const memoryDir = join(cwd, '.arckit', 'memory');
+const lastSessionFile = join(memoryDir, '.last-session');
+let sinceArg = '4 hours ago'; // first-run fallback
+
+if (isFile(lastSessionFile)) {
+  const ts = readText(lastSessionFile)?.trim();
+  if (ts) sinceArg = ts;
+}
+
+// Collect git commits since last session
+let commits = '';
+try {
+  commits = execFileSync('git', ['log', `--since=${sinceArg}`, '--oneline', '--no-merges'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  }).trim();
+} catch {
+  process.exit(0);
+}
+
+if (!commits) process.exit(0);
+
+const commitLines = commits.split('\n').filter(Boolean);
+const commitCount = commitLines.length;
+
+// Detect changed files from recent commits
+let changedFiles = '';
+try {
+  changedFiles = execFileSync('git', ['log', `--since=${sinceArg}`, '--no-merges', '--name-only', '--pretty=format:'], {
+    cwd,
+    encoding: 'utf8',
+    timeout: 5000,
+  }).trim();
+} catch {
+  changedFiles = '';
+}
+
+const files = [...new Set(changedFiles.split('\n').filter(Boolean))];
+
+// Detect artifact types from filenames using DOC_TYPES config
+const detectedTypes = new Set();
+for (const f of files) {
+  for (const [code, info] of Object.entries(DOC_TYPES)) {
+    if (f.includes(`-${code}-`) || f.includes(`-${code}.`)) {
+      detectedTypes.add(`${info.name} (${info.category})`);
+    }
+  }
+}
+
+// Classify session by dominant DOC_TYPES category (priority order)
+const CATEGORY_PRIORITY = [
+  'Compliance', 'Governance', 'Research', 'Procurement',
+  'Architecture', 'Planning', 'Discovery', 'Operations',
+];
+
+function classifySession(types) {
+  const categories = new Set();
+  for (const t of types) {
+    const match = t.match(/\((.+)\)$/);
+    if (match) categories.add(match[1]);
+  }
+  for (const cat of CATEGORY_PRIORITY) {
+    if (categories.has(cat)) return cat.toLowerCase();
+  }
+  return 'general';
+}
+
+const sessionType = classifySession(detectedTypes);
+
+// Extract commit message summaries (strip hashes)
+const commitSummaries = commitLines.map(line => {
+  const spaceIdx = line.indexOf(' ');
+  return spaceIdx > 0 ? line.substring(spaceIdx + 1) : line;
+});
+
+// Build markdown entry
+const now = new Date();
+const dateStr = now.toISOString().substring(0, 10);
+const timeStr = now.toISOString().substring(11, 16);
+const artifactList = [...detectedTypes].join(', ') || 'none detected';
+
+let entry = `### ${dateStr} ${timeStr} — ${sessionType}\n\n`;
+entry += `- **Commits:** ${commitCount} | **Files changed:** ${files.length}\n`;
+entry += `- **Artifacts:** ${artifactList}\n`;
+
+if (commitSummaries.length > 0) {
+  entry += '- **Summary:**\n';
+  for (const s of commitSummaries.slice(0, 8)) {
+    entry += `  - ${s}\n`;
+  }
+}
+
+// Ensure memory directory exists
+mkdirSync(memoryDir, { recursive: true });
+
+const sessionsFile = join(memoryDir, 'sessions.md');
+
+// Read existing content or create with header
+let existing = '';
+if (isFile(sessionsFile)) {
+  existing = readText(sessionsFile) || '';
+}
+
+if (!existing.trim()) {
+  existing = '# Session Log\n\nAutomated session summaries captured by the ArcKit session-learner hook.\n';
+}
+
+// Split into header + entries, prepend new entry, trim to 30
+const sections = existing.split(/\n(?=### \d{4}-\d{2}-\d{2})/);
+const header = sections[0];
+const entries = sections.slice(1);
+
+entries.unshift(entry);
+
+const trimmed = entries.slice(0, 30);
+const output = header.trimEnd() + '\n\n' + trimmed.join('\n');
+
+writeFileSync(sessionsFile, output);
+
+// Write timestamp for next session boundary
+writeFileSync(lastSessionFile, now.toISOString());
+
+process.exit(0);

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -144,7 +144,7 @@ const entries = sections.slice(1);
 entries.unshift(entry);
 
 const trimmed = entries.slice(0, 30);
-const output = header.trimEnd() + '\n\n' + trimmed.join('\n');
+const output = header.trimEnd() + '\n\n' + trimmed.join('\n') + '\n';
 
 writeFileSync(sessionsFile, output);
 

--- a/arckit-codex/README.md
+++ b/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 62 skills (58 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- 63 skills (59 commands + 4 reference skills, auto-discovered by Codex)
 - `.codex/agents/` -- 6 agent configs (research, datascout, cloud providers, framework)
 - `.codex/config.toml` -- MCP servers and agent roles
 - `.arckit/templates/` -- document templates
@@ -58,7 +58,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 58 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes all 59 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -75,7 +75,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 58 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+All 59 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -219,7 +219,7 @@ arckit-codex/
 ├── README.md              # This file
 ├── VERSION                # Extension version (tracks plugin)
 ├── config.toml            # MCP servers + agent configuration
-├── skills/                # 62 skills (58 commands + 4 reference)
+├── skills/                # 63 skills (59 commands + 4 reference)
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
@@ -230,7 +230,7 @@ arckit-codex/
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 58 prompts (deprecated, use skills instead)
+├── prompts/               # 59 prompts (deprecated, use skills instead)
 ├── agents/                # 6 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -243,7 +243,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v3.1.2 (58 commands, 4 reference skills)**
+**Current Release: v3.1.2 (59 commands, 4 reference skills)**
 
 ---
 

--- a/arckit-codex/README.md
+++ b/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 61 skills (57 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- 62 skills (58 commands + 4 reference skills, auto-discovered by Codex)
 - `.codex/agents/` -- 6 agent configs (research, datascout, cloud providers, framework)
 - `.codex/config.toml` -- MCP servers and agent roles
 - `.arckit/templates/` -- document templates
@@ -58,7 +58,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 57 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes all 58 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -75,7 +75,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 57 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+All 58 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -219,7 +219,7 @@ arckit-codex/
 ├── README.md              # This file
 ├── VERSION                # Extension version (tracks plugin)
 ├── config.toml            # MCP servers + agent configuration
-├── skills/                # 61 skills (57 commands + 4 reference)
+├── skills/                # 62 skills (58 commands + 4 reference)
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
@@ -230,7 +230,7 @@ arckit-codex/
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 57 prompts (deprecated, use skills instead)
+├── prompts/               # 58 prompts (deprecated, use skills instead)
 ├── agents/                # 6 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -243,7 +243,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v3.1.2 (57 commands, 4 reference skills)**
+**Current Release: v3.1.2 (58 commands, 4 reference skills)**
 
 ---
 

--- a/arckit-codex/commands/arckit.adr.md
+++ b/arckit-codex/commands/arckit.adr.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/commands/arckit.ai-playbook.md
+++ b/arckit-codex/commands/arckit.ai-playbook.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-codex/commands/arckit.atrs.md
+++ b/arckit-codex/commands/arckit.atrs.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-codex/commands/arckit.backlog.md
+++ b/arckit-codex/commands/arckit.backlog.md
@@ -89,7 +89,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-codex/commands/arckit.conformance.md
+++ b/arckit-codex/commands/arckit.conformance.md
@@ -67,7 +67,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/commands/arckit.data-mesh-contract.md
+++ b/arckit-codex/commands/arckit.data-mesh-contract.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-codex/commands/arckit.data-model.md
+++ b/arckit-codex/commands/arckit.data-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/commands/arckit.devops.md
+++ b/arckit-codex/commands/arckit.devops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.dfd.md
+++ b/arckit-codex/commands/arckit.dfd.md
@@ -31,7 +31,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-codex/commands/arckit.diagram.md
+++ b/arckit-codex/commands/arckit.diagram.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-codex/commands/arckit.dld-review.md
+++ b/arckit-codex/commands/arckit.dld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/commands/arckit.dos.md
+++ b/arckit-codex/commands/arckit.dos.md
@@ -22,7 +22,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/commands/arckit.dpia.md
+++ b/arckit-codex/commands/arckit.dpia.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.evaluate.md
+++ b/arckit-codex/commands/arckit.evaluate.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-codex/commands/arckit.finops.md
+++ b/arckit-codex/commands/arckit.finops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.gcloud-clarify.md
+++ b/arckit-codex/commands/arckit.gcloud-clarify.md
@@ -23,7 +23,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.gcloud-search.md
+++ b/arckit-codex/commands/arckit.gcloud-search.md
@@ -46,7 +46,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-codex/commands/arckit.glossary.md
+++ b/arckit-codex/commands/arckit.glossary.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/commands/arckit.hld-review.md
+++ b/arckit-codex/commands/arckit.hld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/commands/arckit.impact.md
+++ b/arckit-codex/commands/arckit.impact.md
@@ -1,0 +1,86 @@
+---
+description: "Analyse the blast radius of a change to a requirement, decision, or design document"
+---
+
+# Impact Analysis
+
+You are helping an enterprise architect understand the blast radius of a change to an existing requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Impact hook has already built a dependency graph from all project artifacts and provided it as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the query** to identify the change source:
+   - **ARC document ID** (e.g., `ARC-001-REQ`, `ARC-001-ADR-003`) → find all documents that reference it
+   - **Requirement ID** (e.g., `BR-003`, `NFR-SEC-001`) → find all documents containing that requirement ID
+   - **Document type + project** (e.g., `ADR --project=001`) → show all dependencies of ADRs in that project
+   - **Plain text** → search node titles and suggest the most likely target
+
+2. **Perform reverse traversal** using the dependency graph:
+   - **Level 0**: The changed document itself
+   - **Level 1**: Documents that directly reference it (via cross-references or shared requirement IDs)
+   - **Level 2**: Documents that reference Level 1 documents
+   - Continue until no more references found (max depth 5)
+
+3. **Classify impact severity** using the `severity` field from the graph nodes:
+   - **HIGH**: Compliance/Governance documents (TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF) — may need formal re-assessment
+   - **MEDIUM**: Architecture documents (HLDR, DLDR, ADR, DATA, DIAG, PLAT) — may need design updates
+   - **LOW**: Planning/Other documents (PLAN, ROAD, BKLG, SOBC, OPS, PRES) — review recommended
+
+4. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Impact Analysis: BR-003 (Data Residency Requirement)
+
+   ### Change Source
+   - **Requirement:** BR-003 — "All customer data must reside within UK data centres"
+   - **Defined in:** ARC-001-REQ-v2.0 (projects/001-payments/)
+
+   ### Impact Chain
+
+   | Level | Document | Type | Impact | Action Needed |
+   |-------|----------|------|--------|---------------|
+   | 1 | ARC-001-ADR-002-v1.0 | ADR | MEDIUM | Review cloud provider decision |
+   | 1 | ARC-001-HLDR-v1.0 | HLDR | MEDIUM | Update deployment architecture |
+   | 2 | ARC-001-SECD-v1.0 | SECD | HIGH | Re-assess data protection controls |
+   | 2 | ARC-001-DPIA-v1.0 | DPIA | HIGH | Re-run DPIA assessment |
+   | 3 | ARC-001-OPS-v1.0 | OPS | LOW | Check operational procedures |
+
+   ### Summary
+   - **Total impacted:** 5 documents
+   - **HIGH severity:** 2 (compliance re-assessment needed)
+   - **MEDIUM severity:** 2 (design updates needed)
+   - **LOW severity:** 1 (review recommended)
+
+   ### Recommended Actions
+   1. Re-run `/arckit:secure` to update Secure by Design assessment
+   2. Re-run `/arckit:dpia` to update Data Protection Impact Assessment
+   3. Review ADR-002 decision rationale against updated requirement
+   ```
+
+5. **Recommend specific `/arckit:` commands** for HIGH severity impacts:
+   - SECD impacted → `/arckit:secure`
+   - DPIA impacted → `/arckit:dpia`
+   - TCOP impacted → `/arckit:tcop`
+   - HLDR impacted → `/arckit:hld-review`
+   - RISK impacted → `/arckit:risk`
+   - TRAC impacted → `/arckit:traceability`
+
+6. **If no impacts found**, report that the document has no downstream dependencies. Note this may indicate a traceability gap — suggest running `/arckit:traceability` to check coverage.
+
+7. **If the query matches multiple documents**, list them and ask the user to specify which one to analyse.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:traceability` -- Update traceability matrix after impact assessment *(when Impact analysis revealed traceability gaps)*
+- `/arckit:health` -- Check health of impacted artifacts *(when Impacted documents may be stale)*
+- `/arckit:conformance` -- Re-assess conformance after changes *(when Impact includes architecture design documents)*
+

--- a/arckit-codex/commands/arckit.jsp-936.md
+++ b/arckit-codex/commands/arckit.jsp-936.md
@@ -49,7 +49,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.maturity-model.md
+++ b/arckit-codex/commands/arckit.maturity-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/commands/arckit.mlops.md
+++ b/arckit-codex/commands/arckit.mlops.md
@@ -52,7 +52,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.mod-secure.md
+++ b/arckit-codex/commands/arckit.mod-secure.md
@@ -64,7 +64,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-codex/commands/arckit.operationalize.md
+++ b/arckit-codex/commands/arckit.operationalize.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.pages.md
+++ b/arckit-codex/commands/arckit.pages.md
@@ -23,24 +23,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -69,7 +74,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -130,6 +135,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -159,12 +165,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -213,7 +213,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -245,10 +244,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -408,9 +408,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -430,10 +476,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -472,6 +514,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/commands/arckit.plan.md
+++ b/arckit-codex/commands/arckit.plan.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-codex/commands/arckit.platform-design.md
+++ b/arckit-codex/commands/arckit.platform-design.md
@@ -20,7 +20,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.presentation.md
+++ b/arckit-codex/commands/arckit.presentation.md
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-codex/commands/arckit.principles-compliance.md
+++ b/arckit-codex/commands/arckit.principles-compliance.md
@@ -49,7 +49,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/commands/arckit.principles.md
+++ b/arckit-codex/commands/arckit.principles.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-codex/commands/arckit.requirements.md
+++ b/arckit-codex/commands/arckit.requirements.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/commands/arckit.risk.md
+++ b/arckit-codex/commands/arckit.risk.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-codex/commands/arckit.roadmap.md
+++ b/arckit-codex/commands/arckit.roadmap.md
@@ -43,7 +43,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-codex/commands/arckit.score.md
+++ b/arckit-codex/commands/arckit.score.md
@@ -1,0 +1,159 @@
+---
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `/arckit:sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-codex/commands/arckit.score.md
+++ b/arckit-codex/commands/arckit.score.md
@@ -12,7 +12,7 @@ You are helping an enterprise architect score vendor proposals against evaluatio
 $ARGUMENTS
 ```
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ## Sub-Actions
 
@@ -129,7 +129,7 @@ Show the scoring audit trail.
 
 If no recognised action, show usage:
 
-```
+```text
 Usage: /arckit:score <action> [options]
 
 Actions:

--- a/arckit-codex/commands/arckit.search.md
+++ b/arckit-codex/commands/arckit.search.md
@@ -55,7 +55,8 @@ $ARGUMENTS
    - Trying alternative terms
 
 6. **If the query is empty**, show a usage summary:
-   ```
+
+   ```text
    Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 
    Examples:

--- a/arckit-codex/commands/arckit.search.md
+++ b/arckit-codex/commands/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/commands/arckit.secure.md
+++ b/arckit-codex/commands/arckit.secure.md
@@ -29,7 +29,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-codex/commands/arckit.service-assessment.md
+++ b/arckit-codex/commands/arckit.service-assessment.md
@@ -54,7 +54,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-codex/commands/arckit.servicenow.md
+++ b/arckit-codex/commands/arckit.servicenow.md
@@ -64,7 +64,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-codex/commands/arckit.sobc.md
+++ b/arckit-codex/commands/arckit.sobc.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-codex/commands/arckit.sow.md
+++ b/arckit-codex/commands/arckit.sow.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/commands/arckit.stakeholders.md
+++ b/arckit-codex/commands/arckit.stakeholders.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/commands/arckit.story.md
+++ b/arckit-codex/commands/arckit.story.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/commands/arckit.strategy.md
+++ b/arckit-codex/commands/arckit.strategy.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/commands/arckit.tcop.md
+++ b/arckit-codex/commands/arckit.tcop.md
@@ -31,7 +31,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-codex/commands/arckit.traceability.md
+++ b/arckit-codex/commands/arckit.traceability.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-codex/commands/arckit.wardley.md
+++ b/arckit-codex/commands/arckit.wardley.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/docs/guides/impact.md
+++ b/arckit-codex/docs/guides/impact.md
@@ -1,0 +1,68 @@
+# Impact Analysis
+
+Analyse the blast radius of a change to a requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability (`/arckit:traceability`).
+
+## Usage
+
+```bash
+/arckit:impact <document ID or requirement ID>
+```
+
+## Examples
+
+```bash
+# Impact of changing a requirement
+/arckit:impact BR-003
+/arckit:impact NFR-SEC-001
+
+# Impact of changing a document
+/arckit:impact ARC-001-REQ
+/arckit:impact ARC-001-ADR-002
+
+# Show all dependencies for a document type in a project
+/arckit:impact ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook builds a dependency graph on invocation:
+
+1. Scans all ARC-\*.md files across all projects
+2. Extracts cross-references between documents (ARC-NNN-TYPE patterns)
+3. Maps requirement IDs to the documents that contain them
+4. Classifies each document's impact severity by type category
+
+The command then performs reverse traversal through the graph to find all downstream dependencies.
+
+## Impact Severity
+
+| Severity | Category | Document Types | Action |
+|----------|----------|---------------|--------|
+| **HIGH** | Compliance/Governance | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF | Formal re-assessment likely needed |
+| **MEDIUM** | Architecture | HLDR, DLDR, ADR, DATA, DIAG, PLAT | Design updates may be needed |
+| **LOW** | Planning/Other | PLAN, ROAD, BKLG, SOBC, OPS, PRES | Review recommended |
+
+## Traversal Depth
+
+The analysis traces dependencies up to 5 levels deep:
+
+- **Level 0**: The changed document itself
+- **Level 1**: Documents that directly reference it
+- **Level 2**: Documents that reference Level 1 documents
+- **Level 3-5**: Further indirect dependencies
+
+## When to Use
+
+- **Before changing a requirement** — understand what other documents will be affected
+- **Before updating an ADR** — check if compliance documents reference it
+- **After a design review** — trace what else needs updating when conditions are imposed
+- **During change governance** — document the full impact chain for approval boards
+
+## Relationship to Traceability
+
+| Command | Direction | Question |
+|---------|-----------|----------|
+| `/arckit:traceability` | Forward | "Are my requirements covered by design decisions?" |
+| `/arckit:impact` | Reverse | "If I change this requirement, what breaks?" |
+
+Use traceability to check coverage. Use impact to assess change risk.

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 59 slash commands
+- **Commands**: 60 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 59 ArcKit commands and 6 research agents remain fully available
+- All 60 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/score.md
+++ b/arckit-codex/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/arckit-codex/docs/guides/score.md
+++ b/arckit-codex/docs/guides/score.md
@@ -4,7 +4,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Usage
 
-```
+```text
 /arckit:score vendor <name> --project=NNN    # Score a vendor
 /arckit:score compare --project=NNN          # Compare all scored vendors
 /arckit:score audit --project=NNN            # View scoring audit trail
@@ -12,7 +12,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Workflow
 
-```
+```text
 /arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
    (criteria)         (score each)             (decide)                  (procure)
 ```

--- a/arckit-codex/docs/guides/search.md
+++ b/arckit-codex/docs/guides/search.md
@@ -4,7 +4,7 @@ Search across all project artifacts by keyword, document type, or requirement ID
 
 ## Usage
 
-```
+```text
 /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 ```
 

--- a/arckit-codex/docs/guides/search.md
+++ b/arckit-codex/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 59 commands | Plugin mode
+Version 2.10.0 | 60 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/prompts/arckit.adr.md
+++ b/arckit-codex/prompts/arckit.adr.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/prompts/arckit.ai-playbook.md
+++ b/arckit-codex/prompts/arckit.ai-playbook.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-codex/prompts/arckit.atrs.md
+++ b/arckit-codex/prompts/arckit.atrs.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-codex/prompts/arckit.backlog.md
+++ b/arckit-codex/prompts/arckit.backlog.md
@@ -89,7 +89,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-codex/prompts/arckit.conformance.md
+++ b/arckit-codex/prompts/arckit.conformance.md
@@ -67,7 +67,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/prompts/arckit.data-mesh-contract.md
+++ b/arckit-codex/prompts/arckit.data-mesh-contract.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-codex/prompts/arckit.data-model.md
+++ b/arckit-codex/prompts/arckit.data-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/prompts/arckit.devops.md
+++ b/arckit-codex/prompts/arckit.devops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.dfd.md
+++ b/arckit-codex/prompts/arckit.dfd.md
@@ -31,7 +31,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-codex/prompts/arckit.diagram.md
+++ b/arckit-codex/prompts/arckit.diagram.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-codex/prompts/arckit.dld-review.md
+++ b/arckit-codex/prompts/arckit.dld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/prompts/arckit.dos.md
+++ b/arckit-codex/prompts/arckit.dos.md
@@ -22,7 +22,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/prompts/arckit.dpia.md
+++ b/arckit-codex/prompts/arckit.dpia.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.evaluate.md
+++ b/arckit-codex/prompts/arckit.evaluate.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-codex/prompts/arckit.finops.md
+++ b/arckit-codex/prompts/arckit.finops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.gcloud-clarify.md
+++ b/arckit-codex/prompts/arckit.gcloud-clarify.md
@@ -23,7 +23,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.gcloud-search.md
+++ b/arckit-codex/prompts/arckit.gcloud-search.md
@@ -46,7 +46,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-codex/prompts/arckit.glossary.md
+++ b/arckit-codex/prompts/arckit.glossary.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/prompts/arckit.hld-review.md
+++ b/arckit-codex/prompts/arckit.hld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/prompts/arckit.impact.md
+++ b/arckit-codex/prompts/arckit.impact.md
@@ -1,0 +1,86 @@
+---
+description: "Analyse the blast radius of a change to a requirement, decision, or design document"
+---
+
+# Impact Analysis
+
+You are helping an enterprise architect understand the blast radius of a change to an existing requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Impact hook has already built a dependency graph from all project artifacts and provided it as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the query** to identify the change source:
+   - **ARC document ID** (e.g., `ARC-001-REQ`, `ARC-001-ADR-003`) → find all documents that reference it
+   - **Requirement ID** (e.g., `BR-003`, `NFR-SEC-001`) → find all documents containing that requirement ID
+   - **Document type + project** (e.g., `ADR --project=001`) → show all dependencies of ADRs in that project
+   - **Plain text** → search node titles and suggest the most likely target
+
+2. **Perform reverse traversal** using the dependency graph:
+   - **Level 0**: The changed document itself
+   - **Level 1**: Documents that directly reference it (via cross-references or shared requirement IDs)
+   - **Level 2**: Documents that reference Level 1 documents
+   - Continue until no more references found (max depth 5)
+
+3. **Classify impact severity** using the `severity` field from the graph nodes:
+   - **HIGH**: Compliance/Governance documents (TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF) — may need formal re-assessment
+   - **MEDIUM**: Architecture documents (HLDR, DLDR, ADR, DATA, DIAG, PLAT) — may need design updates
+   - **LOW**: Planning/Other documents (PLAN, ROAD, BKLG, SOBC, OPS, PRES) — review recommended
+
+4. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Impact Analysis: BR-003 (Data Residency Requirement)
+
+   ### Change Source
+   - **Requirement:** BR-003 — "All customer data must reside within UK data centres"
+   - **Defined in:** ARC-001-REQ-v2.0 (projects/001-payments/)
+
+   ### Impact Chain
+
+   | Level | Document | Type | Impact | Action Needed |
+   |-------|----------|------|--------|---------------|
+   | 1 | ARC-001-ADR-002-v1.0 | ADR | MEDIUM | Review cloud provider decision |
+   | 1 | ARC-001-HLDR-v1.0 | HLDR | MEDIUM | Update deployment architecture |
+   | 2 | ARC-001-SECD-v1.0 | SECD | HIGH | Re-assess data protection controls |
+   | 2 | ARC-001-DPIA-v1.0 | DPIA | HIGH | Re-run DPIA assessment |
+   | 3 | ARC-001-OPS-v1.0 | OPS | LOW | Check operational procedures |
+
+   ### Summary
+   - **Total impacted:** 5 documents
+   - **HIGH severity:** 2 (compliance re-assessment needed)
+   - **MEDIUM severity:** 2 (design updates needed)
+   - **LOW severity:** 1 (review recommended)
+
+   ### Recommended Actions
+   1. Re-run `/arckit:secure` to update Secure by Design assessment
+   2. Re-run `/arckit:dpia` to update Data Protection Impact Assessment
+   3. Review ADR-002 decision rationale against updated requirement
+   ```
+
+5. **Recommend specific `/arckit:` commands** for HIGH severity impacts:
+   - SECD impacted → `/arckit:secure`
+   - DPIA impacted → `/arckit:dpia`
+   - TCOP impacted → `/arckit:tcop`
+   - HLDR impacted → `/arckit:hld-review`
+   - RISK impacted → `/arckit:risk`
+   - TRAC impacted → `/arckit:traceability`
+
+6. **If no impacts found**, report that the document has no downstream dependencies. Note this may indicate a traceability gap — suggest running `/arckit:traceability` to check coverage.
+
+7. **If the query matches multiple documents**, list them and ask the user to specify which one to analyse.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:traceability` -- Update traceability matrix after impact assessment *(when Impact analysis revealed traceability gaps)*
+- `/arckit:health` -- Check health of impacted artifacts *(when Impacted documents may be stale)*
+- `/arckit:conformance` -- Re-assess conformance after changes *(when Impact includes architecture design documents)*
+

--- a/arckit-codex/prompts/arckit.jsp-936.md
+++ b/arckit-codex/prompts/arckit.jsp-936.md
@@ -49,7 +49,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.maturity-model.md
+++ b/arckit-codex/prompts/arckit.maturity-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/prompts/arckit.mlops.md
+++ b/arckit-codex/prompts/arckit.mlops.md
@@ -52,7 +52,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.mod-secure.md
+++ b/arckit-codex/prompts/arckit.mod-secure.md
@@ -64,7 +64,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-codex/prompts/arckit.operationalize.md
+++ b/arckit-codex/prompts/arckit.operationalize.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.pages.md
+++ b/arckit-codex/prompts/arckit.pages.md
@@ -23,24 +23,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -69,7 +74,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -130,6 +135,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -159,12 +165,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -213,7 +213,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -245,10 +244,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -408,9 +408,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -430,10 +476,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -472,6 +514,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/prompts/arckit.plan.md
+++ b/arckit-codex/prompts/arckit.plan.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-codex/prompts/arckit.platform-design.md
+++ b/arckit-codex/prompts/arckit.platform-design.md
@@ -20,7 +20,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.presentation.md
+++ b/arckit-codex/prompts/arckit.presentation.md
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-codex/prompts/arckit.principles-compliance.md
+++ b/arckit-codex/prompts/arckit.principles-compliance.md
@@ -49,7 +49,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/prompts/arckit.principles.md
+++ b/arckit-codex/prompts/arckit.principles.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-codex/prompts/arckit.requirements.md
+++ b/arckit-codex/prompts/arckit.requirements.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/prompts/arckit.risk.md
+++ b/arckit-codex/prompts/arckit.risk.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-codex/prompts/arckit.roadmap.md
+++ b/arckit-codex/prompts/arckit.roadmap.md
@@ -43,7 +43,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-codex/prompts/arckit.score.md
+++ b/arckit-codex/prompts/arckit.score.md
@@ -1,0 +1,159 @@
+---
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `/arckit:sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-codex/prompts/arckit.score.md
+++ b/arckit-codex/prompts/arckit.score.md
@@ -12,7 +12,7 @@ You are helping an enterprise architect score vendor proposals against evaluatio
 $ARGUMENTS
 ```
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ## Sub-Actions
 
@@ -129,7 +129,7 @@ Show the scoring audit trail.
 
 If no recognised action, show usage:
 
-```
+```text
 Usage: /arckit:score <action> [options]
 
 Actions:

--- a/arckit-codex/prompts/arckit.search.md
+++ b/arckit-codex/prompts/arckit.search.md
@@ -55,7 +55,8 @@ $ARGUMENTS
    - Trying alternative terms
 
 6. **If the query is empty**, show a usage summary:
-   ```
+
+   ```text
    Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 
    Examples:

--- a/arckit-codex/prompts/arckit.search.md
+++ b/arckit-codex/prompts/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/prompts/arckit.secure.md
+++ b/arckit-codex/prompts/arckit.secure.md
@@ -29,7 +29,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-codex/prompts/arckit.service-assessment.md
+++ b/arckit-codex/prompts/arckit.service-assessment.md
@@ -54,7 +54,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-codex/prompts/arckit.servicenow.md
+++ b/arckit-codex/prompts/arckit.servicenow.md
@@ -64,7 +64,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-codex/prompts/arckit.sobc.md
+++ b/arckit-codex/prompts/arckit.sobc.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-codex/prompts/arckit.sow.md
+++ b/arckit-codex/prompts/arckit.sow.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/prompts/arckit.stakeholders.md
+++ b/arckit-codex/prompts/arckit.stakeholders.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/prompts/arckit.story.md
+++ b/arckit-codex/prompts/arckit.story.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/prompts/arckit.strategy.md
+++ b/arckit-codex/prompts/arckit.strategy.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/prompts/arckit.tcop.md
+++ b/arckit-codex/prompts/arckit.tcop.md
@@ -31,7 +31,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-codex/prompts/arckit.traceability.md
+++ b/arckit-codex/prompts/arckit.traceability.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-codex/prompts/arckit.wardley.md
+++ b/arckit-codex/prompts/arckit.wardley.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-adr/SKILL.md
+++ b/arckit-codex/skills/arckit-adr/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/skills/arckit-ai-playbook/SKILL.md
+++ b/arckit-codex/skills/arckit-ai-playbook/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-codex/skills/arckit-atrs/SKILL.md
+++ b/arckit-codex/skills/arckit-atrs/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-codex/skills/arckit-backlog/SKILL.md
+++ b/arckit-codex/skills/arckit-backlog/SKILL.md
@@ -90,7 +90,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-codex/skills/arckit-conformance/SKILL.md
+++ b/arckit-codex/skills/arckit-conformance/SKILL.md
@@ -68,7 +68,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/skills/arckit-data-mesh-contract/SKILL.md
+++ b/arckit-codex/skills/arckit-data-mesh-contract/SKILL.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-codex/skills/arckit-data-model/SKILL.md
+++ b/arckit-codex/skills/arckit-data-model/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-codex/skills/arckit-devops/SKILL.md
+++ b/arckit-codex/skills/arckit-devops/SKILL.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-dfd/SKILL.md
+++ b/arckit-codex/skills/arckit-dfd/SKILL.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-codex/skills/arckit-diagram/SKILL.md
+++ b/arckit-codex/skills/arckit-diagram/SKILL.md
@@ -24,7 +24,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-codex/skills/arckit-dld-review/SKILL.md
+++ b/arckit-codex/skills/arckit-dld-review/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/skills/arckit-dos/SKILL.md
+++ b/arckit-codex/skills/arckit-dos/SKILL.md
@@ -23,7 +23,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/skills/arckit-dpia/SKILL.md
+++ b/arckit-codex/skills/arckit-dpia/SKILL.md
@@ -15,7 +15,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-evaluate/SKILL.md
+++ b/arckit-codex/skills/arckit-evaluate/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-codex/skills/arckit-finops/SKILL.md
+++ b/arckit-codex/skills/arckit-finops/SKILL.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-gcloud-clarify/SKILL.md
+++ b/arckit-codex/skills/arckit-gcloud-clarify/SKILL.md
@@ -24,7 +24,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-gcloud-search/SKILL.md
+++ b/arckit-codex/skills/arckit-gcloud-search/SKILL.md
@@ -47,7 +47,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-codex/skills/arckit-glossary/SKILL.md
+++ b/arckit-codex/skills/arckit-glossary/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/skills/arckit-hld-review/SKILL.md
+++ b/arckit-codex/skills/arckit-hld-review/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-codex/skills/arckit-impact/SKILL.md
+++ b/arckit-codex/skills/arckit-impact/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: arckit-impact
+description: "Analyse the blast radius of a change to a requirement, decision, or design document"
+---
+
+# Impact Analysis
+
+You are helping an enterprise architect understand the blast radius of a change to an existing requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Impact hook has already built a dependency graph from all project artifacts and provided it as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the query** to identify the change source:
+   - **ARC document ID** (e.g., `ARC-001-REQ`, `ARC-001-ADR-003`) → find all documents that reference it
+   - **Requirement ID** (e.g., `BR-003`, `NFR-SEC-001`) → find all documents containing that requirement ID
+   - **Document type + project** (e.g., `ADR --project=001`) → show all dependencies of ADRs in that project
+   - **Plain text** → search node titles and suggest the most likely target
+
+2. **Perform reverse traversal** using the dependency graph:
+   - **Level 0**: The changed document itself
+   - **Level 1**: Documents that directly reference it (via cross-references or shared requirement IDs)
+   - **Level 2**: Documents that reference Level 1 documents
+   - Continue until no more references found (max depth 5)
+
+3. **Classify impact severity** using the `severity` field from the graph nodes:
+   - **HIGH**: Compliance/Governance documents (TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF) — may need formal re-assessment
+   - **MEDIUM**: Architecture documents (HLDR, DLDR, ADR, DATA, DIAG, PLAT) — may need design updates
+   - **LOW**: Planning/Other documents (PLAN, ROAD, BKLG, SOBC, OPS, PRES) — review recommended
+
+4. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Impact Analysis: BR-003 (Data Residency Requirement)
+
+   ### Change Source
+   - **Requirement:** BR-003 — "All customer data must reside within UK data centres"
+   - **Defined in:** ARC-001-REQ-v2.0 (projects/001-payments/)
+
+   ### Impact Chain
+
+   | Level | Document | Type | Impact | Action Needed |
+   |-------|----------|------|--------|---------------|
+   | 1 | ARC-001-ADR-002-v1.0 | ADR | MEDIUM | Review cloud provider decision |
+   | 1 | ARC-001-HLDR-v1.0 | HLDR | MEDIUM | Update deployment architecture |
+   | 2 | ARC-001-SECD-v1.0 | SECD | HIGH | Re-assess data protection controls |
+   | 2 | ARC-001-DPIA-v1.0 | DPIA | HIGH | Re-run DPIA assessment |
+   | 3 | ARC-001-OPS-v1.0 | OPS | LOW | Check operational procedures |
+
+   ### Summary
+   - **Total impacted:** 5 documents
+   - **HIGH severity:** 2 (compliance re-assessment needed)
+   - **MEDIUM severity:** 2 (design updates needed)
+   - **LOW severity:** 1 (review recommended)
+
+   ### Recommended Actions
+   1. Re-run `$arckit-secure` to update Secure by Design assessment
+   2. Re-run `$arckit-dpia` to update Data Protection Impact Assessment
+   3. Review ADR-002 decision rationale against updated requirement
+   ```
+
+5. **Recommend specific `/arckit:` commands** for HIGH severity impacts:
+   - SECD impacted → `$arckit-secure`
+   - DPIA impacted → `$arckit-dpia`
+   - TCOP impacted → `$arckit-tcop`
+   - HLDR impacted → `$arckit-hld-review`
+   - RISK impacted → `$arckit-risk`
+   - TRAC impacted → `$arckit-traceability`
+
+6. **If no impacts found**, report that the document has no downstream dependencies. Note this may indicate a traceability gap — suggest running `$arckit-traceability` to check coverage.
+
+7. **If the query matches multiple documents**, list them and ask the user to specify which one to analyse.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-traceability` -- Update traceability matrix after impact assessment *(when Impact analysis revealed traceability gaps)*
+- `$arckit-health` -- Check health of impacted artifacts *(when Impacted documents may be stale)*
+- `$arckit-conformance` -- Re-assess conformance after changes *(when Impact includes architecture design documents)*
+

--- a/arckit-codex/skills/arckit-impact/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-impact/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-jsp-936/SKILL.md
+++ b/arckit-codex/skills/arckit-jsp-936/SKILL.md
@@ -50,7 +50,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-maturity-model/SKILL.md
+++ b/arckit-codex/skills/arckit-maturity-model/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-codex/skills/arckit-mlops/SKILL.md
+++ b/arckit-codex/skills/arckit-mlops/SKILL.md
@@ -53,7 +53,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-mod-secure/SKILL.md
+++ b/arckit-codex/skills/arckit-mod-secure/SKILL.md
@@ -65,7 +65,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-codex/skills/arckit-operationalize/SKILL.md
+++ b/arckit-codex/skills/arckit-operationalize/SKILL.md
@@ -47,7 +47,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-pages/SKILL.md
+++ b/arckit-codex/skills/arckit-pages/SKILL.md
@@ -24,24 +24,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -70,7 +75,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -131,6 +136,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -160,12 +166,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -214,7 +214,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -246,10 +245,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -409,9 +409,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `$arckit-customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -431,10 +477,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -473,6 +515,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-codex/skills/arckit-plan/SKILL.md
+++ b/arckit-codex/skills/arckit-plan/SKILL.md
@@ -36,7 +36,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-codex/skills/arckit-platform-design/SKILL.md
+++ b/arckit-codex/skills/arckit-platform-design/SKILL.md
@@ -21,7 +21,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-presentation/SKILL.md
+++ b/arckit-codex/skills/arckit-presentation/SKILL.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-codex/skills/arckit-principles-compliance/SKILL.md
+++ b/arckit-codex/skills/arckit-principles-compliance/SKILL.md
@@ -50,7 +50,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-codex/skills/arckit-principles/SKILL.md
+++ b/arckit-codex/skills/arckit-principles/SKILL.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-codex/skills/arckit-requirements/SKILL.md
+++ b/arckit-codex/skills/arckit-requirements/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/skills/arckit-risk/SKILL.md
+++ b/arckit-codex/skills/arckit-risk/SKILL.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-codex/skills/arckit-roadmap/SKILL.md
+++ b/arckit-codex/skills/arckit-roadmap/SKILL.md
@@ -44,7 +44,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-codex/skills/arckit-score/SKILL.md
+++ b/arckit-codex/skills/arckit-score/SKILL.md
@@ -1,0 +1,160 @@
+---
+name: arckit-score
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `$arckit-evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: $arckit-score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  $arckit-score vendor "Acme Cloud" --project=001
+  $arckit-score compare --project=001
+  $arckit-score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `$arckit-sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-codex/skills/arckit-score/SKILL.md
+++ b/arckit-codex/skills/arckit-score/SKILL.md
@@ -13,7 +13,7 @@ You are helping an enterprise architect score vendor proposals against evaluatio
 $ARGUMENTS
 ```
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ## Sub-Actions
 
@@ -130,7 +130,7 @@ Show the scoring audit trail.
 
 If no recognised action, show usage:
 
-```
+```text
 Usage: $arckit-score <action> [options]
 
 Actions:

--- a/arckit-codex/skills/arckit-score/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-score/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-search/SKILL.md
+++ b/arckit-codex/skills/arckit-search/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: arckit-search
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: $arckit-search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     $arckit-search PostgreSQL
+     $arckit-search "data residency" --type=ADR
+     $arckit-search --id=BR-003
+     $arckit-search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `$arckit-traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `$arckit-impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-codex/skills/arckit-search/SKILL.md
+++ b/arckit-codex/skills/arckit-search/SKILL.md
@@ -56,7 +56,8 @@ $ARGUMENTS
    - Trying alternative terms
 
 6. **If the query is empty**, show a usage summary:
-   ```
+
+   ```text
    Usage: $arckit-search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 
    Examples:

--- a/arckit-codex/skills/arckit-search/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-search/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-secure/SKILL.md
+++ b/arckit-codex/skills/arckit-secure/SKILL.md
@@ -30,7 +30,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-codex/skills/arckit-service-assessment/SKILL.md
+++ b/arckit-codex/skills/arckit-service-assessment/SKILL.md
@@ -55,7 +55,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-codex/skills/arckit-servicenow/SKILL.md
+++ b/arckit-codex/skills/arckit-servicenow/SKILL.md
@@ -65,7 +65,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-codex/skills/arckit-sobc/SKILL.md
+++ b/arckit-codex/skills/arckit-sobc/SKILL.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-codex/skills/arckit-sow/SKILL.md
+++ b/arckit-codex/skills/arckit-sow/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/skills/arckit-stakeholders/SKILL.md
+++ b/arckit-codex/skills/arckit-stakeholders/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-codex/skills/arckit-story/SKILL.md
+++ b/arckit-codex/skills/arckit-story/SKILL.md
@@ -20,7 +20,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-codex/skills/arckit-strategy/SKILL.md
+++ b/arckit-codex/skills/arckit-strategy/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-codex/skills/arckit-tcop/SKILL.md
+++ b/arckit-codex/skills/arckit-tcop/SKILL.md
@@ -32,7 +32,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-codex/skills/arckit-traceability/SKILL.md
+++ b/arckit-codex/skills/arckit-traceability/SKILL.md
@@ -13,7 +13,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-codex/skills/arckit-wardley/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley/SKILL.md
@@ -33,7 +33,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 59 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 57 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 58 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 59 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 60 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 58 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 59 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 58 Commands
+## All 59 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 57 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 58 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 57 Commands
+## All 58 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 59 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 60 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 59 Commands
+## All 60 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/agents/arckit-aws-research.md
+++ b/arckit-gemini/agents/arckit-aws-research.md
@@ -30,6 +30,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-azure-research.md
+++ b/arckit-gemini/agents/arckit-azure-research.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-datascout.md
+++ b/arckit-gemini/agents/arckit-datascout.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-framework.md
+++ b/arckit-gemini/agents/arckit-framework.md
@@ -50,6 +50,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-gcp-research.md
+++ b/arckit-gemini/agents/arckit-gcp-research.md
@@ -33,6 +33,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-research.md
+++ b/arckit-gemini/agents/arckit-research.md
@@ -73,6 +73,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/commands/arckit/pages.toml
+++ b/arckit-gemini/commands/arckit/pages.toml
@@ -31,24 +31,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote \"origin\"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions \"Guide Sync Complete\" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with \" — ArcKit Command Guide\" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `~/.gemini/extensions/arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -77,7 +82,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip \" — ArcKit Command Guide\" suffix). Map the DDaT family from the filename using the table above. Count the rows in the \"Primary Commands\" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -138,6 +143,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -167,12 +173,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -221,7 +221,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -253,10 +252,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -416,9 +416,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Run `cat ~/.gemini/extensions/arckit/templates/pages-template.html` to read the file (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`~/.gemini/extensions/arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under \"Document Stats\") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -438,10 +484,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -480,7 +522,54 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show \"Document not found\")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `~/.gemini/extensions/arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
 """

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 59 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 57 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 58 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.0.2",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 59 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 60 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-opencode/commands/arckit.adr.md
+++ b/arckit-opencode/commands/arckit.adr.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. **Read existing artifacts from the project context:**
 

--- a/arckit-opencode/commands/arckit.ai-playbook.md
+++ b/arckit-opencode/commands/arckit.ai-playbook.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify AI system context**:
    - AI system name and purpose

--- a/arckit-opencode/commands/arckit.atrs.md
+++ b/arckit-opencode/commands/arckit.atrs.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies

--- a/arckit-opencode/commands/arckit.backlog.md
+++ b/arckit-opencode/commands/arckit.backlog.md
@@ -89,7 +89,7 @@ Scans all ArcKit artifacts and automatically:
 
 ### Step 1: Identify Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number). If no match, create a new project:
 

--- a/arckit-opencode/commands/arckit.conformance.md
+++ b/arckit-opencode/commands/arckit.conformance.md
@@ -67,7 +67,7 @@ c. `.arckit/conformance-rules.md` in the project root (if exists):
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-opencode/commands/arckit.data-mesh-contract.md
+++ b/arckit-opencode/commands/arckit.data-mesh-contract.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Check Prerequisites
 

--- a/arckit-opencode/commands/arckit.data-model.md
+++ b/arckit-opencode/commands/arckit.data-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Read existing artifacts from the project context:**
 

--- a/arckit-opencode/commands/arckit.devops.md
+++ b/arckit-opencode/commands/arckit.devops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.dfd.md
+++ b/arckit-opencode/commands/arckit.dfd.md
@@ -31,7 +31,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to understand what to diagram:
 

--- a/arckit-opencode/commands/arckit.diagram.md
+++ b/arckit-opencode/commands/arckit.diagram.md
@@ -23,7 +23,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing artifacts from the project context to understand what to diagram:
 

--- a/arckit-opencode/commands/arckit.dld-review.md
+++ b/arckit-opencode/commands/arckit.dld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-opencode/commands/arckit.dos.md
+++ b/arckit-opencode/commands/arckit.dos.md
@@ -22,7 +22,7 @@ This command generates DOS-compliant procurement documentation from your existin
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-opencode/commands/arckit.dpia.md
+++ b/arckit-opencode/commands/arckit.dpia.md
@@ -14,7 +14,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.evaluate.md
+++ b/arckit-opencode/commands/arckit.evaluate.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Create evaluation framework for payment gateway project"

--- a/arckit-opencode/commands/arckit.finops.md
+++ b/arckit-opencode/commands/arckit.finops.md
@@ -45,7 +45,7 @@ Parse the user input for:
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.gcloud-clarify.md
+++ b/arckit-opencode/commands/arckit.gcloud-clarify.md
@@ -23,7 +23,7 @@ This command analyzes gaps between requirements and service descriptions, then g
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.gcloud-search.md
+++ b/arckit-opencode/commands/arckit.gcloud-search.md
@@ -46,7 +46,7 @@ b. **Architecture Principles** (RECOMMENDED):
 
 ### 2. Load Project Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. Read the **REQ** (Requirements) artifact for the target project
 2. Read the **PRIN** (Architecture Principles, in 000-global) if available

--- a/arckit-opencode/commands/arckit.glossary.md
+++ b/arckit-opencode/commands/arckit.glossary.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-opencode/commands/arckit.hld-review.md
+++ b/arckit-opencode/commands/arckit.hld-review.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the context**: The user should specify:
    - Project name/number

--- a/arckit-opencode/commands/arckit.impact.md
+++ b/arckit-opencode/commands/arckit.impact.md
@@ -1,0 +1,86 @@
+---
+description: "Analyse the blast radius of a change to a requirement, decision, or design document"
+---
+
+# Impact Analysis
+
+You are helping an enterprise architect understand the blast radius of a change to an existing requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Impact hook has already built a dependency graph from all project artifacts and provided it as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the query** to identify the change source:
+   - **ARC document ID** (e.g., `ARC-001-REQ`, `ARC-001-ADR-003`) → find all documents that reference it
+   - **Requirement ID** (e.g., `BR-003`, `NFR-SEC-001`) → find all documents containing that requirement ID
+   - **Document type + project** (e.g., `ADR --project=001`) → show all dependencies of ADRs in that project
+   - **Plain text** → search node titles and suggest the most likely target
+
+2. **Perform reverse traversal** using the dependency graph:
+   - **Level 0**: The changed document itself
+   - **Level 1**: Documents that directly reference it (via cross-references or shared requirement IDs)
+   - **Level 2**: Documents that reference Level 1 documents
+   - Continue until no more references found (max depth 5)
+
+3. **Classify impact severity** using the `severity` field from the graph nodes:
+   - **HIGH**: Compliance/Governance documents (TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF) — may need formal re-assessment
+   - **MEDIUM**: Architecture documents (HLDR, DLDR, ADR, DATA, DIAG, PLAT) — may need design updates
+   - **LOW**: Planning/Other documents (PLAN, ROAD, BKLG, SOBC, OPS, PRES) — review recommended
+
+4. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Impact Analysis: BR-003 (Data Residency Requirement)
+
+   ### Change Source
+   - **Requirement:** BR-003 — "All customer data must reside within UK data centres"
+   - **Defined in:** ARC-001-REQ-v2.0 (projects/001-payments/)
+
+   ### Impact Chain
+
+   | Level | Document | Type | Impact | Action Needed |
+   |-------|----------|------|--------|---------------|
+   | 1 | ARC-001-ADR-002-v1.0 | ADR | MEDIUM | Review cloud provider decision |
+   | 1 | ARC-001-HLDR-v1.0 | HLDR | MEDIUM | Update deployment architecture |
+   | 2 | ARC-001-SECD-v1.0 | SECD | HIGH | Re-assess data protection controls |
+   | 2 | ARC-001-DPIA-v1.0 | DPIA | HIGH | Re-run DPIA assessment |
+   | 3 | ARC-001-OPS-v1.0 | OPS | LOW | Check operational procedures |
+
+   ### Summary
+   - **Total impacted:** 5 documents
+   - **HIGH severity:** 2 (compliance re-assessment needed)
+   - **MEDIUM severity:** 2 (design updates needed)
+   - **LOW severity:** 1 (review recommended)
+
+   ### Recommended Actions
+   1. Re-run `/arckit:secure` to update Secure by Design assessment
+   2. Re-run `/arckit:dpia` to update Data Protection Impact Assessment
+   3. Review ADR-002 decision rationale against updated requirement
+   ```
+
+5. **Recommend specific `/arckit:` commands** for HIGH severity impacts:
+   - SECD impacted → `/arckit:secure`
+   - DPIA impacted → `/arckit:dpia`
+   - TCOP impacted → `/arckit:tcop`
+   - HLDR impacted → `/arckit:hld-review`
+   - RISK impacted → `/arckit:risk`
+   - TRAC impacted → `/arckit:traceability`
+
+6. **If no impacts found**, report that the document has no downstream dependencies. Note this may indicate a traceability gap — suggest running `/arckit:traceability` to check coverage.
+
+7. **If the query matches multiple documents**, list them and ask the user to specify which one to analyse.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:traceability` -- Update traceability matrix after impact assessment *(when Impact analysis revealed traceability gaps)*
+- `/arckit:health` -- Check health of impacted artifacts *(when Impacted documents may be stale)*
+- `/arckit:conformance` -- Re-assess conformance after changes *(when Impact includes architecture design documents)*
+

--- a/arckit-opencode/commands/arckit.jsp-936.md
+++ b/arckit-opencode/commands/arckit.jsp-936.md
@@ -49,7 +49,7 @@ Generate comprehensive JSP 936 AI assurance documentation following this rigorou
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.maturity-model.md
+++ b/arckit-opencode/commands/arckit.maturity-model.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **RECOMMENDED** (read if available, note if missing):
 

--- a/arckit-opencode/commands/arckit.mlops.md
+++ b/arckit-opencode/commands/arckit.mlops.md
@@ -52,7 +52,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.mod-secure.md
+++ b/arckit-opencode/commands/arckit.mod-secure.md
@@ -64,7 +64,7 @@ Generate a comprehensive Secure by Design assessment document using the **contin
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: NFR-SEC (security), NFR-A (availability), INT (integration), DR (data) requirements, data classification

--- a/arckit-opencode/commands/arckit.operationalize.md
+++ b/arckit-opencode/commands/arckit.operationalize.md
@@ -46,7 +46,7 @@ Parse the user input for:
 
 ### Phase 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.pages.md
+++ b/arckit-opencode/commands/arckit.pages.md
@@ -23,24 +23,29 @@ The Pages Generator creates a `docs/index.html` file that:
 
 Generate a documentation site for this ArcKit repository.
 
-## Steps 0–4: Handled by Hook
+## Step 0: Determine Repository Info
 
-**The `sync-guides` hook runs before this command and handles everything:**
+Determine the repository name and URL:
 
-1. Syncs all guide `.md` files from plugin to `docs/guides/`
-2. Extracts titles from each guide
-3. Reads `.git/config` for repo name, owner, URL
-4. Reads plugin VERSION
-5. Processes `pages-template.html` → writes `docs/index.html`
-6. Scans all projects, artifacts, vendors, external files → writes `docs/manifest.json`
+1. Read the `.git/config` file and find the `[remote "origin"]` section to get the remote URL
+2. Extract the repo name and owner from the URL (e.g. `https://github.com/owner/repo-name` → repo name is `repo-name`, owner is `owner`)
+3. If `.git/config` doesn't exist or has no remote, use the current directory name as the repo name
 
-**CRITICAL: The hook's hook context contains ALL document stats you need. Use ONLY those stats for the Step 5 summary. Do NOT call any tools — no Read, Write, Glob, Grep, or Bash. Do NOT read manifest.json or any other file. The hook has already written docs/index.html and docs/manifest.json with correct data. Go directly to Step 5 and output the summary using the stats from the hook context.**
+## Step 1: Discover Repository Structure
 
-The following reference sections document the manifest structure and data tables used by the hook. They are preserved here for maintenance reference only — the command does not need to process them.
+Use **Glob** and **Read** tools to scan the repository. Do NOT use `ls`, `find`, `for` loops, `head`, `grep`, `sed`, or any Bash commands for file discovery.
 
----
+### 1.1 Guides (Command Documentation)
 
-### Reference: Guide Categories
+**Guide sync and title extraction are handled automatically by the `sync-guides` hook** which runs before this command executes. The hook copies all guide `.md` files from the plugin to `docs/guides/` and extracts the first `#` heading from each file — zero tool round-trips.
+
+- **If the hook systemMessage is present** (mentions "Guide Sync Complete" and contains a `guideTitles` JSON map): guides are synced and titles are pre-extracted. Use the `guideTitles` map directly — do NOT use Glob or Read on guide files. The map keys are repo-relative paths (e.g., `docs/guides/requirements.md`, `docs/guides/roles/enterprise-architect.md`) and values are the extracted titles (with " — ArcKit Command Guide" suffix already stripped for role guides).
+- **If no hook message** (hook unavailable or failed): fall back to manual sync and title extraction:
+  1. Use **Glob** to list all `.md` files in `.arckit/docs/guides/` (and any subdirectories like `uk-government/`, `uk-mod/`, `roles/`)
+  2. For each guide file, **Read** from the plugin path and **Write** to the corresponding path under `docs/guides/`, creating subdirectories as needed
+  3. Use **Glob** to scan `docs/guides/*.md` then **Read** (with `limit: 5`) each file to extract the `#` title
+
+Use the titles (from hook or manual extraction) to build the `guides` array for top-level guides (excluding `roles/` subdirectory) and the `roleGuides` array for role guides. Role guides in `docs/guides/roles/` are added to a separate `roleGuides` array in manifest.json (see DDaT Role Guides section below).
 
 **Guide Categories** (based on filename):
 
@@ -69,7 +74,7 @@ Role guides map ArcKit commands to [DDaT Capability Framework](https://ddat-capa
 | IT Operations | it-service-manager |
 | Software Development | devops-engineer |
 
-Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). Use titles from the hook's `guideTitles` map for `docs/guides/roles/*.md` paths (suffix already stripped). Map the DDaT family from the filename using the table above. Use the commandCount reference table below to populate `commandCount`.
+Add role guides to a separate `roleGuides` array in manifest.json (not the `guides` array). If the hook provided `guideTitles`, use titles from the map for `docs/guides/roles/*.md` paths (suffix already stripped). Otherwise, use **Glob** to scan `docs/guides/roles/*.md` (excluding `README.md`) and **Read** (with `limit: 5`) to extract the title from the first `#` heading (strip " — ArcKit Command Guide" suffix). Map the DDaT family from the filename using the table above. Count the rows in the "Primary Commands" table to populate `commandCount`.
 
 **Role guide commandCount reference**:
 
@@ -130,6 +135,7 @@ projects/
 │   ├── ARC-001-RISK-v1.0.md     # Risk Register
 │   ├── ARC-001-SOBC-v1.0.md     # Strategic Outline Business Case
 │   ├── ARC-001-DATA-v1.0.md     # Data Model
+│   ├── ARC-001-RSCH-v1.0.md     # Research Findings
 │   ├── ARC-001-TRAC-v1.0.md     # Traceability Matrix
 │   ├── ARC-001-SOW-v1.0.md      # Statement of Work
 │   ├── ARC-001-EVAL-v1.0.md     # Evaluation Criteria
@@ -159,12 +165,6 @@ projects/
 │   │   └── ARC-001-WARD-{NNN}-v1.0.md  # Wardley Maps
 │   ├── data-contracts/
 │   │   └── ARC-001-DMC-{NNN}-v1.0.md   # Data Mesh Contracts
-│   ├── research/
-│   │   ├── ARC-001-RSCH-{NNN}-v1.0.md  # Research Findings
-│   │   ├── ARC-001-DSCT-{NNN}-v1.0.md  # Data Source Discovery
-│   │   ├── ARC-001-AWRS-{NNN}-v1.0.md  # AWS Research
-│   │   ├── ARC-001-AZRS-{NNN}-v1.0.md  # Azure Research
-│   │   └── ARC-001-GCRS-{NNN}-v1.0.md  # GCP Research
 │   ├── reviews/
 │   │   ├── ARC-001-HLDR-v1.0.md        # HLD Review
 │   │   └── ARC-001-DLDR-v1.0.md        # DLD Review
@@ -213,7 +213,6 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | RISK | `ARC-*-RISK-*.md` | Risk Register |
 | | TRAC | `ARC-*-TRAC-*.md` | Traceability Matrix |
 | | PRIN-COMP | `ARC-*-PRIN-COMP-*.md` | Principles Compliance |
-| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 | **Compliance** | | | |
 | | TCOP | `ARC-*-TCOP-*.md` | TCoP Assessment |
 | | SECD | `ARC-*-SECD-*.md` | Secure by Design |
@@ -245,10 +244,11 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | DSCT | `ARC-*-DSCT-*.md` | Data Source Discovery |
 | **Other** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | ANAL | `ARC-*-ANAL-*.md` | Analysis Report |
 
-### Reference: Manifest Structure
+## Step 2: Generate manifest.json
 
-The hook generates `docs/manifest.json` with this structure:
+Create `docs/manifest.json` with the discovered structure:
 
 ```json
 {
@@ -408,9 +408,55 @@ The hook generates `docs/manifest.json` with this structure:
 }
 ```
 
+## Step 3: Generate index.html
+
+### 3.1 Read the template (MANDATORY)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/pages-template.html` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/pages-template.html` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize pages`
+
+This template is the single source of truth for the pages site — it contains all HTML structure, CSS styling, and JavaScript functionality.
+
+1. Read the appropriate template file (custom override or default) using the **Read** tool
+2. Store the entire template content in memory
+3. Replace the placeholder values **in memory** (string replacement) with actual repository details:
+   - `'{{REPO}}'` → the repository name (e.g. `'arckit-test-project-v17-fuel-prices'`)
+   - `'{{REPO_URL}}'` → the full repository URL (e.g. `'https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices'`)
+   - `'{{CONTENT_BASE_URL}}'` → the raw content base URL for fallback loading (e.g. `'https://raw.githubusercontent.com/tractorjuice/arckit-test-project-v17-fuel-prices/main'`). For GitHub repos use `https://raw.githubusercontent.com/{owner}/{repo}/{branch}`. For non-GitHub hosting set to `''` (empty string).
+   - `'{{VERSION}}'` → the ArcKit version from the plugin's VERSION file (`.arckit/VERSION`)
+   - `'{{DEFAULT_DOC}}'` → the default document path (principles if exists, or `''`)
+4. Write the final HTML to `docs/index.html` using the **Write** tool
+
+**IMPORTANT**: Do NOT use `sed`, `cp`, or any Bash commands for template processing. Read the template with the Read tool, perform all placeholder replacements in memory, then write the result with the Write tool. This ensures cross-platform compatibility (Windows, macOS, Linux).
+
+**Do NOT generate HTML from scratch. Do NOT modify the template structure, CSS, or JavaScript. Only replace the `{{...}}` config placeholders.**
+
+**If the template file does not exist, STOP and show an error**: Tell the user to run `arckit init` to install templates, or check that the template exists. Do NOT generate fallback HTML.
+
+## Step 4: Write Output Files
+
+**IMPORTANT**: Use the Write tool to create both files.
+
+### 4.1 Write manifest.json
+
+```text
+docs/manifest.json
+```
+
+### 4.2 Write index.html
+
+```text
+docs/index.html
+```
+
 ## Step 5: Provide Summary
 
-Use the stats from the hook's hook context (under "Document Stats") to fill in the summary:
+After generating, provide this summary:
 
 ```text
 Documentation Site Generated
@@ -430,10 +476,6 @@ Document Breakdown:
 - Project Documents: {project_doc_count}
 - Diagrams: {diagram_count}
 - ADRs: {adr_count}
-- Wardley Maps: {wardley_map_count}
-- Data Contracts: {data_contract_count}
-- Research: {research_count}
-- Reviews: {review_count}
 - Vendor Documents: {vendor_doc_count}
 - Vendor Profiles: {vendor_profile_count}
 - Tech Notes: {tech_note_count}
@@ -472,6 +514,53 @@ Next Steps:
 - The dashboard displays KPI cards, category charts, coverage bars, and governance checklist computed from manifest.json
 - Users can navigate to any document via sidebar, search, or dashboard project table
 
+### Cross-Platform Compatibility
+
+**This command MUST work on Windows, macOS, and Linux without modification.** To achieve this:
+
+- Use **Glob** for all file discovery (never `ls`, `find`, or `for` loops in bash)
+- Use **Read** + **Write** for all file copying (never `cp`, `cp -r`, or `mkdir -p` in bash)
+- Use **Read** + in-memory string replacement + **Write** for template processing (never `sed`)
+- Use **Grep** for content searching (never `grep` or `head` in bash)
+- Do NOT use Bash at all — all operations can be done with Glob/Read/Write/Grep
+
+### File Discovery
+
+- Only include files that actually exist in the repository
+- Use **Glob** to discover files (never bash commands)
+- Don't include placeholder entries for missing files
+
+### Error Handling
+
+The generated HTML should handle:
+
+- Missing documents gracefully (show "Document not found")
+- Failed fetch requests (show error message)
+- Invalid markdown (display raw content)
+- Invalid mermaid syntax (show error, display raw code)
+
+### Mobile Responsiveness
+
+- Sidebar should collapse on mobile
+- Content should be readable on all screen sizes
+- Touch-friendly navigation
+
+### Accessibility
+
+- Proper heading hierarchy
+- ARIA labels for navigation
+- Keyboard navigation support
+- Skip to content link
+
+### Performance
+
+- Lazy load documents (only fetch when selected)
+- Cache fetched documents in memory
+- Show loading indicator during fetch
+
 ---
 
-**Remember**: The `sync-guides` hook handles ALL I/O before this command runs — guide sync, title extraction, repo info, template processing, project scanning, and manifest generation. The command MUST output the Step 5 summary using ONLY the stats from the hook's hook context. Do NOT call any tools — no Read, no Glob, no Write, no Bash. The hook's stats are the single source of truth.
+**Remember**: You MUST read and use `.arckit/templates/pages-template.html` as the base for `docs/index.html`. The template is the source of truth for all HTML, CSS, and JavaScript. Only replace the `{{...}}` config placeholders with actual values.
+
+- **Cross-platform**: Do NOT use Bash for file operations. Use Glob/Read/Write/Grep tools exclusively. The only acceptable Bash use is a single simple `git` command (no pipes, no `&&`, no `$()`).
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji

--- a/arckit-opencode/commands/arckit.plan.md
+++ b/arckit-opencode/commands/arckit.plan.md
@@ -35,7 +35,7 @@ $ARGUMENTS
 
 ## Step 1: Understand the Context
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Read existing project artifacts to tailor the plan:
 

--- a/arckit-opencode/commands/arckit.platform-design.md
+++ b/arckit-opencode/commands/arckit.platform-design.md
@@ -20,7 +20,7 @@ Generate a comprehensive platform strategy design document using PDT v2.2.1 meth
 
 ### Step 0: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.presentation.md
+++ b/arckit-opencode/commands/arckit.presentation.md
@@ -18,7 +18,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 1: Identify the target project
 

--- a/arckit-opencode/commands/arckit.principles-compliance.md
+++ b/arckit-opencode/commands/arckit.principles-compliance.md
@@ -49,7 +49,7 @@ More artifacts = better evidence = more accurate assessment:
 
 ## Execution Steps
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 0. Read the Template
 

--- a/arckit-opencode/commands/arckit.principles.md
+++ b/arckit-opencode/commands/arckit.principles.md
@@ -21,7 +21,7 @@ $ARGUMENTS
 
 2. **Read external documents and policies**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    - Read any **global policies** listed in the project context (`000-global/policies/`) — extract existing architecture principles, TOGAF standards, departmental policies, technology standards
    - If no external governance documents found, ask: "Do you have any existing architecture principles, governance frameworks, or departmental technology standards? I can read PDFs and Word docs directly. Place them in `projects/000-global/policies/` and re-run, or skip to create principles from scratch."

--- a/arckit-opencode/commands/arckit.requirements.md
+++ b/arckit-opencode/commands/arckit.requirements.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-opencode/commands/arckit.risk.md
+++ b/arckit-opencode/commands/arckit.risk.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **comprehensive risk register** following HM Treasury Orange Book principles and integrates with ArcKit's stakeholder-driven workflow.
 

--- a/arckit-opencode/commands/arckit.roadmap.md
+++ b/arckit-opencode/commands/arckit.roadmap.md
@@ -43,7 +43,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### 1. Identify the target project
 

--- a/arckit-opencode/commands/arckit.score.md
+++ b/arckit-opencode/commands/arckit.score.md
@@ -1,0 +1,159 @@
+---
+description: "Score vendor proposals against evaluation criteria with persistent structured storage"
+---
+
+# Vendor Scoring
+
+You are helping an enterprise architect score vendor proposals against evaluation criteria, compare vendors, and maintain an auditable scoring record.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+## Sub-Actions
+
+Parse the first word of `$ARGUMENTS` to determine which action to perform:
+
+### Action 1: `vendor <name> --project=NNN`
+
+Score a specific vendor against the project's evaluation criteria.
+
+1. **Read the project's EVAL artifact** (evaluation criteria):
+   - If no EVAL exists, tell the user to run `/arckit:evaluate` first
+   - Extract all evaluation criteria with their weights and categories
+
+2. **Read vendor proposal** from `projects/{id}/vendors/{vendor-name}/`:
+   - If the directory doesn't exist, create it
+   - Read any `.md` or `.pdf` files as vendor proposal content
+
+3. **Read existing scores** from `projects/{id}/vendors/scores.json` (if exists)
+
+4. **Score each criterion** using the 0-3 rubric:
+   | Score | Meaning | Description |
+   |-------|---------|-------------|
+   | 0 | Not Met | No evidence of capability; does not address the criterion |
+   | 1 | Partially Met | Some evidence but significant gaps remain |
+   | 2 | Met | Fully addresses the criterion with adequate evidence |
+   | 3 | Exceeds | Goes beyond requirements with strong differentiation |
+
+5. **For each score, provide:**
+   - The numeric score (0-3)
+   - Evidence from the vendor proposal supporting the score
+   - Any risks or caveats noted
+
+6. **Calculate weighted totals**:
+   - Use weights from the EVAL criteria (default to equal weighting if none specified)
+   - `totalWeighted = sum(score * weight) / sum(weight)`
+   - `totalRaw = sum(scores)`
+   - `maxPossible = 3 * number_of_criteria`
+
+7. **Write scores** to `projects/{id}/vendors/scores.json`:
+
+   ```json
+   {
+     "projectId": "001",
+     "lastUpdated": "2026-03-08T10:00:00Z",
+     "criteria": [
+       { "id": "C-001", "name": "Technical Capability", "weight": 0.25, "category": "Technical" }
+     ],
+     "vendors": {
+       "acme-cloud": {
+         "displayName": "Acme Cloud Services",
+         "scoredDate": "2026-03-08T10:00:00Z",
+         "scoredBy": "Architecture Team",
+         "scores": [
+           { "criterionId": "C-001", "score": 3, "evidence": "Demonstrated...", "risks": "" }
+         ],
+         "totalWeighted": 2.45,
+         "totalRaw": 5,
+         "maxPossible": 6
+       }
+     }
+   }
+   ```
+
+8. **Output a markdown summary** to console showing all scores with evidence.
+
+### Action 2: `compare --project=NNN`
+
+Generate a side-by-side vendor comparison.
+
+1. **Read** `projects/{id}/vendors/scores.json` — if it doesn't exist or has fewer than 2 vendors, explain what's needed
+2. **Output comparison table**:
+
+   ```markdown
+   ## Vendor Comparison: Project 001
+
+   | Criterion | Weight | Acme Cloud | Beta Systems | Gamma Tech |
+   |-----------|--------|------------|--------------|------------|
+   | Technical Capability | 25% | 3 | 2 | 2 |
+   | Security Compliance | 20% | 2 | 3 | 1 |
+   | **Weighted Total** | | **2.45** | **2.30** | **1.95** |
+
+   ### Recommendation
+   **Acme Cloud** scores highest overall (2.45/3.00).
+
+   ### Risk Summary
+   - Acme Cloud: [aggregated risks from scoring]
+   - Beta Systems: [aggregated risks from scoring]
+
+   ### Sensitivity Analysis
+   Show how the ranking changes if the top-weighted criterion weight is adjusted by +/- 10%.
+   ```
+
+3. **Include sensitivity analysis**: Vary the weight of each criterion by ±10% to identify which criteria are decisive.
+
+### Action 3: `audit --project=NNN`
+
+Show the scoring audit trail.
+
+1. **Read** `projects/{id}/vendors/scores.json`
+2. **Output chronological audit**:
+
+   ```markdown
+   ## Scoring Audit Trail: Project 001
+
+   | Date | Vendor | Scored By | Weighted Score | Criteria Count |
+   |------|--------|-----------|----------------|----------------|
+   | 2026-03-08 | Acme Cloud | Architecture Team | 2.45/3.00 | 8 |
+   | 2026-03-07 | Beta Systems | Architecture Team | 2.30/3.00 | 8 |
+   ```
+
+3. Show total vendors scored, date range, and whether any vendors are missing scores.
+
+### Default (no action specified)
+
+If no recognised action, show usage:
+
+```
+Usage: /arckit:score <action> [options]
+
+Actions:
+  vendor <name> --project=NNN   Score a vendor against evaluation criteria
+  compare --project=NNN         Side-by-side vendor comparison
+  audit --project=NNN           Scoring audit trail
+
+Examples:
+  /arckit:score vendor "Acme Cloud" --project=001
+  /arckit:score compare --project=001
+  /arckit:score audit --project=001
+```
+
+## Important Notes
+
+- **Always preserve existing vendor scores** when adding a new vendor — append, don't overwrite
+- **Criterion IDs must be consistent** across all vendors in the same project
+- **The scores.json validator hook** will warn if weights don't sum to 1.0 or scores are out of range
+- **Evidence field is mandatory** — never assign a score without citing supporting evidence from the proposal
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:evaluate` -- Create or update evaluation framework before scoring *(when No EVAL artifact exists for the project)*
+- `/arckit:sow` -- Generate Statement of Work for selected vendor *(when Vendor selection complete, ready for procurement)*
+

--- a/arckit-opencode/commands/arckit.score.md
+++ b/arckit-opencode/commands/arckit.score.md
@@ -12,7 +12,7 @@ You are helping an enterprise architect score vendor proposals against evaluatio
 $ARGUMENTS
 ```
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ## Sub-Actions
 
@@ -129,7 +129,7 @@ Show the scoring audit trail.
 
 If no recognised action, show usage:
 
-```
+```text
 Usage: /arckit:score <action> [options]
 
 Actions:

--- a/arckit-opencode/commands/arckit.search.md
+++ b/arckit-opencode/commands/arckit.search.md
@@ -55,7 +55,8 @@ $ARGUMENTS
    - Trying alternative terms
 
 6. **If the query is empty**, show a usage summary:
-   ```
+
+   ```text
    Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 
    Examples:

--- a/arckit-opencode/commands/arckit.search.md
+++ b/arckit-opencode/commands/arckit.search.md
@@ -1,0 +1,75 @@
+---
+description: "Search across all project artifacts by keyword, document type, or requirement ID"
+---
+
+# Project Search
+
+You are helping an enterprise architect search across all project artifacts to find specific decisions, requirements, risks, or design information.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+> **Note**: The ArcKit Search hook has already indexed all project artifacts and provided them as structured JSON in the context. Use that data — do NOT scan directories manually.
+
+## Instructions
+
+1. **Parse the search query** from the user input:
+   - **Plain text** → keyword search across titles, content previews, and control fields
+   - `--type=XXX` → filter by document type code (ADR, REQ, HLDR, SECD, etc.)
+   - `--project=NNN` → filter by project number (e.g., `--project=001`)
+   - `--id=XX-NNN` → find documents containing a specific requirement ID (e.g., `--id=BR-003`)
+   - Combinations work: `PostgreSQL --type=ADR --project=001`
+
+2. **Search the pre-processed index** from the hook context. Score results by relevance:
+   - **10 points** — match in document title
+   - **5 points** — match in document control fields (owner, status)
+   - **3 points** — match in content preview
+   - **2 points** — match in filename
+   - Exact matches score double
+
+3. **Output format** (console only — do NOT create a file):
+
+   ```markdown
+   ## Search Results for "<query>"
+
+   Found N matches across M projects:
+
+   | Score | Document | Type | Project | Title |
+   |-------|----------|------|---------|-------|
+   | 15 | ARC-001-ADR-003-v1.0 | ADR | 001-payments | Database Selection |
+   | 8 | ARC-001-REQ-v2.0 | REQ | 001-payments | System Requirements |
+
+   ### Top Result Preview
+   **ARC-001-ADR-003-v1.0** (decisions/ARC-001-ADR-003-v1.0.md)
+   > ...relevant excerpt from the content preview...
+   ```
+
+4. **Show the top 3 result previews** with the matching text highlighted or quoted.
+
+5. **If no results found**, suggest:
+   - Broadening the search (fewer keywords, remove filters)
+   - Checking available document types with their codes
+   - Trying alternative terms
+
+6. **If the query is empty**, show a usage summary:
+   ```
+   Usage: /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+
+   Examples:
+     /arckit:search PostgreSQL
+     /arckit:search "data residency" --type=ADR
+     /arckit:search --id=BR-003
+     /arckit:search security --project=001
+   ```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:health` -- Check artifact health after finding relevant documents *(when Search revealed potentially stale artifacts)*
+- `/arckit:traceability` -- Trace requirements found in search results *(when Search included requirement IDs)*
+- `/arckit:impact` -- Analyse impact of changes to found documents *(when User wants to understand change blast radius)*
+

--- a/arckit-opencode/commands/arckit.secure.md
+++ b/arckit-opencode/commands/arckit.secure.md
@@ -29,7 +29,7 @@ UK Government departments must follow NCSC (National Cyber Security Centre) guid
 
 ## Your Task
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 Generate a comprehensive Secure by Design assessment document by:
 

--- a/arckit-opencode/commands/arckit.service-assessment.md
+++ b/arckit-opencode/commands/arckit.service-assessment.md
@@ -54,7 +54,7 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 ## Process
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **Read the template** (with user override support):
 

--- a/arckit-opencode/commands/arckit.servicenow.md
+++ b/arckit-opencode/commands/arckit.servicenow.md
@@ -64,7 +64,7 @@ Read existing artifacts from the project context:
 
 ## Command Workflow
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Phase 1: Context Gathering
 

--- a/arckit-opencode/commands/arckit.sobc.md
+++ b/arckit-opencode/commands/arckit.sobc.md
@@ -22,7 +22,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 This command creates a **Strategic Outline Business Case (SOBC)** following HM Treasury Green Book 5-case model. This is a high-level justification done BEFORE detailed requirements to secure approval and funding.
 

--- a/arckit-opencode/commands/arckit.sow.md
+++ b/arckit-opencode/commands/arckit.sow.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-opencode/commands/arckit.stakeholders.md
+++ b/arckit-opencode/commands/arckit.stakeholders.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)

--- a/arckit-opencode/commands/arckit.story.md
+++ b/arckit-opencode/commands/arckit.story.md
@@ -19,7 +19,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 ### Step 0: Read existing artifacts from the project context
 

--- a/arckit-opencode/commands/arckit.strategy.md
+++ b/arckit-opencode/commands/arckit.strategy.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Prerequisites: Read Strategic Artifacts
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/commands/arckit.tcop.md
+++ b/arckit-opencode/commands/arckit.tcop.md
@@ -31,7 +31,7 @@ Generate a comprehensive TCoP review document by:
 
 2. **Read Available Documents**:
 
-   > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+   > **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
    **MANDATORY** (warn if missing):
    - **REQ** (Requirements) — Extract: FR/NFR IDs, technology constraints, compliance requirements

--- a/arckit-opencode/commands/arckit.traceability.md
+++ b/arckit-opencode/commands/arckit.traceability.md
@@ -12,7 +12,7 @@ $ARGUMENTS
 
 ## Instructions
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 1. **Identify the project**: The user should specify a project name or number
    - Example: "Generate traceability matrix for payment gateway project"

--- a/arckit-opencode/commands/arckit.wardley.md
+++ b/arckit-opencode/commands/arckit.wardley.md
@@ -32,7 +32,7 @@ $ARGUMENTS
 
 ## Step 1: Read Available Documents
 
-> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
 
 **MANDATORY** (warn if missing):
 

--- a/arckit-opencode/docs/guides/impact.md
+++ b/arckit-opencode/docs/guides/impact.md
@@ -1,0 +1,68 @@
+# Impact Analysis
+
+Analyse the blast radius of a change to a requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability (`/arckit:traceability`).
+
+## Usage
+
+```bash
+/arckit:impact <document ID or requirement ID>
+```
+
+## Examples
+
+```bash
+# Impact of changing a requirement
+/arckit:impact BR-003
+/arckit:impact NFR-SEC-001
+
+# Impact of changing a document
+/arckit:impact ARC-001-REQ
+/arckit:impact ARC-001-ADR-002
+
+# Show all dependencies for a document type in a project
+/arckit:impact ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook builds a dependency graph on invocation:
+
+1. Scans all ARC-\*.md files across all projects
+2. Extracts cross-references between documents (ARC-NNN-TYPE patterns)
+3. Maps requirement IDs to the documents that contain them
+4. Classifies each document's impact severity by type category
+
+The command then performs reverse traversal through the graph to find all downstream dependencies.
+
+## Impact Severity
+
+| Severity | Category | Document Types | Action |
+|----------|----------|---------------|--------|
+| **HIGH** | Compliance/Governance | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF | Formal re-assessment likely needed |
+| **MEDIUM** | Architecture | HLDR, DLDR, ADR, DATA, DIAG, PLAT | Design updates may be needed |
+| **LOW** | Planning/Other | PLAN, ROAD, BKLG, SOBC, OPS, PRES | Review recommended |
+
+## Traversal Depth
+
+The analysis traces dependencies up to 5 levels deep:
+
+- **Level 0**: The changed document itself
+- **Level 1**: Documents that directly reference it
+- **Level 2**: Documents that reference Level 1 documents
+- **Level 3-5**: Further indirect dependencies
+
+## When to Use
+
+- **Before changing a requirement** — understand what other documents will be affected
+- **Before updating an ADR** — check if compliance documents reference it
+- **After a design review** — trace what else needs updating when conditions are imposed
+- **During change governance** — document the full impact chain for approval boards
+
+## Relationship to Traceability
+
+| Command | Direction | Question |
+|---------|-----------|----------|
+| `/arckit:traceability` | Forward | "Are my requirements covered by design decisions?" |
+| `/arckit:impact` | Reverse | "If I change this requirement, what breaks?" |
+
+Use traceability to check coverage. Use impact to assess change risk.

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 59 slash commands
+- **Commands**: 60 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 59 ArcKit commands and 6 research agents remain fully available
+- All 60 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/score.md
+++ b/arckit-opencode/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/arckit-opencode/docs/guides/score.md
+++ b/arckit-opencode/docs/guides/score.md
@@ -4,7 +4,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Usage
 
-```
+```text
 /arckit:score vendor <name> --project=NNN    # Score a vendor
 /arckit:score compare --project=NNN          # Compare all scored vendors
 /arckit:score audit --project=NNN            # View scoring audit trail
@@ -12,7 +12,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Workflow
 
-```
+```text
 /arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
    (criteria)         (score each)             (decide)                  (procure)
 ```

--- a/arckit-opencode/docs/guides/search.md
+++ b/arckit-opencode/docs/guides/search.md
@@ -4,7 +4,7 @@ Search across all project artifacts by keyword, document type, or requirement ID
 
 ## Usage
 
-```
+```text
 /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 ```
 

--- a/arckit-opencode/docs/guides/search.md
+++ b/arckit-opencode/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 59 commands | Plugin mode
+Version 2.10.0 | 60 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -161,6 +161,9 @@ Most procurement commands require ARC-*-REQ-*.md:
   - Note: Requirements recommended for search context but not mandatory
 - **gcloud-clarify** → Depends on: requirements (M), gcloud-search (M)
 - **evaluate** → Depends on: requirements (M), sow (M), principles (R), research (R), gcloud-clarify (R)
+- **score** → Depends on: evaluate (M), requirements (M)
+  - Note: Structured vendor scoring with JSON storage, comparison, and audit trail
+  - Integrates with evaluate criteria; scores stored in `projects/{id}/vendors/scores.json`
 
 ### Tier 6: Design Reviews (Depends on Design Documents + Requirements)
 
@@ -350,11 +353,21 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 - **ArcKit Version**: 1.5.0
 - **Matrix Date**: 2026-02-25
-- **Commands Documented**: 58
+- **Commands Documented**: 59
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
 - **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-08 - Added Vendor Scoring Command
+
+- **Added**: `/arckit.score` command (59th ArcKit command) for structured vendor scoring with JSON storage, comparison, and audit trail
+- **Added**: score row and column to dependency matrix
+- **Updated**: Tier 5 Procurement to include score command
+- **Dependencies**: evaluate (M), requirements (M)
+- **Consumed by**: sow (O), pages (R)
+- **Updated**: Commands Documented count from 58 to 59
+- **Note**: First command to use structured JSON output instead of Markdown; includes PreToolUse validator hook for scores.json integrity
 
 ### 2026-03-08 - Added Project Search Command
 

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -350,11 +350,18 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 - **ArcKit Version**: 1.5.0
 - **Matrix Date**: 2026-02-25
-- **Commands Documented**: 57
+- **Commands Documented**: 58
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-08 - Added Project Search Command
+
+- **Added**: `/arckit.search` command (58th ArcKit command) for keyword, type, and requirement ID search across all project artifacts
+- **Not in matrix**: Diagnostic/query command with console-only output — no dependencies and no outputs consumed by other commands
+- **Updated**: Commands Documented count from 57 to 58
+- **Note**: Uses UserPromptSubmit pre-processing hook (`search-scan.mjs`) to index artifacts before search
 
 ### 2026-03-08 - Added DFD Command to Matrix
 

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -353,11 +353,18 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 - **ArcKit Version**: 1.5.0
 - **Matrix Date**: 2026-02-25
-- **Commands Documented**: 59
+- **Commands Documented**: 60
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.impact`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-09 - Added Impact Analysis Command
+
+- **Added**: `/arckit.impact` command (60th ArcKit command) for blast radius analysis and reverse dependency tracing
+- **Not in matrix**: Diagnostic command with console-only output — no dependencies and no outputs consumed by other commands
+- **Updated**: Commands Documented count from 59 to 60
+- **Note**: Uses UserPromptSubmit pre-processing hook (`impact-scan.mjs`) to build a dependency graph with doc-to-doc edges for reverse traversal
 
 ### 2026-03-08 - Added Vendor Scoring Command
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -202,8 +202,9 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.framework` | [framework.md](guides/framework.md) | ✅ Complete |
 | `/arckit.glossary` | [glossary.md](guides/glossary.md) | ✅ Complete |
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
+| `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
 
-**Coverage**: 58/58 commands documented (100%)
+**Coverage**: 59/59 commands documented (100%)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -134,6 +134,7 @@ See the [full index](guides/roles/README.md) for details.
 
 ## 🔧 Technical Guides
 
+- [Session Memory](guides/session-memory.md) - Automated cross-session activity tracking
 - [Upgrading ArcKit](guides/upgrading.md) - Upgrade the CLI and update existing projects
 - [Token Limits Solutions](TOKEN-LIMITS.md) - Handling large projects with AI token limits
 - [File Migration](guides/migration.md) - Migrate legacy filenames to Document ID convention

--- a/docs/README.md
+++ b/docs/README.md
@@ -197,6 +197,7 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.customize` | [customize.md](guides/customize.md) | ✅ Complete |
 | `/arckit.presentation` | [presentation.md](guides/presentation.md) | ✅ Complete |
 | `/arckit.health` | [artifact-health.md](guides/artifact-health.md) | ✅ Complete |
+| `/arckit.impact` | [impact.md](guides/impact.md) | ✅ Complete |
 | `/arckit.search` | [search.md](guides/search.md) | ✅ Complete |
 | `/arckit.start` | [start.md](guides/start.md) | ✅ Complete |
 | `/arckit.template-builder` | [template-builder.md](guides/template-builder.md) | ✅ Complete |
@@ -205,7 +206,7 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
 | `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
 
-**Coverage**: 59/59 commands documented (100%)
+**Coverage**: 60/60 commands documented (100%)
 
 ---
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -196,13 +196,14 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.customize` | [customize.md](guides/customize.md) | ✅ Complete |
 | `/arckit.presentation` | [presentation.md](guides/presentation.md) | ✅ Complete |
 | `/arckit.health` | [artifact-health.md](guides/artifact-health.md) | ✅ Complete |
+| `/arckit.search` | [search.md](guides/search.md) | ✅ Complete |
 | `/arckit.start` | [start.md](guides/start.md) | ✅ Complete |
 | `/arckit.template-builder` | [template-builder.md](guides/template-builder.md) | ✅ Complete |
 | `/arckit.framework` | [framework.md](guides/framework.md) | ✅ Complete |
 | `/arckit.glossary` | [glossary.md](guides/glossary.md) | ✅ Complete |
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
 
-**Coverage**: 57/57 commands documented (100%)
+**Coverage**: 58/58 commands documented (100%)
 
 ---
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">58 AI Commands</span>
+            <span class="app-page-hero__stat">59 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">59 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">58</span> of 58 commands
+                Showing <span id="visible-count">59</span> of 59 commands
             </div>
         </div>
 
@@ -951,6 +951,13 @@
                             <a href="https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/ARC-001-EVAL-v1.0.md" title="Patent">v6</a>
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="procurement">
+                        <td><code>/arckit.score</code></td>
+                        <td class="description">Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail</td>
+                        <td>Procurement</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
 
                     <!-- Design & Architecture -->

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "59 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">59 AI Commands</span>
+            <span class="app-page-hero__stat">60 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">59 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">60 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">59</span> of 59 commands
+                Showing <span id="visible-count">60</span> of 60 commands
             </div>
         </div>
 
@@ -1253,6 +1253,14 @@
                         <td>Quality & Governance</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="governance">
+                        <td><code>/arckit.impact</code></td>
+                        <td class="description">Analyse blast radius of changes — reverse dependency tracing</td>
+                        <td>Quality & Governance</td>
+                        <td class="examples">
+                        </td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
                     <tr data-status="beta" data-category="governance">
                         <td><code>/arckit.search</code></td>

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "57 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "58 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">57 AI Commands</span>
+            <span class="app-page-hero__stat">58 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">57 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">57</span> of 57 commands
+                Showing <span id="visible-count">58</span> of 58 commands
             </div>
         </div>
 
@@ -1244,6 +1244,13 @@
                         <td><code>/arckit.health</code></td>
                         <td class="description">Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift</td>
                         <td>Quality & Governance</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="governance">
+                        <td><code>/arckit.search</code></td>
+                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
+                        <td>Quality &amp; Governance</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -377,7 +377,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 58 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 59 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -417,7 +417,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 58 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 59 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -465,7 +465,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 59 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -515,7 +515,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 59 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -577,7 +577,7 @@ opencode</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 58 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 59 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -377,7 +377,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 59 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 60 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -417,7 +417,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 59 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 60 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -465,7 +465,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 59 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 60 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -515,7 +515,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 59 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 60 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -577,7 +577,7 @@ opencode</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 59 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 60 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -377,7 +377,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 57 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 58 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -417,7 +417,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 57 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 58 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -465,7 +465,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 57 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -515,7 +515,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 57 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 58 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -577,7 +577,7 @@ opencode</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 57 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 58 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/guides/impact.md
+++ b/docs/guides/impact.md
@@ -1,0 +1,68 @@
+# Impact Analysis
+
+Analyse the blast radius of a change to a requirement, decision, or design document. This is reverse dependency tracing — the complement of forward traceability (`/arckit:traceability`).
+
+## Usage
+
+```
+/arckit:impact <document ID or requirement ID>
+```
+
+## Examples
+
+```bash
+# Impact of changing a requirement
+/arckit:impact BR-003
+/arckit:impact NFR-SEC-001
+
+# Impact of changing a document
+/arckit:impact ARC-001-REQ
+/arckit:impact ARC-001-ADR-002
+
+# Show all dependencies for a document type in a project
+/arckit:impact ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook builds a dependency graph on invocation:
+
+1. Scans all ARC-\*.md files across all projects
+2. Extracts cross-references between documents (ARC-NNN-TYPE patterns)
+3. Maps requirement IDs to the documents that contain them
+4. Classifies each document's impact severity by type category
+
+The command then performs reverse traversal through the graph to find all downstream dependencies.
+
+## Impact Severity
+
+| Severity | Category | Document Types | Action |
+|----------|----------|---------------|--------|
+| **HIGH** | Compliance/Governance | TCOP, SECD, DPIA, SVCASS, RISK, TRAC, CONF | Formal re-assessment likely needed |
+| **MEDIUM** | Architecture | HLDR, DLDR, ADR, DATA, DIAG, PLAT | Design updates may be needed |
+| **LOW** | Planning/Other | PLAN, ROAD, BKLG, SOBC, OPS, PRES | Review recommended |
+
+## Traversal Depth
+
+The analysis traces dependencies up to 5 levels deep:
+
+- **Level 0**: The changed document itself
+- **Level 1**: Documents that directly reference it
+- **Level 2**: Documents that reference Level 1 documents
+- **Level 3-5**: Further indirect dependencies
+
+## When to Use
+
+- **Before changing a requirement** — understand what other documents will be affected
+- **Before updating an ADR** — check if compliance documents reference it
+- **After a design review** — trace what else needs updating when conditions are imposed
+- **During change governance** — document the full impact chain for approval boards
+
+## Relationship to Traceability
+
+| Command | Direction | Question |
+|---------|-----------|----------|
+| `/arckit:traceability` | Forward | "Are my requirements covered by design decisions?" |
+| `/arckit:impact` | Reverse | "If I change this requirement, what breaks?" |
+
+Use traceability to check coverage. Use impact to assess change risk.

--- a/docs/guides/impact.md
+++ b/docs/guides/impact.md
@@ -4,7 +4,7 @@ Analyse the blast radius of a change to a requirement, decision, or design docum
 
 ## Usage
 
-```
+```bash
 /arckit:impact <document ID or requirement ID>
 ```
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 58 slash commands
+- **Commands**: 59 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 59 slash commands
+- **Commands**: 60 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 59 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 57 slash commands
+- **Commands**: 58 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 57 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 58 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 58 ArcKit commands and 6 research agents remain fully available
+- All 59 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 57 ArcKit commands and 6 research agents remain fully available
+- All 58 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 59 ArcKit commands and 6 research agents remain fully available
+- All 60 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 57 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 58 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 59 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 59 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 57 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 58 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/score.md
+++ b/docs/guides/score.md
@@ -1,0 +1,91 @@
+# Vendor Scoring
+
+Score vendor proposals against evaluation criteria with persistent structured storage, side-by-side comparison, and audit trail.
+
+## Usage
+
+```
+/arckit:score vendor <name> --project=NNN    # Score a vendor
+/arckit:score compare --project=NNN          # Compare all scored vendors
+/arckit:score audit --project=NNN            # View scoring audit trail
+```
+
+## Workflow
+
+```
+/arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
+   (criteria)         (score each)             (decide)                  (procure)
+```
+
+## Scoring Rubric
+
+| Score | Meaning | Description |
+|-------|---------|-------------|
+| **0** | Not Met | No evidence of capability; does not address the criterion |
+| **1** | Partially Met | Some evidence but significant gaps remain |
+| **2** | Met | Fully addresses the criterion with adequate evidence |
+| **3** | Exceeds | Goes beyond requirements with strong differentiation |
+
+## Examples
+
+```bash
+# Score a vendor against project 001's evaluation criteria
+/arckit:score vendor "Acme Cloud Services" --project=001
+
+# Score another vendor for comparison
+/arckit:score vendor "Beta Systems" --project=001
+
+# Generate side-by-side comparison with sensitivity analysis
+/arckit:score compare --project=001
+
+# View the audit trail
+/arckit:score audit --project=001
+```
+
+## Storage
+
+Scores are stored in `projects/{id}/vendors/scores.json` as structured JSON:
+
+```json
+{
+  "projectId": "001",
+  "lastUpdated": "2026-03-08T10:00:00Z",
+  "criteria": [...],
+  "vendors": {
+    "acme-cloud": {
+      "displayName": "Acme Cloud Services",
+      "scores": [...],
+      "totalWeighted": 2.45
+    }
+  }
+}
+```
+
+This file can be committed to git for team visibility and governance audit.
+
+## Comparison Features
+
+The `compare` sub-action generates:
+
+- **Score matrix** — side-by-side scores for every criterion
+- **Weighted totals** — overall ranking accounting for criterion weights
+- **Risk summary** — aggregated risks from each vendor's scoring
+- **Sensitivity analysis** — how rankings change if criterion weights shift by ±10%
+
+## Validation
+
+A PreToolUse hook validates `scores.json` before every write:
+
+- Score values must be 0-3
+- Criteria weights must sum to approximately 1.0
+- All required fields must be present
+- Referenced criterion IDs must exist
+
+## Governance
+
+The structured format supports:
+
+- **Audit trail** — who scored what and when
+- **Reproducibility** — scores can be re-examined against original evidence
+- **Challenge response** — if a vendor challenges the decision, the evidence chain is documented
+- **Team scoring** — multiple evaluators can score independently and results can be merged

--- a/docs/guides/score.md
+++ b/docs/guides/score.md
@@ -4,7 +4,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Usage
 
-```
+```text
 /arckit:score vendor <name> --project=NNN    # Score a vendor
 /arckit:score compare --project=NNN          # Compare all scored vendors
 /arckit:score audit --project=NNN            # View scoring audit trail
@@ -12,7 +12,7 @@ Score vendor proposals against evaluation criteria with persistent structured st
 
 ## Workflow
 
-```
+```text
 /arckit:evaluate  →  /arckit:score vendor  →  /arckit:score compare  →  /arckit:sow
    (criteria)         (score each)             (decide)                  (procure)
 ```

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -4,7 +4,7 @@ Search across all project artifacts by keyword, document type, or requirement ID
 
 ## Usage
 
-```
+```text
 /arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
 ```
 

--- a/docs/guides/search.md
+++ b/docs/guides/search.md
@@ -1,0 +1,71 @@
+# Project Search
+
+Search across all project artifacts by keyword, document type, or requirement ID.
+
+## Usage
+
+```
+/arckit:search <query> [--type=TYPE] [--project=NNN] [--id=REQ-ID]
+```
+
+## Examples
+
+```bash
+# Keyword search
+/arckit:search PostgreSQL
+/arckit:search "data residency"
+
+# Filter by document type
+/arckit:search --type=ADR
+/arckit:search security --type=SECD
+
+# Filter by project
+/arckit:search authentication --project=001
+
+# Find documents containing a requirement ID
+/arckit:search --id=BR-003
+/arckit:search --id=NFR-SEC-001
+
+# Combine filters
+/arckit:search PostgreSQL --type=ADR --project=001
+```
+
+## How It Works
+
+A pre-processing hook indexes all ARC-\*.md files on invocation:
+
+1. Scans all `projects/*/` directories and subdirectories
+2. Extracts document ID, type, title, control fields, requirement IDs, and a content preview
+3. Passes the index to the search command as context
+
+No persistent index is maintained — the scan runs fresh each time for accuracy.
+
+## Scoring
+
+Results are ranked by relevance:
+
+| Match Location | Score |
+|----------------|-------|
+| Document title | 10 points |
+| Document control fields | 5 points |
+| Content preview | 3 points |
+| Filename | 2 points |
+
+Exact matches score double. Results are sorted by total score descending.
+
+## Filter Syntax
+
+| Filter | Description | Example |
+|--------|-------------|---------|
+| `--type=XXX` | Filter by ARC document type code | `--type=ADR`, `--type=SECD` |
+| `--project=NNN` | Filter by project number | `--project=001` |
+| `--id=XX-NNN` | Find docs containing a requirement ID | `--id=BR-003` |
+
+Filters can be combined with keywords. The keyword search applies after filters are applied.
+
+## Tips
+
+- Use **short, specific keywords** — "PostgreSQL" is better than "database technology selection"
+- Use **`--type` filter** when you know what kind of document you're looking for
+- Use **`--id` filter** to trace where a specific requirement is referenced
+- **Quotes** around multi-word queries help: `/arckit:search "data residency"`

--- a/docs/guides/session-memory.md
+++ b/docs/guides/session-memory.md
@@ -1,0 +1,96 @@
+# Session Memory
+
+ArcKit includes automated session capture that records what happened during each Claude Code session. This complements Claude Code's built-in auto-memory by tracking the *actual work done* (git commits, artifact types) rather than relying on what Claude decides to remember.
+
+## How It Works
+
+```text
+Session N ends
+  └── session-learner.mjs (Stop hook) analyses recent git commits
+       └── appends summary to .arckit/memory/sessions.md
+
+Session N+1 starts
+  └── arckit-session.mjs (SessionStart hook) reads sessions.md
+       └── surfaces last 3 sessions as context
+```
+
+The Stop hook fires automatically when a session ends. No configuration needed beyond installing the ArcKit plugin.
+
+## What Gets Captured
+
+Each session entry includes:
+
+- **Session classification** — compliance, governance, research, procurement, architecture, planning, discovery, operations, or general (auto-detected from artifact types)
+- **Commit count and files changed** — quantitative measure of session activity
+- **Artifact types** — which ArcKit document types (ADR, HLDR, WARD, etc.) were created or modified
+- **Commit summaries** — up to 8 commit messages for context
+
+## Session Classification
+
+Sessions are classified by the highest-priority category of artifacts touched:
+
+| Priority | Classification | Triggered by category |
+|---|---|---|
+| 1 | `compliance` | Compliance artifacts (TCOP, SECD, DPIA, JSP936, SVCASS, etc.) |
+| 2 | `governance` | Governance artifacts (RISK, TRAC, PRIN-COMP, CONF, etc.) |
+| 3 | `research` | Cloud research artifacts (AWRS, AZRS, GCRS) |
+| 4 | `procurement` | Procurement artifacts (SOW, EVAL, DOS, GCLD, VEND, etc.) |
+| 5 | `architecture` | Architecture artifacts (ADR, HLDR, DLDR, DIAG, WARD, etc.) |
+| 6 | `planning` | Planning artifacts (SOBC, PLAN, ROAD, STRAT, BKLG) |
+| 7 | `discovery` | Discovery artifacts (REQ, STKE, RSCH, DSCT) |
+| 8 | `operations` | Operations artifacts (SNOW, DEVOPS, MLOPS, FINOPS, OPS) |
+| 9 | `general` | No ARC artifacts or Other category only |
+
+## Timestamp Tracking
+
+The session-learner uses timestamp-based tracking to capture exactly the commits from each session:
+
+- Timestamp stored in `.arckit/memory/.last-session`
+- Each session captures commits since the previous session ended
+- First run uses `--since=4 hours ago` as a bootstrap
+- No overlap between sessions, no missed commits
+
+## Storage
+
+Session history is stored in `.arckit/memory/sessions.md` — a rolling log of the last 30 sessions. This file is committed to git by default for team visibility.
+
+### Example Entry
+
+```markdown
+### 2026-03-08 14:30 — governance
+
+- **Commits:** 4 | **Files changed:** 7
+- **Artifacts:** Risk Register (Governance), Architecture Decision Records (Architecture)
+- **Summary:**
+  - feat: add SECD assessment for cloud migration
+  - docs: update ADR-003 with security review outcome
+  - fix: correct risk rating in RISK register
+  - chore: update traceability matrix
+```
+
+## Relationship to Auto-Memory
+
+| Feature | Claude Auto-Memory | Session Learner |
+|---|---|---|
+| **What it captures** | What Claude decides is important | What actually happened (git commits) |
+| **Trigger** | Automatic (Claude's judgement) | Deterministic (Stop hook on every session) |
+| **Storage** | `~/.claude/projects/<project>/memory/` (machine-local) | `.arckit/memory/sessions.md` (in-repo) |
+| **Team sharing** | Not shareable | Committed to git |
+| **Content** | Freeform insights, preferences | Structured session summaries |
+
+The two systems are complementary, not competing. Auto-memory captures *insights*; session-learner captures *activity*.
+
+## Troubleshooting
+
+**No sessions.md created after ending a session:**
+
+- Check that `.arckit/` directory exists in your project root
+- Verify there were git commits since the last recorded session (or within 4 hours on first run)
+- Check hook registration: `hooks.json` should include a `Stop` event
+
+**Session classification seems wrong:**
+
+- Classification is based on artifact type codes in filenames (e.g., `ARC-001-SECD-v1.md`)
+- Non-ARC files don't contribute to classification
+- Sessions with no detected ARC artifacts default to `general`
+- When multiple categories are present, the highest-priority one wins (compliance > governance > research > ...)

--- a/docs/guides/session-memory.md
+++ b/docs/guides/session-memory.md
@@ -60,13 +60,17 @@ Session history is stored in `.arckit/memory/sessions.md` — a rolling log of t
 ### 2026-03-08 14:30 — governance
 
 - **Commits:** 4 | **Files changed:** 7
-- **Artifacts:** Risk Register (Governance), Architecture Decision Records (Architecture)
+- **Artifacts:**
+  - [001] Governance: Risk Register | Architecture: Architecture Decision Records
+  - [002] Compliance: Secure by Design
 - **Summary:**
   - feat: add SECD assessment for cloud migration
   - docs: update ADR-003 with security review outcome
   - fix: correct risk rating in RISK register
   - chore: update traceability matrix
 ```
+
+Artifacts are grouped by project number (e.g., `[001]`) and organized by category, making it easy to see which projects were active and what type of work was done.
 
 ## Relationship to Auto-Memory
 

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 58 commands | Plugin mode
+Version 2.10.0 | 59 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 57 commands | Plugin mode
+Version 2.10.0 | 58 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 59 commands | Plugin mode
+Version 2.10.0 | 60 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 59 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "59 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">58</div>
+                    <div class="app-stat-number">59</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">58 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">59 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 58 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 59 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -488,7 +488,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 58 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 59 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 59 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 60 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="60 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="60 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "59 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "60 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "59 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "60 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">59</div>
+                    <div class="app-stat-number">60</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">59 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">60 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 59 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 60 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -488,7 +488,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 59 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 60 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 57 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "57 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "58 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "57 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "58 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">57</div>
+                    <div class="app-stat-number">58</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">57 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">58 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 57 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 58 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -488,7 +488,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 57 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 58 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/docs/plans/2026-03-08-hook-aware-converter-design.md
+++ b/docs/plans/2026-03-08-hook-aware-converter-design.md
@@ -1,0 +1,110 @@
+# Hook-Aware Converter Design
+
+**Date:** 2026-03-08
+**Issues:** #138, #139
+**Scope:** Converter changes only — no modifications to Claude Code source commands
+
+## Summary
+
+The converter (`scripts/converter.py`) blindly copies command prompts with path rewrites, ignoring hook dependencies. 42 commands reference a context injection hook that doesn't exist on Codex/OpenCode, and `/arckit.pages` is a complete no-op on all non-Claude platforms because it assumes the `sync-guides` hook did all the work.
+
+## Architecture
+
+```text
+converter.py
+  ├── AGENT_CONFIG (extended with hook capability flags)
+  ├── rewrite_paths()          — existing, unchanged
+  ├── rewrite_hook_dependencies()  — NEW
+  │     ├── Context injection: replace standard block with self-scan instructions
+  │     └── Other hook refs: strip gracefully
+  └── convert()
+        └── For each command:
+              ├── Check commands-standalone/ for platform override
+              ├── If override exists → use it instead of source command
+              └── If no override → run rewrite_paths() + rewrite_hook_dependencies()
+```
+
+## Decisions
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Where to fix | Converter only | Don't modify source commands — they're correct for Claude Code |
+| Context injection (42 cmds) | Standard block replacement | One paragraph swap, no duplicate files needed |
+| Pages command | Standalone override file | Too different for a text replacement — pre-hook version had full inline logic |
+| Hook capability tracking | Flags in AGENT_CONFIG | Consistent with existing config-driven approach |
+| Self-scan instructions | Single standard block for all 42 commands | Simple, consistent, sufficient |
+
+## AGENT_CONFIG Changes
+
+Add two flags per platform:
+
+```python
+"codex_extension": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"codex_skills": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"opencode": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"gemini": {
+    ...
+    "has_context_hook": True,   # context-inject.py exists
+    "has_sync_guides_hook": False,
+},
+```
+
+## `rewrite_hook_dependencies(prompt, config)`
+
+New function called after `rewrite_paths()`.
+
+### Context Injection Replacement
+
+For platforms where `has_context_hook` is `False`, find and replace the standard block.
+
+**Find:**
+```
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+```
+
+**Replace with:**
+```
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+```
+
+### Other Hook References
+
+Strip gracefully — remove lines that reference specific hooks by name if the platform doesn't support them.
+
+## `commands-standalone/` Directory
+
+```text
+arckit-claude/
+  commands/                  ← hook-dependent (source of truth for Claude Code)
+  commands-standalone/       ← self-contained overrides for hookless platforms
+    pages.md                 ← based on pre-hook version (commit c40418a^)
+```
+
+The converter checks `commands-standalone/{name}.md` first. If it exists, uses that for platforms without the required hook. Otherwise falls back to the standard command with `rewrite_hook_dependencies()` applied.
+
+## What Gets Fixed
+
+| Issue | Fix |
+|-------|-----|
+| #138 — 42 commands reference missing context hook | Standard block replacement in `rewrite_hook_dependencies()` |
+| #139 — pages is a no-op | Standalone `pages.md` used for Codex/OpenCode/Gemini |
+| Future hook-heavy commands | Add standalone version to `commands-standalone/` |
+
+## Out of Scope
+
+- Gemini context injection (already works via `context-inject.py`)
+- Governance/health/traceability scan hooks (graceful fallback already exists)
+- Post-processing manifest hook (low priority)
+- Changes to Claude Code source commands

--- a/docs/plans/2026-03-08-hook-aware-converter-plan.md
+++ b/docs/plans/2026-03-08-hook-aware-converter-plan.md
@@ -1,0 +1,278 @@
+# Hook-Aware Converter Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make the converter aware of hook dependencies so that platforms without hooks get self-contained commands instead of broken references.
+
+**Architecture:** Extend `AGENT_CONFIG` with hook capability flags, add a `rewrite_hook_dependencies()` function that swaps the context injection note for self-scan instructions, and add a standalone command override lookup for commands that are entirely hook-dependent (pages).
+
+**Tech Stack:** Python (`scripts/converter.py`), Markdown standalone commands (`arckit-claude/commands-standalone/`).
+
+**Design doc:** `docs/plans/2026-03-08-hook-aware-converter-design.md`
+
+---
+
+### Task 1: Add hook capability flags to AGENT_CONFIG
+
+**Files:**
+- Modify: `scripts/converter.py:96-133`
+
+**Step 1: Add flags to each config entry**
+
+In `scripts/converter.py`, add `"has_context_hook": False` and `"has_sync_guides_hook": False` to the `codex_extension`, `codex_skills`, and `opencode` entries. Add `"has_context_hook": True` and `"has_sync_guides_hook": False` to the `gemini` entry (Gemini has `context-inject.py`).
+
+After the change, the four entries should include:
+
+```python
+"codex_extension": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"codex_skills": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"opencode": {
+    ...
+    "has_context_hook": False,
+    "has_sync_guides_hook": False,
+},
+"gemini": {
+    ...
+    "has_context_hook": True,
+    "has_sync_guides_hook": False,
+},
+```
+
+**Step 2: Verify syntax**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print('valid')"`
+Expected: `valid`
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: add hook capability flags to AGENT_CONFIG"
+```
+
+---
+
+### Task 2: Add the context hook note constants
+
+**Files:**
+- Modify: `scripts/converter.py` (add constants after `EXTENSION_FILE_ACCESS_BLOCK`)
+
+**Step 1: Add the find/replace constants**
+
+Add these two constants after the `EXTENSION_FILE_ACCESS_BLOCK` definition (after line 91), before the `AGENT_CONFIG` block:
+
+```python
+CONTEXT_HOOK_NOTE = (
+    "> **Note**: The ArcKit Project Context hook has already detected all "
+    "projects, artifacts, external documents, and global policies. Use that "
+    "context below \u2014 no need to scan directories manually."
+)
+
+CONTEXT_HOOK_REPLACEMENT = (
+    "> **Note**: Before generating, scan `projects/` for existing project "
+    "directories. For each project, list all `ARC-*.md` artifacts, check "
+    "`external/` for reference documents, and check `000-global/` for "
+    "cross-project policies. If no external docs exist but they would "
+    "improve output, ask the user."
+)
+```
+
+**Step 2: Verify the find string matches actual commands**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print(repr(CONTEXT_HOOK_NOTE))"`
+Expected: The exact string that appears in 43 commands.
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: add context hook note constants for replacement"
+```
+
+---
+
+### Task 3: Add `rewrite_hook_dependencies()` function
+
+**Files:**
+- Modify: `scripts/converter.py` (add function after `rewrite_paths()`)
+
+**Step 1: Add the function**
+
+Insert this function after `rewrite_paths()` (after line 153):
+
+```python
+def rewrite_hook_dependencies(prompt, config):
+    """Replace hook-dependent content for platforms without hooks."""
+    result = prompt
+
+    # Context injection: replace hook note with self-scan instructions
+    if not config.get("has_context_hook", False):
+        result = result.replace(CONTEXT_HOOK_NOTE, CONTEXT_HOOK_REPLACEMENT)
+
+    return result
+```
+
+**Step 2: Verify syntax**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print('valid')"`
+Expected: `valid`
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: add rewrite_hook_dependencies() function"
+```
+
+---
+
+### Task 4: Wire `rewrite_hook_dependencies()` into `convert()` and add standalone override lookup
+
+**Files:**
+- Modify: `scripts/converter.py` — the `convert()` function
+
+**Step 1: Add standalone override lookup at the top of the per-agent loop**
+
+In the `convert()` function, inside the `for agent_id, config in AGENT_CONFIG.items():` loop (around line 215), before the `rewritten = rewrite_paths(prompt, config)` line, add logic to check for a standalone override:
+
+```python
+        for agent_id, config in AGENT_CONFIG.items():
+            # Check for standalone command override (for hookless platforms)
+            standalone_path = os.path.join(
+                os.path.dirname(commands_dir), "commands-standalone", filename
+            )
+            if os.path.isfile(standalone_path):
+                # Use standalone version if platform lacks required hook
+                needs_standalone = not config.get("has_sync_guides_hook", False)
+                if needs_standalone:
+                    with open(standalone_path, "r") as f:
+                        standalone_content = f.read()
+                    _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
+                    rewritten = rewrite_paths(standalone_prompt, config)
+                    # Skip rewrite_hook_dependencies — standalone is self-contained
+                else:
+                    rewritten = rewrite_paths(prompt, config)
+            else:
+                rewritten = rewrite_paths(prompt, config)
+                rewritten = rewrite_hook_dependencies(rewritten, config)
+```
+
+This replaces the existing `rewritten = rewrite_paths(prompt, config)` line.
+
+**Step 2: Verify syntax**
+
+Run: `python -c "exec(open('scripts/converter.py').read()); print('valid')"`
+Expected: `valid`
+
+**Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "feat: wire rewrite_hook_dependencies and standalone overrides into convert()"
+```
+
+---
+
+### Task 5: Create standalone pages command
+
+**Files:**
+- Create: `arckit-claude/commands-standalone/pages.md`
+
+**Step 1: Extract the pre-hook pages command**
+
+Run: `git show 'c40418a^:arckit-plugin/commands/pages.md' > arckit-claude/commands-standalone/pages.md`
+
+This gets the 568-line version that had full inline logic for scanning projects, reading artifacts, and generating the docs site — before the sync-guides hook replaced all that with "Steps 0-4: Handled by Hook".
+
+**Step 2: Verify the file has the full inline logic**
+
+Run: `wc -l arckit-claude/commands-standalone/pages.md`
+Expected: 568 lines
+
+Run: `head -10 arckit-claude/commands-standalone/pages.md`
+Expected: Frontmatter with description, then the full command prompt.
+
+**Step 3: Rewrite paths for standalone context**
+
+The extracted file uses `${CLAUDE_PLUGIN_ROOT}` paths. These will be rewritten automatically by `rewrite_paths()` during conversion, so no manual changes needed.
+
+**Step 4: Commit**
+
+```bash
+git add arckit-claude/commands-standalone/pages.md
+git commit -m "feat: add standalone pages command for hookless platforms"
+```
+
+---
+
+### Task 6: Run converter and verify output
+
+**Files:** None modified (verification only)
+
+**Step 1: Run the converter**
+
+Run: `python scripts/converter.py`
+Expected: Normal output showing all commands converted for all 4 targets. No errors.
+
+**Step 2: Verify context hook replacement in Codex output**
+
+Run: `grep -l "Before generating, scan" arckit-codex/prompts/*.md | wc -l`
+Expected: 43 (all commands that had the hook note now have the self-scan replacement)
+
+Run: `grep -l "ArcKit Project Context hook has already" arckit-codex/prompts/*.md | wc -l`
+Expected: 0 (no commands still reference the hook)
+
+**Step 3: Verify context hook NOT replaced in Gemini output**
+
+Run: `grep -l "ArcKit Project Context hook has already" arckit-gemini/commands/arckit/*.toml | wc -l`
+Expected: 43 (Gemini has the context hook, so the note should remain)
+
+**Step 4: Verify pages standalone used for Codex**
+
+Run: `wc -l arckit-codex/prompts/arckit.pages.md`
+Expected: Significantly longer than other commands (close to 568 lines of content)
+
+Run: `grep -c "Handled by Hook" arckit-codex/prompts/arckit.pages.md`
+Expected: 0 (standalone version has no hook references)
+
+**Step 5: Verify pages standalone used for OpenCode**
+
+Run: `grep -c "Handled by Hook" arckit-opencode/commands/arckit.pages.md`
+Expected: 0
+
+**Step 6: Commit converted output**
+
+```bash
+git add arckit-codex/ arckit-opencode/ arckit-gemini/
+git commit -m "chore: regenerate extension commands with hook-aware converter"
+```
+
+---
+
+### Task 7: Update GitHub issues
+
+**Files:** None
+
+**Step 1: Close issue #138**
+
+```bash
+gh issue close 138 --comment "Fixed in $(git log --oneline -1 HEAD). The converter now replaces the context hook note with self-scan instructions for platforms without hooks (Codex, OpenCode). Gemini retains the original note since it has context-inject.py."
+```
+
+**Step 2: Close issue #139**
+
+```bash
+gh issue close 139 --comment "Fixed in $(git log --oneline -1 HEAD). The converter now uses a standalone pages command from commands-standalone/pages.md for platforms without the sync-guides hook. The standalone version has full inline logic for scanning projects and generating the docs site."
+```
+
+**Step 3: No commit needed**
+
+Issues are closed on GitHub, no file changes.

--- a/docs/plans/2026-03-08-pr143-search-completion-design.md
+++ b/docs/plans/2026-03-08-pr143-search-completion-design.md
@@ -1,0 +1,35 @@
+# Design: Make PR 143 (Project Search) Merge-Ready
+
+**Date**: 2026-03-08
+**PR**: #143 — feat: project search command with pre-processing hook
+**Branch**: `feat/project-search`
+
+## Context
+
+PR 143 adds `/arckit:search` — keyword, type, and requirement ID search across all project artifacts. The core implementation (hook, command, guide) is solid and follows established patterns. This design covers the missing deliverables needed to make the PR merge-ready.
+
+## Approach
+
+Check out `feat/project-search`, add missing items per the "Adding a New Slash Command" checklist, commit, push.
+
+## Work Items
+
+1. **Run `scripts/converter.py`** — generates Codex skills, OpenCode commands, and Gemini extension TOML. Converter handles path rewriting and format conversion automatically.
+
+2. **Update `docs/DEPENDENCY-MATRIX.md`** — add `search` row. Search has no hard prerequisites but benefits from existing project artifacts.
+
+3. **Update `docs/index.html`** — add search to the command listing.
+
+4. **Update `README.md`** — bump command count from 57 to 58, add search to the command table.
+
+5. **Update `CHANGELOG.md`** — add entry under next version section.
+
+6. **Copy guide to plugin** — ensure `docs/guides/search.md` is also at `arckit-claude/guides/search.md`.
+
+## Out of Scope
+
+- No changes to `search-scan.mjs` (working, follows patterns)
+- No changes to `search.md` command (well-structured with proper handoffs)
+- No changes to `hooks.json` (correctly registered)
+- No template file needed (search is a query command, doesn't generate documents)
+- `extractPreview` edge case left as-is (matches existing hook patterns)

--- a/docs/plans/2026-03-08-pr143-search-completion-plan.md
+++ b/docs/plans/2026-03-08-pr143-search-completion-plan.md
@@ -1,0 +1,255 @@
+# PR 143 Search Command Completion — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make PR 143 (`feat/project-search`) merge-ready by adding missing deliverables per the "Adding a New Slash Command" checklist.
+
+**Architecture:** The core search implementation (hook, command, guide) is already written and solid. This plan only adds the surrounding documentation, converter output, and plugin guide copy that the checklist requires.
+
+**Tech Stack:** Python (converter), Markdown (docs), HTML (commands.html, index.html), Git
+
+---
+
+### Task 1: Check out the PR branch
+
+**Files:**
+- No file changes
+
+**Step 1: Fetch and check out the branch**
+
+Run: `git fetch origin feat/project-search && git checkout feat/project-search`
+Expected: Branch checked out successfully
+
+**Step 2: Verify PR files exist**
+
+Run: `ls arckit-claude/commands/search.md arckit-claude/hooks/search-scan.mjs docs/guides/search.md`
+Expected: All 3 files listed
+
+---
+
+### Task 2: Copy guide to plugin directory
+
+**Files:**
+- Copy: `docs/guides/search.md` → `arckit-claude/guides/search.md`
+
+**Step 1: Copy the guide**
+
+Run: `cp docs/guides/search.md arckit-claude/guides/search.md`
+Expected: File copied
+
+**Step 2: Verify the copy**
+
+Run: `diff docs/guides/search.md arckit-claude/guides/search.md`
+Expected: No differences
+
+---
+
+### Task 3: Run the converter
+
+**Files:**
+- Generated: `arckit-codex/skills/arckit-search/SKILL.md`
+- Generated: `arckit-opencode/commands/arckit.search.md`
+- Generated: `arckit-gemini/commands/arckit/search.toml`
+- Generated: `.codex/prompts/arckit.search.md` (Codex CLI format)
+- Generated: `.opencode/commands/arckit.search.md` (OpenCode CLI format)
+
+**Step 1: Run converter**
+
+Run: `python scripts/converter.py`
+Expected: Converter runs without errors, outputs summary of converted commands
+
+**Step 2: Verify search files were generated**
+
+Run: `ls arckit-codex/skills/arckit-search/SKILL.md arckit-opencode/commands/arckit.search.md arckit-gemini/commands/arckit/search.toml`
+Expected: All 3 extension files exist
+
+---
+
+### Task 4: Update DEPENDENCY-MATRIX.md
+
+**Files:**
+- Modify: `docs/DEPENDENCY-MATRIX.md`
+
+Search is a **diagnostic/utility command** — it queries existing artifacts but produces no output consumed by other commands. It has no mandatory dependencies. Per the existing pattern (health, customize, template-builder, start, init), it should NOT be added to the DSM table but noted in the utility exclusion list.
+
+**Step 1: Update the Version section**
+
+In `docs/DEPENDENCY-MATRIX.md`, update:
+
+```markdown
+- **Commands Documented**: 57
+```
+
+to:
+
+```markdown
+- **Commands Documented**: 58
+```
+
+**Step 2: Add search to the utility command exclusion note**
+
+Update the note at line ~355:
+
+```markdown
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+```
+
+to:
+
+```markdown
+- **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+```
+
+**Step 3: Add changelog entry**
+
+Add to the Changelog section at the top (after the DFD entry):
+
+```markdown
+### 2026-03-08 - Added Project Search Command
+
+- **Added**: `/arckit.search` command (58th ArcKit command) for keyword, type, and requirement ID search across all project artifacts
+- **Not in matrix**: Diagnostic/query command with console-only output — no dependencies and no outputs consumed by other commands
+- **Updated**: Commands Documented count from 57 to 58
+- **Note**: Uses UserPromptSubmit pre-processing hook (`search-scan.mjs`) to index artifacts before search
+```
+
+---
+
+### Task 5: Update README.md
+
+**Files:**
+- Modify: `README.md`
+
+**Step 1: Bump command count**
+
+Find all instances of "57 commands" or "57 " (in context of command counts) and update to 58. Key locations:
+
+- Line 43: `all 57 commands` → `all 58 commands`
+- Any other "57" references in the command count context
+
+**Step 2: Add search to the Quality & Governance command table**
+
+In the Quality & Governance table (around line 1016, after the `/arckit.health` row), add:
+
+```markdown
+| `/arckit.search` | Search across all project artifacts by keyword, document type, or requirement ID | — | 🔵 Beta |
+```
+
+---
+
+### Task 6: Update docs/commands.html
+
+**Files:**
+- Modify: `docs/commands.html`
+
+**Step 1: Bump command count in heading**
+
+Update line ~515:
+
+```html
+<h2 class="govuk-heading-l">57 ArcKit AI Commands</h2>
+```
+
+to:
+
+```html
+<h2 class="govuk-heading-l">58 ArcKit AI Commands</h2>
+```
+
+**Step 2: Add search command row**
+
+In the Diagnostics section (after the `/arckit.health` row, around line 1247), add:
+
+```html
+                    <tr data-status="beta" data-category="governance">
+                        <td><code>/arckit.search</code></td>
+                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
+                        <td>Quality & Governance</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+```
+
+---
+
+### Task 7: Update docs/index.html
+
+**Files:**
+- Modify: `docs/index.html`
+
+**Step 1: Bump command count**
+
+Update all "57" references in meta descriptions and content to "58":
+
+- Line 7: `meta name="description"` — `57 AI-assisted commands` → `58 AI-assisted commands`
+- Line 11: `og:description` — same change
+- Line 18: `twitter:description` — same change
+- Line 315: JSON-LD description — same change
+- Line 392: body text — `57 AI-assisted commands` → `58 AI-assisted commands`
+
+---
+
+### Task 8: Update CHANGELOG.md
+
+**Files:**
+- Modify: `CHANGELOG.md`
+
+**Step 1: Add entry under [Unreleased]**
+
+After the `## [Unreleased]` heading (line 8), add:
+
+```markdown
+
+### Added
+
+- `/arckit.search` command for keyword, type, and requirement ID search across all project artifacts with pre-processing hook
+```
+
+---
+
+### Task 9: Commit and push
+
+**Files:**
+- No new files
+
+**Step 1: Stage all changes**
+
+Run: `git add arckit-claude/guides/search.md arckit-codex/ arckit-opencode/ arckit-gemini/ .codex/ .opencode/ docs/DEPENDENCY-MATRIX.md docs/commands.html docs/index.html README.md CHANGELOG.md`
+Expected: Files staged
+
+**Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+docs: complete search command deliverables for merge readiness
+
+- Run converter to generate Codex/OpenCode/Gemini extension formats
+- Copy guide to plugin directory (arckit-claude/guides/)
+- Update DEPENDENCY-MATRIX.md (58 commands, utility exclusion note)
+- Update README.md (command count, Quality & Governance table)
+- Update commands.html and index.html (command count, table row)
+- Update CHANGELOG.md with search command entry
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Step 3: Push**
+
+Run: `git push origin feat/project-search`
+Expected: Push succeeds
+
+---
+
+### Task 10: Verify
+
+**Step 1: Confirm PR is updated**
+
+Run: `gh pr view 143 --json commits --jq '.commits | length'`
+Expected: 2 (original + our commit)
+
+**Step 2: Run markdownlint on changed files**
+
+Run: `npx markdownlint-cli2 "docs/DEPENDENCY-MATRIX.md" "CHANGELOG.md" "README.md"`
+Expected: No errors

--- a/docs/plans/2026-03-08-pr145-vendor-scoring-design.md
+++ b/docs/plans/2026-03-08-pr145-vendor-scoring-design.md
@@ -1,0 +1,38 @@
+# Design: Make PR 145 (Vendor Scoring) Merge-Ready
+
+**Date**: 2026-03-08
+**PR**: #145 — feat: vendor scoring with structured storage and audit trail
+**Branch**: `feat/vendor-scoring` (based on `feat/project-search` for 58→59 count)
+
+## Context
+
+PR 145 adds `/arckit:score` — vendor scoring with structured JSON storage, side-by-side comparison, sensitivity analysis, and audit trail. Includes a PreToolUse validator hook for scores.json integrity. Core code is solid; needs code fixes from review and missing deliverables.
+
+## Code Fixes
+
+1. **`score-validator.mjs`**: Replace manual stdin parsing (lines 22-38) with `parseHookInput()` from `hook-utils.mjs`
+2. **`score-validator.mjs`**: Add `evidence` non-empty validation — warn if empty string, don't block
+3. **`hooks.json`**: Merge score-validator into existing `"matcher": "Write"` PreToolUse block (line 75) instead of creating a duplicate matcher block
+
+## Missing Deliverables
+
+4. **Run `scripts/converter.py`** — generate Codex skills, OpenCode commands, Gemini TOML
+5. **Copy guide** — `docs/guides/score.md` → `arckit-claude/docs/guides/score.md`
+6. **Update `docs/DEPENDENCY-MATRIX.md`**:
+   - Add `score` row and column to DSM (Tier 5 Procurement)
+   - Dependencies: evaluate (M), requirements (M)
+   - Consumed by: sow (O), pages (R)
+   - Update count 58→59
+   - Add changelog entry
+7. **Update `README.md`** — count 58→59, add score to Procurement table
+8. **Update `docs/commands.html`** — count 58→59, add table row
+9. **Update `docs/index.html`** — count 58→59 in meta descriptions
+10. **Update `CHANGELOG.md`** — add entry under [Unreleased]
+11. **Update all extension/plugin/guide 58→59** (same sweep as PR 146)
+12. **Update `CLAUDE.md`** — count 58→59
+
+## Out of Scope
+
+- No changes to `score.md` command (well-structured)
+- No template file (outputs JSON, not markdown)
+- Guide content unchanged (clear with good examples)

--- a/docs/plans/2026-03-08-pr145-vendor-scoring-plan.md
+++ b/docs/plans/2026-03-08-pr145-vendor-scoring-plan.md
@@ -1,0 +1,312 @@
+# PR 145 Vendor Scoring Completion — Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Make PR 145 (`feat/vendor-scoring`) merge-ready by fixing review issues and adding missing deliverables.
+
+**Architecture:** Cherry-pick PR 145's commit onto `feat/project-search` (which has 58 commands), fix code issues in score-validator.mjs, fix hooks.json structure, then add all missing documentation and converter output for 58→59 count.
+
+**Tech Stack:** Node.js/ESM (hook fixes), Python (converter), Markdown/HTML (docs), Git
+
+---
+
+### Task 1: Create branch and cherry-pick PR 145
+
+**Files:**
+- No file changes
+
+**Step 1: Create branch from feat/project-search**
+
+Run: `git checkout feat/project-search && git checkout -b feat/vendor-scoring`
+Expected: New branch created
+
+**Step 2: Cherry-pick PR 145's commit**
+
+Run: `gh pr view 145 --json commits --jq '.commits[0].oid'`
+Then: `git fetch origin pull/145/head:pr-145-temp && git cherry-pick <SHA>`
+Expected: Commit applied (may need conflict resolution on hooks.json)
+
+**Step 3: If hooks.json conflicts, resolve**
+
+Our `feat/project-search` branch already has the search hook entry. The PR 145 diff adds a new Write matcher block under PreToolUse. Take both changes, but we'll restructure the hooks.json in the next task.
+
+---
+
+### Task 2: Fix score-validator.mjs — use parseHookInput()
+
+**Files:**
+- Modify: `arckit-claude/hooks/score-validator.mjs`
+
+**Step 1: Replace manual stdin parsing with parseHookInput()**
+
+Replace lines 18-38 (the manual stdin read + JSON parse) with:
+
+```javascript
+import { basename } from 'node:path';
+import { isDir, isFile, parseHookInput } from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+const data = parseHookInput();
+```
+
+Remove the `import { readFileSync } from 'node:fs';` line since `parseHookInput()` handles it.
+
+**Step 2: Add evidence non-empty validation**
+
+In the vendor scores validation loop (after the score range check), add:
+
+```javascript
+      if (!s.evidence || !s.evidence.trim()) {
+        warnings.push(`Vendor '${vendorKey}' criterion ${s.criterionId || '?'}: missing evidence (every score must cite supporting evidence)`);
+      }
+```
+
+**Step 3: Verify ESM imports work**
+
+Run: `node -e "import('./arckit-claude/hooks/score-validator.mjs')" 2>&1 || echo "Import check done"`
+Expected: No syntax errors
+
+---
+
+### Task 3: Fix hooks.json — merge into existing Write block
+
+**Files:**
+- Modify: `arckit-claude/hooks/hooks.json`
+
+**Step 1: Remove the duplicate Write matcher block**
+
+PR 145 adds a separate `"matcher": "Write"` block under PreToolUse. Instead, add `score-validator.mjs` to the **existing** `"matcher": "Write"` block (the one with `validate-arc-filename.mjs`).
+
+The existing PreToolUse Write block should become:
+
+```json
+{
+  "matcher": "Write",
+  "hooks": [
+    {
+      "type": "command",
+      "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-arc-filename.mjs",
+      "timeout": 5
+    },
+    {
+      "type": "command",
+      "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/score-validator.mjs",
+      "timeout": 5
+    }
+  ]
+}
+```
+
+Remove the duplicate standalone Write matcher block that PR 145 added.
+
+**Step 2: Validate JSON**
+
+Run: `node -e "JSON.parse(require('fs').readFileSync('arckit-claude/hooks/hooks.json','utf8')); console.log('Valid JSON')"`
+Expected: "Valid JSON"
+
+---
+
+### Task 4: Copy guide to plugin directory
+
+**Files:**
+- Copy: `docs/guides/score.md` → `arckit-claude/docs/guides/score.md`
+
+**Step 1: Copy and verify**
+
+Run: `cp docs/guides/score.md arckit-claude/docs/guides/score.md && diff docs/guides/score.md arckit-claude/docs/guides/score.md`
+Expected: No differences
+
+---
+
+### Task 5: Run converter
+
+**Files:**
+- Generated: `arckit-codex/skills/arckit-score/SKILL.md` (and agents/openai.yaml)
+- Generated: `arckit-opencode/commands/arckit.score.md`
+- Generated: `arckit-gemini/commands/arckit/score.toml`
+
+**Step 1: Run converter**
+
+Run: `python scripts/converter.py`
+Expected: Converter runs without errors
+
+**Step 2: Verify score files generated**
+
+Run: `ls arckit-codex/skills/arckit-score/SKILL.md arckit-opencode/commands/arckit.score.md arckit-gemini/commands/arckit/score.toml`
+Expected: All 3 exist
+
+---
+
+### Task 6: Update all documentation (58→59)
+
+**Files:**
+- Modify: `docs/DEPENDENCY-MATRIX.md`
+- Modify: `README.md`
+- Modify: `docs/commands.html`
+- Modify: `docs/index.html`
+- Modify: `docs/README.md`
+- Modify: `CHANGELOG.md`
+- Modify: `CLAUDE.md`
+- Modify: All extension/plugin/guide files with "58" command counts
+
+**Step 1: DEPENDENCY-MATRIX.md**
+
+a) Update "Commands Documented: 58" → "Commands Documented: 59"
+
+b) Add score to the Tier 5 Procurement section description:
+```markdown
+- **score** → Depends on: evaluate (M), requirements (M)
+  - Note: Structured vendor scoring with JSON storage, comparison, and audit trail
+  - Integrates with evaluate criteria; scores stored in `projects/{id}/vendors/scores.json`
+```
+
+c) Add changelog entry at top of Changelog section:
+```markdown
+### 2026-03-08 - Added Vendor Scoring Command
+
+- **Added**: `/arckit.score` command (59th ArcKit command) for structured vendor scoring with JSON storage, comparison, and audit trail
+- **Added**: score row and column to dependency matrix
+- **Updated**: Tier 5 Procurement to include score command
+- **Dependencies**: evaluate (M), requirements (M)
+- **Consumed by**: sow (O), pages (R)
+- **Updated**: Commands Documented count from 58 to 59
+- **Note**: First command to use structured JSON output instead of Markdown; includes PreToolUse validator hook for scores.json integrity
+```
+
+**Step 2: README.md**
+
+a) Update all "58" command count references to "59"
+
+b) Add score row to Procurement table (after `/arckit.evaluate`):
+```markdown
+| `/arckit.score` | Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail | — | 🔵 Beta |
+```
+
+**Step 3: docs/commands.html**
+
+a) Update "58 ArcKit AI Commands" → "59 ArcKit AI Commands" in heading and all meta/count references
+
+b) Add score row in Procurement section (after evaluate row):
+```html
+                    <tr data-status="beta" data-category="procurement">
+                        <td><code>/arckit.score</code></td>
+                        <td class="description">Score vendor proposals with structured storage, side-by-side comparison, sensitivity analysis, and audit trail</td>
+                        <td>Procurement</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+```
+
+**Step 4: docs/index.html**
+
+Update all "58" meta description and body text references to "59"
+
+**Step 5: docs/README.md**
+
+a) Add to documentation coverage table:
+```markdown
+| `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
+```
+
+b) Update "58/58 commands documented" → "59/59 commands documented"
+
+**Step 6: CHANGELOG.md**
+
+Add under [Unreleased] → Added:
+```markdown
+- `/arckit.score` command for structured vendor scoring with JSON storage, comparison, sensitivity analysis, and audit trail
+```
+
+**Step 7: CLAUDE.md**
+
+Update "58 slash commands" → "59 slash commands"
+
+**Step 8: Sweep all "58" command count references to "59"**
+
+Same pattern as PR 146's sweep — update all extension READMEs, plugin files, guides, marketplace.json, getting-started.html, etc.
+
+---
+
+### Task 7: Commit and push
+
+**Step 1: Stage all changes**
+
+Run: `git add -A` (then verify no sensitive files with `git diff --cached --name-only`)
+
+**Step 2: Commit**
+
+```bash
+git commit -m "$(cat <<'EOF'
+feat: vendor scoring with structured storage and audit trail
+
+Cherry-picked from PR #145 with fixes:
+- Use parseHookInput() instead of manual stdin parsing
+- Add evidence non-empty validation to score-validator
+- Merge score-validator into existing Write matcher block (not duplicate)
+- Run converter for Codex/OpenCode/Gemini extension formats
+- Copy guide to plugin directory
+- Update DEPENDENCY-MATRIX.md (59 commands, Tier 5 Procurement entry)
+- Update all docs and command counts (58→59)
+- Add CHANGELOG entry
+
+Supersedes #145.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
+EOF
+)"
+```
+
+**Step 3: Push**
+
+Run: `git push -u origin feat/vendor-scoring`
+
+---
+
+### Task 8: Create PR and verify
+
+**Step 1: Create PR**
+
+```bash
+gh pr create --base main --head feat/vendor-scoring --title "feat: vendor scoring with structured storage and audit trail" --body "$(cat <<'EOF'
+## Summary
+
+Adds `/arckit:score` for persistent, auditable vendor scoring — completing the procurement workflow chain (`evaluate → score → compare → sow`).
+
+Cherry-picked from #145 with code fixes and complete documentation.
+
+### Code fixes from review
+- Use `parseHookInput()` from hook-utils.mjs (consistent with all other hooks)
+- Add `evidence` non-empty validation to score-validator
+- Merge score-validator into existing Write matcher block (was duplicate)
+
+### Deliverables added
+- Converter output for Codex/OpenCode/Gemini extensions
+- Guide copied to plugin directory
+- DEPENDENCY-MATRIX entry (Tier 5 Procurement, depends on evaluate (M))
+- Command counts 58→59 across all docs, extensions, and manifests
+- CHANGELOG entry
+
+Supersedes #145 (fork PR).
+
+## Test plan
+
+- [ ] JSON validation of hooks.json
+- [ ] ESM import validation of score-validator.mjs
+- [ ] Score a vendor and verify scores.json structure
+- [ ] Compare sub-action with 2+ vendors
+- [ ] Validator catches out-of-range scores and missing evidence
+- [ ] Converter output validates
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+**Step 2: Comment on PR 145**
+
+Run: `gh pr comment 145 --body "Superseded by #<NEW_PR> ..."`
+
+**Step 3: Run markdownlint**
+
+Run: `npx markdownlint-cli2 "docs/DEPENDENCY-MATRIX.md" "CHANGELOG.md" "README.md" "docs/README.md"`
+Expected: 0 errors

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -401,7 +401,7 @@ python scripts/converter.py
 #   Codex Skills: arckit-claude/commands/plan.md -> arckit-codex/skills/arckit-plan/
 #   Gemini:       arckit-claude/commands/plan.md -> arckit-gemini/commands/arckit/plan.toml
 #   ...
-# Generated 58 Codex CLI + 58 Codex Skills + 58 OpenCode + 58 Gemini = 290 total files.
+# Generated 59 Codex CLI + 59 Codex Skills + 59 OpenCode + 59 Gemini = 295 total files.
 ```
 
 **Use Cases**:

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -401,7 +401,7 @@ python scripts/converter.py
 #   Codex Skills: arckit-claude/commands/plan.md -> arckit-codex/skills/arckit-plan/
 #   Gemini:       arckit-claude/commands/plan.md -> arckit-gemini/commands/arckit/plan.toml
 #   ...
-# Generated 57 Codex CLI + 57 Codex Skills + 57 OpenCode + 57 Gemini = 285 total files.
+# Generated 58 Codex CLI + 58 Codex Skills + 58 OpenCode + 58 Gemini = 290 total files.
 ```
 
 **Use Cases**:

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -90,6 +90,20 @@ All extension file access MUST go through shell commands.
 
 """
 
+CONTEXT_HOOK_NOTE = (
+    "> **Note**: The ArcKit Project Context hook has already detected all "
+    "projects, artifacts, external documents, and global policies. Use that "
+    "context below \u2014 no need to scan directories manually."
+)
+
+CONTEXT_HOOK_REPLACEMENT = (
+    "> **Note**: Before generating, scan `projects/` for existing project "
+    "directories. For each project, list all `ARC-*.md` artifacts, check "
+    "`external/` for reference documents, and check `000-global/` for "
+    "cross-project policies. If no external docs exist but they would "
+    "improve output, ask the user."
+)
+
 
 # --- Agent configuration: adding a new AI target = adding a dictionary entry ---
 

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -175,6 +175,17 @@ def rewrite_paths(prompt, config):
     return result
 
 
+def rewrite_hook_dependencies(prompt, config):
+    """Replace hook-dependent content for platforms without hooks."""
+    result = prompt
+
+    # Context injection: replace hook note with self-scan instructions
+    if not config.get("has_context_hook", False):
+        result = result.replace(CONTEXT_HOOK_NOTE, CONTEXT_HOOK_REPLACEMENT)
+
+    return result
+
+
 def format_output(description, prompt, fmt):
     """Format into target format: 'markdown', 'toml', or 'skill'."""
     if fmt == "toml":

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -248,7 +248,7 @@ def convert(commands_dir, agents_dir):
         for agent_id, config in AGENT_CONFIG.items():
             # Check for standalone command override (for hookless platforms)
             standalone_path = os.path.join(
-                os.path.dirname(commands_dir), "commands-standalone", filename
+                os.path.dirname(commands_dir.rstrip(os.sep)), "commands-standalone", filename
             )
             if os.path.isfile(standalone_path):
                 # Use standalone version if platform lacks required hook

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -103,12 +103,16 @@ AGENT_CONFIG = {
         "extension_dir": "arckit-codex",
         "copy_commands_to_extension": True,
         "copy_agents_to_extension": True,
+        "has_context_hook": False,
+        "has_sync_guides_hook": False,
     },
     "codex_skills": {
         "name": "Codex Skills",
         "output_dir": "arckit-codex/skills",
         "format": "skill",
         "path_prefix": ".arckit",
+        "has_context_hook": False,
+        "has_sync_guides_hook": False,
     },
     "opencode": {
         "name": "OpenCode CLI",
@@ -118,6 +122,8 @@ AGENT_CONFIG = {
         "path_prefix": ".arckit",
         "extension_dir": "arckit-opencode",
         "copy_agents_to_extension": True,
+        "has_context_hook": False,
+        "has_sync_guides_hook": False,
     },
     "gemini": {
         "name": "Gemini CLI",
@@ -129,6 +135,8 @@ AGENT_CONFIG = {
         "extension_dir": "arckit-gemini",
         "prepend_block": EXTENSION_FILE_ACCESS_BLOCK,
         "rewrite_read_instructions": True,
+        "has_context_hook": True,
+        "has_sync_guides_hook": False,
     },
 }
 

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -82,6 +82,7 @@ EXTENSION_FILE_ACCESS_BLOCK = """\
 This command runs as a Gemini CLI extension. The extension directory \
 (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you \
 CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -245,22 +245,21 @@ def convert(commands_dir, agents_dir):
 
         base_name = filename.replace(".md", "")
 
+        # Check for standalone command override once (result is agent-independent)
+        standalone_path = os.path.join(
+            os.path.dirname(commands_dir.rstrip(os.sep)), "commands-standalone", filename
+        )
+        has_standalone = os.path.isfile(standalone_path)
+        standalone_prompt = None
+        if has_standalone:
+            with open(standalone_path, "r") as f:
+                standalone_content = f.read()
+            _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
+
         for agent_id, config in AGENT_CONFIG.items():
-            # Check for standalone command override (for hookless platforms)
-            standalone_path = os.path.join(
-                os.path.dirname(commands_dir.rstrip(os.sep)), "commands-standalone", filename
-            )
-            if os.path.isfile(standalone_path):
-                # Use standalone version if platform lacks required hook
-                needs_standalone = not config.get("has_sync_guides_hook", False)
-                if needs_standalone:
-                    with open(standalone_path, "r") as f:
-                        standalone_content = f.read()
-                    _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
-                    rewritten = rewrite_paths(standalone_prompt, config)
-                    # Skip rewrite_hook_dependencies — standalone is self-contained
-                else:
-                    rewritten = rewrite_paths(prompt, config)
+            if has_standalone and not config.get("has_sync_guides_hook", False):
+                # Use standalone version for platforms lacking required hook
+                rewritten = rewrite_paths(standalone_prompt, config)
             else:
                 rewritten = rewrite_paths(prompt, config)
                 rewritten = rewrite_hook_dependencies(rewritten, config)

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -246,7 +246,24 @@ def convert(commands_dir, agents_dir):
         base_name = filename.replace(".md", "")
 
         for agent_id, config in AGENT_CONFIG.items():
-            rewritten = rewrite_paths(prompt, config)
+            # Check for standalone command override (for hookless platforms)
+            standalone_path = os.path.join(
+                os.path.dirname(commands_dir), "commands-standalone", filename
+            )
+            if os.path.isfile(standalone_path):
+                # Use standalone version if platform lacks required hook
+                needs_standalone = not config.get("has_sync_guides_hook", False)
+                if needs_standalone:
+                    with open(standalone_path, "r") as f:
+                        standalone_content = f.read()
+                    _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
+                    rewritten = rewrite_paths(standalone_prompt, config)
+                    # Skip rewrite_hook_dependencies — standalone is self-contained
+                else:
+                    rewritten = rewrite_paths(prompt, config)
+            else:
+                rewritten = rewrite_paths(prompt, config)
+                rewritten = rewrite_hook_dependencies(rewritten, config)
 
             if config["format"] == "skill":
                 skill_name = f"arckit-{base_name}"


### PR DESCRIPTION
## Summary

Combined daily branch with two new features:

### 1. Project Search (`/arckit:search`) — from #146
- Keyword, type, and requirement ID search across all project artifacts
- UserPromptSubmit pre-processing hook (`search-scan.mjs`) indexes ARC documents
- Scoring: title (10pts), control fields (5pts), content (3pts), filename (2pts)

### 2. Vendor Scoring (`/arckit:score`) — from #147
- Structured vendor scoring with JSON storage (`scores.json`)
- Sub-actions: `vendor` (score), `compare` (side-by-side), `audit` (trail)
- PreToolUse validator hook for scores.json integrity
- Code fixes: `parseHookInput()`, evidence validation, hooks.json dedup

### Documentation
- Command count 57→59 across all docs, extensions, and manifests
- Converter output for Codex/OpenCode/Gemini for both commands
- DEPENDENCY-MATRIX, CHANGELOG, README, commands.html, index.html all updated
- Markdown lint passing

Supersedes #146 and #147.

## Test plan

- [ ] Search: keyword search in project with multiple document types
- [ ] Search: filter by type, project, and requirement ID
- [ ] Score: score a vendor and verify scores.json structure
- [ ] Score: compare sub-action with 2+ vendors
- [ ] Score: validator catches out-of-range scores and missing evidence
- [ ] Both: converter output validates for Codex/OpenCode/Gemini
- [ ] Both: hooks.json valid JSON, ESM imports work

🤖 Generated with [Claude Code](https://claude.com/claude-code)