### PR TITLE
fix: correct guide counts in guides.html

### DIFF
--- a/arckit-claude/hooks/sync-guides.mjs
+++ b/arckit-claude/hooks/sync-guides.mjs
@@ -94,7 +94,7 @@ const GUIDE_CATEGORIES = {
   // Getting Started
   'init': 'Getting Started', 'start': 'Getting Started', 'upgrading': 'Getting Started',
   'customize': 'Getting Started', 'template-builder': 'Getting Started',
-  'session-memory': 'Getting Started', 'remote-control': 'Getting Started',
+  'remote-control': 'Getting Started',
   'productivity': 'Getting Started',
   // Discovery
   'requirements': 'Discovery', 'stakeholders': 'Discovery', 'stakeholder-analysis': 'Discovery',
@@ -140,7 +140,7 @@ const GUIDE_STATUS = {};
 for (const name of ['plan','principles','stakeholders','stakeholder-analysis','risk','sobc','requirements','data-model','diagram','traceability','principles-compliance','story','sow','evaluate','customize','risk-management','business-case']) GUIDE_STATUS[name] = 'live';
 for (const name of ['dpia','research','strategy','roadmap','adr','hld-review','dld-review','backlog','servicenow','analyze','service-assessment','tcop','secure','presentation','artifact-health','design-review','procurement','knowledge-compounding','c4-layout-science','security-hooks','codes-of-practice','data-quality-framework','govs-007-security','national-data-strategy','upgrading','start','conformance','productivity','remote-control','mcp-servers','search','score','impact']) GUIDE_STATUS[name] = 'beta';
 for (const name of ['data-mesh-contract','ai-playbook','atrs','pages','template-builder']) GUIDE_STATUS[name] = 'alpha';
-for (const name of ['platform-design','wardley','azure-research','aws-research','gcp-research','datascout','dos','gcloud-search','gcloud-clarify','trello','devops','mlops','finops','operationalize','mod-secure','jsp-936','migration','pinecone-mcp','dfd','framework','health','maturity-model','glossary','init','session-memory']) GUIDE_STATUS[name] = 'experimental';
+for (const name of ['platform-design','wardley','azure-research','aws-research','gcp-research','datascout','dos','gcloud-search','gcloud-clarify','trello','devops','mlops','finops','operationalize','mod-secure','jsp-936','migration','pinecone-mcp','dfd','framework','health','maturity-model','glossary','init']) GUIDE_STATUS[name] = 'experimental';
 
 const ROLE_FAMILIES = {
   'enterprise-architect': 'Architecture', 'solution-architect': 'Architecture',

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Command Guides - 69 usage guides for enterprise architecture governance commands organized by category.">
+    <meta name="description" content="ArcKit Command Guides - 79 usage guides for enterprise architecture governance commands organized by category.">
     <title>Command Guides - ArcKit</title>
     <meta name="keywords" content="ArcKit guides, architecture governance guides, command usage, workflow steps, UK government architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Guides - ArcKit">
-    <meta property="og:description" content="69 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta property="og:description" content="79 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/guides.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Guides - ArcKit">
-    <meta name="twitter:description" content="69 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta name="twitter:description" content="79 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/guides.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -234,7 +234,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/guides.html",
                 "name": "Command Guides - ArcKit",
-                "description": "69 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.",
+                "description": "79 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -278,7 +278,7 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">69 Guides</span>
+            <span class="app-page-hero__stat">79 Guides</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
             <p class="app-page-hero__description">Step-by-step usage guides organised into 10 categories. Each covers prerequisites, workflow steps, and real-world examples.</p>
         </div>
@@ -381,7 +381,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Governance
-                    <span class="app-guide-category__count">11 guides</span>
+                    <span class="app-guide-category__count">13 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">


### PR DESCRIPTION
## Summary
- Fix Governance category: claimed 11, actually has 13 guides
- Update hero stat and meta descriptions: 69 → 79 guides
- Remove `session-memory` from GUIDE_CATEGORIES/GUIDE_STATUS (file doesn't exist)

## Test plan
- [ ] Open guides.html and verify counts match actual items per category
- [ ] Verify hero shows "79 Guides"

🤖 Generated with [Claude Code](https://claude.com/claude-code)