### PR TITLE
feat: add timeline layout to dependency map

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -1642,6 +1642,31 @@
             color: var(--text-secondary);
             font-size: 16px;
         }
+        .app-depmap-layout-toggle {
+            display: inline-flex;
+            border: 1px solid var(--border-main);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .app-depmap-layout-toggle button {
+            border: none;
+            background: var(--bg-surface);
+            color: var(--text-primary);
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            cursor: pointer;
+        }
+        .app-depmap-layout-toggle button:not(:last-child) {
+            border-right: 1px solid var(--border-main);
+        }
+        .app-depmap-layout-toggle button.active {
+            background: var(--text-primary);
+            color: var(--bg-surface);
+        }
+        .app-depmap-layout-toggle button:hover:not(.active) {
+            background: var(--bg-surface-alt);
+        }
     </style>
 </head>
 <body class="govuk-template__body">
@@ -2876,9 +2901,21 @@
             const projects = [...projectSet].sort();
 
             const CATEGORY_ORDER = [
-                'Discovery', 'Planning', 'Architecture', 'Governance',
-                'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'
+                'Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance',
+                'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other'
             ];
+
+            // Check if any nodes have valid dates (for timeline toggle)
+            const hasValidDates = nodeIds.some(id => {
+                const d = nodes[id].createdDate;
+                return d && !isNaN(new Date(d).getTime());
+            });
+
+            let currentLayout = 'category';
+            if (hasValidDates) {
+                const stored = localStorage.getItem('arckit-depmap-layout');
+                if (stored === 'timeline') currentLayout = 'timeline';
+            }
 
             // Build controls DOM
             content.textContent = '';
@@ -2891,6 +2928,45 @@
 
             const controls = document.createElement('div');
             controls.className = 'app-depmap-controls';
+
+            const layoutLabel = document.createElement('label');
+            layoutLabel.textContent = 'Layout:';
+            layoutLabel.style.cssText = 'font-size:14px;font-weight:700;color:var(--text-primary)';
+            controls.appendChild(layoutLabel);
+
+            const toggleWrap = document.createElement('div');
+            toggleWrap.className = 'app-depmap-layout-toggle';
+
+            const btnCategory = document.createElement('button');
+            btnCategory.textContent = 'Category';
+            btnCategory.className = currentLayout === 'category' ? 'active' : '';
+            toggleWrap.appendChild(btnCategory);
+
+            if (hasValidDates) {
+                const btnTimeline = document.createElement('button');
+                btnTimeline.textContent = 'Timeline';
+                btnTimeline.className = currentLayout === 'timeline' ? 'active' : '';
+                toggleWrap.appendChild(btnTimeline);
+
+                btnTimeline.addEventListener('click', () => {
+                    currentLayout = 'timeline';
+                    localStorage.setItem('arckit-depmap-layout', 'timeline');
+                    btnCategory.className = '';
+                    btnTimeline.className = 'active';
+                    renderGraph(select.value);
+                });
+            }
+
+            btnCategory.addEventListener('click', () => {
+                currentLayout = 'category';
+                localStorage.setItem('arckit-depmap-layout', 'category');
+                btnCategory.className = 'active';
+                const btnT = toggleWrap.querySelector('button:nth-child(2)');
+                if (btnT) btnT.className = '';
+                renderGraph(select.value);
+            });
+
+            controls.appendChild(toggleWrap);
 
             const label = document.createElement('label');
             label.setAttribute('for', 'depmap-project-filter');
@@ -2949,6 +3025,236 @@
             tooltip.style.display = 'none';
             document.body.appendChild(tooltip);
 
+            // ── Timeline utilities ──
+            function computeDateBuckets(filteredIds) {
+                const validDates = [];
+                for (const id of filteredIds) {
+                    const d = nodes[id].createdDate;
+                    if (!d) continue;
+                    const parsed = new Date(d);
+                    if (isNaN(parsed.getTime())) continue;
+                    validDates.push(parsed);
+                }
+                if (validDates.length === 0) return null;
+
+                validDates.sort((a, b) => a - b);
+                const minDate = validDates[0];
+                const maxDate = validDates[validDates.length - 1];
+                const rangeDays = (maxDate - minDate) / 86400000;
+
+                let granularity, buckets;
+
+                if (rangeDays < 90) {
+                    granularity = 'weekly';
+                    buckets = generateWeeklyBuckets(minDate, maxDate);
+                } else if (rangeDays <= 547) {
+                    granularity = 'monthly';
+                    buckets = generateMonthlyBuckets(minDate, maxDate);
+                } else {
+                    granularity = 'quarterly';
+                    buckets = generateQuarterlyBuckets(minDate, maxDate);
+                }
+
+                return { granularity, buckets };
+            }
+
+            function generateWeeklyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                const start = new Date(minDate);
+                const day = start.getDay();
+                const diff = day === 0 ? -6 : 1 - day;
+                start.setDate(start.getDate() + diff);
+                start.setHours(0, 0, 0, 0);
+
+                const end = new Date(maxDate);
+                end.setHours(23, 59, 59, 999);
+
+                let current = new Date(start);
+                while (current <= end) {
+                    const weekStart = new Date(current);
+                    const weekEnd = new Date(current);
+                    weekEnd.setDate(weekEnd.getDate() + 6);
+                    weekEnd.setHours(23, 59, 59, 999);
+
+                    const weekNum = Math.ceil(weekStart.getDate() / 7);
+                    const label = 'W' + weekNum + ' ' + MONTHS[weekStart.getMonth()];
+
+                    buckets.push({ label, start: weekStart, end: weekEnd });
+                    current.setDate(current.getDate() + 7);
+                }
+                return buckets;
+            }
+
+            function generateMonthlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                let y = minDate.getFullYear(), m = minDate.getMonth();
+                const endY = maxDate.getFullYear(), endM = maxDate.getMonth();
+
+                while (y < endY || (y === endY && m <= endM)) {
+                    const start = new Date(y, m, 1);
+                    const end = new Date(y, m + 1, 0, 23, 59, 59, 999);
+                    const label = MONTHS[m] + ' ' + y;
+                    buckets.push({ label, start, end });
+                    m++;
+                    if (m > 11) { m = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function generateQuarterlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                let y = minDate.getFullYear();
+                let q = Math.floor(minDate.getMonth() / 3);
+                const endY = maxDate.getFullYear();
+                const endQ = Math.floor(maxDate.getMonth() / 3);
+
+                while (y < endY || (y === endY && q <= endQ)) {
+                    const startMonth = q * 3;
+                    const start = new Date(y, startMonth, 1);
+                    const end = new Date(y, startMonth + 3, 0, 23, 59, 59, 999);
+                    const label = 'Q' + (q + 1) + ' ' + y;
+                    buckets.push({ label, start, end });
+                    q++;
+                    if (q > 3) { q = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function assignNodeToBucket(node, buckets) {
+                if (!node.createdDate) return -1;
+                const d = new Date(node.createdDate);
+                if (isNaN(d.getTime())) return -1;
+                for (let i = 0; i < buckets.length; i++) {
+                    if (d >= buckets[i].start && d <= buckets[i].end) return i;
+                }
+                return -1;
+            }
+
+            function renderNodes(svg, filteredIds, positions, connectedIds, NS) {
+                const nodeW = 110, nodeH = 44;
+
+                for (const id of filteredIds) {
+                    const node = nodes[id];
+                    const pos = positions[id];
+                    if (!pos) continue;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
+                    const isOrphan = !connectedIds.has(id);
+
+                    const shortTitle = (node.title || '').length > 16
+                        ? node.title.substring(0, 15) + '\u2026'
+                        : (node.title || id);
+
+                    const g = document.createElementNS(NS, 'g');
+                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.dataset.id = id;
+                    g.dataset.path = node.path;
+
+                    const rect = document.createElementNS(NS, 'rect');
+                    rect.setAttribute('x', pos.x);
+                    rect.setAttribute('y', pos.y);
+                    rect.setAttribute('width', nodeW);
+                    rect.setAttribute('height', nodeH);
+                    rect.setAttribute('rx', '4');
+                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
+                    rect.setAttribute('stroke', color);
+                    rect.setAttribute('stroke-width', '1.5');
+                    g.appendChild(rect);
+
+                    const typeText = document.createElementNS(NS, 'text');
+                    typeText.setAttribute('x', pos.x + nodeW / 2);
+                    typeText.setAttribute('y', pos.y + 16);
+                    typeText.setAttribute('text-anchor', 'middle');
+                    typeText.setAttribute('font-size', '11');
+                    typeText.setAttribute('font-weight', '700');
+                    typeText.setAttribute('fill', color);
+                    typeText.textContent = node.type;
+                    g.appendChild(typeText);
+
+                    const titleText = document.createElementNS(NS, 'text');
+                    titleText.setAttribute('x', pos.x + nodeW / 2);
+                    titleText.setAttribute('y', pos.y + 30);
+                    titleText.setAttribute('text-anchor', 'middle');
+                    titleText.setAttribute('font-size', '8');
+                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
+                    titleText.textContent = shortTitle;
+                    g.appendChild(titleText);
+
+                    // Last-modified indicator dot
+                    if (node.lastModified) {
+                        const lmDate = new Date(node.lastModified);
+                        if (!isNaN(lmDate.getTime())) {
+                            const daysAgo = (Date.now() - lmDate.getTime()) / 86400000;
+                            let dotColor = null;
+                            if (daysAgo < 7) dotColor = '#00703c';
+                            else if (daysAgo < 30) dotColor = '#f47738';
+                            if (dotColor) {
+                                const dot = document.createElementNS(NS, 'circle');
+                                dot.setAttribute('cx', pos.x + nodeW - 6);
+                                dot.setAttribute('cy', pos.y + 6);
+                                dot.setAttribute('r', '3');
+                                dot.setAttribute('fill', dotColor);
+                                g.appendChild(dot);
+                            }
+                        }
+                    }
+
+                    // Event listeners
+                    g.addEventListener('mouseenter', () => {
+                        const nodeId = g.dataset.id;
+                        const connNodes = new Set([nodeId]);
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
+                                p.classList.add('highlighted');
+                                connNodes.add(p.dataset.from);
+                                connNodes.add(p.dataset.to);
+                            } else {
+                                p.classList.add('dimmed');
+                            }
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
+                        });
+
+                        const nd = nodes[nodeId];
+                        if (nd) {
+                            const ttTitle = document.createElement('strong');
+                            ttTitle.textContent = nd.title || nodeId;
+                            const ttMeta = document.createElement('span');
+                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
+                            tooltip.textContent = '';
+                            tooltip.appendChild(ttTitle);
+                            tooltip.appendChild(ttMeta);
+                            tooltip.style.display = 'block';
+                            const r = g.getBoundingClientRect();
+                            tooltip.style.left = (r.right + 8) + 'px';
+                            tooltip.style.top = r.top + 'px';
+                        }
+                    });
+
+                    g.addEventListener('mouseleave', () => {
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            p.classList.remove('highlighted', 'dimmed');
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            n.classList.remove('dimmed');
+                        });
+                        tooltip.style.display = 'none';
+                    });
+
+                    g.addEventListener('click', () => {
+                        const docPath = g.dataset.path;
+                        if (docPath) {
+                            tooltip.style.display = 'none';
+                            window.location.hash = docPath;
+                        }
+                    });
+
+                    svg.appendChild(g);
+                }
+            }
+
             function renderGraph(filterProject) {
                 const statsEl = document.getElementById('depmap-stats');
 
@@ -2985,12 +3291,29 @@
                     });
                 }
 
+                // Filter edges to visible nodes
+                const filteredSet = new Set(filteredIds);
+                const visibleEdges = edges.filter(e => {
+                    if (!filteredSet.has(e.from)) return false;
+                    return filteredIds.some(id => id.startsWith(e.to));
+                });
+
+                if (currentLayout === 'timeline') {
+                    renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                } else {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                }
+            }
+
+            function renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+
                 // Layout constants
                 const nodeW = 110, nodeH = 44;
                 const gapX = 16, gapY = 24;
                 const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
                 const labelW = 110, padL = 16, padR = 16, padT = 16;
-                const maxCols = 8; // wrap after this many nodes per row
+                const maxCols = 8;
 
                 // Compute positions with wrapping
                 const positions = {};
@@ -3021,16 +3344,9 @@
                 const svgW = padL + labelW + usedCols * nodeW + (usedCols - 1) * gapX + padR;
                 const svgH = y - gapY + padT;
 
-                // Filter edges to visible nodes
-                const filteredSet = new Set(filteredIds);
-                const visibleEdges = edges.filter(e => {
-                    if (!filteredSet.has(e.from)) return false;
-                    return filteredIds.some(id => id.startsWith(e.to));
-                });
-
                 statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
 
-                // Build SVG using DOM (SVG namespace)
+                // Build SVG
                 const NS = 'http://www.w3.org/2000/svg';
                 const svg = document.createElementNS(NS, 'svg');
                 svg.setAttribute('class', 'app-depmap-svg');
@@ -3088,104 +3404,199 @@
                 }
 
                 // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
+
+                svgWrap.textContent = '';
+                svgWrap.appendChild(svg);
+            }
+
+            function renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+                const bucketResult = computeDateBuckets(filteredIds);
+
+                // Fallback to category if no valid dates
+                if (!bucketResult) {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                    return;
+                }
+
+                const { buckets } = bucketResult;
+
+                // Layout constants
+                const nodeW = 110, nodeH = 44;
+                const gapX = 16, gapY = 24;
+                const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
+                const labelW = 110, padL = 16, padR = 16, padT = 16;
+                const colW = nodeW + gapX;
+                const headerH = 24;
+
+                // Total columns = date buckets + optional "No Date"
+                const hasUndated = filteredIds.some(id => assignNodeToBucket(nodes[id], buckets) === -1);
+                const totalCols = buckets.length + (hasUndated ? 1 : 0);
+
+                // Assign nodes to cells: { catKey: { colIdx: [nodeIds] } }
+                const cells = {};
                 for (const id of filteredIds) {
                     const node = nodes[id];
-                    const pos = positions[id];
-                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
-
-                    const shortTitle = (node.title || '').length > 16
-                        ? node.title.substring(0, 15) + '\u2026'
-                        : (node.title || id);
-
-                    const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
-                    g.dataset.id = id;
-                    g.dataset.path = node.path;
-
-                    const rect = document.createElementNS(NS, 'rect');
-                    rect.setAttribute('x', pos.x);
-                    rect.setAttribute('y', pos.y);
-                    rect.setAttribute('width', nodeW);
-                    rect.setAttribute('height', nodeH);
-                    rect.setAttribute('rx', '4');
-                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
-                    rect.setAttribute('stroke', color);
-                    rect.setAttribute('stroke-width', '1.5');
-                    g.appendChild(rect);
-
-                    const typeText = document.createElementNS(NS, 'text');
-                    typeText.setAttribute('x', pos.x + nodeW / 2);
-                    typeText.setAttribute('y', pos.y + 16);
-                    typeText.setAttribute('text-anchor', 'middle');
-                    typeText.setAttribute('font-size', '11');
-                    typeText.setAttribute('font-weight', '700');
-                    typeText.setAttribute('fill', color);
-                    typeText.textContent = node.type;
-                    g.appendChild(typeText);
-
-                    const titleText = document.createElementNS(NS, 'text');
-                    titleText.setAttribute('x', pos.x + nodeW / 2);
-                    titleText.setAttribute('y', pos.y + 30);
-                    titleText.setAttribute('text-anchor', 'middle');
-                    titleText.setAttribute('font-size', '8');
-                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
-                    titleText.textContent = shortTitle;
-                    g.appendChild(titleText);
-
-                    // Event listeners
-                    g.addEventListener('mouseenter', () => {
-                        const nodeId = g.dataset.id;
-                        const connNodes = new Set([nodeId]);
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
-                                p.classList.add('highlighted');
-                                connNodes.add(p.dataset.from);
-                                connNodes.add(p.dataset.to);
-                            } else {
-                                p.classList.add('dimmed');
-                            }
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
-                        });
-
-                        const nd = nodes[nodeId];
-                        if (nd) {
-                            const ttTitle = document.createElement('strong');
-                            ttTitle.textContent = nd.title || nodeId;
-                            const ttMeta = document.createElement('span');
-                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
-                            tooltip.textContent = '';
-                            tooltip.appendChild(ttTitle);
-                            tooltip.appendChild(ttMeta);
-                            tooltip.style.display = 'block';
-                            const r = g.getBoundingClientRect();
-                            tooltip.style.left = (r.right + 8) + 'px';
-                            tooltip.style.top = r.top + 'px';
-                        }
-                    });
-
-                    g.addEventListener('mouseleave', () => {
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            p.classList.remove('highlighted', 'dimmed');
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            n.classList.remove('dimmed');
-                        });
-                        tooltip.style.display = 'none';
-                    });
-
-                    g.addEventListener('click', () => {
-                        const docPath = g.dataset.path;
-                        if (docPath) {
-                            tooltip.style.display = 'none';
-                            window.location.hash = docPath;
-                        }
-                    });
-
-                    svg.appendChild(g);
+                    const cat = (node.type && TYPE_CATEGORIES[node.type]) || 'Other';
+                    const colIdx = assignNodeToBucket(node, buckets);
+                    const actualCol = colIdx === -1 ? buckets.length : colIdx;
+                    if (!cells[cat]) cells[cat] = {};
+                    if (!cells[cat][actualCol]) cells[cat][actualCol] = [];
+                    cells[cat][actualCol].push(id);
                 }
