### PR TITLE
feat: regroup commands.html categories to match dependency matrix tiers

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -2411,14 +2411,6 @@
                 ? Math.round(projectMetrics.reduce((sum, p) => sum + p.coverage, 0) / projectMetrics.length)
                 : 0;
 
-            // Guide maturity
-            const guideCounts = { live: 0, beta: 0, alpha: 0, experimental: 0 };
-            (manifest.guides || []).forEach(g => {
-                if (g.status && guideCounts.hasOwnProperty(g.status)) {
-                    guideCounts[g.status]++;
-                }
-            });
-
             // Governance coverage (portfolio-wide)
             const GOVERNANCE_TYPES = {
                 'Requirements (REQ)': 'REQ',
@@ -2461,7 +2453,6 @@
                 avgCoverage,
                 categoryCounts,
                 projectMetrics,
-                guideCounts,
                 governanceCoverage
             };
         }
@@ -2731,7 +2722,7 @@
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
 
-            // Row 4: Guide maturity + Governance checklist
+            // Row 4: Governance checklist
             let checklistHtml = '';
             Object.entries(m.governanceCoverage).forEach(([label, info]) => {
                 const icon = info.present
@@ -2745,10 +2736,6 @@
 
             html += `
                 <div class="app-dashboard-panels">
-                    <div class="app-dashboard-panel">
-                        <h3>Guide Maturity</h3>
-                        <div id="dashboard-guide-chart"></div>
-                    </div>
                     <div class="app-dashboard-panel">
                         <h3>Governance Coverage</h3>
                         <ul class="app-dashboard-checklist">${checklistHtml}</ul>
@@ -2831,11 +2818,6 @@
             const categoryData = Object.entries(CATEGORY_COLORS)
                 .map(([label, color]) => ({ label, value: m.categoryCounts[label] || 0, color }));
             renderDonutChart('dashboard-category-chart', categoryData);
-
-            const guideColors = { live: '#00703c', beta: '#1d70b8', alpha: '#f47738', experimental: '#912b88' };
-            const guideData = Object.entries(guideColors)
-                .map(([label, color]) => ({ label: label.charAt(0).toUpperCase() + label.slice(1), value: m.guideCounts[label] || 0, color }));
-            renderDonutChart('dashboard-guide-chart', guideData);
 
             // Wire up dashboard links to navigate to documents
             content.querySelectorAll('.app-dashboard-link').forEach(link => {

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -16,6 +16,7 @@
     "agent-sdk-dev@claude-plugins-official": true,
     "commit-commands@claude-plugins-official": true,
     "security-guidance@claude-plugins-official": true,
-    "superpowers@claude-plugins-official": true
+    "superpowers@claude-plugins-official": true,
+    "marketing@knowledge-work-plugins": true
   }
 }

--- a/arckit-claude/docs/guides/pages.md
+++ b/arckit-claude/docs/guides/pages.md
@@ -168,7 +168,6 @@ The dashboard (`#dashboard`) is the default landing page, providing an instant p
 | Documents by Category | SVG donut chart showing document distribution across Discovery, Planning, Architecture, etc. |
 | Project Artifact Coverage | Horizontal bar chart per project with color coding (green >=80%, amber >=50%, red <50%) |
 | Projects Table | Name, Docs, Diagrams, ADRs, Vendors, Coverage mini-bar |
-| Guide Maturity | SVG donut chart showing live/beta/alpha/experimental guide counts |
 | Governance Coverage | Checklist of key artifact types present/absent across portfolio |
 
 ### Coverage Calculation

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -2411,14 +2411,6 @@
                 ? Math.round(projectMetrics.reduce((sum, p) => sum + p.coverage, 0) / projectMetrics.length)
                 : 0;
 
-            // Guide maturity
-            const guideCounts = { live: 0, beta: 0, alpha: 0, experimental: 0 };
-            (manifest.guides || []).forEach(g => {
-                if (g.status && guideCounts.hasOwnProperty(g.status)) {
-                    guideCounts[g.status]++;
-                }
-            });
-
             // Governance coverage (portfolio-wide)
             const GOVERNANCE_TYPES = {
                 'Requirements (REQ)': 'REQ',
@@ -2461,7 +2453,6 @@
                 avgCoverage,
                 categoryCounts,
                 projectMetrics,
-                guideCounts,
                 governanceCoverage
             };
         }
@@ -2731,7 +2722,7 @@
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
 
-            // Row 4: Guide maturity + Governance checklist
+            // Row 4: Governance checklist
             let checklistHtml = '';
             Object.entries(m.governanceCoverage).forEach(([label, info]) => {
                 const icon = info.present
@@ -2745,10 +2736,6 @@
 
             html += `
                 <div class="app-dashboard-panels">
-                    <div class="app-dashboard-panel">
-                        <h3>Guide Maturity</h3>
-                        <div id="dashboard-guide-chart"></div>
-                    </div>
                     <div class="app-dashboard-panel">
                         <h3>Governance Coverage</h3>
                         <ul class="app-dashboard-checklist">${checklistHtml}</ul>
@@ -2831,11 +2818,6 @@
             const categoryData = Object.entries(CATEGORY_COLORS)
                 .map(([label, color]) => ({ label, value: m.categoryCounts[label] || 0, color }));
             renderDonutChart('dashboard-category-chart', categoryData);
-
-            const guideColors = { live: '#00703c', beta: '#1d70b8', alpha: '#f47738', experimental: '#912b88' };
-            const guideData = Object.entries(guideColors)
-                .map(([label, color]) => ({ label: label.charAt(0).toUpperCase() + label.slice(1), value: m.guideCounts[label] || 0, color }));
-            renderDonutChart('dashboard-guide-chart', guideData);
 
             // Wire up dashboard links to navigate to documents
             content.querySelectorAll('.app-dashboard-link').forEach(link => {

--- a/arckit-codex/docs/guides/pages.md
+++ b/arckit-codex/docs/guides/pages.md
@@ -168,7 +168,6 @@ The dashboard (`#dashboard`) is the default landing page, providing an instant p
 | Documents by Category | SVG donut chart showing document distribution across Discovery, Planning, Architecture, etc. |
 | Project Artifact Coverage | Horizontal bar chart per project with color coding (green >=80%, amber >=50%, red <50%) |
 | Projects Table | Name, Docs, Diagrams, ADRs, Vendors, Coverage mini-bar |
-| Guide Maturity | SVG donut chart showing live/beta/alpha/experimental guide counts |
 | Governance Coverage | Checklist of key artifact types present/absent across portfolio |
 
 ### Coverage Calculation

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -2411,14 +2411,6 @@
                 ? Math.round(projectMetrics.reduce((sum, p) => sum + p.coverage, 0) / projectMetrics.length)
                 : 0;
 
-            // Guide maturity
-            const guideCounts = { live: 0, beta: 0, alpha: 0, experimental: 0 };
-            (manifest.guides || []).forEach(g => {
-                if (g.status && guideCounts.hasOwnProperty(g.status)) {
-                    guideCounts[g.status]++;
-                }
-            });
-
             // Governance coverage (portfolio-wide)
             const GOVERNANCE_TYPES = {
                 'Requirements (REQ)': 'REQ',
@@ -2461,7 +2453,6 @@
                 avgCoverage,
                 categoryCounts,
                 projectMetrics,
-                guideCounts,
                 governanceCoverage
             };
         }
@@ -2731,7 +2722,7 @@
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
 
-            // Row 4: Guide maturity + Governance checklist
+            // Row 4: Governance checklist
             let checklistHtml = '';
             Object.entries(m.governanceCoverage).forEach(([label, info]) => {
                 const icon = info.present
@@ -2745,10 +2736,6 @@
 
             html += `
                 <div class="app-dashboard-panels">
-                    <div class="app-dashboard-panel">
-                        <h3>Guide Maturity</h3>
-                        <div id="dashboard-guide-chart"></div>
-                    </div>
                     <div class="app-dashboard-panel">
                         <h3>Governance Coverage</h3>
                         <ul class="app-dashboard-checklist">${checklistHtml}</ul>
@@ -2831,11 +2818,6 @@
             const categoryData = Object.entries(CATEGORY_COLORS)
                 .map(([label, color]) => ({ label, value: m.categoryCounts[label] || 0, color }));
             renderDonutChart('dashboard-category-chart', categoryData);
-
-            const guideColors = { live: '#00703c', beta: '#1d70b8', alpha: '#f47738', experimental: '#912b88' };
-            const guideData = Object.entries(guideColors)
-                .map(([label, color]) => ({ label: label.charAt(0).toUpperCase() + label.slice(1), value: m.guideCounts[label] || 0, color }));
-            renderDonutChart('dashboard-guide-chart', guideData);
 
             // Wire up dashboard links to navigate to documents
             content.querySelectorAll('.app-dashboard-link').forEach(link => {

--- a/arckit-copilot/docs/guides/pages.md
+++ b/arckit-copilot/docs/guides/pages.md
@@ -168,7 +168,6 @@ The dashboard (`#dashboard`) is the default landing page, providing an instant p
 | Documents by Category | SVG donut chart showing document distribution across Discovery, Planning, Architecture, etc. |
 | Project Artifact Coverage | Horizontal bar chart per project with color coding (green >=80%, amber >=50%, red <50%) |
 | Projects Table | Name, Docs, Diagrams, ADRs, Vendors, Coverage mini-bar |
-| Guide Maturity | SVG donut chart showing live/beta/alpha/experimental guide counts |
 | Governance Coverage | Checklist of key artifact types present/absent across portfolio |
 
 ### Coverage Calculation

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -2411,14 +2411,6 @@
                 ? Math.round(projectMetrics.reduce((sum, p) => sum + p.coverage, 0) / projectMetrics.length)
                 : 0;
 
-            // Guide maturity
-            const guideCounts = { live: 0, beta: 0, alpha: 0, experimental: 0 };
-            (manifest.guides || []).forEach(g => {
-                if (g.status && guideCounts.hasOwnProperty(g.status)) {
-                    guideCounts[g.status]++;
-                }
-            });
-
             // Governance coverage (portfolio-wide)
             const GOVERNANCE_TYPES = {
                 'Requirements (REQ)': 'REQ',
@@ -2461,7 +2453,6 @@
                 avgCoverage,
                 categoryCounts,
                 projectMetrics,
-                guideCounts,
                 governanceCoverage
             };
         }
@@ -2731,7 +2722,7 @@
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
 
-            // Row 4: Guide maturity + Governance checklist
+            // Row 4: Governance checklist
             let checklistHtml = '';
             Object.entries(m.governanceCoverage).forEach(([label, info]) => {
                 const icon = info.present
@@ -2745,10 +2736,6 @@
 
             html += `
                 <div class="app-dashboard-panels">
-                    <div class="app-dashboard-panel">
-                        <h3>Guide Maturity</h3>
-                        <div id="dashboard-guide-chart"></div>
-                    </div>
                     <div class="app-dashboard-panel">
                         <h3>Governance Coverage</h3>
                         <ul class="app-dashboard-checklist">${checklistHtml}</ul>
@@ -2831,11 +2818,6 @@
             const categoryData = Object.entries(CATEGORY_COLORS)
                 .map(([label, color]) => ({ label, value: m.categoryCounts[label] || 0, color }));
             renderDonutChart('dashboard-category-chart', categoryData);
-
-            const guideColors = { live: '#00703c', beta: '#1d70b8', alpha: '#f47738', experimental: '#912b88' };
-            const guideData = Object.entries(guideColors)
-                .map(([label, color]) => ({ label: label.charAt(0).toUpperCase() + label.slice(1), value: m.guideCounts[label] || 0, color }));
-            renderDonutChart('dashboard-guide-chart', guideData);
 
             // Wire up dashboard links to navigate to documents
             content.querySelectorAll('.app-dashboard-link').forEach(link => {

--- a/arckit-opencode/docs/guides/pages.md
+++ b/arckit-opencode/docs/guides/pages.md
@@ -168,7 +168,6 @@ The dashboard (`#dashboard`) is the default landing page, providing an instant p
 | Documents by Category | SVG donut chart showing document distribution across Discovery, Planning, Architecture, etc. |
 | Project Artifact Coverage | Horizontal bar chart per project with color coding (green >=80%, amber >=50%, red <50%) |
 | Projects Table | Name, Docs, Diagrams, ADRs, Vendors, Coverage mini-bar |
-| Guide Maturity | SVG donut chart showing live/beta/alpha/experimental guide counts |
 | Governance Coverage | Checklist of key artifact types present/absent across portfolio |
 
 ### Coverage Calculation

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -2411,14 +2411,6 @@
                 ? Math.round(projectMetrics.reduce((sum, p) => sum + p.coverage, 0) / projectMetrics.length)
                 : 0;
 
-            // Guide maturity
-            const guideCounts = { live: 0, beta: 0, alpha: 0, experimental: 0 };
-            (manifest.guides || []).forEach(g => {
-                if (g.status && guideCounts.hasOwnProperty(g.status)) {
-                    guideCounts[g.status]++;
-                }
-            });
-
             // Governance coverage (portfolio-wide)
             const GOVERNANCE_TYPES = {
                 'Requirements (REQ)': 'REQ',
@@ -2461,7 +2453,6 @@
                 avgCoverage,
                 categoryCounts,
                 projectMetrics,
-                guideCounts,
                 governanceCoverage
             };
         }
@@ -2731,7 +2722,7 @@
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
 
-            // Row 4: Guide maturity + Governance checklist
+            // Row 4: Governance checklist
             let checklistHtml = '';
             Object.entries(m.governanceCoverage).forEach(([label, info]) => {
                 const icon = info.present
@@ -2745,10 +2736,6 @@
 
             html += `
                 <div class="app-dashboard-panels">
-                    <div class="app-dashboard-panel">
-                        <h3>Guide Maturity</h3>
-                        <div id="dashboard-guide-chart"></div>
-                    </div>
                     <div class="app-dashboard-panel">
                         <h3>Governance Coverage</h3>
                         <ul class="app-dashboard-checklist">${checklistHtml}</ul>
@@ -2831,11 +2818,6 @@
             const categoryData = Object.entries(CATEGORY_COLORS)
                 .map(([label, color]) => ({ label, value: m.categoryCounts[label] || 0, color }));
             renderDonutChart('dashboard-category-chart', categoryData);
-
-            const guideColors = { live: '#00703c', beta: '#1d70b8', alpha: '#f47738', experimental: '#912b88' };
-            const guideData = Object.entries(guideColors)
-                .map(([label, color]) => ({ label: label.charAt(0).toUpperCase() + label.slice(1), value: m.guideCounts[label] || 0, color }));
-            renderDonutChart('dashboard-guide-chart', guideData);
 
             // Wire up dashboard links to navigate to documents
             content.querySelectorAll('.app-dashboard-link').forEach(link => {

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -551,16 +551,19 @@
                 <label for="category-filter">Category:</label>
                 <select id="category-filter">
                     <option value="all">All categories</option>
-                    <option value="discovery">Discovery</option>
-                    <option value="planning">Planning</option>
-                    <option value="architecture">Architecture</option>
-                    <option value="governance">Governance</option>
-                    <option value="compliance">Compliance</option>
-                    <option value="operations">Operations</option>
+                    <option value="foundation">Foundation</option>
+                    <option value="strategic-context">Strategic Context</option>
+                    <option value="risk-justification">Risk &amp; Justification</option>
+                    <option value="requirements">Requirements</option>
+                    <option value="strategic-planning">Strategic Planning</option>
+                    <option value="detailed-design">Detailed Design</option>
                     <option value="procurement">Procurement</option>
-                    <option value="research">Research</option>
+                    <option value="design-reviews">Design Reviews</option>
+                    <option value="implementation">Implementation</option>
+                    <option value="operations">Operations</option>
+                    <option value="quality-compliance">Quality &amp; Compliance</option>
                     <option value="reporting">Reporting</option>
-                    <option value="other">Other</option>
+                    <option value="utility">Utility</option>
                 </select>
             </div>
             <div>
@@ -585,25 +588,18 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <!-- Planning -->
-                    <tr data-status="live" data-category="planning">
-                        <td><code>/arckit.init</code></td>
-                        <td class="description">Initialize ArcKit project structure with numbered project directories and global artifacts</td>
-                        <td>Planning</td>
-                        <td class="examples">—</td>
-                        <td><span class="app-status-tag app-status-live">Live</span></td>
-                    </tr>
-                    <tr data-status="live" data-category="planning">
+                    <!-- Foundation -->
+                    <tr data-status="live" data-category="foundation">
                         <td><code>/arckit.start</code></td>
                         <td class="description">Get oriented with ArcKit — check project status, explore available commands, and choose your next step</td>
-                        <td>Planning</td>
+                        <td>Foundation</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="live" data-category="planning">
+                    <tr data-status="live" data-category="foundation">
                         <td><code>/arckit.plan</code></td>
                         <td class="description">Create project plan with timeline, phases, gates, and Mermaid diagrams</td>
-                        <td>Planning</td>
+                        <td>Foundation</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-PLAN-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-PLAN-v1.0.md" title="App Packaging">v3/002</a>
@@ -619,10 +615,10 @@
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="live" data-category="architecture">
+                    <tr data-status="live" data-category="foundation">
                         <td><code>/arckit.principles</code></td>
                         <td class="description">Create or update enterprise architecture principles</td>
-                        <td>Architecture</td>
+                        <td>Foundation</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/000-global/ARC-000-PRIN-v1.0.md" title="M365">v1</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/000-global/ARC-000-PRIN-v1.0.md" title="HMRC">v2</a>
@@ -642,11 +638,11 @@
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
 
-                    <!-- Discovery -->
-                    <tr data-status="live" data-category="discovery">
+                    <!-- Strategic Context -->
+                    <tr data-status="live" data-category="strategic-context">
                         <td><code>/arckit.stakeholders</code></td>
                         <td class="description">Analyze stakeholder drivers, goals, and measurable outcomes</td>
-                        <td>Discovery</td>
+                        <td>Strategic Context</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/ARC-001-STKE-v1.0.md" title="M365">v1</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-STKE-v1.0.md" title="HMRC">v2</a>
@@ -670,10 +666,12 @@
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="live" data-category="governance">
+
+                    <!-- Risk & Justification -->
+                    <tr data-status="live" data-category="risk-justification">
                         <td><code>/arckit.risk</code></td>
                         <td class="description">Create comprehensive risk register following HM Treasury Orange Book principles</td>
-                        <td>Governance</td>
+                        <td>Risk &amp; Justification</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-RISK-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-RISK-v1.0.md" title="App Packaging">v3/002</a>
@@ -692,10 +690,10 @@
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="live" data-category="planning">
+                    <tr data-status="live" data-category="risk-justification">
                         <td><code>/arckit.sobc</code></td>
                         <td class="description">Create Strategic Outline Business Case (SOBC) using UK Government Green Book 5-case model</td>
-                        <td>Planning</td>
+                        <td>Risk &amp; Justification</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-SOBC-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-SOBC-v1.0.md" title="App Packaging">v3/002</a>
@@ -709,11 +707,11 @@
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
 
-                    <!-- Discovery (continued) -->
-                    <tr data-status="live" data-category="discovery">
+                    <!-- Requirements -->
+                    <tr data-status="live" data-category="requirements">
                         <td><code>/arckit.requirements</code></td>
                         <td class="description">Create comprehensive business and technical requirements</td>
-                        <td>Discovery</td>
+                        <td>Requirements</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/ARC-001-REQ-v1.0.md" title="M365">v1</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-REQ-v1.0.md" title="HMRC">v2</a>
@@ -738,10 +736,54 @@
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="live" data-category="architecture">
+
+                    <!-- Strategic Planning -->
+                    <tr data-status="experimental" data-category="strategic-planning">
+                        <td><code>/arckit.platform-design</code></td>
+                        <td class="description">Create platform strategy using Platform Design Toolkit (8 canvases for multi-sided ecosystems)</td>
+                        <td>Strategic Planning</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-GAAP-v1.0.md" title="ONS Data">v8</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v10-training-marketplace/#projects/001-ai-training-marketplace/ARC-001-PLAT-v1.0.md" title="Training">v10</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="strategic-planning">
+                        <td><code>/arckit.roadmap</code></td>
+                        <td class="description">Create strategic architecture roadmap with multi-year timeline, capability evolution, and governance</td>
+                        <td>Strategic Planning</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-ROAD-v1.0.md" title="Windows 11">v3</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="strategic-planning">
+                        <td><code>/arckit.strategy</code></td>
+                        <td class="description">Synthesise strategic artifacts into executive-level Architecture Strategy document</td>
+                        <td>Strategic Planning</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="strategic-planning">
+                        <td><code>/arckit.framework</code></td>
+                        <td class="description">Transform architecture artifacts into a structured, reusable framework with principles, patterns, and implementation guidance</td>
+                        <td>Strategic Planning</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="strategic-planning">
+                        <td><code>/arckit.glossary</code></td>
+                        <td class="description">Generate comprehensive project glossary with terms, definitions, acronyms, and cross-references</td>
+                        <td>Strategic Planning</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+
+                    <!-- Detailed Design -->
+                    <tr data-status="live" data-category="detailed-design">
                         <td><code>/arckit.data-model</code></td>
                         <td class="description">Create comprehensive data model with entity relationships, GDPR compliance, and data governance</td>
-                        <td>Architecture</td>
+                        <td>Detailed Design</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-DATA-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-DATA-v1.0.md" title="App Packaging">v3/002</a>
@@ -756,17 +798,17 @@
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="alpha" data-category="architecture">
+                    <tr data-status="alpha" data-category="detailed-design">
                         <td><code>/arckit.data-mesh-contract</code></td>
                         <td class="description">Create federated data product contracts for mesh architectures with SLAs, governance, and interoperability guarantees</td>
-                        <td>Architecture</td>
+                        <td>Detailed Design</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
                     </tr>
-                    <tr data-status="beta" data-category="compliance">
+                    <tr data-status="beta" data-category="detailed-design">
                         <td><code>/arckit.dpia</code></td>
                         <td class="description">Generate <a href="https://ico.org.uk/for-organisations/uk-gdpr-guidance-and-resources/accountability-and-governance/data-protection-impact-assessments-dpias/" class="govuk-link">Data Protection Impact Assessment (DPIA)</a> for UK GDPR Article 35 compliance</td>
-                        <td>Compliance</td>
+                        <td>Detailed Design</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-DPIA-v1.0.md" title="Windows 11">v3</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-DPIA-v1.0.md" title="ONS Data">v8</a>
@@ -778,22 +820,10 @@
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-
-                    <!-- Architecture -->
-                    <tr data-status="experimental" data-category="architecture">
-                        <td><code>/arckit.platform-design</code></td>
-                        <td class="description">Create platform strategy using Platform Design Toolkit (8 canvases for multi-sided ecosystems)</td>
-                        <td>Architecture</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-GAAP-v1.0.md" title="ONS Data">v8</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v10-training-marketplace/#projects/001-ai-training-marketplace/ARC-001-PLAT-v1.0.md" title="Training">v10</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="discovery">
+                    <tr data-status="beta" data-category="detailed-design">
                         <td><code>/arckit.research</code></td>
                         <td class="description">Research technology, services, and products to meet requirements with build vs buy analysis</td>
-                        <td>Discovery</td>
+                        <td>Detailed Design</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-RSCH-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-RSCH-v1.0.md" title="App Packaging">v3/002</a>
@@ -803,55 +833,10 @@
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="experimental" data-category="architecture">
-                        <td><code>/arckit.wardley</code></td>
-                        <td class="description">Create strategic Wardley Maps for architecture decisions and build vs buy analysis</td>
-                        <td>Architecture</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Windows 11">v3</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Patent">v6</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v11-national-highways-data/#projects/001-national-highways-data-architecture-modernization/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Highways">v11</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/wardley-maps/ARC-001-WARD-001-v1.0.md" title="SCTS">v14</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="planning">
-                        <td><code>/arckit.roadmap</code></td>
-                        <td class="description">Create strategic architecture roadmap with multi-year timeline, capability evolution, and governance</td>
-                        <td>Planning</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-ROAD-v1.0.md" title="Windows 11">v3</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="planning">
-                        <td><code>/arckit.strategy</code></td>
-                        <td class="description">Synthesise strategic artifacts into executive-level Architecture Strategy document</td>
-                        <td>Planning</td>
-                        <td class="examples">—</td>
-                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="architecture">
-                        <td><code>/arckit.adr</code></td>
-                        <td class="description">Document architectural decisions with options analysis and traceability</td>
-                        <td>Architecture</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/decisions/ARC-001-ADR-001-v1.0.md" title="Windows 11 Migration">v3/001</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/decisions/ARC-002-ADR-001-v1.0.md" title="App Packaging">v3/002</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/003-peripherals-update-upgrade/decisions/ARC-003-ADR-001-v1.0.md" title="Peripherals">v3/003</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/004-conference-facilities-modernization/decisions/ARC-004-ADR-001-v1.0.md" title="Conference">v3/004</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/005-cloud-pki/decisions/ARC-005-ADR-001-v1.0.md" title="Cloud PKI">v3/005</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/007-vpn-service-windows11-autopilot/decisions/ARC-007-ADR-001-v1.0.md" title="VPN">v3/007</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/decisions/ARC-001-ADR-001-v1.0.md" title="SCTS">v14</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
-                    </tr>
-
-                    <!-- Research -->
-                    <tr data-status="experimental" data-category="research">
+                    <tr data-status="experimental" data-category="detailed-design">
                         <td><code>/arckit.azure-research</code></td>
                         <td class="description">Research Azure services and architecture patterns using Microsoft Learn MCP for authoritative guidance</td>
-                        <td>Research</td>
+                        <td>Detailed Design</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/research/ARC-001-AZRS-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/research/ARC-002-AZRS-v1.0.md" title="App Packaging">v3/002</a>
@@ -862,10 +847,10 @@
                         </td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
-                    <tr data-status="experimental" data-category="research">
+                    <tr data-status="experimental" data-category="detailed-design">
                         <td><code>/arckit.aws-research</code></td>
                         <td class="description">Research AWS services and architecture patterns using AWS Knowledge MCP for authoritative guidance</td>
-                        <td>Research</td>
+                        <td>Detailed Design</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/research/ARC-001-AWRS-v1.0.md" title="SCTS">v14</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v17-fuel-prices/#projects/001-uk-fuel-price-transparency-service/research/ARC-001-AWRS-v1.0.md" title="Fuel Prices">v17</a>
@@ -874,25 +859,73 @@
                         </td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
-                    <tr data-status="experimental" data-category="research">
+                    <tr data-status="experimental" data-category="detailed-design">
                         <td><code>/arckit.gcp-research</code></td>
                         <td class="description">Research Google Cloud services and architecture patterns using <a href="https://developerknowledge.googleapis.com/mcp">Google Developer Knowledge MCP</a></td>
-                        <td>Research</td>
+                        <td>Detailed Design</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
-
-                    <!-- Discovery (datascout) -->
-                    <tr data-status="experimental" data-category="discovery">
+                    <tr data-status="experimental" data-category="detailed-design">
                         <td><code>/arckit.datascout</code></td>
                         <td class="description">Discover external data sources (APIs, datasets, open data portals) to fulfil project requirements</td>
-                        <td>Discovery</td>
+                        <td>Detailed Design</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v17-fuel-prices/#projects/001-uk-fuel-price-transparency-service/ARC-001-DSCT-v1.0.md" title="Fuel Prices">v17</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v18-smart-meter/#projects/001-smart-meter-app/ARC-001-DSCT-v1.0.md" title="Smart Meter">v18</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v19-gov-api-aggregator/#projects/001-uk-government-api-aggregator/ARC-001-DSCT-v1.0.md" title="Gov API Aggregator">v19</a>
                         </td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="detailed-design">
+                        <td><code>/arckit.dfd</code></td>
+                        <td class="description">Generate Data Flow Diagrams (DFD) showing how data moves through system components, trust boundaries, and external entities</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="detailed-design">
+                        <td><code>/arckit.wardley</code></td>
+                        <td class="description">Create strategic Wardley Maps for architecture decisions and build vs buy analysis</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Windows 11">v3</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Patent">v6</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v11-national-highways-data/#projects/001-national-highways-data-architecture-modernization/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Highways">v11</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/wardley-maps/ARC-001-WARD-001-v1.0.md" title="SCTS">v14</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="detailed-design">
+                        <td><code>/arckit.diagram</code></td>
+                        <td class="description">Generate architecture diagrams using Mermaid for visual documentation</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/diagrams/ARC-001-DIAG-001-v1.0.md" title="M365">v1</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/diagrams/ARC-001-DIAG-001-v1.0.md" title="Windows 11 Migration">v3/001</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/005-cloud-pki/diagrams/ARC-005-DIAG-001-v1.0.md" title="Cloud PKI">v3/005</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/007-vpn-service-windows11-autopilot/diagrams/ARC-007-DIAG-001-v1.0.md" title="VPN">v3/007</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v10-training-marketplace/#projects/001-ai-training-marketplace/diagrams/ARC-001-DIAG-001-v1.0.md" title="Training">v10</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/diagrams/ARC-001-DIAG-001-v1.0.md" title="SCTS">v14</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v17-fuel-prices/#projects/001-uk-fuel-price-transparency-service/diagrams/ARC-001-DIAG-001-v1.0.md" title="Fuel Prices">v17</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v19-gov-api-aggregator/#projects/001-uk-government-api-aggregator/diagrams/ARC-001-DIAG-001-v1.0.md" title="Gov API Aggregator">v19</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="detailed-design">
+                        <td><code>/arckit.adr</code></td>
+                        <td class="description">Document architectural decisions with options analysis and traceability</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/decisions/ARC-001-ADR-001-v1.0.md" title="Windows 11 Migration">v3/001</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/decisions/ARC-002-ADR-001-v1.0.md" title="App Packaging">v3/002</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/003-peripherals-update-upgrade/decisions/ARC-003-ADR-001-v1.0.md" title="Peripherals">v3/003</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/004-conference-facilities-modernization/decisions/ARC-004-ADR-001-v1.0.md" title="Conference">v3/004</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/005-cloud-pki/decisions/ARC-005-ADR-001-v1.0.md" title="Cloud PKI">v3/005</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/007-vpn-service-windows11-autopilot/decisions/ARC-007-ADR-001-v1.0.md" title="VPN">v3/007</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/decisions/ARC-001-ADR-001-v1.0.md" title="SCTS">v14</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
 
                     <!-- Procurement -->
@@ -957,53 +990,30 @@
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
 
-                    <!-- Architecture (continued) -->
-                    <tr data-status="live" data-category="architecture">
-                        <td><code>/arckit.diagram</code></td>
-                        <td class="description">Generate architecture diagrams using Mermaid for visual documentation</td>
-                        <td>Architecture</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/diagrams/ARC-001-DIAG-001-v1.0.md" title="M365">v1</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/diagrams/ARC-001-DIAG-001-v1.0.md" title="Windows 11 Migration">v3/001</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/005-cloud-pki/diagrams/ARC-005-DIAG-001-v1.0.md" title="Cloud PKI">v3/005</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/007-vpn-service-windows11-autopilot/diagrams/ARC-007-DIAG-001-v1.0.md" title="VPN">v3/007</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v10-training-marketplace/#projects/001-ai-training-marketplace/diagrams/ARC-001-DIAG-001-v1.0.md" title="Training">v10</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/diagrams/ARC-001-DIAG-001-v1.0.md" title="SCTS">v14</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v17-fuel-prices/#projects/001-uk-fuel-price-transparency-service/diagrams/ARC-001-DIAG-001-v1.0.md" title="Fuel Prices">v17</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v19-gov-api-aggregator/#projects/001-uk-government-api-aggregator/diagrams/ARC-001-DIAG-001-v1.0.md" title="Gov API Aggregator">v19</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-live">Live</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="architecture">
-                        <td><code>/arckit.dfd</code></td>
-                        <td class="description">Generate Data Flow Diagrams (DFD) showing how data moves through system components, trust boundaries, and external entities</td>
-                        <td>Architecture</td>
-                        <td class="examples">—</td>
-                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="architecture">
+                    <!-- Design Reviews -->
+                    <tr data-status="beta" data-category="design-reviews">
                         <td><code>/arckit.hld-review</code></td>
                         <td class="description">Review High-Level Design (HLD) against architecture principles and requirements</td>
-                        <td>Architecture</td>
+                        <td>Design Reviews</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/reviews/ARC-001-HLD-v1.0.md" title="Windows 11">v3</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/reviews/ARC-001-HLD-v1.0.md" title="SCTS">v14</a>
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="beta" data-category="architecture">
+                    <tr data-status="beta" data-category="design-reviews">
                         <td><code>/arckit.dld-review</code></td>
                         <td class="description">Review Detailed Design (DLD) for implementation readiness</td>
-                        <td>Architecture</td>
+                        <td>Design Reviews</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
 
-                    <!-- Operations -->
-                    <tr data-status="beta" data-category="planning">
+                    <!-- Implementation -->
+                    <tr data-status="beta" data-category="implementation">
                         <td><code>/arckit.backlog</code></td>
                         <td class="description">Generate prioritised product backlog from ArcKit artifacts - convert requirements to user stories, organise into sprints</td>
-                        <td>Planning</td>
+                        <td>Implementation</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-BKLG-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-BKLG-v1.0.md" title="App Packaging">v3/002</a>
@@ -1016,13 +1026,15 @@
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="experimental" data-category="reporting">
+                    <tr data-status="experimental" data-category="implementation">
                         <td><code>/arckit.trello</code></td>
                         <td class="description">Export product backlog to Trello - create board, lists, cards with labels and checklists from backlog JSON</td>
-                        <td>Reporting</td>
+                        <td>Implementation</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
+
+                    <!-- Operations -->
                     <tr data-status="beta" data-category="operations">
                         <td><code>/arckit.servicenow</code></td>
                         <td class="description">Create comprehensive ServiceNow service design with CMDB, SLAs, incident management, and change control</td>
@@ -1068,10 +1080,10 @@
                         </td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
-                    <tr data-status="live" data-category="governance">
+                    <tr data-status="live" data-category="operations">
                         <td><code>/arckit.traceability</code></td>
                         <td class="description">Generate requirements traceability matrix from requirements to design to tests</td>
-                        <td>Governance</td>
+                        <td>Operations</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v1-m365/#projects/001-exchange-online-migration/ARC-001-TRAC-v1.0.md" title="M365">v1</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-TRAC-v1.0.md" title="HMRC">v2</a>
@@ -1085,11 +1097,11 @@
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
 
-                    <!-- Governance -->
-                    <tr data-status="beta" data-category="governance">
+                    <!-- Quality & Compliance -->
+                    <tr data-status="beta" data-category="quality-compliance">
                         <td><code>/arckit.analyze</code></td>
                         <td class="description">Perform comprehensive governance quality analysis across architecture artifacts (requirements, principles, designs, assessments)</td>
-                        <td>Governance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/ARC-001-ANAL-v1.0.md" title="Patent">v6</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-ANAL-v1.0.md" title="Cabinet Office">v9</a>
@@ -1098,39 +1110,44 @@
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="live" data-category="governance">
+                    <tr data-status="live" data-category="quality-compliance">
                         <td><code>/arckit.principles-compliance</code></td>
                         <td class="description">Assess compliance with architecture principles and generate scorecard with evidence, gaps, and recommendations</td>
-                        <td>Governance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-PRIN-COMP-v1.0.md" title="Windows 11">v3</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-PRIN-COMP-v1.0.md" title="SCTS">v14</a>
                         </td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-                    <tr data-status="beta" data-category="governance">
+                    <tr data-status="beta" data-category="quality-compliance">
                         <td><code>/arckit.conformance</code></td>
                         <td class="description">Systematic architecture conformance assessment — validates ADR decisions against designs, checks architecture drift, tracks technical debt, and enforces custom constraint rules</td>
-                        <td>Governance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-
-                    <!-- Compliance -->
-                    <tr data-status="beta" data-category="compliance">
+                    <tr data-status="beta" data-category="quality-compliance">
+                        <td><code>/arckit.maturity-model</code></td>
+                        <td class="description">Generate capability maturity model with current-state assessment, target-state definition, and improvement roadmap</td>
+                        <td>Quality &amp; Compliance</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="quality-compliance">
                         <td><code>/arckit.service-assessment</code></td>
                         <td class="description">Prepare for <a href="https://www.gov.uk/service-manual/service-assessments" class="govuk-link">GDS Service Standard</a> assessment - analyze evidence against 14 points, identify gaps, generate readiness report</td>
-                        <td>Compliance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v16-doctors-appointment/#projects/001-doctors-appointment/ARC-001-SASS-v1.0.md" title="Doctors">v16</a>
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="beta" data-category="compliance">
+                    <tr data-status="beta" data-category="quality-compliance">
                         <td><code>/arckit.tcop</code></td>
                         <td class="description">Generate a <a href="https://www.gov.uk/guidance/the-technology-code-of-practice" class="govuk-link">Technology Code of Practice (TCoP)</a> review document for a UK Government technology project</td>
-                        <td>Compliance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/ARC-001-TCOP-v1.0.md" title="Patent">v6</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-TCOP-v1.0.md" title="ONS Data">v8</a>
@@ -1140,10 +1157,31 @@
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="beta" data-category="compliance">
+                    <tr data-status="alpha" data-category="quality-compliance">
+                        <td><code>/arckit.ai-playbook</code></td>
+                        <td class="description">Assess <a href="https://www.gov.uk/government/publications/ai-playbook-for-the-uk-government" class="govuk-link">UK Government AI Playbook</a> compliance for responsible AI deployment</td>
+                        <td>Quality &amp; Compliance</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-AIPB-v1.0.md" title="Cabinet Office">v9</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-AIPB-v1.0.md" title="SCTS">v14</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
+                    </tr>
+                    <tr data-status="alpha" data-category="quality-compliance">
+                        <td><code>/arckit.atrs</code></td>
+                        <td class="description">Generate <a href="https://www.gov.uk/government/collections/algorithmic-transparency-recording-standard-hub" class="govuk-link">Algorithmic Transparency Recording Standard (ATRS)</a> record for AI/algorithmic tools</td>
+                        <td>Quality &amp; Compliance</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-ATRS-v1.0.md" title="HMRC">v2</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-ATRS-v1.0.md" title="Cabinet Office">v9</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-ATRS-v1.0.md" title="SCTS">v14</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="quality-compliance">
                         <td><code>/arckit.secure</code></td>
                         <td class="description">Generate a Secure by Design assessment for UK Government projects (civilian departments)</td>
-                        <td>Compliance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-SECD-v1.0.md" title="ONS Data">v8</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-SECD-v1.0.md" title="Cabinet Office">v9</a>
@@ -1156,48 +1194,44 @@
                         </td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="alpha" data-category="compliance">
-                        <td><code>/arckit.ai-playbook</code></td>
-                        <td class="description">Assess <a href="https://www.gov.uk/government/publications/ai-playbook-for-the-uk-government" class="govuk-link">UK Government AI Playbook</a> compliance for responsible AI deployment</td>
-                        <td>Compliance</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-AIPB-v1.0.md" title="Cabinet Office">v9</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-AIPB-v1.0.md" title="SCTS">v14</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
-                    </tr>
-                    <tr data-status="alpha" data-category="compliance">
-                        <td><code>/arckit.atrs</code></td>
-                        <td class="description">Generate <a href="https://www.gov.uk/government/collections/algorithmic-transparency-recording-standard-hub" class="govuk-link">Algorithmic Transparency Recording Standard (ATRS)</a> record for AI/algorithmic tools</td>
-                        <td>Compliance</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v2-hmrc-chatbot/#projects/001-hmrc-chatbot/ARC-001-ATRS-v1.0.md" title="HMRC">v2</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-ATRS-v1.0.md" title="Cabinet Office">v9</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-ATRS-v1.0.md" title="SCTS">v14</a>
-                        </td>
-                        <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
-                    </tr>
-
-                    <!-- Compliance (MOD) -->
-                    <tr data-status="experimental" data-category="compliance">
+                    <tr data-status="experimental" data-category="quality-compliance">
                         <td><code>/arckit.mod-secure</code></td>
                         <td class="description">Generate a MOD Secure by Design assessment for UK Ministry of Defence projects using CAAT and continuous assurance</td>
-                        <td>Compliance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-SECD-MOD-v1.0.md" title="Windows 11 Migration">v3/001</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/006-large-format-printer/ARC-006-SECD-MOD-v1.0.md" title="Large Format Printer">v3/006</a>
                         </td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
-                    <tr data-status="experimental" data-category="compliance">
+                    <tr data-status="experimental" data-category="quality-compliance">
                         <td><code>/arckit.jsp-936</code></td>
                         <td class="description">Generate <a href="https://www.gov.uk/government/publications/jsp-936-dependable-artificial-intelligence-ai-in-defence-part-1-directive" class="govuk-link">MOD JSP 936</a> AI assurance documentation for defence AI/ML systems</td>
-                        <td>Compliance</td>
+                        <td>Quality &amp; Compliance</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
 
-                    <!-- Other -->
+                    <!-- Reporting -->
+                    <tr data-status="live" data-category="reporting">
+                        <td><code>/arckit.story</code></td>
+                        <td class="description">Generate comprehensive project story with timeline analysis, traceability, and governance achievements</td>
+                        <td>Reporting</td>
+                        <td class="examples">
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-STORY-v1.0.md" title="Windows 11">v3</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-STORY-v1.0.md" title="ONS Data">v8</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-STORY-v1.0.md" title="Cabinet Office">v9</a>
+                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-STORY-v1.0.md" title="SCTS">v14</a>
+                        </td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="reporting">
+                        <td><code>/arckit.presentation</code></td>
+                        <td class="description">Generate MARP slide deck from project artifacts for governance boards and stakeholder briefings</td>
+                        <td>Reporting</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
                     <tr data-status="alpha" data-category="reporting">
                         <td><code>/arckit.pages</code></td>
                         <td class="description">Generate GitHub Pages documentation site with Mermaid diagrams, artifact health dashboard, vendor profiles, tech notes, dark mode, and guide auto-sync</td>
@@ -1221,59 +1255,49 @@
                         <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
                     </tr>
 
-                    <!-- Reporting -->
-                    <tr data-status="live" data-category="reporting">
-                        <td><code>/arckit.story</code></td>
-                        <td class="description">Generate comprehensive project story with timeline analysis, traceability, and governance achievements</td>
-                        <td>Reporting</td>
-                        <td class="examples">
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-STORY-v1.0.md" title="Windows 11">v3</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-STORY-v1.0.md" title="ONS Data">v8</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v9-cabinet-office-genai/#projects/001-cabinet-office-genai/ARC-001-STORY-v1.0.md" title="Cabinet Office">v9</a>
-                            <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/ARC-001-STORY-v1.0.md" title="SCTS">v14</a>
-                        </td>
+                    <!-- Utility -->
+                    <tr data-status="live" data-category="utility">
+                        <td><code>/arckit.init</code></td>
+                        <td class="description">Initialize ArcKit project structure with numbered project directories and global artifacts</td>
+                        <td>Utility</td>
+                        <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-
-                    <tr data-status="beta" data-category="reporting">
-                        <td><code>/arckit.presentation</code></td>
-                        <td class="description">Generate MARP slide deck from project artifacts for governance boards and stakeholder briefings</td>
-                        <td>Reporting</td>
+                    <tr data-status="live" data-category="utility">
+                        <td><code>/arckit.customize</code></td>
+                        <td class="description">Copy templates to <code>.arckit/templates-custom/</code> for customization (preserved across updates)</td>
+                        <td>Utility</td>
                         <td class="examples">—</td>
-                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
-
-                    <!-- Diagnostics -->
-                    <tr data-status="beta" data-category="governance">
+                    <tr data-status="alpha" data-category="utility">
+                        <td><code>/arckit.template-builder</code></td>
+                        <td class="description">Create new document templates through interactive interview with three-tier origin model (Official/Custom/Community)</td>
+                        <td>Utility</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-alpha">Alpha</span></td>
+                    </tr>
+                    <tr data-status="beta" data-category="utility">
                         <td><code>/arckit.health</code></td>
                         <td class="description">Scan projects for stale research, forgotten ADRs, unresolved review conditions, orphaned requirements, missing traceability, and version drift</td>
-                        <td>Governance</td>
+                        <td>Utility</td>
                         <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-beta">Beta</span></td>
                     </tr>
-                    <tr data-status="experimental" data-category="governance">
+                    <tr data-status="beta" data-category="utility">
+                        <td><code>/arckit.search</code></td>
+                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
+                        <td>Utility</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="utility">
                         <td><code>/arckit.impact</code></td>
                         <td class="description">Analyse blast radius of changes — reverse dependency tracing</td>
-                        <td>Governance</td>
+                        <td>Utility</td>
                         <td class="examples">
                         </td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
-                    </tr>
-                    <tr data-status="beta" data-category="governance">
-                        <td><code>/arckit.search</code></td>
-                        <td class="description">Search across all project artifacts by keyword, document type, or requirement ID</td>
-                        <td>Governance</td>
-                        <td class="examples">—</td>
-                        <td><span class="app-status-tag app-status-beta">Beta</span></td>
-                    </tr>
-
-                    <!-- Template Customization -->
-                    <tr data-status="live" data-category="other">
-                        <td><code>/arckit.customize</code></td>
-                        <td class="description">Copy templates to <code>.arckit/templates-custom/</code> for customization (preserved across updates)</td>
-                        <td>Other</td>
-                        <td class="examples">—</td>
-                        <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
                 </tbody>
             </table>

--- a/docs/guides/pages.md
+++ b/docs/guides/pages.md
@@ -168,7 +168,6 @@ The dashboard (`#dashboard`) is the default landing page, providing an instant p
 | Documents by Category | SVG donut chart showing document distribution across Discovery, Planning, Architecture, etc. |
 | Project Artifact Coverage | Horizontal bar chart per project with color coding (green >=80%, amber >=50%, red <50%) |
 | Projects Table | Name, Docs, Diagrams, ADRs, Vendors, Coverage mini-bar |
-| Guide Maturity | SVG donut chart showing live/beta/alpha/experimental guide counts |
 | Governance Coverage | Checklist of key artifact types present/absent across portfolio |
 
 ### Coverage Calculation


### PR DESCRIPTION
## Summary
- Replaces 10 functional categories (Discovery, Planning, Architecture, etc.) with 13 tier-aligned categories matching the Command Dependencies section on the same page
- Adds 4 missing commands: `framework`, `glossary`, `maturity-model`, `template-builder`
- Reorders all 60 command rows by new category groupings with HTML comment markers

## Test plan
- [ ] Open commands.html locally and verify category filter dropdown shows new categories
- [ ] Verify filtering works correctly for each category
- [ ] Verify all 60 commands display with correct category labels
- [ ] Verify category groupings match the dependency matrix tier labels below

🤖 Generated with [Claude Code](https://claude.com/claude-code)