### PR TITLE
fix: wrap mermaid.run() in try-catch to prevent page crash

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -3964,7 +3964,7 @@
                 buildTableOfContents(content.querySelector('.app-markdown'));
 
                 // Render mermaid diagrams
-                await mermaid.run({ querySelector: '.mermaid' });
+                try { await mermaid.run({ querySelector: '.mermaid' }); } catch (e) { console.warn('Mermaid render error:', e); }
 
                 // Render PlantUML diagrams (via PlantUML server)
                 renderPlantUMLDiagrams();

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -3964,7 +3964,7 @@
                 buildTableOfContents(content.querySelector('.app-markdown'));
 
                 // Render mermaid diagrams
-                await mermaid.run({ querySelector: '.mermaid' });
+                try { await mermaid.run({ querySelector: '.mermaid' }); } catch (e) { console.warn('Mermaid render error:', e); }
 
                 // Render PlantUML diagrams (via PlantUML server)
                 renderPlantUMLDiagrams();

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -3964,7 +3964,7 @@
                 buildTableOfContents(content.querySelector('.app-markdown'));
 
                 // Render mermaid diagrams
-                await mermaid.run({ querySelector: '.mermaid' });
+                try { await mermaid.run({ querySelector: '.mermaid' }); } catch (e) { console.warn('Mermaid render error:', e); }
 
                 // Render PlantUML diagrams (via PlantUML server)
                 renderPlantUMLDiagrams();

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -3964,7 +3964,7 @@
                 buildTableOfContents(content.querySelector('.app-markdown'));
 
                 // Render mermaid diagrams
-                await mermaid.run({ querySelector: '.mermaid' });
+                try { await mermaid.run({ querySelector: '.mermaid' }); } catch (e) { console.warn('Mermaid render error:', e); }
 
                 // Render PlantUML diagrams (via PlantUML server)
                 renderPlantUMLDiagrams();

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -3964,7 +3964,7 @@
                 buildTableOfContents(content.querySelector('.app-markdown'));
 
                 // Render mermaid diagrams
-                await mermaid.run({ querySelector: '.mermaid' });
+                try { await mermaid.run({ querySelector: '.mermaid' }); } catch (e) { console.warn('Mermaid render error:', e); }
 
                 // Render PlantUML diagrams (via PlantUML server)
                 renderPlantUMLDiagrams();


### PR DESCRIPTION
## Summary
- Wraps `mermaid.run()` in try-catch across all 5 pages-template.html files
- A malformed mermaid diagram now logs a warning instead of crashing the entire page
- Fix ported from test repo observation

## Test plan
- [ ] Open a docs page with a valid mermaid diagram — renders normally
- [ ] Open a docs page with a malformed mermaid diagram — page loads, warning logged to console

🤖 Generated with [Claude Code](https://claude.com/claude-code)