+
+                // Sort within each cell by project then type
+                for (const cat of Object.keys(cells)) {
+                    for (const col of Object.keys(cells[cat])) {
+                        cells[cat][col].sort((a, b) => {
+                            const na = nodes[a], nb = nodes[b];
+                            return (na.project || '').localeCompare(nb.project || '') || (na.type || '').localeCompare(nb.type || '');
+                        });
+                    }
+                }
+
+                // Compute row heights (expand for stacked nodes)
+                const positions = {};
+                let y = padT + headerH;
+                const rowBands = [];
+
+                for (const cat of CATEGORY_ORDER) {
+                    if (!catGroups[cat] || catGroups[cat].length === 0) continue;
+
+                    // Find max stack in any column for this category
+                    let maxStack = 1;
+                    if (cells[cat]) {
+                        for (const col of Object.keys(cells[cat])) {
+                            maxStack = Math.max(maxStack, cells[cat][col].length);
+                        }
+                    }
+
+                    const numRows = maxStack;
+                    const rowH = rowPadTop + numRows * nodeH + (numRows - 1) * rowGapY + rowPadBot;
+                    rowBands.push({ cat, y, h: rowH });
+
+                    // Position nodes
+                    if (cells[cat]) {
+                        for (const [colStr, ids] of Object.entries(cells[cat])) {
+                            const col = parseInt(colStr, 10);
+                            for (let i = 0; i < ids.length; i++) {
+                                positions[ids[i]] = {
+                                    x: padL + labelW + col * colW,
+                                    y: y + rowPadTop + i * (nodeH + rowGapY),
+                                };
+                            }
+                        }
+                    }
+
+                    y += rowH + gapY;
+                }
+
+                const svgW = padL + labelW + totalCols * colW + padR;
+                const svgH = y - gapY + padT;
+
+                statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
+
+                // Build SVG
+                const NS = 'http://www.w3.org/2000/svg';
+                const svg = document.createElementNS(NS, 'svg');
+                svg.setAttribute('class', 'app-depmap-svg');
+                svg.setAttribute('viewBox', '0 0 ' + svgW + ' ' + svgH);
+                svg.setAttribute('width', svgW);
+                svg.setAttribute('height', svgH);
+
+                // Column headers
+                for (let i = 0; i < buckets.length; i++) {
+                    const cx = padL + labelW + i * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', 'var(--text-secondary, #666)');
+                    hdr.textContent = buckets[i].label;
+                    svg.appendChild(hdr);
+                }
+
+                // "No Date" header
+                if (hasUndated) {
+                    const cx = padL + labelW + buckets.length * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', '#b1b4b6');
+                    hdr.textContent = 'No Date';
+                    svg.appendChild(hdr);
+                }
+
+                // Column separator lines
+                for (let i = 1; i < totalCols; i++) {
+                    const lx = padL + labelW + i * colW - gapX / 2;
+                    const line = document.createElementNS(NS, 'line');
+                    line.setAttribute('x1', lx);
+                    line.setAttribute('y1', padT + headerH);
+                    line.setAttribute('x2', lx);
+                    line.setAttribute('y2', svgH - padT);
+                    line.setAttribute('stroke', 'var(--border-main, #e8e8e8)');
+                    line.setAttribute('stroke-width', '1');
+                    line.setAttribute('opacity', '0.3');
+                    svg.appendChild(line);
+                }
+
+                // Row backgrounds
+                for (const band of rowBands) {
+                    const color = CATEGORY_COLORS[band.cat] || CATEGORY_COLORS.Other;
+                    const bg = document.createElementNS(NS, 'rect');
+                    bg.setAttribute('x', 0);
+                    bg.setAttribute('y', band.y);
+                    bg.setAttribute('width', svgW);
+                    bg.setAttribute('height', band.h);
+                    bg.setAttribute('fill', color);
+                    bg.setAttribute('opacity', '0.06');
+                    bg.setAttribute('rx', '4');
+                    svg.appendChild(bg);
+
+                    const lbl = document.createElementNS(NS, 'text');
+                    lbl.setAttribute('x', padL);
+                    lbl.setAttribute('y', band.y + 18);
+                    lbl.setAttribute('font-size', '11');
+                    lbl.setAttribute('font-weight', '700');
+                    lbl.setAttribute('fill', color);
+                    lbl.textContent = band.cat;
+                    svg.appendChild(lbl);
+                }
+
+                // Edges
+                for (const e of visibleEdges) {
+                    const fromPos = positions[e.from];
+                    if (!fromPos) continue;
+                    const toId = filteredIds.find(id => id.startsWith(e.to));
+                    if (!toId) continue;
+                    const toPos = positions[toId];
+                    if (!toPos) continue;
+
+                    const x1 = fromPos.x + nodeW / 2;
+                    const y1 = fromPos.y + nodeH;
+                    const x2 = toPos.x + nodeW / 2;
+                    const y2 = toPos.y;
+                    const dy = Math.abs(y2 - y1) * 0.4;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[nodes[e.from].type] || 'Other'] || CATEGORY_COLORS.Other;
+
+                    const path = document.createElementNS(NS, 'path');
+                    path.setAttribute('class', 'app-depmap-edge');
+                    path.dataset.from = e.from;
+                    path.dataset.to = toId;
+                    path.setAttribute('d', 'M' + x1 + ',' + y1 + ' C' + x1 + ',' + (y1 + dy) + ' ' + x2 + ',' + (y2 - dy) + ' ' + x2 + ',' + y2);
+                    path.setAttribute('stroke', color);
+                    svg.appendChild(path);
+                }
+
+                // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
 
                 svgWrap.textContent = '';
                 svgWrap.appendChild(svg);

--- a/arckit-claude/hooks/graph-utils.mjs
+++ b/arckit-claude/hooks/graph-utils.mjs
@@ -90,6 +90,8 @@ export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) 
         title,
         status,
         severity: classifySeverity(docType),
+        createdDate: fields['Created Date'] || null,
+        lastModified: fields['Last Modified'] || null,
       };
 
       const reqIds = extractRequirementIds(content);

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -2876,8 +2876,8 @@
             const projects = [...projectSet].sort();
 
             const CATEGORY_ORDER = [
-                'Discovery', 'Planning', 'Architecture', 'Governance',
-                'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'
+                'Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance',
+                'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other'
             ];
 
             // Build controls DOM

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -3025,6 +3025,236 @@
             tooltip.style.display = 'none';
             document.body.appendChild(tooltip);
 
+            // ── Timeline utilities ──
+            function computeDateBuckets(filteredIds) {
+                const validDates = [];
+                for (const id of filteredIds) {
+                    const d = nodes[id].createdDate;
+                    if (!d) continue;
+                    const parsed = new Date(d);
+                    if (isNaN(parsed.getTime())) continue;
+                    validDates.push(parsed);
+                }
+                if (validDates.length === 0) return null;
+
+                validDates.sort((a, b) => a - b);
+                const minDate = validDates[0];
+                const maxDate = validDates[validDates.length - 1];
+                const rangeDays = (maxDate - minDate) / 86400000;
+
+                let granularity, buckets;
+
+                if (rangeDays < 90) {
+                    granularity = 'weekly';
+                    buckets = generateWeeklyBuckets(minDate, maxDate);
+                } else if (rangeDays <= 547) {
+                    granularity = 'monthly';
+                    buckets = generateMonthlyBuckets(minDate, maxDate);
+                } else {
+                    granularity = 'quarterly';
+                    buckets = generateQuarterlyBuckets(minDate, maxDate);
+                }
+
+                return { granularity, buckets };
+            }
+
+            function generateWeeklyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                const start = new Date(minDate);
+                const day = start.getDay();
+                const diff = day === 0 ? -6 : 1 - day;
+                start.setDate(start.getDate() + diff);
+                start.setHours(0, 0, 0, 0);
+
+                const end = new Date(maxDate);
+                end.setHours(23, 59, 59, 999);
+
+                let current = new Date(start);
+                while (current <= end) {
+                    const weekStart = new Date(current);
+                    const weekEnd = new Date(current);
+                    weekEnd.setDate(weekEnd.getDate() + 6);
+                    weekEnd.setHours(23, 59, 59, 999);
+
+                    const weekNum = Math.ceil(weekStart.getDate() / 7);
+                    const label = 'W' + weekNum + ' ' + MONTHS[weekStart.getMonth()];
+
+                    buckets.push({ label, start: weekStart, end: weekEnd });
+                    current.setDate(current.getDate() + 7);
+                }
+                return buckets;
+            }
+
+            function generateMonthlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                let y = minDate.getFullYear(), m = minDate.getMonth();
+                const endY = maxDate.getFullYear(), endM = maxDate.getMonth();
+
+                while (y < endY || (y === endY && m <= endM)) {
+                    const start = new Date(y, m, 1);
+                    const end = new Date(y, m + 1, 0, 23, 59, 59, 999);
+                    const label = MONTHS[m] + ' ' + y;
+                    buckets.push({ label, start, end });
+                    m++;
+                    if (m > 11) { m = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function generateQuarterlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                let y = minDate.getFullYear();
+                let q = Math.floor(minDate.getMonth() / 3);
+                const endY = maxDate.getFullYear();
+                const endQ = Math.floor(maxDate.getMonth() / 3);
+
+                while (y < endY || (y === endY && q <= endQ)) {
+                    const startMonth = q * 3;
+                    const start = new Date(y, startMonth, 1);
+                    const end = new Date(y, startMonth + 3, 0, 23, 59, 59, 999);
+                    const label = 'Q' + (q + 1) + ' ' + y;
+                    buckets.push({ label, start, end });
+                    q++;
+                    if (q > 3) { q = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function assignNodeToBucket(node, buckets) {
+                if (!node.createdDate) return -1;
+                const d = new Date(node.createdDate);
+                if (isNaN(d.getTime())) return -1;
+                for (let i = 0; i < buckets.length; i++) {
+                    if (d >= buckets[i].start && d <= buckets[i].end) return i;
+                }
+                return -1;
+            }
+
+            function renderNodes(svg, filteredIds, positions, connectedIds, NS) {
+                const nodeW = 110, nodeH = 44;
+
+                for (const id of filteredIds) {
+                    const node = nodes[id];
+                    const pos = positions[id];
+                    if (!pos) continue;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
+                    const isOrphan = !connectedIds.has(id);
+
+                    const shortTitle = (node.title || '').length > 16
+                        ? node.title.substring(0, 15) + '\u2026'
+                        : (node.title || id);
+
+                    const g = document.createElementNS(NS, 'g');
+                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.dataset.id = id;
+                    g.dataset.path = node.path;
+
+                    const rect = document.createElementNS(NS, 'rect');
+                    rect.setAttribute('x', pos.x);
+                    rect.setAttribute('y', pos.y);
+                    rect.setAttribute('width', nodeW);
+                    rect.setAttribute('height', nodeH);
+                    rect.setAttribute('rx', '4');
+                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
+                    rect.setAttribute('stroke', color);
+                    rect.setAttribute('stroke-width', '1.5');
+                    g.appendChild(rect);
+
+                    const typeText = document.createElementNS(NS, 'text');
+                    typeText.setAttribute('x', pos.x + nodeW / 2);
+                    typeText.setAttribute('y', pos.y + 16);
+                    typeText.setAttribute('text-anchor', 'middle');
+                    typeText.setAttribute('font-size', '11');
+                    typeText.setAttribute('font-weight', '700');
+                    typeText.setAttribute('fill', color);
+                    typeText.textContent = node.type;
+                    g.appendChild(typeText);
+
+                    const titleText = document.createElementNS(NS, 'text');
+                    titleText.setAttribute('x', pos.x + nodeW / 2);
+                    titleText.setAttribute('y', pos.y + 30);
+                    titleText.setAttribute('text-anchor', 'middle');
+                    titleText.setAttribute('font-size', '8');
+                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
+                    titleText.textContent = shortTitle;
+                    g.appendChild(titleText);
+
+                    // Last-modified indicator dot
+                    if (node.lastModified) {
+                        const lmDate = new Date(node.lastModified);
+                        if (!isNaN(lmDate.getTime())) {
+                            const daysAgo = (Date.now() - lmDate.getTime()) / 86400000;
+                            let dotColor = null;
+                            if (daysAgo < 7) dotColor = '#00703c';
+                            else if (daysAgo < 30) dotColor = '#f47738';
+                            if (dotColor) {
+                                const dot = document.createElementNS(NS, 'circle');
+                                dot.setAttribute('cx', pos.x + nodeW - 6);
+                                dot.setAttribute('cy', pos.y + 6);
+                                dot.setAttribute('r', '3');
+                                dot.setAttribute('fill', dotColor);
+                                g.appendChild(dot);
+                            }
+                        }
+                    }
+
+                    // Event listeners
+                    g.addEventListener('mouseenter', () => {
+                        const nodeId = g.dataset.id;
+                        const connNodes = new Set([nodeId]);
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
+                                p.classList.add('highlighted');
+                                connNodes.add(p.dataset.from);
+                                connNodes.add(p.dataset.to);
+                            } else {
+                                p.classList.add('dimmed');
+                            }
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
+                        });
+
+                        const nd = nodes[nodeId];
+                        if (nd) {
+                            const ttTitle = document.createElement('strong');
+                            ttTitle.textContent = nd.title || nodeId;
+                            const ttMeta = document.createElement('span');
+                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
+                            tooltip.textContent = '';
+                            tooltip.appendChild(ttTitle);
+                            tooltip.appendChild(ttMeta);
+                            tooltip.style.display = 'block';
+                            const r = g.getBoundingClientRect();
+                            tooltip.style.left = (r.right + 8) + 'px';
+                            tooltip.style.top = r.top + 'px';
+                        }
+                    });
+
+                    g.addEventListener('mouseleave', () => {
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            p.classList.remove('highlighted', 'dimmed');
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            n.classList.remove('dimmed');
+                        });
+                        tooltip.style.display = 'none';
+                    });
+
+                    g.addEventListener('click', () => {
+                        const docPath = g.dataset.path;
+                        if (docPath) {
+                            tooltip.style.display = 'none';
+                            window.location.hash = docPath;
+                        }
+                    });
+
+                    svg.appendChild(g);
+                }
+            }
+
             function renderGraph(filterProject) {
                 const statsEl = document.getElementById('depmap-stats');
 
@@ -3061,12 +3291,29 @@
                     });
                 }
 
