### PR TITLE
feat: add GitHub issue forms for bugs, features, and questions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,110 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour
+labels: ["bug"]
+body:
+  - type: input
+    id: command
+    attributes:
+      label: Command
+      description: Which ArcKit command triggered the bug?
+      placeholder: "/arckit.requirements"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps to reproduce the issue.
+      placeholder: |
+        1. Run `/arckit.requirements My Project`
+        2. Wait for output
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include any error messages.
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / logs
+      description: Paste screenshots or terminal output if helpful.
+      render: text
+    validations:
+      required: false
+
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: AI Tool
+      description: Which AI tool are you using?
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - OpenCode CLI
+        - GitHub Copilot
+        - ArcKit CLI
+    validations:
+      required: true
+
+  - type: input
+    id: ai-tool-version
+    attributes:
+      label: AI Tool version
+      description: The version of your AI tool.
+      placeholder: "Claude Code v2.1.71"
+    validations:
+      required: true
+
+  - type: input
+    id: arckit-version
+    attributes:
+      label: ArcKit version
+      description: The ArcKit plugin/CLI version.
+      placeholder: "4.2.9"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Windows
+        - Linux/WSL
+        - Codespaces/DevContainer
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/e28w3deA
+    about: Ask general questions and discuss ideas with the community
+  - name: Documentation
+    url: https://tractorjuice.github.io/arc-kit/
+    about: Browse ArcKit documentation and command guides

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -1,0 +1,60 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line summary of the feature.
+      placeholder: "Add /arckit.security-review command"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What problem does this solve? What's the use case?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you envision this working?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: AI Tool
+      description: Which AI tool is this most relevant to?
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - OpenCode CLI
+        - GitHub Copilot
+        - ArcKit CLI
+        - All
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Examples, screenshots, or references.
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/question.yml
+++ b/.github/ISSUE_TEMPLATE/question.yml
@@ -1,0 +1,51 @@
+name: Question
+description: Ask a question or get help with ArcKit
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you need help with?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I've tried
+      description: What have you already tried or looked at?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: AI Tool
+      description: Which AI tool are you using?
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - OpenCode CLI
+        - GitHub Copilot
+        - ArcKit CLI
+    validations:
+      required: true
+
+  - type: input
+    id: arckit-version
+    attributes:
+      label: ArcKit version
+      description: The ArcKit plugin/CLI version, if known.
+      placeholder: "4.2.9"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, or links.
+    validations:
+      required: false

