### PR TITLE
fix: add explicit UTF-8 encoding to all Python file I/O (#160)

### DIFF
--- a/docs/plans/2026-03-09-sdg-repo-design.md
+++ b/docs/plans/2026-03-09-sdg-repo-design.md
@@ -1,0 +1,335 @@
+# SDG Mono-Repo Design
+
+**Date**: 2026-03-09
+**Issue**: #44
+**Status**: Approved
+
+## Summary
+
+Create a single GitHub repo (`arckit-test-project-v46-sdg`) containing all 17 UN Sustainable Development Goals as self-contained ArcKit workspaces, with 78 pre-created UK Government technology projects across them.
+
+## Approach
+
+Standalone Python script (`scripts/create-sdg-repo.py`) that creates the repo, scaffolds all files, and pushes to GitHub. Does not reuse `create-project.sh` — replicates its logic to avoid fighting with repo-root assumptions.
+
+## Repo Structure
+
+```text
+arckit-test-project-v46-sdg/
+├── .claude/settings.json          # Plugin marketplace config
+├── .devcontainer/devcontainer.json
+├── .mcp.json                      # Data Commons + AWS + Azure + Google MCPs
+├── CLAUDE.md                      # Top-level context
+├── README.md                      # Overview of all 17 SDGs
+├── CHANGELOG.md
+├── VERSION
+├── docs/
+│   ├── README.md
+│   ├── guides/.gitkeep
+│   ├── DEPENDENCY-MATRIX.md
+│   └── WORKFLOW-DIAGRAMS.md
+│
+├── sdg-01-no-poverty/
+│   ├── .arckit/.gitkeep           # ArcKit workspace root marker
+│   ├── README.md                  # SDG-level readme
+│   └── projects/
+│       ├── 000-global/
+│       │   ├── policies/
+│       │   └── external/
+│       ├── 001-universal-credit-modernisation/
+│       │   ├── README.md
+│       │   ├── external/
+│       │   └── vendors/
+│       ├── 002-social-housing-allocation-platform/
+│       └── ... (5 projects)
+│
+├── sdg-02-zero-hunger/
+│   └── ... (5 projects)
+│
+└── ... (17 SDG directories, 78 projects total)
+```
+
+## Key Design Decisions
+
+### One repo, not 17
+
+Issue #44 originally proposed 17 separate repos (v46-v62). Consolidating into one repo reduces GitHub sprawl and keeps all SDG work in one place. Each SDG dir is a self-contained ArcKit workspace.
+
+### `.arckit/` per SDG directory
+
+Each `sdg-XX/` dir contains `.arckit/.gitkeep` so that `create-project.sh` and other scripts find the correct workspace root when the user `cd`s into an SDG directory. This means `find_repo_root()` in `common.sh` resolves to the SDG dir, not the top-level repo.
+
+### Plugin-only (no CLI init)
+
+Each SDG workspace uses the Claude Code plugin (enabled via top-level `.claude/settings.json`). No `.codex/`, `.opencode/`, or CLI scaffolding. Matches the plugin-only pattern used by all test repos since v23.
+
+### Pre-created project directories
+
+All 78 project directories are created by the script with README.md, external/, and vendors/ subdirectories. Projects are ready for immediate use with ArcKit commands.
+
+### All 4 MCP servers
+
+The `.mcp.json` includes all MCP servers from the plugin:
+- `aws-knowledge` — AWS service research
+- `microsoft-learn` — Azure documentation
+- `google-developer-knowledge` — GCP documentation
+- `datacommons-mcp` — UN SDG datasets (population, GDP, health, climate, education)
+
+## `.mcp.json`
+
+```json
+{
+  "mcpServers": {
+    "aws-knowledge": {
+      "type": "http",
+      "url": "https://knowledge-mcp.global.api.aws"
+    },
+    "microsoft-learn": {
+      "type": "http",
+      "url": "https://learn.microsoft.com/api/mcp"
+    },
+    "google-developer-knowledge": {
+      "type": "http",
+      "url": "https://developerknowledge.googleapis.com/mcp",
+      "headers": {
+        "X-Goog-Api-Key": "${GOOGLE_API_KEY}"
+      }
+    },
+    "datacommons-mcp": {
+      "type": "http",
+      "url": "https://api.datacommons.org/mcp",
+      "headers": {
+        "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
+    }
+  }
+}
+```
+
+## Script: `scripts/create-sdg-repo.py`
+
+### Data structure
+
+```python
+SDGS = [
+    {
+        "number": 1,
+        "name": "No Poverty",
+        "slug": "no-poverty",
+        "projects": [
+            {"name": "Universal Credit Modernisation", "desc": "DWP digital platform..."},
+            ...
+        ]
+    },
+    ...  # all 17 SDGs, 78 projects
+]
+```
+
+### Steps
+
+1. Read `VERSION` from main repo
+2. Create repo via `gh repo create tractorjuice/arckit-test-project-v46-sdg --public --clone`
+3. Scaffold top-level files:
+   - `.claude/settings.json` (plugin marketplace)
+   - `.devcontainer/devcontainer.json` (Claude Code auto-install)
+   - `.mcp.json` (4 MCP servers)
+   - `CLAUDE.md` (navigation context)
+   - `README.md` (SDG overview with project tables)
+   - `CHANGELOG.md`
+   - `VERSION`
+   - `docs/README.md`, `docs/guides/.gitkeep`
+   - Copy `docs/DEPENDENCY-MATRIX.md` and `docs/WORKFLOW-DIAGRAMS.md` from main repo
+4. Loop through 17 SDGs:
+   - Create `sdg-{NN}-{slug}/`
+   - Create `.arckit/.gitkeep`
+   - Create `projects/000-global/policies/`, `projects/000-global/external/`
+   - Create SDG-level `README.md`
+   - Loop through projects:
+     - Create `projects/{NNN}-{slug}/`
+     - Create `README.md` (project workflow, document codes, status checklist)
+     - Create `external/` and `vendors/` dirs (with `.gitkeep`)
+5. `git add -A && git commit && git push`
+6. Clean up `/tmp/`
+
+### Workflow
+
+```bash
+# Run from arc-kit repo
+python scripts/create-sdg-repo.py
+
+# Then in any SDG workspace:
+cd /path/to/arckit-test-project-v46-sdg/sdg-01-no-poverty/
+# ArcKit commands work from here
+/arckit:stakeholders "Universal Credit Modernisation"
+```
+
+## SDG-to-Project Mapping
+
+### SDG 1: No Poverty (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Universal Credit Modernisation | DWP digital platform for benefits administration and claims processing |
+| 002 | Social Housing Allocation Platform | DLUHC system for fair, transparent social housing allocation |
+| 003 | Debt Advice Digital Service | MaPS digital debt advice and financial guidance service |
+| 004 | Food Bank Coordination System | Cross-government platform linking food banks with referral agencies |
+| 005 | Fuel Poverty Intervention Tracker | DESNZ system to identify and support fuel-poor households |
+
+### SDG 2: Zero Hunger (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Food Supply Chain Resilience Platform | DEFRA system for monitoring UK food supply chain risks |
+| 002 | School Meals Management System | DfE platform for free school meals eligibility and delivery |
+| 003 | Food Waste Reduction Analytics | DEFRA data platform tracking food waste across the supply chain |
+| 004 | Agricultural Subsidy Management | DEFRA post-Brexit Environmental Land Management scheme platform |
+| 005 | National Food Strategy Dashboard | Cabinet Office monitoring platform for national food strategy KPIs |
+
+### SDG 3: Good Health and Well-Being (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | NHS Appointment Booking Platform | DHSC next-generation patient appointment and referral system |
+| 002 | Mental Health Digital Triage | NHS England AI-assisted mental health assessment and routing |
+| 003 | Pandemic Preparedness System | UKHSA disease surveillance and early warning platform |
+| 004 | Health Data Research Platform | DHSC secure research environment for health data analytics |
+| 005 | Social Prescribing Link Worker System | NHS platform connecting patients with community support services |
+
+### SDG 4: Quality Education (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | National Digital Learning Platform | DfE unified learning platform for schools and colleges |
+| 002 | School Performance Analytics | Ofsted data platform for school inspection and performance |
+| 003 | SEND Case Management System | DfE platform for Special Educational Needs and Disabilities support |
+| 004 | Apprenticeship Matching Service | DfE platform connecting apprentices with employers |
+| 005 | Teacher Recruitment Portal | DfE digital service for teacher training and recruitment |
+
+### SDG 5: Gender Equality (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Gender Pay Gap Reporting Platform | GEO automated gender pay gap collection and analytics |
+| 002 | Domestic Abuse Case Management | Home Office multi-agency case management for DA support |
+| 003 | Workplace Equality Monitoring | EHRC platform for monitoring workplace equality duties |
+| 004 | Women in STEM Tracking Dashboard | DSIT platform tracking gender diversity in science and technology |
+
+### SDG 6: Clean Water and Sanitation (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Water Quality Monitoring Platform | DEFRA real-time water quality monitoring across UK waterways |
+| 002 | Flood Risk Management System | Environment Agency flood forecasting and warning platform |
+| 003 | Wastewater Treatment Analytics | Ofwat platform for sewage treatment performance monitoring |
+| 004 | Water Resource Planning Tool | DEFRA long-term water supply and demand planning system |
+
+### SDG 7: Affordable and Clean Energy (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Smart Meter Data Platform | DESNZ national smart meter data collection and analytics |
+| 002 | Renewable Energy Grid Management | National Grid ESO platform for renewable energy integration |
+| 003 | Energy Performance Certificate System | DLUHC digital EPC rating and building efficiency platform |
+| 004 | Green Homes Grant Portal | DESNZ application and management system for home energy grants |
+| 005 | Community Energy Fund Tracker | DESNZ platform for community renewable energy project funding |
+
+### SDG 8: Decent Work and Economic Growth (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Job Matching Platform | DWP AI-powered job matching and career guidance service |
+| 002 | Skills Passport System | DfE digital skills and qualifications verification platform |
+| 003 | Labour Market Intelligence | ONS real-time labour market analytics and forecasting |
+| 004 | Small Business Support Portal | DBT integrated support platform for SMEs |
+| 005 | Modern Slavery Reporting System | Home Office platform for modern slavery transparency compliance |
+
+### SDG 9: Industry Innovation and Infrastructure (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Digital Infrastructure Mapping | DSIT national broadband and 5G coverage mapping platform |
+| 002 | Smart Transport Network | DfT connected transport infrastructure management |
+| 003 | Innovation Funding Platform | UKRI grants application and portfolio management system |
+| 004 | National Underground Asset Register | Geospatial Commission platform for sub-surface infrastructure |
+| 005 | Research Collaboration Hub | DSIT platform connecting UK research institutions with industry |
+
+### SDG 10: Reduced Inequalities (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Accessibility Compliance Platform | GDS monitoring service for public sector website accessibility |
+| 002 | Digital Inclusion Tracker | DSIT platform measuring digital skills and internet access gaps |
+| 003 | Levelling Up Dashboard | DLUHC regional inequality monitoring and fund tracking |
+| 004 | Disability Confident Employer Portal | DWP platform for disability-inclusive employment certification |
+
+### SDG 11: Sustainable Cities and Communities (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Smart City IoT Platform | DLUHC connected sensors platform for urban services |
+| 002 | Urban Planning Analytics | DLUHC data-driven spatial planning and development system |
+| 003 | Public Transport Optimisation | DfT platform for multi-modal transport planning and scheduling |
+| 004 | Heritage Asset Management | DCMS digital platform for listed buildings and heritage sites |
+| 005 | Air Quality Monitoring Network | DEFRA real-time air pollution monitoring and alerts |
+
+### SDG 12: Responsible Consumption and Production (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Carbon Footprint Calculator | DESNZ product and service carbon footprint assessment tool |
+| 002 | Circular Economy Marketplace | DEFRA platform connecting waste producers with recyclers |
+| 003 | Waste Management Analytics | DEFRA national waste tracking and reporting platform |
+| 004 | Sustainable Procurement Portal | Crown Commercial Service green procurement decision support |
+
+### SDG 13: Climate Action (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Net Zero Tracking Dashboard | DESNZ national net zero progress monitoring platform |
+| 002 | Climate Risk Assessment Platform | DEFRA infrastructure climate risk assessment and adaptation |
+| 003 | UK Emissions Trading Registry | DESNZ carbon trading scheme registration and compliance |
+| 004 | Climate Adaptation Planning Tool | DEFRA local authority climate adaptation planning system |
+| 005 | Green Finance Taxonomy Platform | HMT platform for classifying green investment activities |
+
+### SDG 14: Life Below Water (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Marine Protected Areas Monitoring | DEFRA surveillance platform for UK marine conservation zones |
+| 002 | Fishing Quota Management | MMO digital catch reporting and quota allocation system |
+| 003 | Ocean Pollution Tracking | DEFRA platform for monitoring marine litter and pollution |
+| 004 | Coastal Erosion Monitoring | Environment Agency coastal change mapping and prediction |
+
+### SDG 15: Life on Land (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Biodiversity Net Gain Platform | DEFRA platform for biodiversity credits and habitat banking |
+| 002 | Forestry Management System | Forestry Commission woodland creation and management platform |
+| 003 | Land Use Planning Analytics | DEFRA land use change monitoring and environmental impact |
+| 004 | Wildlife Crime Intelligence | NCA platform for wildlife trafficking intelligence and enforcement |
+
+### SDG 16: Peace Justice and Strong Institutions (5 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | Digital Court Case Management | HMCTS end-to-end digital case management for courts |
+| 002 | Legal Aid Digital Service | LAA legal aid eligibility and application platform |
+| 003 | Open Government Data Portal | Cabinet Office transparency and open data publishing platform |
+| 004 | Anti-Fraud Analytics Platform | Cabinet Office cross-government fraud detection and prevention |
+| 005 | Citizen Participation Platform | DLUHC digital platform for public consultations and engagement |
+
+### SDG 17: Partnerships for the Goals (4 projects)
+
+| # | Project | Description |
+|---|---------|-------------|
+| 001 | International Aid Tracking | FCDO overseas development assistance tracking and reporting |
+| 002 | Cross-Government Data Sharing | Cabinet Office platform for secure inter-departmental data exchange |
+| 003 | SDG Progress Dashboard | ONS UK SDG indicator monitoring and reporting platform |
+| 004 | Global Britain Trade Platform | DBT international trade and partnership management system |
+
+## Version Numbering
+
+- Repo uses `v46` (per issue #44 comment: v44 and v45 already taken)
+- Total test repos after creation: 47 (v0-v46), but only one new repo instead of 17
+- Issue #44 to be updated to reflect the mono-repo approach

--- a/docs/plans/2026-03-09-sdg-repo-plan.md
+++ b/docs/plans/2026-03-09-sdg-repo-plan.md
@@ -1,0 +1,105 @@
+# SDG Mono-Repo Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create `scripts/create-sdg-repo.py` that builds a single GitHub repo with 17 SDG workspaces and 78 pre-created UK Government projects.
+
+**Architecture:** Single Python script with embedded SDG data structure. Creates repo via `gh` CLI, scaffolds all files using `os`/`pathlib`, copies docs from main repo, commits and pushes.
+
+**Tech Stack:** Python 3 (stdlib only: `os`, `pathlib`, `subprocess`, `json`, `shutil`, `datetime`), `gh` CLI for GitHub operations.
+
+**Design doc:** `docs/plans/2026-03-09-sdg-repo-design.md`
+
+---
+
+### Task 1: Create the script and run it
+
+**Files:**
+- Create: `scripts/create-sdg-repo.py`
+
+**Step 1: Create the complete script**
+
+Create `scripts/create-sdg-repo.py` with all SDG data (17 SDGs, 78 projects), file scaffolding functions, and main entry point. The script:
+
+1. Reads `VERSION` from the main arc-kit repo
+2. Creates the GitHub repo via `gh repo create`
+3. Scaffolds top-level files: `.claude/settings.json`, `.devcontainer/devcontainer.json`, `.mcp.json`, `CLAUDE.md`, `README.md`, `CHANGELOG.md`, `VERSION`, `docs/`
+4. Loops through 17 SDGs creating self-contained workspaces with `.arckit/.gitkeep`, `projects/000-global/`, SDG README, and all numbered project dirs
+5. Each project gets `README.md` (matching `create-project.sh` output format), `external/.gitkeep`, `vendors/.gitkeep`
+6. Copies `DEPENDENCY-MATRIX.md` and `WORKFLOW-DIAGRAMS.md` from main repo
+7. Commits and pushes
+8. Cleans up `/tmp/`
+
+Key data: all 78 projects from issue #44 with full names and descriptions. SDG slugs match issue #44 (`no-poverty`, `zero-hunger`, `good-health`, etc.).
+
+The script uses `subprocess.run()` with hardcoded commands only (no user input) for `gh` and `git` CLI calls.
+
+**Step 2: Verify data integrity**
+
+Run: `python -c "import importlib.util; spec = importlib.util.spec_from_file_location('m', 'scripts/create-sdg-repo.py'); mod = importlib.util.module_from_spec(spec); exec(open('scripts/create-sdg-repo.py').read().split('def slugify')[0]); print(f'{len(SDGS)} SDGs, {sum(len(s[\"projects\"]) for s in SDGS)} projects')"`
+
+Expected: `17 SDGs, 78 projects`
+
+**Step 3: Run the script**
+
+Run: `cd /workspaces/arc-kit && python scripts/create-sdg-repo.py`
+
+Expected: Repo created, all files scaffolded, committed, pushed. Final summary printed.
+
+**Step 4: Verify the repo exists**
+
+Run: `gh repo view tractorjuice/arckit-test-project-v46-sdg --json name,description`
+
+Expected: `{"name":"arckit-test-project-v46-sdg","description":"ArcKit test project: UN Sustainable Development Goals — UK Government Technology Initiatives"}`
+
+**Step 5: Spot-check file structure**
+
+Run: `gh api repos/tractorjuice/arckit-test-project-v46-sdg/git/trees/main?recursive=1 --jq '.tree[].path' | head -40`
+
+Expected: Correct directory structure with `.claude/settings.json`, `.mcp.json`, SDG dirs, project dirs, READMEs.
+
+**Step 6: Commit the script to arc-kit repo**
+
+```bash
+git add scripts/create-sdg-repo.py docs/plans/2026-03-09-sdg-repo-design.md docs/plans/2026-03-09-sdg-repo-plan.md
+git commit -m "feat: add SDG mono-repo creation script (#44)
+
+Creates arckit-test-project-v46-sdg with 17 SDG workspaces
+and 78 UK Government technology projects. Implements #44
+as a single mono-repo instead of 17 separate repos.
+
+Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>"
+```
+
+---
+
+## Script Reference
+
+The complete script source is embedded in this plan. Key details:
+
+### SDG Data (SDGS list)
+
+All 17 SDGs with slug, name, and projects array. Each project has `name` and `desc`. Full data from issue #44.
+
+### File Templates
+
+- **`.claude/settings.json`**: Plugin marketplace config (matches `create-test-repo` command)
+- **`.devcontainer/devcontainer.json`**: Claude Code auto-install (matches `create-test-repo`)
+- **`.mcp.json`**: 4 MCP servers — `aws-knowledge`, `microsoft-learn`, `google-developer-knowledge`, `datacommons-mcp` (from `arckit-claude/.mcp.json`)
+- **`CLAUDE.md`**: SDG-specific with workspace listing and navigation instructions
+- **`README.md`**: Full SDG overview with project tables
+- **SDG `README.md`**: Per-SDG overview with project table and getting started
+- **Project `README.md`**: Matches `create-project.sh` output — workflow phases, document type codes, status checklist, SDG alignment note added
+
+### Functions
+
+- `slugify(name)` — kebab-case conversion
+- `run(cmd)` — shell command with logging
+- `write_file(path, content)` — write with auto-mkdir
+- `create_gitkeep(path)` — create dir with .gitkeep
+- `create_github_repo()` — `gh repo create`
+- `scaffold_top_level(version, today)` — all top-level files
+- `scaffold_sdg(sdg, version, today)` — one SDG workspace with all projects
+- `commit_and_push(version)` — git add/commit/push
+- `cleanup()` — remove /tmp/ dir
+- `main()` — orchestrate everything

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -21,7 +21,7 @@ def build_agent_map(agents_dir):
             name = filename.replace("arckit-", "", 1).replace(".md", "")
             command_filename = f"{name}.md"
             agent_path = os.path.join(agents_dir, filename)
-            with open(agent_path, "r") as f:
+            with open(agent_path, "r", encoding="utf-8") as f:
                 agent_content = f.read()
             agent_prompt = extract_agent_prompt(agent_content)
             agent_map[command_filename] = (agent_path, agent_prompt)
@@ -261,7 +261,7 @@ def convert(commands_dir, agents_dir):
 
         command_path = os.path.join(commands_dir, filename)
 
-        with open(command_path, "r") as f:
+        with open(command_path, "r", encoding="utf-8") as f:
             command_content = f.read()
 
         # Extract frontmatter from command (always use command's description)
@@ -292,7 +292,7 @@ def convert(commands_dir, agents_dir):
         has_standalone = os.path.isfile(standalone_path)
         standalone_prompt = None
         if has_standalone:
-            with open(standalone_path, "r") as f:
+            with open(standalone_path, "r", encoding="utf-8") as f:
                 standalone_content = f.read()
             _, standalone_prompt = extract_frontmatter_and_prompt(standalone_content)
 
@@ -339,7 +339,7 @@ def convert(commands_dir, agents_dir):
 
                 out_filename = config["filename_pattern"].format(name=base_name)
                 out_path = os.path.join(config["output_dir"], out_filename)
-                with open(out_path, "w") as f:
+                with open(out_path, "w", encoding="utf-8") as f:
                     f.write(content)
                 print(f"  {config['name'] + ':':14s}{source_label} -> {out_path} (agent wrapper)")
                 counts[agent_id] += 1
@@ -355,9 +355,9 @@ def convert(commands_dir, agents_dir):
                 skill_md = f'---\nname: {skill_name}\ndescription: "{escaped_desc}"\n---\n\n{rewritten}\n'
                 openai_yaml = "policy:\n  allow_implicit_invocation: false\n"
 
-                with open(os.path.join(skill_dir, "SKILL.md"), "w") as f:
+                with open(os.path.join(skill_dir, "SKILL.md"), "w", encoding="utf-8") as f:
                     f.write(skill_md)
-                with open(os.path.join(skill_dir, "agents", "openai.yaml"), "w") as f:
+                with open(os.path.join(skill_dir, "agents", "openai.yaml"), "w", encoding="utf-8") as f:
                     f.write(openai_yaml)
 
                 print(f"  {config['name'] + ':':14s}{source_label} -> {skill_dir}/")
@@ -366,7 +366,7 @@ def convert(commands_dir, agents_dir):
                 content = format_output(description, rewritten, config["format"])
                 out_filename = config["filename_pattern"].format(name=base_name)
                 out_path = os.path.join(config["output_dir"], out_filename)
-                with open(out_path, "w") as f:
+                with open(out_path, "w", encoding="utf-8") as f:
                     f.write(content)
                 print(f"  {config['name'] + ':':14s}{source_label} -> {out_path}")
                 counts[agent_id] += 1
@@ -415,7 +415,7 @@ def generate_codex_config_toml(mcp_json_path, agents_dir, output_path):
 
     # MCP servers section
     if os.path.isfile(mcp_json_path):
-        with open(mcp_json_path, "r") as f:
+        with open(mcp_json_path, "r", encoding="utf-8") as f:
             mcp_config = json.load(f)
         servers = mcp_config.get("mcpServers", {})
         if servers:
@@ -451,7 +451,7 @@ def generate_codex_config_toml(mcp_json_path, agents_dir, output_path):
 
             for filename in agent_files:
                 agent_path = os.path.join(agents_dir, filename)
-                with open(agent_path, "r") as f:
+                with open(agent_path, "r", encoding="utf-8") as f:
                     content = f.read()
                 frontmatter, _ = extract_frontmatter_and_prompt(content)
                 name = frontmatter.get("name", filename.replace(".md", ""))
@@ -466,7 +466,7 @@ def generate_codex_config_toml(mcp_json_path, agents_dir, output_path):
                 lines.append("")
 
     os.makedirs(os.path.dirname(output_path), exist_ok=True)
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write("\n".join(lines))
     print(f"  Generated: {output_path}")
 
@@ -484,7 +484,7 @@ def generate_agent_toml_files(agents_dir, output_dir, path_prefix=".arckit"):
             continue
 
         agent_path = os.path.join(agents_dir, filename)
-        with open(agent_path, "r") as f:
+        with open(agent_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         prompt = extract_agent_prompt(content)
@@ -503,7 +503,7 @@ def generate_agent_toml_files(agents_dir, output_dir, path_prefix=".arckit"):
             f'"""\n'
         )
 
-        with open(toml_path, "w") as f:
+        with open(toml_path, "w", encoding="utf-8") as f:
             f.write(toml_content)
         count += 1
 
@@ -528,7 +528,7 @@ def rewrite_codex_skills(skills_dir):
             if not filename.endswith(".md"):
                 continue
             filepath = os.path.join(root, filename)
-            with open(filepath, "r") as f:
+            with open(filepath, "r", encoding="utf-8") as f:
                 content = f.read()
 
             original = content
@@ -561,7 +561,7 @@ def rewrite_codex_skills(skills_dir):
             content = content.replace("${CLAUDE_PLUGIN_ROOT}", ".arckit")
 
             if content != original:
-                with open(filepath, "w") as f:
+                with open(filepath, "w", encoding="utf-8") as f:
                     f.write(content)
                 rel_path = os.path.relpath(filepath, skills_dir)
                 print(f"  Rewrote: {skills_dir}/{rel_path}")
@@ -592,7 +592,7 @@ def generate_gemini_agents(agents_dir, output_dir):
             continue
 
         agent_path = os.path.join(agents_dir, filename)
-        with open(agent_path, "r") as f:
+        with open(agent_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         frontmatter, prompt = extract_frontmatter_and_prompt(content)
@@ -625,7 +625,7 @@ def generate_gemini_agents(agents_dir, output_dir):
         output_content = f"---\n{fm_str}\n---\n\n{prompt}\n"
 
         out_path = os.path.join(output_dir, filename)
-        with open(out_path, "w") as f:
+        with open(out_path, "w", encoding="utf-8") as f:
             f.write(output_content)
         print(f"  {filename}")
         count += 1
@@ -714,7 +714,7 @@ def generate_gemini_hooks(output_dir):
     }
 
     hooks_path = os.path.join(hooks_dir, "hooks.json")
-    with open(hooks_path, "w") as f:
+    with open(hooks_path, "w", encoding="utf-8") as f:
         json.dump(hooks_config, f, indent=2)
         f.write("\n")
 
@@ -746,7 +746,7 @@ reason = "File content may contain secrets. Please confirm this is intentional."
 '''
 
     rules_path = os.path.join(policies_dir, "rules.toml")
-    with open(rules_path, "w") as f:
+    with open(rules_path, "w", encoding="utf-8") as f:
         f.write(rules)
     print(f"  Generated: {rules_path}")
 
@@ -765,7 +765,7 @@ def generate_copilot_agents(agents_dir, output_dir):
             continue
 
         agent_path = os.path.join(agents_dir, filename)
-        with open(agent_path, "r") as f:
+        with open(agent_path, "r", encoding="utf-8") as f:
             content = f.read()
 
         frontmatter, prompt = extract_frontmatter_and_prompt(content)
@@ -787,7 +787,7 @@ def generate_copilot_agents(agents_dir, output_dir):
         output_content = f"---\n{fm_str}\n---\n\n{prompt}\n"
 
         out_path = os.path.join(output_dir, out_filename)
-        with open(out_path, "w") as f:
+        with open(out_path, "w", encoding="utf-8") as f:
             f.write(output_content)
         print(f"  {out_filename}")
         count += 1
@@ -837,7 +837,7 @@ projects/
 ```
 """
     os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
-    with open(output_path, "w") as f:
+    with open(output_path, "w", encoding="utf-8") as f:
         f.write(content)
     print(f"  Generated: {output_path}")
 

--- a/scripts/create-sdg-repo.py
+++ b/scripts/create-sdg-repo.py
@@ -1,0 +1,820 @@
+#!/usr/bin/env python3
+"""Create the arckit-test-project-v46-sdg mono-repo.
+
+Scaffolds a single GitHub repo containing all 17 UN SDGs as self-contained
+ArcKit workspaces, with 78 pre-created UK Government technology projects.
+
+Uses Python stdlib only (pathlib, subprocess, json, shutil, datetime).
+"""
+
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import date
+from pathlib import Path
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+ARCKIT_ROOT = Path(__file__).resolve().parent.parent
+VERSION = (ARCKIT_ROOT / "VERSION").read_text().strip()
+TODAY = date.today().isoformat()
+
+REPO_NAME = "arckit-test-project-v46-sdg"
+REPO_FULL = f"tractorjuice/{REPO_NAME}"
+CLONE_BASE = Path("/tmp/arckit-test-setup")
+REPO_DIR = CLONE_BASE / REPO_NAME
+
+# ---------------------------------------------------------------------------
+# SDG Data
+# ---------------------------------------------------------------------------
+
+SDGS = [
+    {
+        "number": 1,
+        "name": "No Poverty",
+        "slug": "no-poverty",
+        "projects": [
+            ("Universal Credit Modernisation", "universal-credit-modernisation", "DWP digital platform for benefits administration and claims processing"),
+            ("Social Housing Allocation Platform", "social-housing-allocation-platform", "DLUHC system for fair, transparent social housing allocation"),
+            ("Debt Advice Digital Service", "debt-advice-digital-service", "MaPS digital debt advice and financial guidance service"),
+            ("Food Bank Coordination System", "food-bank-coordination-system", "Cross-government platform linking food banks with referral agencies"),
+            ("Fuel Poverty Intervention Tracker", "fuel-poverty-intervention-tracker", "DESNZ system to identify and support fuel-poor households"),
+        ],
+    },
+    {
+        "number": 2,
+        "name": "Zero Hunger",
+        "slug": "zero-hunger",
+        "projects": [
+            ("Food Supply Chain Resilience Platform", "food-supply-chain-resilience-platform", "DEFRA system for monitoring UK food supply chain risks"),
+            ("School Meals Management System", "school-meals-management-system", "DfE platform for free school meals eligibility and delivery"),
+            ("Food Waste Reduction Analytics", "food-waste-reduction-analytics", "DEFRA data platform tracking food waste across the supply chain"),
+            ("Agricultural Subsidy Management", "agricultural-subsidy-management", "DEFRA post-Brexit Environmental Land Management scheme platform"),
+            ("National Food Strategy Dashboard", "national-food-strategy-dashboard", "Cabinet Office monitoring platform for national food strategy KPIs"),
+        ],
+    },
+    {
+        "number": 3,
+        "name": "Good Health and Well-Being",
+        "slug": "good-health",
+        "projects": [
+            ("NHS Appointment Booking Platform", "nhs-appointment-booking-platform", "DHSC next-generation patient appointment and referral system"),
+            ("Mental Health Digital Triage", "mental-health-digital-triage", "NHS England AI-assisted mental health assessment and routing"),
+            ("Pandemic Preparedness System", "pandemic-preparedness-system", "UKHSA disease surveillance and early warning platform"),
+            ("Health Data Research Platform", "health-data-research-platform", "DHSC secure research environment for health data analytics"),
+            ("Social Prescribing Link Worker System", "social-prescribing-link-worker-system", "NHS platform connecting patients with community support services"),
+        ],
+    },
+    {
+        "number": 4,
+        "name": "Quality Education",
+        "slug": "quality-education",
+        "projects": [
+            ("National Digital Learning Platform", "national-digital-learning-platform", "DfE unified learning platform for schools and colleges"),
+            ("School Performance Analytics", "school-performance-analytics", "Ofsted data platform for school inspection and performance"),
+            ("SEND Case Management System", "send-case-management-system", "DfE platform for Special Educational Needs and Disabilities support"),
+            ("Apprenticeship Matching Service", "apprenticeship-matching-service", "DfE platform connecting apprentices with employers"),
+            ("Teacher Recruitment Portal", "teacher-recruitment-portal", "DfE digital service for teacher training and recruitment"),
+        ],
+    },
+    {
+        "number": 5,
+        "name": "Gender Equality",
+        "slug": "gender-equality",
+        "projects": [
+            ("Gender Pay Gap Reporting Platform", "gender-pay-gap-reporting-platform", "GEO automated gender pay gap collection and analytics"),
+            ("Domestic Abuse Case Management", "domestic-abuse-case-management", "Home Office multi-agency case management for DA support"),
+            ("Workplace Equality Monitoring", "workplace-equality-monitoring", "EHRC platform for monitoring workplace equality duties"),
+            ("Women in STEM Tracking Dashboard", "women-in-stem-tracking-dashboard", "DSIT platform tracking gender diversity in science and technology"),
+        ],
+    },
+    {
+        "number": 6,
+        "name": "Clean Water and Sanitation",
+        "slug": "clean-water",
+        "projects": [
+            ("Water Quality Monitoring Platform", "water-quality-monitoring-platform", "DEFRA real-time water quality monitoring across UK waterways"),
+            ("Flood Risk Management System", "flood-risk-management-system", "Environment Agency flood forecasting and warning platform"),
+            ("Wastewater Treatment Analytics", "wastewater-treatment-analytics", "Ofwat platform for sewage treatment performance monitoring"),
+            ("Water Resource Planning Tool", "water-resource-planning-tool", "DEFRA long-term water supply and demand planning system"),
+        ],
+    },
+    {
+        "number": 7,
+        "name": "Affordable and Clean Energy",
+        "slug": "clean-energy",
+        "projects": [
+            ("Smart Meter Data Platform", "smart-meter-data-platform", "DESNZ national smart meter data collection and analytics"),
+            ("Renewable Energy Grid Management", "renewable-energy-grid-management", "National Grid ESO platform for renewable energy integration"),
+            ("Energy Performance Certificate System", "energy-performance-certificate-system", "DLUHC digital EPC rating and building efficiency platform"),
+            ("Green Homes Grant Portal", "green-homes-grant-portal", "DESNZ application and management system for home energy grants"),
+            ("Community Energy Fund Tracker", "community-energy-fund-tracker", "DESNZ platform for community renewable energy project funding"),
+        ],
+    },
+    {
+        "number": 8,
+        "name": "Decent Work and Economic Growth",
+        "slug": "economic-growth",
+        "projects": [
+            ("Job Matching Platform", "job-matching-platform", "DWP AI-powered job matching and career guidance service"),
+            ("Skills Passport System", "skills-passport-system", "DfE digital skills and qualifications verification platform"),
+            ("Labour Market Intelligence", "labour-market-intelligence", "ONS real-time labour market analytics and forecasting"),
+            ("Small Business Support Portal", "small-business-support-portal", "DBT integrated support platform for SMEs"),
+            ("Modern Slavery Reporting System", "modern-slavery-reporting-system", "Home Office platform for modern slavery transparency compliance"),
+        ],
+    },
+    {
+        "number": 9,
+        "name": "Industry Innovation and Infrastructure",
+        "slug": "innovation",
+        "projects": [
+            ("Digital Infrastructure Mapping", "digital-infrastructure-mapping", "DSIT national broadband and 5G coverage mapping platform"),
+            ("Smart Transport Network", "smart-transport-network", "DfT connected transport infrastructure management"),
+            ("Innovation Funding Platform", "innovation-funding-platform", "UKRI grants application and portfolio management system"),
+            ("National Underground Asset Register", "national-underground-asset-register", "Geospatial Commission platform for sub-surface infrastructure"),
+            ("Research Collaboration Hub", "research-collaboration-hub", "DSIT platform connecting UK research institutions with industry"),
+        ],
+    },
+    {
+        "number": 10,
+        "name": "Reduced Inequalities",
+        "slug": "reduced-inequalities",
+        "projects": [
+            ("Accessibility Compliance Platform", "accessibility-compliance-platform", "GDS monitoring service for public sector website accessibility"),
+            ("Digital Inclusion Tracker", "digital-inclusion-tracker", "DSIT platform measuring digital skills and internet access gaps"),
+            ("Levelling Up Dashboard", "levelling-up-dashboard", "DLUHC regional inequality monitoring and fund tracking"),
+            ("Disability Confident Employer Portal", "disability-confident-employer-portal", "DWP platform for disability-inclusive employment certification"),
+        ],
+    },
+    {
+        "number": 11,
+        "name": "Sustainable Cities and Communities",
+        "slug": "sustainable-cities",
+        "projects": [
+            ("Smart City IoT Platform", "smart-city-iot-platform", "DLUHC connected sensors platform for urban services"),
+            ("Urban Planning Analytics", "urban-planning-analytics", "DLUHC data-driven spatial planning and development system"),
+            ("Public Transport Optimisation", "public-transport-optimisation", "DfT platform for multi-modal transport planning and scheduling"),
+            ("Heritage Asset Management", "heritage-asset-management", "DCMS digital platform for listed buildings and heritage sites"),
+            ("Air Quality Monitoring Network", "air-quality-monitoring-network", "DEFRA real-time air pollution monitoring and alerts"),
+        ],
+    },
+    {
+        "number": 12,
+        "name": "Responsible Consumption and Production",
+        "slug": "responsible-consumption",
+        "projects": [
+            ("Carbon Footprint Calculator", "carbon-footprint-calculator", "DESNZ product and service carbon footprint assessment tool"),
+            ("Circular Economy Marketplace", "circular-economy-marketplace", "DEFRA platform connecting waste producers with recyclers"),
+            ("Waste Management Analytics", "waste-management-analytics", "DEFRA national waste tracking and reporting platform"),
+            ("Sustainable Procurement Portal", "sustainable-procurement-portal", "Crown Commercial Service green procurement decision support"),
+        ],
+    },
+    {
+        "number": 13,
+        "name": "Climate Action",
+        "slug": "climate-action",
+        "projects": [
+            ("Net Zero Tracking Dashboard", "net-zero-tracking-dashboard", "DESNZ national net zero progress monitoring platform"),
+            ("Climate Risk Assessment Platform", "climate-risk-assessment-platform", "DEFRA infrastructure climate risk assessment and adaptation"),
+            ("UK Emissions Trading Registry", "uk-emissions-trading-registry", "DESNZ carbon trading scheme registration and compliance"),
+            ("Climate Adaptation Planning Tool", "climate-adaptation-planning-tool", "DEFRA local authority climate adaptation planning system"),
+            ("Green Finance Taxonomy Platform", "green-finance-taxonomy-platform", "HMT platform for classifying green investment activities"),
+        ],
+    },
+    {
+        "number": 14,
+        "name": "Life Below Water",
+        "slug": "life-below-water",
+        "projects": [
+            ("Marine Protected Areas Monitoring", "marine-protected-areas-monitoring", "DEFRA surveillance platform for UK marine conservation zones"),
+            ("Fishing Quota Management", "fishing-quota-management", "MMO digital catch reporting and quota allocation system"),
+            ("Ocean Pollution Tracking", "ocean-pollution-tracking", "DEFRA platform for monitoring marine litter and pollution"),
+            ("Coastal Erosion Monitoring", "coastal-erosion-monitoring", "Environment Agency coastal change mapping and prediction"),
+        ],
+    },
+    {
+        "number": 15,
+        "name": "Life on Land",
+        "slug": "life-on-land",
+        "projects": [
+            ("Biodiversity Net Gain Platform", "biodiversity-net-gain-platform", "DEFRA platform for biodiversity credits and habitat banking"),
+            ("Forestry Management System", "forestry-management-system", "Forestry Commission woodland creation and management platform"),
+            ("Land Use Planning Analytics", "land-use-planning-analytics", "DEFRA land use change monitoring and environmental impact"),
+            ("Wildlife Crime Intelligence", "wildlife-crime-intelligence", "NCA platform for wildlife trafficking intelligence and enforcement"),
+        ],
+    },
+    {
+        "number": 16,
+        "name": "Peace Justice and Strong Institutions",
+        "slug": "peace-justice",
+        "projects": [
+            ("Digital Court Case Management", "digital-court-case-management", "HMCTS end-to-end digital case management for courts"),
+            ("Legal Aid Digital Service", "legal-aid-digital-service", "LAA legal aid eligibility and application platform"),
+            ("Open Government Data Portal", "open-government-data-portal", "Cabinet Office transparency and open data publishing platform"),
+            ("Anti-Fraud Analytics Platform", "anti-fraud-analytics-platform", "Cabinet Office cross-government fraud detection and prevention"),
+            ("Citizen Participation Platform", "citizen-participation-platform", "DLUHC digital platform for public consultations and engagement"),
+        ],
+    },
+    {
+        "number": 17,
+        "name": "Partnerships for the Goals",
+        "slug": "partnerships",
+        "projects": [
+            ("International Aid Tracking", "international-aid-tracking", "FCDO overseas development assistance tracking and reporting"),
+            ("Cross-Government Data Sharing", "cross-government-data-sharing", "Cabinet Office platform for secure inter-departmental data exchange"),
+            ("SDG Progress Dashboard", "sdg-progress-dashboard", "ONS UK SDG indicator monitoring and reporting platform"),
+            ("Global Britain Trade Platform", "global-britain-trade-platform", "DBT international trade and partnership management system"),
+        ],
+    },
+]
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def run(cmd: list[str], cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Run a subprocess command, printing it first. Exits on failure."""
+    print(f"  > {' '.join(cmd)}")
+    result = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+    if result.returncode != 0:
+        print(f"  ERROR: {result.stderr.strip()}", file=sys.stderr)
+        sys.exit(result.returncode)
+    return result
+
+
+def write(path: Path, content: str) -> None:
+    """Write content to a file, creating parent dirs as needed."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content)
+
+
+def gitkeep(path: Path) -> None:
+    """Create a directory with a .gitkeep file."""
+    path.mkdir(parents=True, exist_ok=True)
+    (path / ".gitkeep").touch()
+
+
+def fmt_sdg_num(n: int) -> str:
+    """Format SDG number as zero-padded two-digit string."""
+    return f"{n:02d}"
+
+
+def fmt_project_num(n: int) -> str:
+    """Format project number as zero-padded three-digit string."""
+    return f"{n:03d}"
+
+
+# ---------------------------------------------------------------------------
+# Top-level file generators
+# ---------------------------------------------------------------------------
+
+
+def create_claude_settings() -> None:
+    """Create .claude/settings.json."""
+    settings = {
+        "extraKnownMarketplaces": {
+            "arc-kit": {
+                "source": {
+                    "source": "github",
+                    "repo": "tractorjuice/arc-kit",
+                }
+            }
+        },
+        "enabledPlugins": {
+            "arckit@arc-kit": True,
+        },
+    }
+    write(REPO_DIR / ".claude" / "settings.json", json.dumps(settings, indent=2) + "\n")
+
+
+def create_devcontainer() -> None:
+    """Create .devcontainer/devcontainer.json."""
+    devcontainer = {
+        "postCreateCommand": "curl -fsSL https://claude.ai/install.sh | bash",
+        "remoteEnv": {
+            "CLAUDE_CODE_MAX_OUTPUT_TOKENS": "64000",
+        },
+    }
+    write(REPO_DIR / ".devcontainer" / "devcontainer.json", json.dumps(devcontainer, indent=2) + "\n")
+
+
+def create_mcp_json() -> None:
+    """Create .mcp.json with MCP server configs."""
+    mcp = {
+        "mcpServers": {
+            "aws-knowledge": {
+                "type": "http",
+                "url": "https://knowledge-mcp.global.api.aws",
+            },
+            "microsoft-learn": {
+                "type": "http",
+                "url": "https://learn.microsoft.com/api/mcp",
+            },
+            "google-developer-knowledge": {
+                "type": "http",
+                "url": "https://developerknowledge.googleapis.com/mcp",
+                "headers": {
+                    "X-Goog-Api-Key": "${GOOGLE_API_KEY}",
+                },
+            },
+            "datacommons-mcp": {
+                "type": "http",
+                "url": "https://api.datacommons.org/mcp",
+                "headers": {
+                    "X-API-Key": "${DATA_COMMONS_API_KEY}",
+                },
+            },
+        }
+    }
+    write(REPO_DIR / ".mcp.json", json.dumps(mcp, indent=2) + "\n")
+
+
+def create_version() -> None:
+    """Create VERSION file."""
+    write(REPO_DIR / "VERSION", VERSION + "\n")
+
+
+def create_changelog() -> None:
+    """Create CHANGELOG.md."""
+    content = f"""# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [{VERSION}] - {TODAY}
+
+### Added
+
+- Initial mono-repo creation with 17 UN SDG workspaces
+- 78 UK Government technology projects across all SDGs
+- ArcKit plugin integration via marketplace
+- MCP server configuration (AWS, Azure, GCP, Data Commons)
+"""
+    write(REPO_DIR / "CHANGELOG.md", content)
+
+
+def build_sdg_table() -> str:
+    """Build a Markdown table of all SDGs with project counts."""
+    lines = [
+        "| SDG | Name | Workspace | Projects |",
+        "|-----|------|-----------|----------|",
+    ]
+    for sdg in SDGS:
+        nn = fmt_sdg_num(sdg["number"])
+        slug = sdg["slug"]
+        lines.append(
+            f"| {sdg['number']} | {sdg['name']} | `sdg-{nn}-{slug}/` | {len(sdg['projects'])} |"
+        )
+    return "\n".join(lines)
+
+
+def create_claude_md() -> None:
+    """Create top-level CLAUDE.md with navigation context."""
+    sdg_listing = ""
+    for sdg in SDGS:
+        nn = fmt_sdg_num(sdg["number"])
+        slug = sdg["slug"]
+        sdg_listing += f"- `sdg-{nn}-{slug}/` -- SDG {sdg['number']}: {sdg['name']} ({len(sdg['projects'])} projects)\n"
+
+    content = f"""# CLAUDE.md
+
+## Overview
+
+This is the **ArcKit SDG Mono-Repo** -- a single repository containing 17 UN Sustainable Development Goal workspaces, each with UK Government technology projects scaffolded for architecture governance using ArcKit.
+
+**Total**: 17 SDG workspaces, 78 projects
+
+## Navigation
+
+Each SDG workspace is a self-contained ArcKit workspace under `sdg-{{NN}}-{{slug}}/`:
+
+{sdg_listing}
+
+## How to Use
+
+1. Navigate to an SDG workspace directory
+2. Use ArcKit slash commands to generate architecture artifacts for any project
+3. Each project has its own `projects/{{NNN}}-{{slug}}/` directory with standard ArcKit structure
+
+## ArcKit Commands
+
+This repo uses the ArcKit plugin via the Claude Code marketplace. Commands are available as `/arckit.{{command}}` slash commands.
+
+Key commands for getting started:
+- `/arckit.stakeholders` -- Analyze stakeholder drivers and goals
+- `/arckit.requirements` -- Define comprehensive requirements
+- `/arckit.risk` -- Create risk register
+- `/arckit.sobc` -- Create Strategic Outline Business Case
+- `/arckit.research` -- Research technology options
+
+## MCP Servers
+
+Four MCP servers are configured for cloud platform research:
+- **AWS Knowledge** -- AWS service documentation and recommendations
+- **Microsoft Learn** -- Azure documentation and code samples
+- **Google Developer Knowledge** -- GCP documentation
+- **Data Commons** -- UN SDG indicators and statistical data
+
+## Version
+
+ArcKit Version: {VERSION}
+"""
+    write(REPO_DIR / "CLAUDE.md", content)
+
+
+def create_readme() -> None:
+    """Create top-level README.md."""
+    sdg_table = build_sdg_table()
+    total_projects = sum(len(s["projects"]) for s in SDGS)
+
+    content = f"""# ArcKit SDG Mono-Repo
+
+Enterprise Architecture Governance for UN Sustainable Development Goals -- UK Government Technology Projects
+
+## Overview
+
+This repository contains **{total_projects} UK Government technology projects** organised across all **17 UN Sustainable Development Goals (SDGs)**. Each SDG is a self-contained ArcKit workspace with pre-scaffolded project directories ready for architecture artifact generation.
+
+## SDG Workspaces
+
+{sdg_table}
+
+**Total: {total_projects} projects across 17 SDGs**
+
+## Getting Started
+
+### Prerequisites
+
+- [Claude Code](https://claude.ai/code) with ArcKit plugin enabled
+- GitHub Codespaces (recommended) or local development environment
+
+### Quick Start
+
+1. Open this repo in GitHub Codespaces (Claude Code auto-installs via devcontainer)
+2. Navigate to an SDG workspace: `cd sdg-01-no-poverty/`
+3. Run ArcKit commands to generate architecture artifacts:
+
+```bash
+# Stakeholder analysis for a project
+/arckit.stakeholders Universal Credit Modernisation
+
+# Requirements specification
+/arckit.requirements Universal Credit Modernisation
+
+# Risk register
+/arckit.risk Universal Credit Modernisation
+```
+
+## Repository Structure
+
+```
+{REPO_NAME}/
+├── .claude/settings.json          # ArcKit plugin marketplace config
+├── .devcontainer/devcontainer.json # Claude Code auto-install
+├── .mcp.json                      # MCP server configuration
+├── CLAUDE.md                      # AI assistant context
+├── README.md                      # This file
+├── CHANGELOG.md                   # Release history
+├── VERSION                        # ArcKit version
+├── docs/                          # Documentation
+│   ├── README.md
+│   ├── guides/
+│   ├── DEPENDENCY-MATRIX.md
+│   └── WORKFLOW-DIAGRAMS.md
+└── sdg-NN-slug/                   # SDG workspaces (x17)
+    ├── .arckit/                   # Workspace root marker
+    ├── README.md                  # SDG overview with project table
+    └── projects/
+        ├── 000-global/            # Cross-project artifacts
+        │   ├── policies/
+        │   └── external/
+        └── NNN-project-slug/      # Individual projects
+            ├── README.md
+            ├── external/
+            └── vendors/
+```
+
+## ArcKit
+
+This repository is powered by [ArcKit](https://github.com/tractorjuice/arc-kit) -- an Enterprise Architecture Governance & Vendor Procurement Toolkit providing 60 slash commands for AI coding assistants.
+
+**Version**: {VERSION}
+"""
+    write(REPO_DIR / "README.md", content)
+
+
+def create_docs() -> None:
+    """Create docs/ directory with README and copy dependency/workflow files."""
+    write(REPO_DIR / "docs" / "README.md", f"""# Documentation
+
+ArcKit SDG Mono-Repo documentation.
+
+## Guides
+
+See `guides/` for ArcKit command usage guides.
+
+## References
+
+- [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md) -- Command dependency matrix
+- [WORKFLOW-DIAGRAMS.md](WORKFLOW-DIAGRAMS.md) -- Visual workflow diagrams
+
+## ArcKit Version
+
+{VERSION}
+""")
+    gitkeep(REPO_DIR / "docs" / "guides")
+
+    # Copy dependency matrix and workflow diagrams from arc-kit
+    src_dep = ARCKIT_ROOT / "docs" / "DEPENDENCY-MATRIX.md"
+    src_wf = ARCKIT_ROOT / "docs" / "WORKFLOW-DIAGRAMS.md"
+    if src_dep.exists():
+        shutil.copy2(src_dep, REPO_DIR / "docs" / "DEPENDENCY-MATRIX.md")
+    if src_wf.exists():
+        shutil.copy2(src_wf, REPO_DIR / "docs" / "WORKFLOW-DIAGRAMS.md")
+
+
+# ---------------------------------------------------------------------------
+# SDG workspace generators
+# ---------------------------------------------------------------------------
+
+
+def create_project_readme(
+    project_dir: Path,
+    project_name: str,
+    project_number: str,
+    project_slug: str,
+    description: str,
+    sdg_name: str,
+    sdg_number: int,
+) -> None:
+    """Create a project README matching create-project.sh output format."""
+    dir_name = f"{project_number}-{project_slug}"
+    content = f"""# {project_name}
+
+Project ID: {project_number}
+Created: {TODAY}
+
+## Overview
+
+{description}
+
+**SDG Alignment**: SDG {sdg_number} -- {sdg_name}
+
+## Workflow
+
+Use ArcKit commands to generate project artifacts in the recommended order:
+
+### Discovery Phase
+1. `/arckit.stakeholders` - Analyze stakeholder drivers and goals
+2. `/arckit.risk` - Create risk register
+3. `/arckit.sobc` - Create Strategic Outline Business Case
+
+### Alpha Phase
+4. `/arckit.requirements` - Define comprehensive requirements
+5. `/arckit.data-model` - Design data model and GDPR compliance
+6. `/arckit.wardley` - Create Wardley maps for strategic planning
+7. `/arckit.research` - Research technology options (if needed)
+8. `/arckit.sow` - Generate Statement of Work for vendor procurement (if needed)
+9. `/arckit.evaluate` - Create vendor evaluation framework (if needed)
+
+### Beta Phase
+10. `/arckit.hld-review` - Review High-Level Design
+11. `/arckit.dld-review` - Review Detailed Design
+12. `/arckit.traceability` - Generate requirements traceability matrix
+
+### Compliance (as needed)
+- `/arckit.secure` - UK Government Secure by Design review
+- `/arckit.tcop` - Technology Code of Practice assessment
+- `/arckit.ai-playbook` - AI Playbook compliance (for AI systems)
+
+## Project Structure
+
+Documents use standardized naming: `ARC-{{PROJECT_ID}}-{{TYPE}}-v{{VERSION}}.md`
+
+```
+{dir_name}/
+├── README.md (this file)
+│
+├── # Core Documents
+├── ARC-{project_number}-STKE-v1.0.md     # Stakeholder drivers (/arckit.stakeholders)
+├── ARC-{project_number}-RISK-v1.0.md     # Risk register (/arckit.risk)
+├── ARC-{project_number}-SOBC-v1.0.md     # Business case (/arckit.sobc)
+├── ARC-{project_number}-REQ-v1.0.md      # Requirements (/arckit.requirements)
+├── ARC-{project_number}-DATA-v1.0.md     # Data model (/arckit.data-model)
+├── ARC-{project_number}-RSCH-v1.0.md     # Research findings (/arckit.research)
+├── ARC-{project_number}-TRAC-v1.0.md     # Traceability matrix (/arckit.traceability)
+│
+├── # Procurement
+├── ARC-{project_number}-SOW-v1.0.md      # Statement of Work (/arckit.sow)
+├── ARC-{project_number}-EVAL-v1.0.md     # Evaluation criteria (/arckit.evaluate)
+│
+├── # Multi-instance Documents (subdirectories)
+├── decisions/
+│   ├── ARC-{project_number}-ADR-001-v1.0.md  # Architecture decisions (/arckit.adr)
+│   └── ARC-{project_number}-ADR-002-v1.0.md
+├── diagrams/
+│   └── ARC-{project_number}-DIAG-001-v1.0.md # Diagrams (/arckit.diagram)
+├── wardley-maps/
+│   └── ARC-{project_number}-WARD-001-v1.0.md # Wardley maps (/arckit.wardley)
+├── reviews/
+│   ├── ARC-{project_number}-HLD-v1.0.md      # HLD review (/arckit.hld-review)
+│   └── ARC-{project_number}-DLD-v1.0.md      # DLD review (/arckit.dld-review)
+│
+├── external/                            # External documents (PDFs, specs, reports)
+└── vendors/                             # Vendor proposals
+```
+
+## Document Type Codes
+
+| Code | Document Type |
+|------|---------------|
+| REQ | Requirements |
+| STKE | Stakeholder Analysis |
+| RISK | Risk Register |
+| SOBC | Strategic Outline Business Case |
+| DATA | Data Model |
+| ADR | Architecture Decision Record |
+| RSCH | Research Findings |
+| SOW | Statement of Work |
+| EVAL | Evaluation Criteria |
+| HLD | High-Level Design Review |
+| DLD | Detailed-Level Design Review |
+| TRAC | Traceability Matrix |
+| DIAG | Architecture Diagram |
+| WARD | Wardley Map |
+| TCOP | Technology Code of Practice |
+| SECD | Secure by Design |
+
+## Status
+
+Track your progress through the workflow:
+
+**Discovery Phase:**
+- [ ] Stakeholder analysis complete
+- [ ] Risk register created
+- [ ] Business case approved
+
+**Alpha Phase:**
+- [ ] Requirements defined
+- [ ] Data model designed
+- [ ] Vendor procurement started (if needed)
+
+**Beta Phase:**
+- [ ] HLD reviewed and approved
+- [ ] DLD reviewed and approved
+- [ ] Traceability matrix validated
+
+**Live Phase:**
+- [ ] Implementation complete
+- [ ] Production deployment
+"""
+    write(project_dir / "README.md", content)
+
+
+def create_sdg_workspace(sdg: dict) -> None:
+    """Create a complete SDG workspace directory."""
+    nn = fmt_sdg_num(sdg["number"])
+    slug = sdg["slug"]
+    workspace_dir = REPO_DIR / f"sdg-{nn}-{slug}"
+
+    # .arckit workspace root marker
+    gitkeep(workspace_dir / ".arckit")
+
+    # Global project directories
+    gitkeep(workspace_dir / "projects" / "000-global" / "policies")
+    gitkeep(workspace_dir / "projects" / "000-global" / "external")
+
+    # Build project table for SDG README
+    project_rows = []
+    for idx, (name, proj_slug, desc) in enumerate(sdg["projects"], start=1):
+        pid = fmt_project_num(idx)
+        project_rows.append(f"| {pid} | {name} | {desc} |")
+
+    project_table = "| ID | Project | Description |\n|-----|---------|-------------|\n" + "\n".join(project_rows)
+
+    # SDG-level README
+    sdg_readme = f"""# SDG {sdg['number']}: {sdg['name']}
+
+UN Sustainable Development Goal {sdg['number']} -- UK Government Technology Projects
+
+## Projects
+
+{project_table}
+
+## Getting Started
+
+Navigate to a project directory and use ArcKit commands:
+
+```bash
+cd projects/{fmt_project_num(1)}-{sdg['projects'][0][1]}/
+/arckit.stakeholders {sdg['projects'][0][0]}
+```
+
+## Workspace Structure
+
+```
+sdg-{nn}-{slug}/
+├── .arckit/                    # Workspace root marker
+├── README.md                   # This file
+└── projects/
+    ├── 000-global/             # Cross-project artifacts
+    │   ├── policies/
+    │   └── external/
+"""
+    for idx, (name, proj_slug, _desc) in enumerate(sdg["projects"], start=1):
+        pid = fmt_project_num(idx)
+        sdg_readme += f"    ├── {pid}-{proj_slug}/\n"
+    sdg_readme += "```\n"
+
+    write(workspace_dir / "README.md", sdg_readme)
+
+    # Create individual projects
+    for idx, (name, proj_slug, desc) in enumerate(sdg["projects"], start=1):
+        pid = fmt_project_num(idx)
+        project_dir = workspace_dir / "projects" / f"{pid}-{proj_slug}"
+        project_dir.mkdir(parents=True, exist_ok=True)
+
+        create_project_readme(
+            project_dir=project_dir,
+            project_name=name,
+            project_number=pid,
+            project_slug=proj_slug,
+            description=desc,
+            sdg_name=sdg["name"],
+            sdg_number=sdg["number"],
+        )
+        gitkeep(project_dir / "external")
+        gitkeep(project_dir / "vendors")
+
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    """Create the SDG mono-repo."""
+    total_projects = sum(len(s["projects"]) for s in SDGS)
+    print(f"ArcKit SDG Mono-Repo Creator")
+    print(f"Version: {VERSION}")
+    print(f"SDGs: {len(SDGS)}, Projects: {total_projects}")
+    print()
+
+    # 1. Clean up any previous attempt
+    if REPO_DIR.exists():
+        print(f"Removing existing {REPO_DIR}...")
+        shutil.rmtree(REPO_DIR)
+    CLONE_BASE.mkdir(parents=True, exist_ok=True)
+
+    # 2. Create GitHub repo and clone into target dir
+    print(f"\nCreating GitHub repo {REPO_FULL}...")
+    orig_cwd = os.getcwd()
+    os.chdir(CLONE_BASE)
+    run([
+        "gh", "repo", "create", REPO_FULL,
+        "--public",
+        "--clone",
+        "--description", f"ArcKit SDG Mono-Repo: 17 UN SDGs, {total_projects} UK Government technology projects",
+    ])
+    os.chdir(orig_cwd)
+
+    # 3. Scaffold top-level files
+    print("\nCreating top-level files...")
+    create_claude_settings()
+    create_devcontainer()
+    create_mcp_json()
+    create_version()
+    create_changelog()
+    create_claude_md()
+    create_readme()
+    create_docs()
+
+    # 4. Create SDG workspaces
+    print("\nCreating SDG workspaces...")
+    for sdg in SDGS:
+        nn = fmt_sdg_num(sdg["number"])
+        print(f"  SDG {sdg['number']:2d}: {sdg['name']} ({len(sdg['projects'])} projects)")
+        create_sdg_workspace(sdg)
+
+    # 5. Git commit and push
+    print("\nCommitting and pushing...")
+    run(["git", "add", "-A"], cwd=REPO_DIR)
+    run([
+        "git", "commit", "-m",
+        f"feat: initial SDG mono-repo with 17 SDGs and {total_projects} UK Government projects\n\nArcKit Version: {VERSION}\n\nCo-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>",
+    ], cwd=REPO_DIR)
+    run(["git", "push", "-u", "origin", "main"], cwd=REPO_DIR)
+
+    # 6. Clean up (only after successful push)
+    print("\nCleaning up...")
+    shutil.rmtree(CLONE_BASE)
+
+    print(f"\nDone! Repo created at https://github.com/{REPO_FULL}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/arckit_cli/__init__.py
+++ b/src/arckit_cli/__init__.py
@@ -832,7 +832,7 @@ Example:
 
 export OPENCODE_HOME="$PWD/.opencode"
 """
-        envrc_path.write_text(envrc_content)
+        envrc_path.write_text(envrc_content, encoding="utf-8")
 
         # Copy .opencode/README.md if it exists
         opencode_src = data_paths.get("opencode_root")
@@ -877,7 +877,7 @@ export OPENCODE_HOME="$PWD/.opencode"
   }
 }
 """
-            opencode_json_path.write_text(opencode_json_content)
+            opencode_json_path.write_text(opencode_json_content, encoding="utf-8")
             console.print(
                 f"[green]✓[/green] Created .opencode/opencode.json with MCP servers"
             )
@@ -906,12 +906,12 @@ export OPENCODE_HOME="$PWD/.opencode"
         ]
 
         if gitignore_path.exists():
-            existing_content = gitignore_path.read_text()
+            existing_content = gitignore_path.read_text(encoding="utf-8")
             if ".opencode" not in existing_content:
-                with open(gitignore_path, "a") as f:
+                with open(gitignore_path, "a", encoding="utf-8") as f:
                     f.write("\n" + "\n".join(opencode_ignore_entries) + "\n")
         else:
-            gitignore_path.write_text("\n".join(opencode_ignore_entries) + "\n")
+            gitignore_path.write_text("\n".join(opencode_ignore_entries) + "\n", encoding="utf-8")
 
         console.print(
             "[green]✓[/green] OpenCode environment configured (.envrc created)"


### PR DESCRIPTION
## Summary

- Adds explicit `encoding="utf-8"` to all 23 `open()` calls in `scripts/converter.py` and 5 `write_text`/`read_text`/`open()` calls in `src/arckit_cli/__init__.py`
- No functional change on Linux/macOS (UTF-8 is already the default), but fixes accent preservation on Windows systems that default to `cp1252`
- Part of #160 — the `slugify()` fix is held pending clarification from the reporter

## Test plan

- [x] `python scripts/converter.py` runs clean, generates all 300 files
- [x] `arckit --help` works
- [x] No remaining `open()` calls without explicit encoding in either file

Closes partially #160

🤖 Generated with [Claude Code](https://claude.com/claude-code)