+                // Filter edges to visible nodes
+                const filteredSet = new Set(filteredIds);
+                const visibleEdges = edges.filter(e => {
+                    if (!filteredSet.has(e.from)) return false;
+                    return filteredIds.some(id => id.startsWith(e.to));
+                });
+
+                if (currentLayout === 'timeline') {
+                    renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                } else {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                }
+            }
+
+            function renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+
                 // Layout constants
                 const nodeW = 110, nodeH = 44;
                 const gapX = 16, gapY = 24;
                 const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
                 const labelW = 110, padL = 16, padR = 16, padT = 16;
-                const maxCols = 8; // wrap after this many nodes per row
+                const maxCols = 8;
 
                 // Compute positions with wrapping
                 const positions = {};
@@ -3097,16 +3344,9 @@
                 const svgW = padL + labelW + usedCols * nodeW + (usedCols - 1) * gapX + padR;
                 const svgH = y - gapY + padT;
 
-                // Filter edges to visible nodes
-                const filteredSet = new Set(filteredIds);
-                const visibleEdges = edges.filter(e => {
-                    if (!filteredSet.has(e.from)) return false;
-                    return filteredIds.some(id => id.startsWith(e.to));
-                });
-
                 statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
 
-                // Build SVG using DOM (SVG namespace)
+                // Build SVG
                 const NS = 'http://www.w3.org/2000/svg';
                 const svg = document.createElementNS(NS, 'svg');
                 svg.setAttribute('class', 'app-depmap-svg');
@@ -3164,104 +3404,199 @@
                 }
 
                 // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
+
+                svgWrap.textContent = '';
+                svgWrap.appendChild(svg);
+            }
+
+            function renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+                const bucketResult = computeDateBuckets(filteredIds);
+
+                // Fallback to category if no valid dates
+                if (!bucketResult) {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                    return;
+                }
+
+                const { buckets } = bucketResult;
+
+                // Layout constants
+                const nodeW = 110, nodeH = 44;
+                const gapX = 16, gapY = 24;
+                const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
+                const labelW = 110, padL = 16, padR = 16, padT = 16;
+                const colW = nodeW + gapX;
+                const headerH = 24;
+
+                // Total columns = date buckets + optional "No Date"
+                const hasUndated = filteredIds.some(id => assignNodeToBucket(nodes[id], buckets) === -1);
+                const totalCols = buckets.length + (hasUndated ? 1 : 0);
+
+                // Assign nodes to cells: { catKey: { colIdx: [nodeIds] } }
+                const cells = {};
                 for (const id of filteredIds) {
                     const node = nodes[id];
-                    const pos = positions[id];
-                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
-
-                    const shortTitle = (node.title || '').length > 16
-                        ? node.title.substring(0, 15) + '\u2026'
-                        : (node.title || id);
-
-                    const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
-                    g.dataset.id = id;
-                    g.dataset.path = node.path;
-
-                    const rect = document.createElementNS(NS, 'rect');
-                    rect.setAttribute('x', pos.x);
-                    rect.setAttribute('y', pos.y);
-                    rect.setAttribute('width', nodeW);
-                    rect.setAttribute('height', nodeH);
-                    rect.setAttribute('rx', '4');
-                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
-                    rect.setAttribute('stroke', color);
-                    rect.setAttribute('stroke-width', '1.5');
-                    g.appendChild(rect);
-
-                    const typeText = document.createElementNS(NS, 'text');
-                    typeText.setAttribute('x', pos.x + nodeW / 2);
-                    typeText.setAttribute('y', pos.y + 16);
-                    typeText.setAttribute('text-anchor', 'middle');
-                    typeText.setAttribute('font-size', '11');
-                    typeText.setAttribute('font-weight', '700');
-                    typeText.setAttribute('fill', color);
-                    typeText.textContent = node.type;
-                    g.appendChild(typeText);
-
-                    const titleText = document.createElementNS(NS, 'text');
-                    titleText.setAttribute('x', pos.x + nodeW / 2);
-                    titleText.setAttribute('y', pos.y + 30);
-                    titleText.setAttribute('text-anchor', 'middle');
-                    titleText.setAttribute('font-size', '8');
-                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
-                    titleText.textContent = shortTitle;
-                    g.appendChild(titleText);
-
-                    // Event listeners
-                    g.addEventListener('mouseenter', () => {
-                        const nodeId = g.dataset.id;
-                        const connNodes = new Set([nodeId]);
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
-                                p.classList.add('highlighted');
-                                connNodes.add(p.dataset.from);
-                                connNodes.add(p.dataset.to);
-                            } else {
-                                p.classList.add('dimmed');
-                            }
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
-                        });
-
-                        const nd = nodes[nodeId];
-                        if (nd) {
-                            const ttTitle = document.createElement('strong');
-                            ttTitle.textContent = nd.title || nodeId;
-                            const ttMeta = document.createElement('span');
-                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
-                            tooltip.textContent = '';
-                            tooltip.appendChild(ttTitle);
-                            tooltip.appendChild(ttMeta);
-                            tooltip.style.display = 'block';
-                            const r = g.getBoundingClientRect();
-                            tooltip.style.left = (r.right + 8) + 'px';
-                            tooltip.style.top = r.top + 'px';
-                        }
-                    });
-
-                    g.addEventListener('mouseleave', () => {
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            p.classList.remove('highlighted', 'dimmed');
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            n.classList.remove('dimmed');
-                        });
-                        tooltip.style.display = 'none';
-                    });
-
-                    g.addEventListener('click', () => {
-                        const docPath = g.dataset.path;
-                        if (docPath) {
-                            tooltip.style.display = 'none';
-                            window.location.hash = docPath;
-                        }
-                    });
-
-                    svg.appendChild(g);
+                    const cat = (node.type && TYPE_CATEGORIES[node.type]) || 'Other';
+                    const colIdx = assignNodeToBucket(node, buckets);
+                    const actualCol = colIdx === -1 ? buckets.length : colIdx;
+                    if (!cells[cat]) cells[cat] = {};
+                    if (!cells[cat][actualCol]) cells[cat][actualCol] = [];
+                    cells[cat][actualCol].push(id);
                 }
+
+                // Sort within each cell by project then type
+                for (const cat of Object.keys(cells)) {
+                    for (const col of Object.keys(cells[cat])) {
+                        cells[cat][col].sort((a, b) => {
+                            const na = nodes[a], nb = nodes[b];
+                            return (na.project || '').localeCompare(nb.project || '') || (na.type || '').localeCompare(nb.type || '');
+                        });
+                    }
+                }
+
+                // Compute row heights (expand for stacked nodes)
+                const positions = {};
+                let y = padT + headerH;
+                const rowBands = [];
+
+                for (const cat of CATEGORY_ORDER) {
+                    if (!catGroups[cat] || catGroups[cat].length === 0) continue;
+
+                    // Find max stack in any column for this category
+                    let maxStack = 1;
+                    if (cells[cat]) {
+                        for (const col of Object.keys(cells[cat])) {
+                            maxStack = Math.max(maxStack, cells[cat][col].length);
+                        }
+                    }
+
+                    const numRows = maxStack;
+                    const rowH = rowPadTop + numRows * nodeH + (numRows - 1) * rowGapY + rowPadBot;
+                    rowBands.push({ cat, y, h: rowH });
+
+                    // Position nodes
+                    if (cells[cat]) {
+                        for (const [colStr, ids] of Object.entries(cells[cat])) {
+                            const col = parseInt(colStr, 10);
+                            for (let i = 0; i < ids.length; i++) {
+                                positions[ids[i]] = {
+                                    x: padL + labelW + col * colW,
+                                    y: y + rowPadTop + i * (nodeH + rowGapY),
+                                };
+                            }
+                        }
+                    }
+
+                    y += rowH + gapY;
+                }
+
+                const svgW = padL + labelW + totalCols * colW + padR;
+                const svgH = y - gapY + padT;
+
+                statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
+
+                // Build SVG
+                const NS = 'http://www.w3.org/2000/svg';
+                const svg = document.createElementNS(NS, 'svg');
+                svg.setAttribute('class', 'app-depmap-svg');
+                svg.setAttribute('viewBox', '0 0 ' + svgW + ' ' + svgH);
+                svg.setAttribute('width', svgW);
+                svg.setAttribute('height', svgH);
+
+                // Column headers
+                for (let i = 0; i < buckets.length; i++) {
+                    const cx = padL + labelW + i * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', 'var(--text-secondary, #666)');
+                    hdr.textContent = buckets[i].label;
+                    svg.appendChild(hdr);
+                }
+
+                // "No Date" header
+                if (hasUndated) {
+                    const cx = padL + labelW + buckets.length * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', '#b1b4b6');
+                    hdr.textContent = 'No Date';
+                    svg.appendChild(hdr);
+                }
+
+                // Column separator lines
+                for (let i = 1; i < totalCols; i++) {
+                    const lx = padL + labelW + i * colW - gapX / 2;
+                    const line = document.createElementNS(NS, 'line');
+                    line.setAttribute('x1', lx);
+                    line.setAttribute('y1', padT + headerH);
+                    line.setAttribute('x2', lx);
+                    line.setAttribute('y2', svgH - padT);
+                    line.setAttribute('stroke', 'var(--border-main, #e8e8e8)');
+                    line.setAttribute('stroke-width', '1');
+                    line.setAttribute('opacity', '0.3');
+                    svg.appendChild(line);
+                }
+
+                // Row backgrounds
+                for (const band of rowBands) {
+                    const color = CATEGORY_COLORS[band.cat] || CATEGORY_COLORS.Other;
+                    const bg = document.createElementNS(NS, 'rect');
+                    bg.setAttribute('x', 0);
+                    bg.setAttribute('y', band.y);
+                    bg.setAttribute('width', svgW);
+                    bg.setAttribute('height', band.h);
+                    bg.setAttribute('fill', color);
+                    bg.setAttribute('opacity', '0.06');
+                    bg.setAttribute('rx', '4');
+                    svg.appendChild(bg);
+
+                    const lbl = document.createElementNS(NS, 'text');
+                    lbl.setAttribute('x', padL);
+                    lbl.setAttribute('y', band.y + 18);
+                    lbl.setAttribute('font-size', '11');
+                    lbl.setAttribute('font-weight', '700');
+                    lbl.setAttribute('fill', color);
+                    lbl.textContent = band.cat;
+                    svg.appendChild(lbl);
+                }
+
+                // Edges
+                for (const e of visibleEdges) {
+                    const fromPos = positions[e.from];
+                    if (!fromPos) continue;
+                    const toId = filteredIds.find(id => id.startsWith(e.to));
+                    if (!toId) continue;
+                    const toPos = positions[toId];
+                    if (!toPos) continue;
+
+                    const x1 = fromPos.x + nodeW / 2;
+                    const y1 = fromPos.y + nodeH;
+                    const x2 = toPos.x + nodeW / 2;
+                    const y2 = toPos.y;
+                    const dy = Math.abs(y2 - y1) * 0.4;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[nodes[e.from].type] || 'Other'] || CATEGORY_COLORS.Other;
+
+                    const path = document.createElementNS(NS, 'path');
+                    path.setAttribute('class', 'app-depmap-edge');
+                    path.dataset.from = e.from;
+                    path.dataset.to = toId;
+                    path.setAttribute('d', 'M' + x1 + ',' + y1 + ' C' + x1 + ',' + (y1 + dy) + ' ' + x2 + ',' + (y2 - dy) + ' ' + x2 + ',' + y2);
+                    path.setAttribute('stroke', color);
+                    svg.appendChild(path);
+                }
+
+                // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
 
                 svgWrap.textContent = '';
                 svgWrap.appendChild(svg);

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -2905,6 +2905,18 @@
                 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other'
             ];
 
+            // Check if any nodes have valid dates (for timeline toggle)
+            const hasValidDates = nodeIds.some(id => {
+                const d = nodes[id].createdDate;
+                return d && !isNaN(new Date(d).getTime());
+            });
+
+            let currentLayout = 'category';
+            if (hasValidDates) {
+                const stored = localStorage.getItem('arckit-depmap-layout');
+                if (stored === 'timeline') currentLayout = 'timeline';
+            }
+
             // Build controls DOM
             content.textContent = '';
             const h1 = document.createElement('h1');
@@ -2916,6 +2928,45 @@
 
             const controls = document.createElement('div');
             controls.className = 'app-depmap-controls';
+
+            const layoutLabel = document.createElement('label');
+            layoutLabel.textContent = 'Layout:';
+            layoutLabel.style.cssText = 'font-size:14px;font-weight:700;color:var(--text-primary)';
+            controls.appendChild(layoutLabel);
+
+            const toggleWrap = document.createElement('div');
+            toggleWrap.className = 'app-depmap-layout-toggle';
+
+            const btnCategory = document.createElement('button');
+            btnCategory.textContent = 'Category';
+            btnCategory.className = currentLayout === 'category' ? 'active' : '';
+            toggleWrap.appendChild(btnCategory);
+
+            if (hasValidDates) {
+                const btnTimeline = document.createElement('button');
+                btnTimeline.textContent = 'Timeline';
+                btnTimeline.className = currentLayout === 'timeline' ? 'active' : '';
+                toggleWrap.appendChild(btnTimeline);
+
+                btnTimeline.addEventListener('click', () => {
+                    currentLayout = 'timeline';
+                    localStorage.setItem('arckit-depmap-layout', 'timeline');
+                    btnCategory.className = '';
+                    btnTimeline.className = 'active';
+                    renderGraph(select.value);
+                });
+            }
+
+            btnCategory.addEventListener('click', () => {
+                currentLayout = 'category';
+                localStorage.setItem('arckit-depmap-layout', 'category');
+                btnCategory.className = 'active';
+                const btnT = toggleWrap.querySelector('button:nth-child(2)');
+                if (btnT) btnT.className = '';
+                renderGraph(select.value);
+            });
+
+            controls.appendChild(toggleWrap);
 
             const label = document.createElement('label');
             label.setAttribute('for', 'depmap-project-filter');

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -1642,6 +1642,31 @@
             color: var(--text-secondary);
             font-size: 16px;
         }
+        .app-depmap-layout-toggle {
+            display: inline-flex;
+            border: 1px solid var(--border-main);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .app-depmap-layout-toggle button {
+            border: none;
+            background: var(--bg-surface);
+            color: var(--text-primary);
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            cursor: pointer;
+        }
+        .app-depmap-layout-toggle button:not(:last-child) {
+            border-right: 1px solid var(--border-main);
+        }
+        .app-depmap-layout-toggle button.active {
+            background: var(--text-primary);
+            color: var(--bg-surface);
+        }
+        .app-depmap-layout-toggle button:hover:not(.active) {
+            background: var(--bg-surface-alt);
+        }
     </style>
 </head>
 <body class="govuk-template__body">

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -1642,6 +1642,31 @@
             color: var(--text-secondary);
             font-size: 16px;
         }