--- a/docs/superpowers/plans/2026-03-13-github-issue-templates.md
+++ b/docs/superpowers/plans/2026-03-13-github-issue-templates.md
@@ -1,0 +1,329 @@
+# GitHub Issue Templates Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add GitHub issue forms (YAML) to enforce structured bug reports, feature requests, and questions.
+
+**Architecture:** 4 static YAML files in `.github/ISSUE_TEMPLATE/`. No code, no Actions, no dependencies.
+
+**Tech Stack:** GitHub Issue Forms (YAML)
+
+**Spec:** `docs/superpowers/specs/2026-03-13-github-issue-templates-design.md`
+
+---
+
+## Chunk 1: Issue Templates
+
+### Task 1: Create bug report form
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/bug-report.yml`
+
+- [ ] **Step 1: Create the bug report form**
+
+```yaml
+name: Bug Report
+description: Report a bug or unexpected behaviour
+labels: ["bug"]
+body:
+  - type: input
+    id: command
+    attributes:
+      label: Command
+      description: Which ArcKit command triggered the bug?
+      placeholder: "/arckit.requirements"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the problem.
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: Numbered steps to reproduce the issue.
+      placeholder: |
+        1. Run `/arckit.requirements My Project`
+        2. Wait for output
+        3. See error...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behaviour
+      description: What should have happened?
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behaviour
+      description: What actually happened? Include any error messages.
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: Screenshots / logs
+      description: Paste screenshots or terminal output if helpful.
+      render: text
+    validations:
+      required: false
+
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: AI Tool
+      description: Which AI tool are you using?
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - OpenCode CLI
+        - GitHub Copilot
+        - ArcKit CLI
+    validations:
+      required: true
+
+  - type: input
+    id: ai-tool-version
+    attributes:
+      label: AI Tool version
+      description: The version of your AI tool.
+      placeholder: "Claude Code v2.1.71"
+    validations:
+      required: true
+
+  - type: input
+    id: arckit-version
+    attributes:
+      label: ArcKit version
+      description: The ArcKit plugin/CLI version.
+      placeholder: "4.2.9"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: os
+    attributes:
+      label: Operating System
+      options:
+        - macOS
+        - Windows
+        - Linux/WSL
+        - Codespaces/DevContainer
+    validations:
+      required: true
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Anything else that might help.
+    validations:
+      required: false
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/bug-report.yml
+git commit -m "feat: add bug report issue form"
+```
+
+### Task 2: Create feature request form
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/feature-request.yml`
+
+- [ ] **Step 1: Create the feature request form**
+
+```yaml
+name: Feature Request
+description: Suggest a new feature or enhancement
+labels: ["enhancement"]
+body:
+  - type: input
+    id: summary
+    attributes:
+      label: Summary
+      description: One-line summary of the feature.
+      placeholder: "Add /arckit.security-review command"
+    validations:
+      required: true
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What problem does this solve? What's the use case?
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: How do you envision this working?
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches you've thought about.
+    validations:
+      required: false
+
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: AI Tool
+      description: Which AI tool is this most relevant to?
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - OpenCode CLI
+        - GitHub Copilot
+        - ArcKit CLI
+        - All
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Examples, screenshots, or references.
+    validations:
+      required: false
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/feature-request.yml
+git commit -m "feat: add feature request issue form"
+```
+
+### Task 3: Create question form
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/question.yml`
+
+- [ ] **Step 1: Create the question form**
+
+```yaml
+name: Question
+description: Ask a question or get help with ArcKit
+labels: ["question"]
+body:
+  - type: textarea
+    id: question
+    attributes:
+      label: Question
+      description: What do you need help with?
+    validations:
+      required: true
+
+  - type: textarea
+    id: tried
+    attributes:
+      label: What I've tried
+      description: What have you already tried or looked at?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: ai-tool
+    attributes:
+      label: AI Tool
+      description: Which AI tool are you using?
+      options:
+        - Claude Code
+        - Codex CLI
+        - Gemini CLI
+        - OpenCode CLI
+        - GitHub Copilot
+        - ArcKit CLI
+    validations:
+      required: true
+
+  - type: input
+    id: arckit-version
+    attributes:
+      label: ArcKit version
+      description: The ArcKit plugin/CLI version, if known.
+      placeholder: "4.2.9"
+    validations:
+      required: false
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: Additional context
+      description: Screenshots, logs, or links.
+    validations:
+      required: false
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/question.yml
+git commit -m "feat: add question issue form"
+```
+
+### Task 4: Create config to disable blank issues
+
+**Files:**
+- Create: `.github/ISSUE_TEMPLATE/config.yml`
+
+- [ ] **Step 1: Create the config**
+
+```yaml
+blank_issues_enabled: false
+contact_links:
+  - name: Discord
+    url: https://discord.gg/e28w3deA
+    about: Ask general questions and discuss ideas with the community
+  - name: Documentation
+    url: https://tractorjuice.github.io/arc-kit/
+    about: Browse ArcKit documentation and command guides
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add .github/ISSUE_TEMPLATE/config.yml
+git commit -m "feat: add issue template config — disable blank issues, add Discord link"
+```
+
+### Task 5: Validate YAML syntax
+
+- [ ] **Step 1: Validate all YAML files parse correctly**
+
+```bash
+python -c "
+import yaml, sys
+for f in ['.github/ISSUE_TEMPLATE/bug-report.yml', '.github/ISSUE_TEMPLATE/feature-request.yml', '.github/ISSUE_TEMPLATE/question.yml', '.github/ISSUE_TEMPLATE/config.yml']:
+    with open(f) as fh:
+        yaml.safe_load(fh)
+    print(f'{f}: OK')
+print('All valid')
+"
+```
+
+Expected: All 4 files print OK.

--- a/docs/superpowers/specs/2026-03-13-github-issue-templates-design.md
+++ b/docs/superpowers/specs/2026-03-13-github-issue-templates-design.md
@@ -1,0 +1,103 @@
+# GitHub Issue Templates Design
+
+**Date:** 2026-03-13
+**Status:** Approved
+
+## Problem
+
+ArcKit's GitHub issues are frequently low-quality: vague titles, missing reproduction steps, screenshots with no text explanation, no environment information, and unclear whether the report is a bug, question, or feature request. There are no issue templates or forms enforcing structure, and CONTRIBUTING.md's text checklist is routinely ignored.
+
+## Goals
+
+- Force users to provide structured, actionable information when raising issues
+- Auto-categorise issues by type (bug, feature request, question) with labels
+- Capture environment details (AI tool, version, OS) for bug reports
+- Eliminate blank/unstructured issues
+- Serve both technical and non-technical users equally
+
+## Approach
+
+**Issue Forms (YAML)** — 3 structured form templates plus a `config.yml` to disable blank issues and provide external links. No bots, no GitHub Actions, no ongoing maintenance.
+
+### Alternatives Considered
+
+1. **Markdown templates** — simpler but users can delete pre-filled text, defeating the purpose
+2. **Forms + bot enforcement** — adds a GitHub Action to auto-comment on incomplete issues; more maintenance for marginal benefit since forms already enforce required fields
+
+## File Structure
+
+```
+.github/
+├── ISSUE_TEMPLATE/
+│   ├── bug-report.yml
+│   ├── feature-request.yml
+│   ├── question.yml
+│   └── config.yml
+```
+
+## Form Designs
+
+### Bug Report (`bug-report.yml`)
+
+**Auto-labels:** `bug`
+
+| Field | Type | Required | Details |
+|-------|------|----------|---------|
+| Command | input | yes | Which `/arckit.*` command triggered the bug |
+| Description | textarea | yes | Clear description of the problem |
+| Steps to reproduce | textarea | yes | Numbered steps to reproduce |
+| Expected behaviour | textarea | yes | What should have happened |
+| Actual behaviour | textarea | yes | What actually happened (including error messages) |
+| Screenshots/logs | textarea | no | Paste screenshots or terminal output |
+| AI Tool | dropdown | yes | Claude Code, Codex CLI, Gemini CLI, OpenCode CLI, GitHub Copilot, ArcKit CLI |
+| AI Tool version | input | yes | e.g., "Claude Code v2.1.71" |
+| ArcKit version | input | yes | e.g., "4.2.9" |
+| OS | dropdown | yes | macOS, Windows, Linux/WSL, Codespaces/DevContainer |
+| Additional context | textarea | no | Anything else relevant |
+
+### Feature Request (`feature-request.yml`)
+
+**Auto-labels:** `enhancement`
+
+| Field | Type | Required | Details |
+|-------|------|----------|---------|
+| Summary | input | yes | One-line summary of the feature |
+| Problem/use case | textarea | yes | What problem does this solve? |
+| Proposed solution | textarea | yes | How do you envision this working? |
+| Alternatives considered | textarea | no | Other approaches you've thought about |
+| AI Tool | dropdown | no | Most relevant tool (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI, GitHub Copilot, ArcKit CLI, All) |
+| Additional context | textarea | no | Examples, screenshots, references |
+
+### Question (`question.yml`)
+
+**Auto-labels:** `question`
+
+| Field | Type | Required | Details |
+|-------|------|----------|---------|
+| Question | textarea | yes | What do you need help with? |
+| What I've tried | textarea | yes | What have you already tried or looked at? |
+| AI Tool | dropdown | yes | Claude Code, Codex CLI, Gemini CLI, OpenCode CLI, GitHub Copilot, ArcKit CLI |
+| ArcKit version | input | no | If known |
+| Additional context | textarea | no | Screenshots, logs, links |
+
+### Config (`config.yml`)
+
+- Blank issues: **disabled**
+- Contact links:
+  - Discord — for general questions and community discussion
+  - Documentation — browse ArcKit docs and command guides
+
+## What This Solves
+
+Looking at actual issues from the repo:
+
+- **#160** "all spanish documentation..." — one-line body with no reproduction steps → Bug form forces steps, command, environment
+- **#157** "/arckit.story pls tell me what happen here" — raw terminal dump → Bug form separates description from logs
+- **#155** "is consuming a lot of tokens" — one-line body "that is a normal behaviour" → Question form requires "what I've tried"
+- **#121** screenshots only, no text → Bug form requires text description; screenshots go in optional field
+
+## Out of Scope
+
+- GitHub Actions for automated triage or validation
+- Issue labelling beyond the auto-applied type labels
+- Changes to CONTRIBUTING.md (could be updated later to reference the forms)


### PR DESCRIPTION
## Summary

- Adds 3 structured YAML issue forms (bug report, feature request, question) with required fields to enforce quality
- Disables blank issues — users must pick a template
- Adds Discord and documentation links to the issue chooser
- Includes design spec and implementation plan in `docs/superpowers/`

## Context

Current issues frequently lack reproduction steps, environment info, and clear problem descriptions. These forms enforce the information needed to triage and resolve issues efficiently.

## Files

- `.github/ISSUE_TEMPLATE/bug-report.yml` — 11 fields (command, steps, expected/actual, environment)
- `.github/ISSUE_TEMPLATE/feature-request.yml` — 6 fields (problem, solution, alternatives)
- `.github/ISSUE_TEMPLATE/question.yml` — 5 fields (question, what I've tried, tool)
- `.github/ISSUE_TEMPLATE/config.yml` — disables blank issues, links to Discord + docs

## Test plan

- [ ] Open https://github.com/tractorjuice/arc-kit/issues/new/choose and verify 3 form types appear
- [ ] Verify blank issue option is not available
- [ ] Verify Discord and Documentation links appear
- [ ] Submit a test bug report and confirm required fields are enforced

🤖 Generated with [Claude Code](https://claude.com/claude-code)