### PR TITLE
feat: document quality gate hook — advisory content validation

### DIFF
--- a/arckit-claude/hooks/document-quality-gate.mjs
+++ b/arckit-claude/hooks/document-quality-gate.mjs
@@ -1,0 +1,212 @@
+#!/usr/bin/env node
+/**
+ * ArcKit PostToolUse (Write) Hook — Document Quality Gate
+ *
+ * Advisory hook that validates ARC document content quality after writes.
+ * Never blocks writes — surfaces warnings as additionalContext so Claude
+ * can offer to fix issues.
+ *
+ * Checks:
+ *   1. Document control completeness (detects placeholder text)
+ *   2. Requirement ID format validation
+ *   3. Empty section detection (headings with no content)
+ *   4. Cross-reference integrity (referenced ARC docs exist)
+ *
+ * Hook Type: PostToolUse
+ * Matcher: Write
+ * Input (stdin):  JSON { tool_name, tool_input: { file_path, content }, tool_output }
+ * Output (stdout): JSON with additionalContext warnings (or empty for pass-through)
+ */
+
+import { readFileSync, readdirSync } from 'node:fs';
+import { basename, dirname, join } from 'node:path';
+import { isDir, isFile, extractDocType } from './hook-utils.mjs';
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+// --- Read stdin ---
+let raw = '';
+try {
+  raw = readFileSync(0, 'utf8');
+} catch {
+  process.exit(0);
+}
+if (!raw || !raw.trim()) process.exit(0);
+
+let data;
+try {
+  data = JSON.parse(raw);
+} catch {
+  process.exit(0);
+}
+
+// --- Early exit: only process ARC-*.md files ---
+const filePath = (data.tool_input || {}).file_path || '';
+const filename = basename(filePath);
+if (!filename.startsWith('ARC-') || !filename.endsWith('.md')) process.exit(0);
+if (!filePath.includes('/projects/')) process.exit(0);
+
+const content = (data.tool_input || {}).content || '';
+if (!content) process.exit(0);
+
+const docType = extractDocType(filename);
+if (!docType) process.exit(0);
+
+const warnings = [];
+
+// --- Check 1: Document Control Completeness ---
+const PLACEHOLDER_PATTERNS = [
+  /\[Project Name\]/i,
+  /\[Author\]/i,
+  /\[Owner\]/i,
+  /\[Your Name\]/i,
+  /\[Organisation\]/i,
+  /\[Date\]/i,
+  /\[Version\]/i,
+  /\bTBD\b/,
+  /\bTODO\b/i,
+  /\bPLACEHOLDER\b/i,
+  /\[INSERT\b/i,
+  /\bXXX\b/,
+  /\[FILL IN\]/i,
+];
+
+const DOC_CONTROL_RE = /^\|\s*\*\*([^*]+)\*\*\s*\|\s*(.+?)\s*\|/;
+const lines = content.split('\n');
+const placeholderFields = [];
+
+for (const line of lines) {
+  const m = line.match(DOC_CONTROL_RE);
+  if (!m) continue;
+  const fieldName = m[1].trim();
+  const fieldValue = m[2].trim();
+
+  for (const pattern of PLACEHOLDER_PATTERNS) {
+    if (pattern.test(fieldValue)) {
+      placeholderFields.push(fieldName + ': "' + fieldValue + '"');
+      break;
+    }
+  }
+}
+
+if (placeholderFields.length > 0) {
+  warnings.push('**Placeholder text detected** in document control:\n' + placeholderFields.map(f => '  - ' + f).join('\n'));
+}
+
+// --- Check 2: Requirement ID Validity ---
+const MALFORMED_RE = /\b(BR|FR|NFR|INT|DR)-(\d{1,2})\b(?!\d)/g;
+
+const malformedIds = [];
+let match;
+while ((match = MALFORMED_RE.exec(content)) !== null) {
+  malformedIds.push(match[0]);
+}
+
+if (malformedIds.length > 0) {
+  const unique = [...new Set(malformedIds)];
+  warnings.push('**Malformed requirement IDs** (should be 3 digits, e.g. BR-001):\n' + unique.map(id => '  - ' + id).join('\n'));
+}
+
+// --- Check 3: Empty Section Detection ---
+const emptySections = [];
+for (let i = 0; i < lines.length; i++) {
+  const line = lines[i];
+  if (!/^##\s+/.test(line)) continue;
+
+  let hasContent = false;
+  for (let j = i + 1; j < lines.length; j++) {
+    const nextLine = lines[j].trim();
+    if (/^#{1,3}\s+/.test(nextLine)) break;
+    if (nextLine && !nextLine.startsWith('|') && nextLine !== '---') {
+      hasContent = true;
+      break;
+    }
+    if (nextLine.startsWith('|') && !nextLine.includes('---')) {
+      hasContent = true;
+      break;
+    }
+  }
+
+  if (!hasContent) {
+    const heading = line.replace(/^##\s+/, '').trim();
+    if (!['Document Control', 'Revision History', 'Appendices', 'References'].includes(heading)) {
+      emptySections.push(heading);
+    }
+  }
+}
+
+if (emptySections.length > 0) {
+  warnings.push('**Empty sections** (heading with no content below):\n' + emptySections.map(s => '  - ## ' + s).join('\n'));
+}
+
+// --- Check 4: Cross-Reference Integrity ---
+const ARC_REF_RE = /\bARC-(\d{3})-([A-Z][\w-]*?)(?:-v[\d.]+)?(?:\.md)?\b/g;
+const referencedDocs = new Set();
+while ((match = ARC_REF_RE.exec(content)) !== null) {
+  const refId = match[0].replace(/\.md$/, '');
+  if (!filename.includes(refId)) {
+    referencedDocs.add(refId);
+  }
+}
+
+if (referencedDocs.size > 0) {
+  const afterProjects = filePath.split('projects/')[1];
+  if (afterProjects) {
+    const projectDirName = afterProjects.split('/')[0];
+    const projectsBase = filePath.split('projects/')[0] + 'projects';
+    const projectDir = join(projectsBase, projectDirName);
+
+    const missingRefs = [];
+    for (const ref of referencedDocs) {
+      let found = false;
+      const searchDirs = [projectDir];
+      for (const subdir of ['decisions', 'diagrams', 'wardley-maps', 'data-contracts', 'reviews']) {
+        const subPath = join(projectDir, subdir);
+        if (isDir(subPath)) searchDirs.push(subPath);
+      }
+
+      for (const dir of searchDirs) {
+        try {
+          const files = readdirSync(dir);
+          if (files.some(f => f.includes(ref))) {
+            found = true;
+            break;
+          }
+        } catch { /* ignore */ }
+      }
+
+      if (!found) missingRefs.push(ref);
+    }
+
+    if (missingRefs.length > 0) {
+      warnings.push('**Cross-references to non-existent documents**:\n' + missingRefs.map(r => '  - ' + r).join('\n'));
+    }
+  }
+}
+
+// --- Output ---
+if (warnings.length === 0) process.exit(0);
+
+const typeInfo = DOC_TYPES[docType];
+const typeName = typeInfo ? typeInfo.name : docType;
+
+const messageParts = [
+  '## Document Quality Gate — ' + warnings.length + ' warning(s)',
+  '',
+  '**File:** ' + filename + ' (' + typeName + ')',
+  '',
+];
+for (let i = 0; i < warnings.length; i++) {
+  messageParts.push('### ' + (i + 1) + '. ' + warnings[i]);
+}
+messageParts.push('');
+messageParts.push('*These are advisory warnings — the file has been written successfully. Consider addressing the issues above.*');
+
+const message = messageParts.join('\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'PostToolUse',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -105,6 +105,11 @@
             "type": "command",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/update-manifest.mjs",
             "timeout": 5
+          },
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/document-quality-gate.mjs",
+            "timeout": 5
           }
         ]
       }

--- a/arckit-gemini/agents/arckit-aws-research.md
+++ b/arckit-gemini/agents/arckit-aws-research.md
@@ -30,6 +30,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-azure-research.md
+++ b/arckit-gemini/agents/arckit-azure-research.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-datascout.md
+++ b/arckit-gemini/agents/arckit-datascout.md
@@ -31,6 +31,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-framework.md
+++ b/arckit-gemini/agents/arckit-framework.md
@@ -50,6 +50,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-gcp-research.md
+++ b/arckit-gemini/agents/arckit-gcp-research.md
@@ -33,6 +33,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/arckit-gemini/agents/arckit-research.md
+++ b/arckit-gemini/agents/arckit-research.md
@@ -73,6 +73,7 @@ timeout_mins: 10
 
 **IMPORTANT — Gemini Extension File Access**:
 This command runs as a Gemini CLI extension. The extension directory (`~/.gemini/extensions/arckit/`) is outside the workspace sandbox, so you CANNOT use the read_file tool to access it. Instead:
+
 - To read templates/files: use a shell command, e.g. `cat ~/.gemini/extensions/arckit/templates/foo-template.md`
 - To list files: use `ls ~/.gemini/extensions/arckit/templates/`
 - To run scripts: use `python3 ~/.gemini/extensions/arckit/scripts/python/create-project.py --json`

--- a/docs/guides/document-quality-gate.md
+++ b/docs/guides/document-quality-gate.md
@@ -1,0 +1,65 @@
+# Document Quality Gate
+
+The document quality gate is an advisory hook that validates ARC document content after every write. It catches common issues like placeholder text, malformed requirement IDs, and broken cross-references — before they become governance problems.
+
+## What Gets Checked
+
+| Check | What It Detects | Severity |
+|-------|----------------|----------|
+| **Document Control Completeness** | Placeholder text like `[Project Name]`, `TBD`, `TODO`, `XXX` in document control fields | Medium |
+| **Requirement ID Format** | IDs with fewer than 3 digits (e.g., `BR-1` instead of `BR-001`) | Low |
+| **Empty Sections** | H2 headings with no content below them (excluding structural headings) | Low |
+| **Cross-Reference Integrity** | References to ARC documents that don't exist in the project | High |
+
+## Behaviour
+
+- **Advisory only** — never blocks writes. The document is always saved.
+- **Warnings surface as context** — Claude sees the warnings and can offer to fix issues.
+- **Only ARC documents** — non-ARC files are silently ignored.
+- **Scoped to project** — cross-references are checked within the same project directory.
+
+## Interpreting Warnings
+
+### Placeholder Text
+
+```
+**Placeholder text detected** in document control:
+  - Owner: "[Author]"
+  - Project: "TBD"
+```
+
+The document control table still has template placeholders. Replace them with real values.
+
+### Malformed Requirement IDs
+
+```
+**Malformed requirement IDs** (should be 3 digits, e.g. BR-001):
+  - BR-1
+  - FR-12
+```
+
+Requirement IDs must use 3-digit numbering: `BR-001`, `FR-012`, `NFR-100`.
+
+### Empty Sections
+
+```
+**Empty sections** (heading with no content below):
+  - ## Risk Assessment
+  - ## Alternatives Considered
+```
+
+These sections exist but have no content. Either populate them or remove them if not applicable.
+
+### Missing Cross-References
+
+```
+**Cross-references to non-existent documents**:
+  - ARC-001-ADR-005
+  - ARC-001-HLDR
+```
+
+The document references ARC documents that don't exist in the project directory. Either create the referenced document or correct the reference.
+
+## Structural Headings (Excluded)
+
+These headings are allowed to be empty: Document Control, Revision History, Appendices, References. They are structural sections that may not always have content.

--- a/docs/guides/document-quality-gate.md
+++ b/docs/guides/document-quality-gate.md
@@ -22,7 +22,7 @@ The document quality gate is an advisory hook that validates ARC document conten
 
 ### Placeholder Text
 
-```
+```text
 **Placeholder text detected** in document control:
   - Owner: "[Author]"
   - Project: "TBD"
@@ -32,7 +32,7 @@ The document control table still has template placeholders. Replace them with re
 
 ### Malformed Requirement IDs
 
-```
+```text
 **Malformed requirement IDs** (should be 3 digits, e.g. BR-001):
   - BR-1
   - FR-12
@@ -42,7 +42,7 @@ Requirement IDs must use 3-digit numbering: `BR-001`, `FR-012`, `NFR-100`.
 
 ### Empty Sections
 
-```
+```text
 **Empty sections** (heading with no content below):
   - ## Risk Assessment
   - ## Alternatives Considered
@@ -52,7 +52,7 @@ These sections exist but have no content. Either populate them or remove them if
 
 ### Missing Cross-References
 
-```
+```text
 **Cross-references to non-existent documents**:
   - ARC-001-ADR-005
   - ARC-001-HLDR


### PR DESCRIPTION
## Summary

PostToolUse hook that validates ARC document content quality after every write. Advisory only — never blocks, surfaces warnings as context so Claude can offer to fix issues.

- **Document control completeness** — detects placeholder text (`[Author]`, `TBD`, `TODO`, `XXX`)
- **Requirement ID format** — flags malformed IDs (e.g., `BR-1` instead of `BR-001`)
- **Empty section detection** — headings with no content below them
- **Cross-reference integrity** — references to ARC documents that don't exist in the project

## Files Changed

| File | Change |
|------|--------|
| `arckit-claude/hooks/document-quality-gate.mjs` | New — PostToolUse hook |
| `arckit-claude/hooks/hooks.json` | Register hook after update-manifest |
| `docs/guides/document-quality-gate.md` | New — usage guide |

## Design Decisions

- **Advisory, not blocking** — architects should never be prevented from saving work. Warnings surface as context for Claude to address.
- **Uses existing extractors** — imports `extractDocType` from `hook-utils.mjs` and `DOC_TYPES` from `doc-types.mjs`
- **Scoped to ARC documents** — only fires on `ARC-*.md` files under `projects/`

## Test plan

- [x] JSON validation of hooks.json
- [x] ESM import validation
- [ ] Write an ARC document with placeholder text — verify warnings surface
- [ ] Write an ARC document with clean content — verify no warnings
- [ ] Write a non-ARC file — verify silent pass-through

Replaces #142 (lint fixes applied).

🤖 Generated with [Claude Code](https://claude.com/claude-code)