+        .app-depmap-layout-toggle {
+            display: inline-flex;
+            border: 1px solid var(--border-main);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .app-depmap-layout-toggle button {
+            border: none;
+            background: var(--bg-surface);
+            color: var(--text-primary);
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            cursor: pointer;
+        }
+        .app-depmap-layout-toggle button:not(:last-child) {
+            border-right: 1px solid var(--border-main);
+        }
+        .app-depmap-layout-toggle button.active {
+            background: var(--text-primary);
+            color: var(--bg-surface);
+        }
+        .app-depmap-layout-toggle button:hover:not(.active) {
+            background: var(--bg-surface-alt);
+        }
     </style>
 </head>
 <body class="govuk-template__body">
@@ -2876,9 +2901,21 @@
             const projects = [...projectSet].sort();
 
             const CATEGORY_ORDER = [
-                'Discovery', 'Planning', 'Architecture', 'Governance',
-                'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'
+                'Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance',
+                'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other'
             ];
+
+            // Check if any nodes have valid dates (for timeline toggle)
+            const hasValidDates = nodeIds.some(id => {
+                const d = nodes[id].createdDate;
+                return d && !isNaN(new Date(d).getTime());
+            });
+
+            let currentLayout = 'category';
+            if (hasValidDates) {
+                const stored = localStorage.getItem('arckit-depmap-layout');
+                if (stored === 'timeline') currentLayout = 'timeline';
+            }
 
             // Build controls DOM
             content.textContent = '';
@@ -2891,6 +2928,45 @@
 
             const controls = document.createElement('div');
             controls.className = 'app-depmap-controls';
+
+            const layoutLabel = document.createElement('label');
+            layoutLabel.textContent = 'Layout:';
+            layoutLabel.style.cssText = 'font-size:14px;font-weight:700;color:var(--text-primary)';
+            controls.appendChild(layoutLabel);
+
+            const toggleWrap = document.createElement('div');
+            toggleWrap.className = 'app-depmap-layout-toggle';
+
+            const btnCategory = document.createElement('button');
+            btnCategory.textContent = 'Category';
+            btnCategory.className = currentLayout === 'category' ? 'active' : '';
+            toggleWrap.appendChild(btnCategory);
+
+            if (hasValidDates) {
+                const btnTimeline = document.createElement('button');
+                btnTimeline.textContent = 'Timeline';
+                btnTimeline.className = currentLayout === 'timeline' ? 'active' : '';
+                toggleWrap.appendChild(btnTimeline);
+
+                btnTimeline.addEventListener('click', () => {
+                    currentLayout = 'timeline';
+                    localStorage.setItem('arckit-depmap-layout', 'timeline');
+                    btnCategory.className = '';
+                    btnTimeline.className = 'active';
+                    renderGraph(select.value);
+                });
+            }
+
+            btnCategory.addEventListener('click', () => {
+                currentLayout = 'category';
+                localStorage.setItem('arckit-depmap-layout', 'category');
+                btnCategory.className = 'active';
+                const btnT = toggleWrap.querySelector('button:nth-child(2)');
+                if (btnT) btnT.className = '';
+                renderGraph(select.value);
+            });
+
+            controls.appendChild(toggleWrap);
 
             const label = document.createElement('label');
             label.setAttribute('for', 'depmap-project-filter');
@@ -2949,6 +3025,236 @@
             tooltip.style.display = 'none';
             document.body.appendChild(tooltip);
 
+            // ── Timeline utilities ──
+            function computeDateBuckets(filteredIds) {
+                const validDates = [];
+                for (const id of filteredIds) {
+                    const d = nodes[id].createdDate;
+                    if (!d) continue;
+                    const parsed = new Date(d);
+                    if (isNaN(parsed.getTime())) continue;
+                    validDates.push(parsed);
+                }
+                if (validDates.length === 0) return null;
+
+                validDates.sort((a, b) => a - b);
+                const minDate = validDates[0];
+                const maxDate = validDates[validDates.length - 1];
+                const rangeDays = (maxDate - minDate) / 86400000;
+
+                let granularity, buckets;
+
+                if (rangeDays < 90) {
+                    granularity = 'weekly';
+                    buckets = generateWeeklyBuckets(minDate, maxDate);
+                } else if (rangeDays <= 547) {
+                    granularity = 'monthly';
+                    buckets = generateMonthlyBuckets(minDate, maxDate);
+                } else {
+                    granularity = 'quarterly';
+                    buckets = generateQuarterlyBuckets(minDate, maxDate);
+                }
+
+                return { granularity, buckets };
+            }
+
+            function generateWeeklyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                const start = new Date(minDate);
+                const day = start.getDay();
+                const diff = day === 0 ? -6 : 1 - day;
+                start.setDate(start.getDate() + diff);
+                start.setHours(0, 0, 0, 0);
+
+                const end = new Date(maxDate);
+                end.setHours(23, 59, 59, 999);
+
+                let current = new Date(start);
+                while (current <= end) {
+                    const weekStart = new Date(current);
+                    const weekEnd = new Date(current);
+                    weekEnd.setDate(weekEnd.getDate() + 6);
+                    weekEnd.setHours(23, 59, 59, 999);
+
+                    const weekNum = Math.ceil(weekStart.getDate() / 7);
+                    const label = 'W' + weekNum + ' ' + MONTHS[weekStart.getMonth()];
+
+                    buckets.push({ label, start: weekStart, end: weekEnd });
+                    current.setDate(current.getDate() + 7);
+                }
+                return buckets;
+            }
+
+            function generateMonthlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                let y = minDate.getFullYear(), m = minDate.getMonth();
+                const endY = maxDate.getFullYear(), endM = maxDate.getMonth();
+
+                while (y < endY || (y === endY && m <= endM)) {
+                    const start = new Date(y, m, 1);
+                    const end = new Date(y, m + 1, 0, 23, 59, 59, 999);
+                    const label = MONTHS[m] + ' ' + y;
+                    buckets.push({ label, start, end });
+                    m++;
+                    if (m > 11) { m = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function generateQuarterlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                let y = minDate.getFullYear();
+                let q = Math.floor(minDate.getMonth() / 3);
+                const endY = maxDate.getFullYear();
+                const endQ = Math.floor(maxDate.getMonth() / 3);
+
+                while (y < endY || (y === endY && q <= endQ)) {
+                    const startMonth = q * 3;
+                    const start = new Date(y, startMonth, 1);
+                    const end = new Date(y, startMonth + 3, 0, 23, 59, 59, 999);
+                    const label = 'Q' + (q + 1) + ' ' + y;
+                    buckets.push({ label, start, end });
+                    q++;
+                    if (q > 3) { q = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function assignNodeToBucket(node, buckets) {
+                if (!node.createdDate) return -1;
+                const d = new Date(node.createdDate);
+                if (isNaN(d.getTime())) return -1;
+                for (let i = 0; i < buckets.length; i++) {
+                    if (d >= buckets[i].start && d <= buckets[i].end) return i;
+                }
+                return -1;
+            }
+
+            function renderNodes(svg, filteredIds, positions, connectedIds, NS) {
+                const nodeW = 110, nodeH = 44;
+
+                for (const id of filteredIds) {
+                    const node = nodes[id];
+                    const pos = positions[id];
+                    if (!pos) continue;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
+                    const isOrphan = !connectedIds.has(id);
+
+                    const shortTitle = (node.title || '').length > 16
+                        ? node.title.substring(0, 15) + '\u2026'
+                        : (node.title || id);
+
+                    const g = document.createElementNS(NS, 'g');
+                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.dataset.id = id;
+                    g.dataset.path = node.path;
+
+                    const rect = document.createElementNS(NS, 'rect');
+                    rect.setAttribute('x', pos.x);
+                    rect.setAttribute('y', pos.y);
+                    rect.setAttribute('width', nodeW);
+                    rect.setAttribute('height', nodeH);
+                    rect.setAttribute('rx', '4');
+                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
+                    rect.setAttribute('stroke', color);
+                    rect.setAttribute('stroke-width', '1.5');
+                    g.appendChild(rect);
+
+                    const typeText = document.createElementNS(NS, 'text');
+                    typeText.setAttribute('x', pos.x + nodeW / 2);
+                    typeText.setAttribute('y', pos.y + 16);
+                    typeText.setAttribute('text-anchor', 'middle');
+                    typeText.setAttribute('font-size', '11');
+                    typeText.setAttribute('font-weight', '700');
+                    typeText.setAttribute('fill', color);
+                    typeText.textContent = node.type;
+                    g.appendChild(typeText);
+
+                    const titleText = document.createElementNS(NS, 'text');
+                    titleText.setAttribute('x', pos.x + nodeW / 2);
+                    titleText.setAttribute('y', pos.y + 30);
+                    titleText.setAttribute('text-anchor', 'middle');
+                    titleText.setAttribute('font-size', '8');
+                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
+                    titleText.textContent = shortTitle;
+                    g.appendChild(titleText);
+
+                    // Last-modified indicator dot
+                    if (node.lastModified) {
+                        const lmDate = new Date(node.lastModified);
+                        if (!isNaN(lmDate.getTime())) {
+                            const daysAgo = (Date.now() - lmDate.getTime()) / 86400000;
+                            let dotColor = null;
+                            if (daysAgo < 7) dotColor = '#00703c';
+                            else if (daysAgo < 30) dotColor = '#f47738';
+                            if (dotColor) {
+                                const dot = document.createElementNS(NS, 'circle');
+                                dot.setAttribute('cx', pos.x + nodeW - 6);
+                                dot.setAttribute('cy', pos.y + 6);
+                                dot.setAttribute('r', '3');
+                                dot.setAttribute('fill', dotColor);
+                                g.appendChild(dot);
+                            }
+                        }
+                    }
+
+                    // Event listeners
+                    g.addEventListener('mouseenter', () => {
+                        const nodeId = g.dataset.id;
+                        const connNodes = new Set([nodeId]);
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
+                                p.classList.add('highlighted');
+                                connNodes.add(p.dataset.from);
+                                connNodes.add(p.dataset.to);
+                            } else {
+                                p.classList.add('dimmed');
+                            }
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
+                        });
+
+                        const nd = nodes[nodeId];
+                        if (nd) {
+                            const ttTitle = document.createElement('strong');
+                            ttTitle.textContent = nd.title || nodeId;
+                            const ttMeta = document.createElement('span');
+                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
+                            tooltip.textContent = '';
+                            tooltip.appendChild(ttTitle);
+                            tooltip.appendChild(ttMeta);
+                            tooltip.style.display = 'block';
+                            const r = g.getBoundingClientRect();
+                            tooltip.style.left = (r.right + 8) + 'px';
+                            tooltip.style.top = r.top + 'px';
+                        }
+                    });
+
+                    g.addEventListener('mouseleave', () => {
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            p.classList.remove('highlighted', 'dimmed');
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            n.classList.remove('dimmed');
+                        });
+                        tooltip.style.display = 'none';
+                    });
+
+                    g.addEventListener('click', () => {
+                        const docPath = g.dataset.path;
+                        if (docPath) {
+                            tooltip.style.display = 'none';
+                            window.location.hash = docPath;
+                        }
+                    });
+
+                    svg.appendChild(g);
+                }
+            }
+
             function renderGraph(filterProject) {
                 const statsEl = document.getElementById('depmap-stats');
 
@@ -2985,12 +3291,29 @@
                     });
                 }
 
+                // Filter edges to visible nodes
+                const filteredSet = new Set(filteredIds);
+                const visibleEdges = edges.filter(e => {
+                    if (!filteredSet.has(e.from)) return false;
+                    return filteredIds.some(id => id.startsWith(e.to));
+                });
+
+                if (currentLayout === 'timeline') {
+                    renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                } else {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                }
+            }
+
+            function renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+
                 // Layout constants
                 const nodeW = 110, nodeH = 44;
                 const gapX = 16, gapY = 24;
                 const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
                 const labelW = 110, padL = 16, padR = 16, padT = 16;
-                const maxCols = 8; // wrap after this many nodes per row
+                const maxCols = 8;
 
                 // Compute positions with wrapping
                 const positions = {};
@@ -3021,16 +3344,9 @@
                 const svgW = padL + labelW + usedCols * nodeW + (usedCols - 1) * gapX + padR;
                 const svgH = y - gapY + padT;
 
-                // Filter edges to visible nodes
-                const filteredSet = new Set(filteredIds);
-                const visibleEdges = edges.filter(e => {
-                    if (!filteredSet.has(e.from)) return false;
-                    return filteredIds.some(id => id.startsWith(e.to));
-                });
-
                 statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
 
-                // Build SVG using DOM (SVG namespace)
+                // Build SVG
                 const NS = 'http://www.w3.org/2000/svg';
                 const svg = document.createElementNS(NS, 'svg');
                 svg.setAttribute('class', 'app-depmap-svg');
@@ -3088,104 +3404,199 @@
                 }
 
                 // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
+
+                svgWrap.textContent = '';
+                svgWrap.appendChild(svg);
+            }
+
+            function renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+                const bucketResult = computeDateBuckets(filteredIds);
+
+                // Fallback to category if no valid dates
+                if (!bucketResult) {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                    return;
+                }
+
+                const { buckets } = bucketResult;
+
+                // Layout constants
+                const nodeW = 110, nodeH = 44;
+                const gapX = 16, gapY = 24;
+                const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
+                const labelW = 110, padL = 16, padR = 16, padT = 16;
+                const colW = nodeW + gapX;
+                const headerH = 24;
+
+                // Total columns = date buckets + optional "No Date"
+                const hasUndated = filteredIds.some(id => assignNodeToBucket(nodes[id], buckets) === -1);
+                const totalCols = buckets.length + (hasUndated ? 1 : 0);
+
+                // Assign nodes to cells: { catKey: { colIdx: [nodeIds] } }
+                const cells = {};
                 for (const id of filteredIds) {
                     const node = nodes[id];
-                    const pos = positions[id];
-                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
-
-                    const shortTitle = (node.title || '').length > 16
-                        ? node.title.substring(0, 15) + '\u2026'
-                        : (node.title || id);
-
-                    const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
-                    g.dataset.id = id;
-                    g.dataset.path = node.path;
-
-                    const rect = document.createElementNS(NS, 'rect');
-                    rect.setAttribute('x', pos.x);
-                    rect.setAttribute('y', pos.y);
-                    rect.setAttribute('width', nodeW);
-                    rect.setAttribute('height', nodeH);
-                    rect.setAttribute('rx', '4');
-                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
-                    rect.setAttribute('stroke', color);
-                    rect.setAttribute('stroke-width', '1.5');
-                    g.appendChild(rect);
-
-                    const typeText = document.createElementNS(NS, 'text');
-                    typeText.setAttribute('x', pos.x + nodeW / 2);
-                    typeText.setAttribute('y', pos.y + 16);
-                    typeText.setAttribute('text-anchor', 'middle');
-                    typeText.setAttribute('font-size', '11');
-                    typeText.setAttribute('font-weight', '700');
-                    typeText.setAttribute('fill', color);
-                    typeText.textContent = node.type;
-                    g.appendChild(typeText);
-
-                    const titleText = document.createElementNS(NS, 'text');
-                    titleText.setAttribute('x', pos.x + nodeW / 2);
-                    titleText.setAttribute('y', pos.y + 30);
-                    titleText.setAttribute('text-anchor', 'middle');
-                    titleText.setAttribute('font-size', '8');
-                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
-                    titleText.textContent = shortTitle;
-                    g.appendChild(titleText);
-
-                    // Event listeners
-                    g.addEventListener('mouseenter', () => {
-                        const nodeId = g.dataset.id;
-                        const connNodes = new Set([nodeId]);
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
-                                p.classList.add('highlighted');
-                                connNodes.add(p.dataset.from);
-                                connNodes.add(p.dataset.to);
-                            } else {
-                                p.classList.add('dimmed');
-                            }
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
-                        });
-
-                        const nd = nodes[nodeId];
-                        if (nd) {
-                            const ttTitle = document.createElement('strong');
-                            ttTitle.textContent = nd.title || nodeId;
-                            const ttMeta = document.createElement('span');
-                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
-                            tooltip.textContent = '';
-                            tooltip.appendChild(ttTitle);
-                            tooltip.appendChild(ttMeta);
-                            tooltip.style.display = 'block';
-                            const r = g.getBoundingClientRect();
-                            tooltip.style.left = (r.right + 8) + 'px';
-                            tooltip.style.top = r.top + 'px';
-                        }
-                    });
-
-                    g.addEventListener('mouseleave', () => {
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            p.classList.remove('highlighted', 'dimmed');
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            n.classList.remove('dimmed');
-                        });
-                        tooltip.style.display = 'none';
-                    });
-
-                    g.addEventListener('click', () => {
-                        const docPath = g.dataset.path;
-                        if (docPath) {
-                            tooltip.style.display = 'none';
-                            window.location.hash = docPath;
-                        }
-                    });
-
-                    svg.appendChild(g);
+                    const cat = (node.type && TYPE_CATEGORIES[node.type]) || 'Other';
+                    const colIdx = assignNodeToBucket(node, buckets);
+                    const actualCol = colIdx === -1 ? buckets.length : colIdx;
+                    if (!cells[cat]) cells[cat] = {};
+                    if (!cells[cat][actualCol]) cells[cat][actualCol] = [];
+                    cells[cat][actualCol].push(id);
                 }
