### PR TITLE
fix: recategorize guides into Integrations and Getting Started

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -2175,7 +2175,7 @@
             });
 
             // Sort categories
-            const categoryOrder = ['Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'];
+            const categoryOrder = ['Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting'];
             const sortedCategories = Object.keys(byCategory).sort((a, b) => {
                 const aIdx = categoryOrder.indexOf(a);
                 const bIdx = categoryOrder.indexOf(b);
@@ -2295,6 +2295,7 @@
         let TYPE_CATEGORIES = {};
 
         const CATEGORY_COLORS = {
+            'Getting Started': '#4c6272',
             Discovery: '#1d70b8',
             Planning: '#00703c',
             Architecture: '#f47738',
@@ -2302,7 +2303,7 @@
             Compliance: '#5694ca',
             Operations: '#28a197',
             Procurement: '#d53880',
-            Research: '#4c6272',
+            Integrations: '#4c2c92',
             Reporting: '#85994b',
             Other: '#b1b4b6'
         };

--- a/arckit-claude/hooks/sync-guides.mjs
+++ b/arckit-claude/hooks/sync-guides.mjs
@@ -91,38 +91,56 @@ const DOC_TYPE_META = Object.fromEntries(
 );
 
 const GUIDE_CATEGORIES = {
+  // Getting Started
+  'init': 'Getting Started', 'start': 'Getting Started', 'upgrading': 'Getting Started',
+  'customize': 'Getting Started', 'template-builder': 'Getting Started',
+  'session-memory': 'Getting Started', 'remote-control': 'Getting Started',
+  'productivity': 'Getting Started',
+  // Discovery
   'requirements': 'Discovery', 'stakeholders': 'Discovery', 'stakeholder-analysis': 'Discovery',
   'research': 'Discovery', 'datascout': 'Discovery',
+  // Planning
   'sobc': 'Planning', 'business-case': 'Planning', 'plan': 'Planning', 'roadmap': 'Planning',
-  'backlog': 'Planning', 'strategy': 'Planning',
+  'backlog': 'Planning', 'strategy': 'Planning', 'migration': 'Planning',
+  // Architecture
   'principles': 'Architecture', 'adr': 'Architecture', 'diagram': 'Architecture',
   'wardley': 'Architecture', 'data-model': 'Architecture', 'hld-review': 'Architecture',
   'dld-review': 'Architecture', 'design-review': 'Architecture', 'platform-design': 'Architecture',
   'data-mesh-contract': 'Architecture', 'c4-layout-science': 'Architecture',
+  'dfd': 'Architecture', 'framework': 'Architecture',
+  // Governance
   'risk': 'Governance', 'risk-management': 'Governance', 'traceability': 'Governance',
   'principles-compliance': 'Governance', 'analyze': 'Governance', 'artifact-health': 'Governance',
   'data-quality-framework': 'Governance', 'knowledge-compounding': 'Governance',
+  'search': 'Governance', 'impact': 'Governance',
+  'conformance': 'Governance', 'health': 'Governance', 'maturity-model': 'Governance',
+  // Compliance
   'tcop': 'Compliance', 'secure': 'Compliance', 'mod-secure': 'Compliance', 'dpia': 'Compliance',
   'ai-playbook': 'Compliance', 'atrs': 'Compliance', 'jsp-936': 'Compliance',
   'service-assessment': 'Compliance', 'govs-007-security': 'Compliance',
   'national-data-strategy': 'Compliance', 'codes-of-practice': 'Compliance',
   'security-hooks': 'Compliance',
+  // Operations
   'devops': 'Operations', 'mlops': 'Operations', 'finops': 'Operations',
-  'servicenow': 'Operations', 'operationalize': 'Operations',
+  'operationalize': 'Operations',
+  // Procurement
   'sow': 'Procurement', 'evaluate': 'Procurement', 'dos': 'Procurement',
   'gcloud-search': 'Procurement', 'gcloud-clarify': 'Procurement', 'procurement': 'Procurement',
   'score': 'Procurement',
-  'aws-research': 'Research', 'azure-research': 'Research', 'gcp-research': 'Research',
-  'search': 'Governance', 'impact': 'Governance',
-  'pages': 'Reporting', 'story': 'Reporting', 'presentation': 'Reporting', 'trello': 'Reporting',
-  'template-builder': 'Other',
+  // Integrations
+  'aws-research': 'Integrations', 'azure-research': 'Integrations', 'gcp-research': 'Integrations',
+  'mcp-servers': 'Integrations', 'pinecone-mcp': 'Integrations',
+  'trello': 'Integrations', 'servicenow': 'Integrations',
+  // Reporting
+  'pages': 'Reporting', 'story': 'Reporting', 'presentation': 'Reporting',
+  'glossary': 'Reporting',
 };
 
 const GUIDE_STATUS = {};
 for (const name of ['plan','principles','stakeholders','stakeholder-analysis','risk','sobc','requirements','data-model','diagram','traceability','principles-compliance','story','sow','evaluate','customize','risk-management','business-case']) GUIDE_STATUS[name] = 'live';
 for (const name of ['dpia','research','strategy','roadmap','adr','hld-review','dld-review','backlog','servicenow','analyze','service-assessment','tcop','secure','presentation','artifact-health','design-review','procurement','knowledge-compounding','c4-layout-science','security-hooks','codes-of-practice','data-quality-framework','govs-007-security','national-data-strategy','upgrading','start','conformance','productivity','remote-control','mcp-servers','search','score','impact']) GUIDE_STATUS[name] = 'beta';
 for (const name of ['data-mesh-contract','ai-playbook','atrs','pages','template-builder']) GUIDE_STATUS[name] = 'alpha';
-for (const name of ['platform-design','wardley','azure-research','aws-research','gcp-research','datascout','dos','gcloud-search','gcloud-clarify','trello','devops','mlops','finops','operationalize','mod-secure','jsp-936','migration','pinecone-mcp']) GUIDE_STATUS[name] = 'experimental';
+for (const name of ['platform-design','wardley','azure-research','aws-research','gcp-research','datascout','dos','gcloud-search','gcloud-clarify','trello','devops','mlops','finops','operationalize','mod-secure','jsp-936','migration','pinecone-mcp','dfd','framework','health','maturity-model','glossary','init','session-memory']) GUIDE_STATUS[name] = 'experimental';
 
 const ROLE_FAMILIES = {
   'enterprise-architect': 'Architecture', 'solution-architect': 'Architecture',

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -2175,7 +2175,7 @@
             });
 
             // Sort categories
-            const categoryOrder = ['Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'];
+            const categoryOrder = ['Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting'];
             const sortedCategories = Object.keys(byCategory).sort((a, b) => {
                 const aIdx = categoryOrder.indexOf(a);
                 const bIdx = categoryOrder.indexOf(b);
@@ -2295,6 +2295,7 @@
         let TYPE_CATEGORIES = {};
 
         const CATEGORY_COLORS = {
+            'Getting Started': '#4c6272',
             Discovery: '#1d70b8',
             Planning: '#00703c',
             Architecture: '#f47738',
@@ -2302,7 +2303,7 @@
             Compliance: '#5694ca',
             Operations: '#28a197',
             Procurement: '#d53880',
-            Research: '#4c6272',
+            Integrations: '#4c2c92',
             Reporting: '#85994b',
             Other: '#b1b4b6'
         };

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -2175,7 +2175,7 @@
             });
 
             // Sort categories
-            const categoryOrder = ['Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'];
+            const categoryOrder = ['Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting'];
             const sortedCategories = Object.keys(byCategory).sort((a, b) => {
                 const aIdx = categoryOrder.indexOf(a);
                 const bIdx = categoryOrder.indexOf(b);
@@ -2295,6 +2295,7 @@
         let TYPE_CATEGORIES = {};
 
         const CATEGORY_COLORS = {
+            'Getting Started': '#4c6272',
             Discovery: '#1d70b8',
             Planning: '#00703c',
             Architecture: '#f47738',
@@ -2302,7 +2303,7 @@
             Compliance: '#5694ca',
             Operations: '#28a197',
             Procurement: '#d53880',
-            Research: '#4c6272',
+            Integrations: '#4c2c92',
             Reporting: '#85994b',
             Other: '#b1b4b6'
         };

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -2175,7 +2175,7 @@
             });
 
             // Sort categories
-            const categoryOrder = ['Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'];
+            const categoryOrder = ['Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting'];
             const sortedCategories = Object.keys(byCategory).sort((a, b) => {
                 const aIdx = categoryOrder.indexOf(a);
                 const bIdx = categoryOrder.indexOf(b);
@@ -2295,6 +2295,7 @@
         let TYPE_CATEGORIES = {};
 
         const CATEGORY_COLORS = {
+            'Getting Started': '#4c6272',
             Discovery: '#1d70b8',
             Planning: '#00703c',
             Architecture: '#f47738',
@@ -2302,7 +2303,7 @@
             Compliance: '#5694ca',
             Operations: '#28a197',
             Procurement: '#d53880',
-            Research: '#4c6272',
+            Integrations: '#4c2c92',
             Reporting: '#85994b',
             Other: '#b1b4b6'
         };

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -2175,7 +2175,7 @@
             });
 
             // Sort categories
-            const categoryOrder = ['Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'];
+            const categoryOrder = ['Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting'];
             const sortedCategories = Object.keys(byCategory).sort((a, b) => {
                 const aIdx = categoryOrder.indexOf(a);
                 const bIdx = categoryOrder.indexOf(b);
@@ -2295,6 +2295,7 @@
         let TYPE_CATEGORIES = {};
 
         const CATEGORY_COLORS = {
+            'Getting Started': '#4c6272',
             Discovery: '#1d70b8',
             Planning: '#00703c',
             Architecture: '#f47738',
@@ -2302,7 +2303,7 @@
             Compliance: '#5694ca',
             Operations: '#28a197',
             Procurement: '#d53880',
-            Research: '#4c6272',
+            Integrations: '#4c2c92',
             Reporting: '#85994b',
             Other: '#b1b4b6'
         };


### PR DESCRIPTION
## Summary
- Added **Integrations** category for cloud research (AWS, Azure, GCP), MCP servers, Pinecone, Trello, ServiceNow
- Added **Getting Started** category for init, start, upgrading, customize, template-builder, session-memory, remote-control, productivity
- Moved dfd, framework → Architecture; migration → Planning; conformance, health, maturity-model → Governance; glossary → Reporting
- Eliminated empty Research category (was only cloud guides, now in Integrations) and Other category
- Updated `CATEGORY_COLORS` and `categoryOrder` in pages-template.html
- Added missing guides to `GUIDE_STATUS`

## Test plan
- [ ] Run `/arckit.pages` in a test repo and verify guides are grouped correctly
- [ ] Verify Integrations category shows cloud research + MCP guides
- [ ] Verify Getting Started category shows setup/config guides
- [ ] Verify no guides appear in "Other" category

🤖 Generated with [Claude Code](https://claude.com/claude-code)