+
+                // Sort within each cell by project then type
+                for (const cat of Object.keys(cells)) {
+                    for (const col of Object.keys(cells[cat])) {
+                        cells[cat][col].sort((a, b) => {
+                            const na = nodes[a], nb = nodes[b];
+                            return (na.project || '').localeCompare(nb.project || '') || (na.type || '').localeCompare(nb.type || '');
+                        });
+                    }
+                }
+
+                // Compute row heights (expand for stacked nodes)
+                const positions = {};
+                let y = padT + headerH;
+                const rowBands = [];
+
+                for (const cat of CATEGORY_ORDER) {
+                    if (!catGroups[cat] || catGroups[cat].length === 0) continue;
+
+                    // Find max stack in any column for this category
+                    let maxStack = 1;
+                    if (cells[cat]) {
+                        for (const col of Object.keys(cells[cat])) {
+                            maxStack = Math.max(maxStack, cells[cat][col].length);
+                        }
+                    }
+
+                    const numRows = maxStack;
+                    const rowH = rowPadTop + numRows * nodeH + (numRows - 1) * rowGapY + rowPadBot;
+                    rowBands.push({ cat, y, h: rowH });
+
+                    // Position nodes
+                    if (cells[cat]) {
+                        for (const [colStr, ids] of Object.entries(cells[cat])) {
+                            const col = parseInt(colStr, 10);
+                            for (let i = 0; i < ids.length; i++) {
+                                positions[ids[i]] = {
+                                    x: padL + labelW + col * colW,
+                                    y: y + rowPadTop + i * (nodeH + rowGapY),
+                                };
+                            }
+                        }
+                    }
+
+                    y += rowH + gapY;
+                }
+
+                const svgW = padL + labelW + totalCols * colW + padR;
+                const svgH = y - gapY + padT;
+
+                statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
+
+                // Build SVG
+                const NS = 'http://www.w3.org/2000/svg';
+                const svg = document.createElementNS(NS, 'svg');
+                svg.setAttribute('class', 'app-depmap-svg');
+                svg.setAttribute('viewBox', '0 0 ' + svgW + ' ' + svgH);
+                svg.setAttribute('width', svgW);
+                svg.setAttribute('height', svgH);
+
+                // Column headers
+                for (let i = 0; i < buckets.length; i++) {
+                    const cx = padL + labelW + i * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', 'var(--text-secondary, #666)');
+                    hdr.textContent = buckets[i].label;
+                    svg.appendChild(hdr);
+                }
+
+                // "No Date" header
+                if (hasUndated) {
+                    const cx = padL + labelW + buckets.length * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', '#b1b4b6');
+                    hdr.textContent = 'No Date';
+                    svg.appendChild(hdr);
+                }
+
+                // Column separator lines
+                for (let i = 1; i < totalCols; i++) {
+                    const lx = padL + labelW + i * colW - gapX / 2;
+                    const line = document.createElementNS(NS, 'line');
+                    line.setAttribute('x1', lx);
+                    line.setAttribute('y1', padT + headerH);
+                    line.setAttribute('x2', lx);
+                    line.setAttribute('y2', svgH - padT);
+                    line.setAttribute('stroke', 'var(--border-main, #e8e8e8)');
+                    line.setAttribute('stroke-width', '1');
+                    line.setAttribute('opacity', '0.3');
+                    svg.appendChild(line);
+                }
+
+                // Row backgrounds
+                for (const band of rowBands) {
+                    const color = CATEGORY_COLORS[band.cat] || CATEGORY_COLORS.Other;
+                    const bg = document.createElementNS(NS, 'rect');
+                    bg.setAttribute('x', 0);
+                    bg.setAttribute('y', band.y);
+                    bg.setAttribute('width', svgW);
+                    bg.setAttribute('height', band.h);
+                    bg.setAttribute('fill', color);
+                    bg.setAttribute('opacity', '0.06');
+                    bg.setAttribute('rx', '4');
+                    svg.appendChild(bg);
+
+                    const lbl = document.createElementNS(NS, 'text');
+                    lbl.setAttribute('x', padL);
+                    lbl.setAttribute('y', band.y + 18);
+                    lbl.setAttribute('font-size', '11');
+                    lbl.setAttribute('font-weight', '700');
+                    lbl.setAttribute('fill', color);
+                    lbl.textContent = band.cat;
+                    svg.appendChild(lbl);
+                }
+
+                // Edges
+                for (const e of visibleEdges) {
+                    const fromPos = positions[e.from];
+                    if (!fromPos) continue;
+                    const toId = filteredIds.find(id => id.startsWith(e.to));
+                    if (!toId) continue;
+                    const toPos = positions[toId];
+                    if (!toPos) continue;
+
+                    const x1 = fromPos.x + nodeW / 2;
+                    const y1 = fromPos.y + nodeH;
+                    const x2 = toPos.x + nodeW / 2;
+                    const y2 = toPos.y;
+                    const dy = Math.abs(y2 - y1) * 0.4;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[nodes[e.from].type] || 'Other'] || CATEGORY_COLORS.Other;
+
+                    const path = document.createElementNS(NS, 'path');
+                    path.setAttribute('class', 'app-depmap-edge');
+                    path.dataset.from = e.from;
+                    path.dataset.to = toId;
+                    path.setAttribute('d', 'M' + x1 + ',' + y1 + ' C' + x1 + ',' + (y1 + dy) + ' ' + x2 + ',' + (y2 - dy) + ' ' + x2 + ',' + y2);
+                    path.setAttribute('stroke', color);
+                    svg.appendChild(path);
+                }
+
+                // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
 
                 svgWrap.textContent = '';
                 svgWrap.appendChild(svg);

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -1642,6 +1642,31 @@
             color: var(--text-secondary);
             font-size: 16px;
         }
+        .app-depmap-layout-toggle {
+            display: inline-flex;
+            border: 1px solid var(--border-main);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .app-depmap-layout-toggle button {
+            border: none;
+            background: var(--bg-surface);
+            color: var(--text-primary);
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            cursor: pointer;
+        }
+        .app-depmap-layout-toggle button:not(:last-child) {
+            border-right: 1px solid var(--border-main);
+        }
+        .app-depmap-layout-toggle button.active {
+            background: var(--text-primary);
+            color: var(--bg-surface);
+        }
+        .app-depmap-layout-toggle button:hover:not(.active) {
+            background: var(--bg-surface-alt);
+        }
     </style>
 </head>
 <body class="govuk-template__body">
@@ -2876,9 +2901,21 @@
             const projects = [...projectSet].sort();
 
             const CATEGORY_ORDER = [
-                'Discovery', 'Planning', 'Architecture', 'Governance',
-                'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'
+                'Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance',
+                'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other'
             ];
+
+            // Check if any nodes have valid dates (for timeline toggle)
+            const hasValidDates = nodeIds.some(id => {
+                const d = nodes[id].createdDate;
+                return d && !isNaN(new Date(d).getTime());
+            });
+
+            let currentLayout = 'category';
+            if (hasValidDates) {
+                const stored = localStorage.getItem('arckit-depmap-layout');
+                if (stored === 'timeline') currentLayout = 'timeline';
+            }
 
             // Build controls DOM
             content.textContent = '';
@@ -2891,6 +2928,45 @@
 
             const controls = document.createElement('div');
             controls.className = 'app-depmap-controls';
+
+            const layoutLabel = document.createElement('label');
+            layoutLabel.textContent = 'Layout:';
+            layoutLabel.style.cssText = 'font-size:14px;font-weight:700;color:var(--text-primary)';
+            controls.appendChild(layoutLabel);
+
+            const toggleWrap = document.createElement('div');
+            toggleWrap.className = 'app-depmap-layout-toggle';
+
+            const btnCategory = document.createElement('button');
+            btnCategory.textContent = 'Category';
+            btnCategory.className = currentLayout === 'category' ? 'active' : '';
+            toggleWrap.appendChild(btnCategory);
+
+            if (hasValidDates) {
+                const btnTimeline = document.createElement('button');
+                btnTimeline.textContent = 'Timeline';
+                btnTimeline.className = currentLayout === 'timeline' ? 'active' : '';
+                toggleWrap.appendChild(btnTimeline);
+
+                btnTimeline.addEventListener('click', () => {
+                    currentLayout = 'timeline';
+                    localStorage.setItem('arckit-depmap-layout', 'timeline');
+                    btnCategory.className = '';
+                    btnTimeline.className = 'active';
+                    renderGraph(select.value);
+                });
+            }
+
+            btnCategory.addEventListener('click', () => {
+                currentLayout = 'category';
+                localStorage.setItem('arckit-depmap-layout', 'category');
+                btnCategory.className = 'active';
+                const btnT = toggleWrap.querySelector('button:nth-child(2)');
+                if (btnT) btnT.className = '';
+                renderGraph(select.value);
+            });
+
+            controls.appendChild(toggleWrap);
 
             const label = document.createElement('label');
             label.setAttribute('for', 'depmap-project-filter');
@@ -2949,6 +3025,236 @@
             tooltip.style.display = 'none';
             document.body.appendChild(tooltip);
 
+            // ── Timeline utilities ──
+            function computeDateBuckets(filteredIds) {
+                const validDates = [];
+                for (const id of filteredIds) {
+                    const d = nodes[id].createdDate;
+                    if (!d) continue;
+                    const parsed = new Date(d);
+                    if (isNaN(parsed.getTime())) continue;
+                    validDates.push(parsed);
+                }
+                if (validDates.length === 0) return null;
+
+                validDates.sort((a, b) => a - b);
+                const minDate = validDates[0];
+                const maxDate = validDates[validDates.length - 1];
+                const rangeDays = (maxDate - minDate) / 86400000;
+
+                let granularity, buckets;
+
+                if (rangeDays < 90) {
+                    granularity = 'weekly';
+                    buckets = generateWeeklyBuckets(minDate, maxDate);
+                } else if (rangeDays <= 547) {
+                    granularity = 'monthly';
+                    buckets = generateMonthlyBuckets(minDate, maxDate);
+                } else {
+                    granularity = 'quarterly';
+                    buckets = generateQuarterlyBuckets(minDate, maxDate);
+                }
+
+                return { granularity, buckets };
+            }
+
+            function generateWeeklyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                const start = new Date(minDate);
+                const day = start.getDay();
+                const diff = day === 0 ? -6 : 1 - day;
+                start.setDate(start.getDate() + diff);
+                start.setHours(0, 0, 0, 0);
+
+                const end = new Date(maxDate);
+                end.setHours(23, 59, 59, 999);
+
+                let current = new Date(start);
+                while (current <= end) {
+                    const weekStart = new Date(current);
+                    const weekEnd = new Date(current);
+                    weekEnd.setDate(weekEnd.getDate() + 6);
+                    weekEnd.setHours(23, 59, 59, 999);
+
+                    const weekNum = Math.ceil(weekStart.getDate() / 7);
+                    const label = 'W' + weekNum + ' ' + MONTHS[weekStart.getMonth()];
+
+                    buckets.push({ label, start: weekStart, end: weekEnd });
+                    current.setDate(current.getDate() + 7);
+                }
+                return buckets;
+            }
+
+            function generateMonthlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                let y = minDate.getFullYear(), m = minDate.getMonth();
+                const endY = maxDate.getFullYear(), endM = maxDate.getMonth();
+
+                while (y < endY || (y === endY && m <= endM)) {
+                    const start = new Date(y, m, 1);
+                    const end = new Date(y, m + 1, 0, 23, 59, 59, 999);
+                    const label = MONTHS[m] + ' ' + y;
+                    buckets.push({ label, start, end });
+                    m++;
+                    if (m > 11) { m = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function generateQuarterlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                let y = minDate.getFullYear();
+                let q = Math.floor(minDate.getMonth() / 3);
+                const endY = maxDate.getFullYear();
+                const endQ = Math.floor(maxDate.getMonth() / 3);
+
+                while (y < endY || (y === endY && q <= endQ)) {
+                    const startMonth = q * 3;
+                    const start = new Date(y, startMonth, 1);
+                    const end = new Date(y, startMonth + 3, 0, 23, 59, 59, 999);
+                    const label = 'Q' + (q + 1) + ' ' + y;
+                    buckets.push({ label, start, end });
+                    q++;
+                    if (q > 3) { q = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function assignNodeToBucket(node, buckets) {
+                if (!node.createdDate) return -1;
+                const d = new Date(node.createdDate);
+                if (isNaN(d.getTime())) return -1;
+                for (let i = 0; i < buckets.length; i++) {
+                    if (d >= buckets[i].start && d <= buckets[i].end) return i;
+                }
+                return -1;
+            }
+
+            function renderNodes(svg, filteredIds, positions, connectedIds, NS) {
+                const nodeW = 110, nodeH = 44;
+
+                for (const id of filteredIds) {
+                    const node = nodes[id];
+                    const pos = positions[id];
+                    if (!pos) continue;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
+                    const isOrphan = !connectedIds.has(id);
+
+                    const shortTitle = (node.title || '').length > 16
+                        ? node.title.substring(0, 15) + '\u2026'
+                        : (node.title || id);
+
+                    const g = document.createElementNS(NS, 'g');
+                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.dataset.id = id;
+                    g.dataset.path = node.path;
+
+                    const rect = document.createElementNS(NS, 'rect');
+                    rect.setAttribute('x', pos.x);
+                    rect.setAttribute('y', pos.y);
+                    rect.setAttribute('width', nodeW);
+                    rect.setAttribute('height', nodeH);
+                    rect.setAttribute('rx', '4');
+                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
+                    rect.setAttribute('stroke', color);
+                    rect.setAttribute('stroke-width', '1.5');
+                    g.appendChild(rect);
+
+                    const typeText = document.createElementNS(NS, 'text');
+                    typeText.setAttribute('x', pos.x + nodeW / 2);
+                    typeText.setAttribute('y', pos.y + 16);
+                    typeText.setAttribute('text-anchor', 'middle');
+                    typeText.setAttribute('font-size', '11');
+                    typeText.setAttribute('font-weight', '700');
+                    typeText.setAttribute('fill', color);
+                    typeText.textContent = node.type;
+                    g.appendChild(typeText);
+
+                    const titleText = document.createElementNS(NS, 'text');
+                    titleText.setAttribute('x', pos.x + nodeW / 2);
+                    titleText.setAttribute('y', pos.y + 30);
+                    titleText.setAttribute('text-anchor', 'middle');
+                    titleText.setAttribute('font-size', '8');
+                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
+                    titleText.textContent = shortTitle;
+                    g.appendChild(titleText);
+
+                    // Last-modified indicator dot
+                    if (node.lastModified) {
+                        const lmDate = new Date(node.lastModified);
+                        if (!isNaN(lmDate.getTime())) {
+                            const daysAgo = (Date.now() - lmDate.getTime()) / 86400000;
+                            let dotColor = null;
+                            if (daysAgo < 7) dotColor = '#00703c';
+                            else if (daysAgo < 30) dotColor = '#f47738';
+                            if (dotColor) {
+                                const dot = document.createElementNS(NS, 'circle');
+                                dot.setAttribute('cx', pos.x + nodeW - 6);
+                                dot.setAttribute('cy', pos.y + 6);
+                                dot.setAttribute('r', '3');
+                                dot.setAttribute('fill', dotColor);
+                                g.appendChild(dot);
+                            }
+                        }
+                    }
+
+                    // Event listeners
+                    g.addEventListener('mouseenter', () => {
+                        const nodeId = g.dataset.id;
+                        const connNodes = new Set([nodeId]);
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
+                                p.classList.add('highlighted');
+                                connNodes.add(p.dataset.from);
+                                connNodes.add(p.dataset.to);
+                            } else {
+                                p.classList.add('dimmed');
+                            }
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
+                        });
+
+                        const nd = nodes[nodeId];
+                        if (nd) {
+                            const ttTitle = document.createElement('strong');
+                            ttTitle.textContent = nd.title || nodeId;
+                            const ttMeta = document.createElement('span');
+                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
+                            tooltip.textContent = '';
+                            tooltip.appendChild(ttTitle);
+                            tooltip.appendChild(ttMeta);
+                            tooltip.style.display = 'block';
+                            const r = g.getBoundingClientRect();
+                            tooltip.style.left = (r.right + 8) + 'px';
+                            tooltip.style.top = r.top + 'px';
+                        }
+                    });
+
+                    g.addEventListener('mouseleave', () => {
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            p.classList.remove('highlighted', 'dimmed');
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            n.classList.remove('dimmed');
+                        });
+                        tooltip.style.display = 'none';
+                    });
+
+                    g.addEventListener('click', () => {
+                        const docPath = g.dataset.path;
+                        if (docPath) {
+                            tooltip.style.display = 'none';
+                            window.location.hash = docPath;
+                        }
+                    });
+
+                    svg.appendChild(g);
+                }
+            }
+
             function renderGraph(filterProject) {
                 const statsEl = document.getElementById('depmap-stats');
 
@@ -2985,12 +3291,29 @@
                     });
                 }
 
+                // Filter edges to visible nodes
+                const filteredSet = new Set(filteredIds);
+                const visibleEdges = edges.filter(e => {
+                    if (!filteredSet.has(e.from)) return false;
+                    return filteredIds.some(id => id.startsWith(e.to));
+                });
+
+                if (currentLayout === 'timeline') {
+                    renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                } else {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                }
+            }
+
+            function renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+
                 // Layout constants
                 const nodeW = 110, nodeH = 44;
                 const gapX = 16, gapY = 24;
                 const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
                 const labelW = 110, padL = 16, padR = 16, padT = 16;
-                const maxCols = 8; // wrap after this many nodes per row
+                const maxCols = 8;
 
                 // Compute positions with wrapping
                 const positions = {};
@@ -3021,16 +3344,9 @@
                 const svgW = padL + labelW + usedCols * nodeW + (usedCols - 1) * gapX + padR;
                 const svgH = y - gapY + padT;
 
-                // Filter edges to visible nodes
-                const filteredSet = new Set(filteredIds);
-                const visibleEdges = edges.filter(e => {
-                    if (!filteredSet.has(e.from)) return false;
-                    return filteredIds.some(id => id.startsWith(e.to));
-                });
-
                 statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
 
-                // Build SVG using DOM (SVG namespace)
+                // Build SVG
                 const NS = 'http://www.w3.org/2000/svg';
                 const svg = document.createElementNS(NS, 'svg');
                 svg.setAttribute('class', 'app-depmap-svg');
@@ -3088,104 +3404,199 @@
                 }
 
                 // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
+
+                svgWrap.textContent = '';
+                svgWrap.appendChild(svg);
+            }
+
+            function renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+                const bucketResult = computeDateBuckets(filteredIds);
+
+                // Fallback to category if no valid dates
+                if (!bucketResult) {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                    return;
+                }
+
+                const { buckets } = bucketResult;
+
+                // Layout constants
+                const nodeW = 110, nodeH = 44;
+                const gapX = 16, gapY = 24;
+                const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
+                const labelW = 110, padL = 16, padR = 16, padT = 16;
+                const colW = nodeW + gapX;
+                const headerH = 24;
+
+                // Total columns = date buckets + optional "No Date"
+                const hasUndated = filteredIds.some(id => assignNodeToBucket(nodes[id], buckets) === -1);
+                const totalCols = buckets.length + (hasUndated ? 1 : 0);
+
+                // Assign nodes to cells: { catKey: { colIdx: [nodeIds] } }
+                const cells = {};
                 for (const id of filteredIds) {
                     const node = nodes[id];
-                    const pos = positions[id];
-                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
-
-                    const shortTitle = (node.title || '').length > 16
-                        ? node.title.substring(0, 15) + '\u2026'
-                        : (node.title || id);
-
-                    const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
-                    g.dataset.id = id;
-                    g.dataset.path = node.path;
-
-                    const rect = document.createElementNS(NS, 'rect');
-                    rect.setAttribute('x', pos.x);
-                    rect.setAttribute('y', pos.y);
-                    rect.setAttribute('width', nodeW);
-                    rect.setAttribute('height', nodeH);
-                    rect.setAttribute('rx', '4');
-                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
-                    rect.setAttribute('stroke', color);
-                    rect.setAttribute('stroke-width', '1.5');
-                    g.appendChild(rect);
-
-                    const typeText = document.createElementNS(NS, 'text');
-                    typeText.setAttribute('x', pos.x + nodeW / 2);
-                    typeText.setAttribute('y', pos.y + 16);
-                    typeText.setAttribute('text-anchor', 'middle');
-                    typeText.setAttribute('font-size', '11');
-                    typeText.setAttribute('font-weight', '700');
-                    typeText.setAttribute('fill', color);
-                    typeText.textContent = node.type;
-                    g.appendChild(typeText);
-
-                    const titleText = document.createElementNS(NS, 'text');
-                    titleText.setAttribute('x', pos.x + nodeW / 2);
-                    titleText.setAttribute('y', pos.y + 30);
-                    titleText.setAttribute('text-anchor', 'middle');
-                    titleText.setAttribute('font-size', '8');
-                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
-                    titleText.textContent = shortTitle;
-                    g.appendChild(titleText);
-
-                    // Event listeners
-                    g.addEventListener('mouseenter', () => {
-                        const nodeId = g.dataset.id;
-                        const connNodes = new Set([nodeId]);
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
-                                p.classList.add('highlighted');
-                                connNodes.add(p.dataset.from);
-                                connNodes.add(p.dataset.to);
-                            } else {
-                                p.classList.add('dimmed');
-                            }
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
-                        });
-
-                        const nd = nodes[nodeId];
-                        if (nd) {
-                            const ttTitle = document.createElement('strong');
-                            ttTitle.textContent = nd.title || nodeId;
-                            const ttMeta = document.createElement('span');
-                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
-                            tooltip.textContent = '';
-                            tooltip.appendChild(ttTitle);
-                            tooltip.appendChild(ttMeta);
-                            tooltip.style.display = 'block';
-                            const r = g.getBoundingClientRect();
-                            tooltip.style.left = (r.right + 8) + 'px';
-                            tooltip.style.top = r.top + 'px';
-                        }
-                    });
-
-                    g.addEventListener('mouseleave', () => {
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            p.classList.remove('highlighted', 'dimmed');
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            n.classList.remove('dimmed');
-                        });
-                        tooltip.style.display = 'none';
-                    });
-
-                    g.addEventListener('click', () => {
-                        const docPath = g.dataset.path;
-                        if (docPath) {
-                            tooltip.style.display = 'none';
-                            window.location.hash = docPath;
-                        }
-                    });
-
-                    svg.appendChild(g);
+                    const cat = (node.type && TYPE_CATEGORIES[node.type]) || 'Other';
+                    const colIdx = assignNodeToBucket(node, buckets);
+                    const actualCol = colIdx === -1 ? buckets.length : colIdx;
+                    if (!cells[cat]) cells[cat] = {};
+                    if (!cells[cat][actualCol]) cells[cat][actualCol] = [];
+                    cells[cat][actualCol].push(id);
                 }
+
+                // Sort within each cell by project then type
+                for (const cat of Object.keys(cells)) {
+                    for (const col of Object.keys(cells[cat])) {
+                        cells[cat][col].sort((a, b) => {
+                            const na = nodes[a], nb = nodes[b];
+                            return (na.project || '').localeCompare(nb.project || '') || (na.type || '').localeCompare(nb.type || '');
+                        });
+                    }
+                }
+
+                // Compute row heights (expand for stacked nodes)
+                const positions = {};
+                let y = padT + headerH;
+                const rowBands = [];
+
+                for (const cat of CATEGORY_ORDER) {
+                    if (!catGroups[cat] || catGroups[cat].length === 0) continue;
+
+                    // Find max stack in any column for this category
+                    let maxStack = 1;
+                    if (cells[cat]) {
+                        for (const col of Object.keys(cells[cat])) {
+                            maxStack = Math.max(maxStack, cells[cat][col].length);
+                        }
+                    }
+
+                    const numRows = maxStack;
+                    const rowH = rowPadTop + numRows * nodeH + (numRows - 1) * rowGapY + rowPadBot;
+                    rowBands.push({ cat, y, h: rowH });
+
+                    // Position nodes
+                    if (cells[cat]) {
+                        for (const [colStr, ids] of Object.entries(cells[cat])) {
+                            const col = parseInt(colStr, 10);
+                            for (let i = 0; i < ids.length; i++) {
+                                positions[ids[i]] = {
+                                    x: padL + labelW + col * colW,
+                                    y: y + rowPadTop + i * (nodeH + rowGapY),
+                                };
+                            }
+                        }
+                    }
+
+                    y += rowH + gapY;
+                }
+
+                const svgW = padL + labelW + totalCols * colW + padR;
+                const svgH = y - gapY + padT;
+
+                statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
+
+                // Build SVG
+                const NS = 'http://www.w3.org/2000/svg';
+                const svg = document.createElementNS(NS, 'svg');
+                svg.setAttribute('class', 'app-depmap-svg');
+                svg.setAttribute('viewBox', '0 0 ' + svgW + ' ' + svgH);
+                svg.setAttribute('width', svgW);
+                svg.setAttribute('height', svgH);
+
+                // Column headers
+                for (let i = 0; i < buckets.length; i++) {
+                    const cx = padL + labelW + i * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', 'var(--text-secondary, #666)');
+                    hdr.textContent = buckets[i].label;
+                    svg.appendChild(hdr);
+                }
+
+                // "No Date" header
+                if (hasUndated) {
+                    const cx = padL + labelW + buckets.length * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', '#b1b4b6');
+                    hdr.textContent = 'No Date';
+                    svg.appendChild(hdr);
+                }
+
+                // Column separator lines
+                for (let i = 1; i < totalCols; i++) {
+                    const lx = padL + labelW + i * colW - gapX / 2;
+                    const line = document.createElementNS(NS, 'line');
+                    line.setAttribute('x1', lx);
+                    line.setAttribute('y1', padT + headerH);
+                    line.setAttribute('x2', lx);
+                    line.setAttribute('y2', svgH - padT);
+                    line.setAttribute('stroke', 'var(--border-main, #e8e8e8)');
+                    line.setAttribute('stroke-width', '1');
+                    line.setAttribute('opacity', '0.3');
+                    svg.appendChild(line);
+                }
+
+                // Row backgrounds
+                for (const band of rowBands) {
+                    const color = CATEGORY_COLORS[band.cat] || CATEGORY_COLORS.Other;
+                    const bg = document.createElementNS(NS, 'rect');
+                    bg.setAttribute('x', 0);
+                    bg.setAttribute('y', band.y);
+                    bg.setAttribute('width', svgW);
+                    bg.setAttribute('height', band.h);
+                    bg.setAttribute('fill', color);
+                    bg.setAttribute('opacity', '0.06');
+                    bg.setAttribute('rx', '4');
+                    svg.appendChild(bg);
+
+                    const lbl = document.createElementNS(NS, 'text');
+                    lbl.setAttribute('x', padL);
+                    lbl.setAttribute('y', band.y + 18);
+                    lbl.setAttribute('font-size', '11');
+                    lbl.setAttribute('font-weight', '700');
+                    lbl.setAttribute('fill', color);
+                    lbl.textContent = band.cat;
+                    svg.appendChild(lbl);
+                }
+
+                // Edges
+                for (const e of visibleEdges) {
+                    const fromPos = positions[e.from];
+                    if (!fromPos) continue;
+                    const toId = filteredIds.find(id => id.startsWith(e.to));
+                    if (!toId) continue;
+                    const toPos = positions[toId];
+                    if (!toPos) continue;
+
+                    const x1 = fromPos.x + nodeW / 2;
+                    const y1 = fromPos.y + nodeH;
+                    const x2 = toPos.x + nodeW / 2;
+                    const y2 = toPos.y;
+                    const dy = Math.abs(y2 - y1) * 0.4;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[nodes[e.from].type] || 'Other'] || CATEGORY_COLORS.Other;
+
+                    const path = document.createElementNS(NS, 'path');
+                    path.setAttribute('class', 'app-depmap-edge');
+                    path.dataset.from = e.from;
+                    path.dataset.to = toId;
+                    path.setAttribute('d', 'M' + x1 + ',' + y1 + ' C' + x1 + ',' + (y1 + dy) + ' ' + x2 + ',' + (y2 - dy) + ' ' + x2 + ',' + y2);
+                    path.setAttribute('stroke', color);
+                    svg.appendChild(path);
+                }
+
+                // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
 
                 svgWrap.textContent = '';
                 svgWrap.appendChild(svg);

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -1642,6 +1642,31 @@
             color: var(--text-secondary);
             font-size: 16px;
         }
+        .app-depmap-layout-toggle {
+            display: inline-flex;
+            border: 1px solid var(--border-main);
+            border-radius: 4px;
+            overflow: hidden;
+        }
+        .app-depmap-layout-toggle button {
+            border: none;
+            background: var(--bg-surface);
+            color: var(--text-primary);
+            font-size: 12px;
+            font-weight: 600;
+            padding: 4px 12px;
+            cursor: pointer;
+        }
+        .app-depmap-layout-toggle button:not(:last-child) {
+            border-right: 1px solid var(--border-main);
+        }
+        .app-depmap-layout-toggle button.active {
+            background: var(--text-primary);
+            color: var(--bg-surface);
+        }
+        .app-depmap-layout-toggle button:hover:not(.active) {
+            background: var(--bg-surface-alt);
+        }
     </style>
 </head>
 <body class="govuk-template__body">
@@ -2876,9 +2901,21 @@
             const projects = [...projectSet].sort();
 
             const CATEGORY_ORDER = [
-                'Discovery', 'Planning', 'Architecture', 'Governance',
-                'Compliance', 'Operations', 'Procurement', 'Research', 'Reporting', 'Other'
+                'Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance',
+                'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other'
             ];
+
+            // Check if any nodes have valid dates (for timeline toggle)
+            const hasValidDates = nodeIds.some(id => {
+                const d = nodes[id].createdDate;
+                return d && !isNaN(new Date(d).getTime());
+            });
+
+            let currentLayout = 'category';
+            if (hasValidDates) {
+                const stored = localStorage.getItem('arckit-depmap-layout');
+                if (stored === 'timeline') currentLayout = 'timeline';
+            }
 
             // Build controls DOM
             content.textContent = '';
@@ -2891,6 +2928,45 @@
 
             const controls = document.createElement('div');
             controls.className = 'app-depmap-controls';
+
+            const layoutLabel = document.createElement('label');
+            layoutLabel.textContent = 'Layout:';
+            layoutLabel.style.cssText = 'font-size:14px;font-weight:700;color:var(--text-primary)';
+            controls.appendChild(layoutLabel);
+
+            const toggleWrap = document.createElement('div');
+            toggleWrap.className = 'app-depmap-layout-toggle';
+
+            const btnCategory = document.createElement('button');
+            btnCategory.textContent = 'Category';
+            btnCategory.className = currentLayout === 'category' ? 'active' : '';
+            toggleWrap.appendChild(btnCategory);
+
+            if (hasValidDates) {
+                const btnTimeline = document.createElement('button');
+                btnTimeline.textContent = 'Timeline';
+                btnTimeline.className = currentLayout === 'timeline' ? 'active' : '';
+                toggleWrap.appendChild(btnTimeline);
+
+                btnTimeline.addEventListener('click', () => {
+                    currentLayout = 'timeline';
+                    localStorage.setItem('arckit-depmap-layout', 'timeline');
+                    btnCategory.className = '';
+                    btnTimeline.className = 'active';
+                    renderGraph(select.value);
+                });
+            }
+
+            btnCategory.addEventListener('click', () => {
+                currentLayout = 'category';
+                localStorage.setItem('arckit-depmap-layout', 'category');
+                btnCategory.className = 'active';
+                const btnT = toggleWrap.querySelector('button:nth-child(2)');
+                if (btnT) btnT.className = '';
+                renderGraph(select.value);
+            });
+
+            controls.appendChild(toggleWrap);
 
             const label = document.createElement('label');
             label.setAttribute('for', 'depmap-project-filter');
@@ -2949,6 +3025,236 @@
             tooltip.style.display = 'none';
             document.body.appendChild(tooltip);
 
+            // ── Timeline utilities ──
+            function computeDateBuckets(filteredIds) {
+                const validDates = [];
+                for (const id of filteredIds) {
+                    const d = nodes[id].createdDate;
+                    if (!d) continue;
+                    const parsed = new Date(d);
+                    if (isNaN(parsed.getTime())) continue;
+                    validDates.push(parsed);
+                }
+                if (validDates.length === 0) return null;
+
+                validDates.sort((a, b) => a - b);
+                const minDate = validDates[0];
+                const maxDate = validDates[validDates.length - 1];
+                const rangeDays = (maxDate - minDate) / 86400000;
+
+                let granularity, buckets;
+
+                if (rangeDays < 90) {
+                    granularity = 'weekly';
+                    buckets = generateWeeklyBuckets(minDate, maxDate);
+                } else if (rangeDays <= 547) {
+                    granularity = 'monthly';
+                    buckets = generateMonthlyBuckets(minDate, maxDate);
+                } else {
+                    granularity = 'quarterly';
+                    buckets = generateQuarterlyBuckets(minDate, maxDate);
+                }
+
+                return { granularity, buckets };
+            }
+
+            function generateWeeklyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                const start = new Date(minDate);
+                const day = start.getDay();
+                const diff = day === 0 ? -6 : 1 - day;
+                start.setDate(start.getDate() + diff);
+                start.setHours(0, 0, 0, 0);
+
+                const end = new Date(maxDate);
+                end.setHours(23, 59, 59, 999);
+
+                let current = new Date(start);
+                while (current <= end) {
+                    const weekStart = new Date(current);
+                    const weekEnd = new Date(current);
+                    weekEnd.setDate(weekEnd.getDate() + 6);
+                    weekEnd.setHours(23, 59, 59, 999);
+
+                    const weekNum = Math.ceil(weekStart.getDate() / 7);
+                    const label = 'W' + weekNum + ' ' + MONTHS[weekStart.getMonth()];
+
+                    buckets.push({ label, start: weekStart, end: weekEnd });
+                    current.setDate(current.getDate() + 7);
+                }
+                return buckets;
+            }
+
+            function generateMonthlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                const MONTHS = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+                let y = minDate.getFullYear(), m = minDate.getMonth();
+                const endY = maxDate.getFullYear(), endM = maxDate.getMonth();
+
+                while (y < endY || (y === endY && m <= endM)) {
+                    const start = new Date(y, m, 1);
+                    const end = new Date(y, m + 1, 0, 23, 59, 59, 999);
+                    const label = MONTHS[m] + ' ' + y;
+                    buckets.push({ label, start, end });
+                    m++;
+                    if (m > 11) { m = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function generateQuarterlyBuckets(minDate, maxDate) {
+                const buckets = [];
+                let y = minDate.getFullYear();
+                let q = Math.floor(minDate.getMonth() / 3);
+                const endY = maxDate.getFullYear();
+                const endQ = Math.floor(maxDate.getMonth() / 3);
+
+                while (y < endY || (y === endY && q <= endQ)) {
+                    const startMonth = q * 3;
+                    const start = new Date(y, startMonth, 1);
+                    const end = new Date(y, startMonth + 3, 0, 23, 59, 59, 999);
+                    const label = 'Q' + (q + 1) + ' ' + y;
+                    buckets.push({ label, start, end });
+                    q++;
+                    if (q > 3) { q = 0; y++; }
+                }
+                return buckets;
+            }
+
+            function assignNodeToBucket(node, buckets) {
+                if (!node.createdDate) return -1;
+                const d = new Date(node.createdDate);
+                if (isNaN(d.getTime())) return -1;
+                for (let i = 0; i < buckets.length; i++) {
+                    if (d >= buckets[i].start && d <= buckets[i].end) return i;
+                }
+                return -1;
+            }
+
+            function renderNodes(svg, filteredIds, positions, connectedIds, NS) {
+                const nodeW = 110, nodeH = 44;
+
+                for (const id of filteredIds) {
+                    const node = nodes[id];
+                    const pos = positions[id];
+                    if (!pos) continue;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
+                    const isOrphan = !connectedIds.has(id);
+
+                    const shortTitle = (node.title || '').length > 16
+                        ? node.title.substring(0, 15) + '\u2026'
+                        : (node.title || id);
+
+                    const g = document.createElementNS(NS, 'g');
+                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.dataset.id = id;
+                    g.dataset.path = node.path;
+
+                    const rect = document.createElementNS(NS, 'rect');
+                    rect.setAttribute('x', pos.x);
+                    rect.setAttribute('y', pos.y);
+                    rect.setAttribute('width', nodeW);
+                    rect.setAttribute('height', nodeH);
+                    rect.setAttribute('rx', '4');
+                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
+                    rect.setAttribute('stroke', color);
+                    rect.setAttribute('stroke-width', '1.5');
+                    g.appendChild(rect);
+
+                    const typeText = document.createElementNS(NS, 'text');
+                    typeText.setAttribute('x', pos.x + nodeW / 2);
+                    typeText.setAttribute('y', pos.y + 16);
+                    typeText.setAttribute('text-anchor', 'middle');
+                    typeText.setAttribute('font-size', '11');
+                    typeText.setAttribute('font-weight', '700');
+                    typeText.setAttribute('fill', color);
+                    typeText.textContent = node.type;
+                    g.appendChild(typeText);
+
+                    const titleText = document.createElementNS(NS, 'text');
+                    titleText.setAttribute('x', pos.x + nodeW / 2);
+                    titleText.setAttribute('y', pos.y + 30);
+                    titleText.setAttribute('text-anchor', 'middle');
+                    titleText.setAttribute('font-size', '8');
+                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
+                    titleText.textContent = shortTitle;
+                    g.appendChild(titleText);
+
+                    // Last-modified indicator dot
+                    if (node.lastModified) {
+                        const lmDate = new Date(node.lastModified);
+                        if (!isNaN(lmDate.getTime())) {
+                            const daysAgo = (Date.now() - lmDate.getTime()) / 86400000;
+                            let dotColor = null;
+                            if (daysAgo < 7) dotColor = '#00703c';
+                            else if (daysAgo < 30) dotColor = '#f47738';
+                            if (dotColor) {
+                                const dot = document.createElementNS(NS, 'circle');
+                                dot.setAttribute('cx', pos.x + nodeW - 6);
+                                dot.setAttribute('cy', pos.y + 6);
+                                dot.setAttribute('r', '3');
+                                dot.setAttribute('fill', dotColor);
+                                g.appendChild(dot);
+                            }
+                        }
+                    }
+
+                    // Event listeners
+                    g.addEventListener('mouseenter', () => {
+                        const nodeId = g.dataset.id;
+                        const connNodes = new Set([nodeId]);
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
+                                p.classList.add('highlighted');
+                                connNodes.add(p.dataset.from);
+                                connNodes.add(p.dataset.to);
+                            } else {
+                                p.classList.add('dimmed');
+                            }
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
+                        });
+
+                        const nd = nodes[nodeId];
+                        if (nd) {
+                            const ttTitle = document.createElement('strong');
+                            ttTitle.textContent = nd.title || nodeId;
+                            const ttMeta = document.createElement('span');
+                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
+                            tooltip.textContent = '';
+                            tooltip.appendChild(ttTitle);
+                            tooltip.appendChild(ttMeta);
+                            tooltip.style.display = 'block';
+                            const r = g.getBoundingClientRect();
+                            tooltip.style.left = (r.right + 8) + 'px';
+                            tooltip.style.top = r.top + 'px';
+                        }
+                    });
+
+                    g.addEventListener('mouseleave', () => {
+                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
+                            p.classList.remove('highlighted', 'dimmed');
+                        });
+                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
+                            n.classList.remove('dimmed');
+                        });
+                        tooltip.style.display = 'none';
+                    });
+
+                    g.addEventListener('click', () => {
+                        const docPath = g.dataset.path;
+                        if (docPath) {
+                            tooltip.style.display = 'none';
+                            window.location.hash = docPath;
+                        }
+                    });
+
+                    svg.appendChild(g);
+                }
+            }
+
             function renderGraph(filterProject) {
                 const statsEl = document.getElementById('depmap-stats');
 
@@ -2985,12 +3291,29 @@
                     });
                 }
 
+                // Filter edges to visible nodes
+                const filteredSet = new Set(filteredIds);
+                const visibleEdges = edges.filter(e => {
+                    if (!filteredSet.has(e.from)) return false;
+                    return filteredIds.some(id => id.startsWith(e.to));
+                });
+
+                if (currentLayout === 'timeline') {
+                    renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                } else {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                }
+            }
+
+            function renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+
                 // Layout constants
                 const nodeW = 110, nodeH = 44;
                 const gapX = 16, gapY = 24;
                 const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
                 const labelW = 110, padL = 16, padR = 16, padT = 16;
-                const maxCols = 8; // wrap after this many nodes per row
+                const maxCols = 8;
 
                 // Compute positions with wrapping
                 const positions = {};
@@ -3021,16 +3344,9 @@
                 const svgW = padL + labelW + usedCols * nodeW + (usedCols - 1) * gapX + padR;
                 const svgH = y - gapY + padT;
 
-                // Filter edges to visible nodes
-                const filteredSet = new Set(filteredIds);
-                const visibleEdges = edges.filter(e => {
-                    if (!filteredSet.has(e.from)) return false;
-                    return filteredIds.some(id => id.startsWith(e.to));
-                });
-
                 statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
 
-                // Build SVG using DOM (SVG namespace)
+                // Build SVG
                 const NS = 'http://www.w3.org/2000/svg';
                 const svg = document.createElementNS(NS, 'svg');
                 svg.setAttribute('class', 'app-depmap-svg');
@@ -3088,104 +3404,199 @@
                 }
 
                 // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
+
+                svgWrap.textContent = '';
+                svgWrap.appendChild(svg);
+            }
+
+            function renderTimelineLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet) {
+                const statsEl = document.getElementById('depmap-stats');
+                const bucketResult = computeDateBuckets(filteredIds);
+
+                // Fallback to category if no valid dates
+                if (!bucketResult) {
+                    renderCategoryLayout(filteredIds, catGroups, connectedIds, visibleEdges, filteredSet);
+                    return;
+                }
+
+                const { buckets } = bucketResult;
+
+                // Layout constants
+                const nodeW = 110, nodeH = 44;
+                const gapX = 16, gapY = 24;
+                const rowPadTop = 30, rowPadBot = 14, rowGapY = 10;
+                const labelW = 110, padL = 16, padR = 16, padT = 16;
+                const colW = nodeW + gapX;
+                const headerH = 24;
+
+                // Total columns = date buckets + optional "No Date"
+                const hasUndated = filteredIds.some(id => assignNodeToBucket(nodes[id], buckets) === -1);
+                const totalCols = buckets.length + (hasUndated ? 1 : 0);
+
+                // Assign nodes to cells: { catKey: { colIdx: [nodeIds] } }
+                const cells = {};
                 for (const id of filteredIds) {
                     const node = nodes[id];
-                    const pos = positions[id];
-                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
-
-                    const shortTitle = (node.title || '').length > 16
-                        ? node.title.substring(0, 15) + '\u2026'
-                        : (node.title || id);
-
-                    const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
-                    g.dataset.id = id;
-                    g.dataset.path = node.path;
-
-                    const rect = document.createElementNS(NS, 'rect');
-                    rect.setAttribute('x', pos.x);
-                    rect.setAttribute('y', pos.y);
-                    rect.setAttribute('width', nodeW);
-                    rect.setAttribute('height', nodeH);
-                    rect.setAttribute('rx', '4');
-                    rect.setAttribute('fill', 'var(--bg-surface, #fff)');
-                    rect.setAttribute('stroke', color);
-                    rect.setAttribute('stroke-width', '1.5');
-                    g.appendChild(rect);
-
-                    const typeText = document.createElementNS(NS, 'text');
-                    typeText.setAttribute('x', pos.x + nodeW / 2);
-                    typeText.setAttribute('y', pos.y + 16);
-                    typeText.setAttribute('text-anchor', 'middle');
-                    typeText.setAttribute('font-size', '11');
-                    typeText.setAttribute('font-weight', '700');
-                    typeText.setAttribute('fill', color);
-                    typeText.textContent = node.type;
-                    g.appendChild(typeText);
-
-                    const titleText = document.createElementNS(NS, 'text');
-                    titleText.setAttribute('x', pos.x + nodeW / 2);
-                    titleText.setAttribute('y', pos.y + 30);
-                    titleText.setAttribute('text-anchor', 'middle');
-                    titleText.setAttribute('font-size', '8');
-                    titleText.setAttribute('fill', 'var(--text-secondary, #666)');
-                    titleText.textContent = shortTitle;
-                    g.appendChild(titleText);
-
-                    // Event listeners
-                    g.addEventListener('mouseenter', () => {
-                        const nodeId = g.dataset.id;
-                        const connNodes = new Set([nodeId]);
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            if (p.dataset.from === nodeId || p.dataset.to === nodeId) {
-                                p.classList.add('highlighted');
-                                connNodes.add(p.dataset.from);
-                                connNodes.add(p.dataset.to);
-                            } else {
-                                p.classList.add('dimmed');
-                            }
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            if (!connNodes.has(n.dataset.id)) n.classList.add('dimmed');
-                        });
-
-                        const nd = nodes[nodeId];
-                        if (nd) {
-                            const ttTitle = document.createElement('strong');
-                            ttTitle.textContent = nd.title || nodeId;
-                            const ttMeta = document.createElement('span');
-                            ttMeta.textContent = nd.type + ' \u00b7 ' + nd.project + ' \u00b7 ' + (nd.status || 'No status') + ' \u2014 Severity: ' + (nd.severity || 'LOW');
-                            tooltip.textContent = '';
-                            tooltip.appendChild(ttTitle);
-                            tooltip.appendChild(ttMeta);
-                            tooltip.style.display = 'block';
-                            const r = g.getBoundingClientRect();
-                            tooltip.style.left = (r.right + 8) + 'px';
-                            tooltip.style.top = r.top + 'px';
-                        }
-                    });
-
-                    g.addEventListener('mouseleave', () => {
-                        svg.querySelectorAll('.app-depmap-edge').forEach(p => {
-                            p.classList.remove('highlighted', 'dimmed');
-                        });
-                        svg.querySelectorAll('.app-depmap-node').forEach(n => {
-                            n.classList.remove('dimmed');
-                        });
-                        tooltip.style.display = 'none';
-                    });
-
-                    g.addEventListener('click', () => {
-                        const docPath = g.dataset.path;
-                        if (docPath) {
-                            tooltip.style.display = 'none';
-                            window.location.hash = docPath;
-                        }
-                    });
-
-                    svg.appendChild(g);
+                    const cat = (node.type && TYPE_CATEGORIES[node.type]) || 'Other';
+                    const colIdx = assignNodeToBucket(node, buckets);
+                    const actualCol = colIdx === -1 ? buckets.length : colIdx;
+                    if (!cells[cat]) cells[cat] = {};
+                    if (!cells[cat][actualCol]) cells[cat][actualCol] = [];
+                    cells[cat][actualCol].push(id);
                 }
+
+                // Sort within each cell by project then type
+                for (const cat of Object.keys(cells)) {
+                    for (const col of Object.keys(cells[cat])) {
+                        cells[cat][col].sort((a, b) => {
+                            const na = nodes[a], nb = nodes[b];
+                            return (na.project || '').localeCompare(nb.project || '') || (na.type || '').localeCompare(nb.type || '');
+                        });
+                    }
+                }
+
+                // Compute row heights (expand for stacked nodes)
+                const positions = {};
+                let y = padT + headerH;
+                const rowBands = [];
+
+                for (const cat of CATEGORY_ORDER) {
+                    if (!catGroups[cat] || catGroups[cat].length === 0) continue;
+
+                    // Find max stack in any column for this category
+                    let maxStack = 1;
+                    if (cells[cat]) {
+                        for (const col of Object.keys(cells[cat])) {
+                            maxStack = Math.max(maxStack, cells[cat][col].length);
+                        }
+                    }
+
+                    const numRows = maxStack;
+                    const rowH = rowPadTop + numRows * nodeH + (numRows - 1) * rowGapY + rowPadBot;
+                    rowBands.push({ cat, y, h: rowH });
+
+                    // Position nodes
+                    if (cells[cat]) {
+                        for (const [colStr, ids] of Object.entries(cells[cat])) {
+                            const col = parseInt(colStr, 10);
+                            for (let i = 0; i < ids.length; i++) {
+                                positions[ids[i]] = {
+                                    x: padL + labelW + col * colW,
+                                    y: y + rowPadTop + i * (nodeH + rowGapY),
+                                };
+                            }
+                        }
+                    }
+
+                    y += rowH + gapY;
+                }
+
+                const svgW = padL + labelW + totalCols * colW + padR;
+                const svgH = y - gapY + padT;
+
+                statsEl.textContent = filteredIds.length + ' nodes, ' + visibleEdges.length + ' edges';
+
+                // Build SVG
+                const NS = 'http://www.w3.org/2000/svg';
+                const svg = document.createElementNS(NS, 'svg');
+                svg.setAttribute('class', 'app-depmap-svg');
+                svg.setAttribute('viewBox', '0 0 ' + svgW + ' ' + svgH);
+                svg.setAttribute('width', svgW);
+                svg.setAttribute('height', svgH);
+
+                // Column headers
+                for (let i = 0; i < buckets.length; i++) {
+                    const cx = padL + labelW + i * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', 'var(--text-secondary, #666)');
+                    hdr.textContent = buckets[i].label;
+                    svg.appendChild(hdr);
+                }
+
+                // "No Date" header
+                if (hasUndated) {
+                    const cx = padL + labelW + buckets.length * colW + colW / 2;
+                    const hdr = document.createElementNS(NS, 'text');
+                    hdr.setAttribute('x', cx);
+                    hdr.setAttribute('y', padT + headerH - 6);
+                    hdr.setAttribute('text-anchor', 'middle');
+                    hdr.setAttribute('font-size', '10');
+                    hdr.setAttribute('font-weight', '600');
+                    hdr.setAttribute('fill', '#b1b4b6');
+                    hdr.textContent = 'No Date';
+                    svg.appendChild(hdr);
+                }
+
+                // Column separator lines
+                for (let i = 1; i < totalCols; i++) {
+                    const lx = padL + labelW + i * colW - gapX / 2;
+                    const line = document.createElementNS(NS, 'line');
+                    line.setAttribute('x1', lx);
+                    line.setAttribute('y1', padT + headerH);
+                    line.setAttribute('x2', lx);
+                    line.setAttribute('y2', svgH - padT);
+                    line.setAttribute('stroke', 'var(--border-main, #e8e8e8)');
+                    line.setAttribute('stroke-width', '1');
+                    line.setAttribute('opacity', '0.3');
+                    svg.appendChild(line);
+                }
+
+                // Row backgrounds
+                for (const band of rowBands) {
+                    const color = CATEGORY_COLORS[band.cat] || CATEGORY_COLORS.Other;
+                    const bg = document.createElementNS(NS, 'rect');
+                    bg.setAttribute('x', 0);
+                    bg.setAttribute('y', band.y);
+                    bg.setAttribute('width', svgW);
+                    bg.setAttribute('height', band.h);
+                    bg.setAttribute('fill', color);
+                    bg.setAttribute('opacity', '0.06');
+                    bg.setAttribute('rx', '4');
+                    svg.appendChild(bg);
+
+                    const lbl = document.createElementNS(NS, 'text');
+                    lbl.setAttribute('x', padL);
+                    lbl.setAttribute('y', band.y + 18);
+                    lbl.setAttribute('font-size', '11');
+                    lbl.setAttribute('font-weight', '700');
+                    lbl.setAttribute('fill', color);
+                    lbl.textContent = band.cat;
+                    svg.appendChild(lbl);
+                }
+
+                // Edges
+                for (const e of visibleEdges) {
+                    const fromPos = positions[e.from];
+                    if (!fromPos) continue;
+                    const toId = filteredIds.find(id => id.startsWith(e.to));
+                    if (!toId) continue;
+                    const toPos = positions[toId];
+                    if (!toPos) continue;
+
+                    const x1 = fromPos.x + nodeW / 2;
+                    const y1 = fromPos.y + nodeH;
+                    const x2 = toPos.x + nodeW / 2;
+                    const y2 = toPos.y;
+                    const dy = Math.abs(y2 - y1) * 0.4;
+                    const color = CATEGORY_COLORS[TYPE_CATEGORIES[nodes[e.from].type] || 'Other'] || CATEGORY_COLORS.Other;
+
+                    const path = document.createElementNS(NS, 'path');
+                    path.setAttribute('class', 'app-depmap-edge');
+                    path.dataset.from = e.from;
+                    path.dataset.to = toId;
+                    path.setAttribute('d', 'M' + x1 + ',' + y1 + ' C' + x1 + ',' + (y1 + dy) + ' ' + x2 + ',' + (y2 - dy) + ' ' + x2 + ',' + y2);
+                    path.setAttribute('stroke', color);
+                    svg.appendChild(path);
+                }
+
+                // Nodes
+                renderNodes(svg, filteredIds, positions, connectedIds, NS);
 
                 svgWrap.textContent = '';
                 svgWrap.appendChild(svg);

--- a/docs/superpowers/specs/2026-03-11-dependency-map-timeline-design.md
+++ b/docs/superpowers/specs/2026-03-11-dependency-map-timeline-design.md
@@ -1,0 +1,148 @@
+# Dependency Map Timeline View — Design Spec
+
+**Date**: 2026-03-11
+**Status**: Approved
+
+## Overview
+
+Add a timeline layout mode to the dependency map in the ArcKit pages template. Documents are placed into date-based columns (X-axis) while retaining category bands (Y-axis). A toggle switches between the existing "Category" sequential-fill view and the new "Timeline" date-column view.
+
+## Data Layer
+
+**File**: `arckit-claude/hooks/graph-utils.mjs`
+
+In `scanProjectDir()`, `extractDocControlFields(content)` is already called and its result stored in `fields`. Add two fields to each node object alongside the existing `status` extraction:
+
+```js
+nodes[fullId] = {
+  type: docType,
+  project: projectName,
+  path: `projects/${projectName}/${prefix}${f}`,
+  title,
+  status,
+  severity: classifySeverity(docType),
+  createdDate: fields['Created Date'] || null,   // e.g. "2026-01-15"
+  lastModified: fields['Last Modified'] || null,  // e.g. "2026-03-10"
+};
+```
+
+No new parsing logic needed — `extractDocControlFields()` already reads the Document Control table which contains these fields in every ArcKit template.
+
+## Auto-detect Granularity
+
+Runs client-side in the timeline layout function. Collects all `createdDate` values from visible nodes (after project filter is applied), parses them as `Date` objects, discards any that fail to parse (invalid/malformed), computes the date range, and selects bucket size:
+
+| Date range | Granularity | Column header format |
+|------------|-------------|---------------------|
+| < 90 days | Weekly | "W1 Jan", "W2 Jan" |
+| 90 days – 18 months | Monthly | "Jan 2026", "Feb 2026" |
+| > 18 months | Quarterly | "Q1 2026", "Q2 2026" |
+
+**Bucket computation algorithm:**
+
+1. Collect all valid `createdDate` values from filtered nodes, parse as `new Date(str)`
+2. Skip any `NaN` / invalid results
+3. If zero valid dates remain, hide Timeline toggle — only Category view available
+4. Find `minDate` and `maxDate`, compute `rangeMs = maxDate - minDate`
+5. Select granularity based on `rangeDays = rangeMs / 86400000`
+6. Generate contiguous buckets using **calendar boundaries**:
+   - **Weekly**: ISO weeks — bucket starts on Monday of each week from `minDate`'s week to `maxDate`'s week
+   - **Monthly**: Calendar months — `YYYY-MM` from `minDate`'s month to `maxDate`'s month
+   - **Quarterly**: Calendar quarters — Q1 (Jan–Mar), Q2 (Apr–Jun), Q3 (Jul–Sep), Q4 (Oct–Dec)
+7. No gaps skipped — every bucket in the range gets a column, even if empty
+8. Assign each dated node to its bucket by comparing `createdDate` against bucket boundaries
+9. Nodes with no `createdDate` (null or invalid) go in a "No Date" column at the far right
+
+**"No Date" column:**
+
+- Positioned as the rightmost column after all date columns
+- Header text: "No Date"
+- Header colour: `#b1b4b6` (same grey as `CATEGORY_COLORS.Other`)
+- Nodes sorted within by project then type (same as category view)
+- Hidden entirely if all nodes have valid dates
+
+## Layout Toggle
+
+**Location**: Controls bar, before the Project filter dropdown.
+
+```text
+Layout: [Category] [Timeline]   Project: [All Projects ▾]   12 nodes, 8 edges
+```
+
+Two buttons styled as a segmented control. "Category" is the default. Selection persists across page loads via new `localStorage` key `arckit-depmap-layout` (distinct from existing `arckit-theme` key).
+
+Both buttons call `renderGraph()` which checks the current layout mode and delegates to the appropriate layout function. When no nodes have valid dates, the Timeline button is hidden and only Category is shown.
+
+## Timeline Layout
+
+### Axes
+
+- **Y-axis**: Category bands using `CATEGORY_ORDER` from the existing code. Currently: `['Getting Started', 'Discovery', 'Planning', 'Architecture', 'Governance', 'Compliance', 'Operations', 'Procurement', 'Integrations', 'Reporting', 'Other']`. Band background colour from `CATEGORY_COLORS`. Category label on the left. (Note: the `CATEGORY_ORDER` array in the dependency map must be updated to match the current categories — it still has the old `Research` entry.)
+- **X-axis**: Date columns from auto-detect. Column headers rendered as SVG `<text>` elements at the top of the SVG canvas, centred within each column. Font: 10px, weight 600, fill `var(--text-secondary, #666)`. Light vertical separator lines (1px, `var(--border-main, #e8e8e8)`, opacity 0.3) between columns.
+
+### Column dimensions
+
+- Column width: `nodeW + gapX` (110 + 16 = 126px) — matches current node spacing
+- SVG width grows with number of date columns — scrollable via existing `overflow-x: auto` on the wrapper div
+- Column header area: 24px tall at top of SVG, above the first category band
+
+### Node placement
+
+Each node is placed at the intersection of its category row and date-bucket column:
+
+1. Determine the node's date bucket from `createdDate`
+2. Determine the node's category from `TYPE_CATEGORIES[node.type]`
+3. Place at `(columnX, categoryRowY)`
+4. If multiple nodes land in the same cell (same category + same date bucket), stack top-to-bottom within the cell, sorted by project then type (same order as category view). No maximum — the category band height expands to fit all stacked nodes. Each additional node adds `nodeH + rowGapY` (44 + 10 = 54px) to the band height.
+
+### Edges
+
+Same curved Bézier paths as current view, connecting from source node bottom to target node top. Colour matches source node category.
+
+### Interactions
+
+All existing interactions preserved:
+
+- Hover: highlight connected edges, dim others, show tooltip
+- Click: navigate to document
+- Project filter: re-renders with filtered nodes (granularity recomputed for filtered set)
+
+## Last Modified Indicator
+
+Nodes with recent `lastModified` dates display a small indicator dot (4px circle) in the top-right corner of the node rectangle:
+
+| Recency | Colour | Meaning |
+|---------|--------|---------|
+| < 7 days | Green (#00703c) | Recently updated |
+| 7–30 days | Amber (#f47738) | Updated this month |
+| > 30 days or null | No dot | Not recently modified |
+
+This indicator appears in **both** Category and Timeline views. This is the one visual addition to the Category view — the layout and positioning logic remains unchanged.
+
+## Category View
+
+Layout and positioning logic remains exactly as-is (sequential fill within category bands). The only addition is the last-modified indicator dot on nodes (see above). The toggle simply switches which layout function executes inside `renderGraph()`.
+
+## Files Changed
+
+1. **`arckit-claude/hooks/graph-utils.mjs`** — Add `createdDate` and `lastModified` to node data (2 lines added). This is the only backend change.
+2. **`arckit-claude/templates/pages-template.html`** (source of truth) — Layout toggle UI, timeline layout function, auto-detect granularity logic, last-modified indicator dots, column header rendering, update `CATEGORY_ORDER` to match current categories
+3. **`.arckit/templates/pages-template.html`** — Copy from above (keeps the two in sync)
+4. **Run `scripts/converter.py`** — Propagates template changes to `arckit-codex/`, `arckit-opencode/`, `arckit-gemini/`, `arckit-copilot/` extension directories
+
+## Graceful Degradation
+
+- Manifest gains two new optional fields per node (`createdDate`, `lastModified`)
+- All timeline rendering code must null-check these fields — `if (!node.createdDate)` routes to "No Date" column
+- Old manifests without these fields: Timeline toggle hidden (zero valid dates), Category view works as before
+- Category view (default) unchanged except for last-modified dots
+- No new files, no new dependencies
+
+## Edge Cases
+
+- **All dates identical**: Single date column with all nodes stacked by category — functional but sparse
+- **Very wide date ranges** (years): Quarterly buckets keep column count manageable
+- **Mixed dated/undated**: Dated nodes in their columns, undated in "No Date" column at right
+- **Single project filter**: Global docs (000-global) included as they are today; their dates participate in column generation
+- **Malformed dates**: Treated same as missing — node goes to "No Date" column
+- **All dates missing**: Timeline toggle hidden, only Category view available


### PR DESCRIPTION
## Summary

- **Data layer**: Added `createdDate` and `lastModified` fields to dependency graph nodes (from existing Document Control tables)
- **Layout toggle**: Segmented Category/Timeline control with localStorage persistence — Timeline button hidden when no nodes have valid dates
- **Timeline view**: Documents placed into date-based columns (X-axis) with category bands (Y-axis), auto-detecting weekly/monthly/quarterly granularity based on date range
- **Last-modified dots**: Green (<7 days) or amber (7-30 days) indicator dot on nodes in both views
- **Category fix**: Updated `CATEGORY_ORDER` in dependency map to match current categories (added Getting Started, Integrations; removed Research)
- **Shared rendering**: Extracted node rendering into `renderNodes()` to avoid duplication between layouts

## Spec

`docs/superpowers/specs/2026-03-11-dependency-map-timeline-design.md`

## Test plan

- [ ] Open a test repo with `/arckit:pages` generated docs
- [ ] Navigate to Dependency Map — Category view should render as before
- [ ] Toggle to Timeline — documents should appear in date columns
- [ ] Filter by project — timeline should recompute granularity
- [ ] Verify last-modified dots appear on recently updated documents
- [ ] Refresh page — layout preference should persist
- [ ] Test with repo that has no Document Control dates — Timeline toggle should be hidden

🤖 Generated with [Claude Code](https://claude.com/claude-code)