### PR TITLE
feat: Wardley Mapping suite — 4 new commands, enriched references

### DIFF
--- a/.arckit/templates/wardley-climate-template.md
+++ b/.arckit/templates/wardley-climate-template.md
@@ -1,0 +1,260 @@
+# Wardley Climate Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.climate`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Climate Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.climate` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the most significant climate forces acting on this landscape, the components under most pressure, and the key strategic implications. Include whether the overall climate is favourable, neutral, or threatening for the current strategy.]
+
+**Climate Severity**:
+
+| Category | Severity | Most Affected Components |
+|----------|----------|--------------------------|
+| Component Patterns | High / Medium / Low / None | {Component names} |
+| Financial Patterns | High / Medium / Low / None | {Component names} |
+| Speed Patterns | High / Medium / Low / None | {Component names} |
+| Inertia Patterns | High / Medium / Low / None | {Component names} |
+| Competitor Patterns | High / Medium / Low / None | {Component names} |
+| Prediction Patterns | High / Medium / Low / None | {Component names} |
+
+---
+
+## Map Reference
+
+This climate assessment is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+
+---
+
+## Component Inventory
+
+*Extracted from the referenced Wardley Map. All components subject to climate assessment.*
+
+| Component | Visibility | Evolution | Stage |
+|-----------|-----------|-----------|-------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 2} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 3} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 4} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 5} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+
+---
+
+## Climate Assessment by Category
+
+### 1. Component Patterns
+
+*How do components naturally evolve and what forces act on them?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Everything evolves (no component stays still) | Yes / No / Partial | H / M / L | {Observation from the map or market} | {What this means for strategy} |
+| Characteristics change as components evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| No "one size fits all" method | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Success breeds inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems create new sources of worth | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Components can co-evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new areas of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation enables new genesis | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 2. Financial Patterns
+
+*How do economic forces shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Efficiency enables innovation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new sources of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation reduces margin | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New economic models emerge (e.g., SaaS, platform) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Price pressure on product-stage components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Investment bias towards Genesis/Custom stages | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 3. Speed Patterns
+
+*How does the pace of change affect the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Evolution is not uniform (some components evolve faster) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation is accelerating (shorter cycles) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem effects accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Open source accelerates commoditisation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Regulation can slow or accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 4. Inertia Patterns
+
+*What forces resist change in this landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Past success creates resistance to change | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Existing practices embed inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Vendor lock-in creates artificial inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 5. Competitor Patterns
+
+*How do competitor behaviours shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Competitors also face inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants exploit incumbent inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 6. Prediction Patterns
+
+*What can be reliably anticipated about how this landscape will change?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Commoditisation of custom-built components is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Co-evolution of practice and technology is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems will emerge from current commodities | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Shifts from product to utility are visible before they occur | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants will appear at Genesis stage of key components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Inertia creates predictable points of disruption | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem plays follow commoditisation events | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Peace / War / Wonder cycles follow predictable patterns | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+## Per-Component Impact Matrix
+
+*How strongly does each climate category affect each component? H = High, M = Medium, L = Low, — = Not applicable.*
+
+| Component | Component Patterns | Financial Patterns | Speed Patterns | Inertia Patterns | Competitor Patterns | Prediction Patterns |
+|-----------|:-----------------:|:-----------------:|:--------------:|:----------------:|:------------------:|:------------------:|
+| {Component 1} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 2} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 3} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 4} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 5} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+
+---
+
+## Prediction Horizons
+
+*Anticipated evolution of key components over the next 6 and 18 months.*
+
+| Component | Current Stage | 6-Month Prediction | 18-Month Prediction | Confidence | Key Signals |
+|-----------|:------------:|:-----------------:|:------------------:|:----------:|-------------|
+| {Component 1} | Genesis | Custom (0.30) | Custom (0.40) | High / Medium / Low | {Observable signals — market activity, open source, vendor releases} |
+| {Component 2} | Custom | Product (0.55) | Product (0.65) | High / Medium / Low | {Observable signals} |
+| {Component 3} | Product | Product (0.70) | Commodity (0.80) | High / Medium / Low | {Observable signals} |
+| {Component 4} | Commodity | Commodity (0.90) | Commodity (0.95) | High / Medium / Low | {Observable signals} |
+
+---
+
+## Wave Analysis
+
+**Peace / War / Wonder Cycle**:
+
+The Wardley climate framework identifies a recurring cycle in markets:
+
+- **Peace**: Steady improvement of existing products; incumbents dominant; gradual evolution
+- **War**: Rapid disruption as a new model (e.g., cloud, SaaS, open source) makes existing approaches obsolete; major market shift
+- **Wonder**: Post-disruption stabilisation; new commodity enables new genesis; ecosystem flourishes
+
+**Current Positioning for This Context**:
+
+| Market Segment | Current Phase | Evidence | Strategic Implication |
+|----------------|:------------:|----------|-----------------------|
+| {Segment 1} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+| {Segment 2} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+
+**Recommended Response to Phase**:
+
+- {If Peace}: {Strategy for steady-state market — consolidation, efficiency, incremental improvement}
+- {If War}: {Strategy for disruption — move fast, exploit inertia of incumbents, align with the new model}
+- {If Wonder}: {Strategy for post-disruption — explore new genesis opportunities enabled by the new commodity}
+
+---
+
+## Inertia Assessment
+
+| Component | Inertia Type | Severity | Mitigation Strategy |
+|-----------|-------------|:--------:|---------------------|
+| {Component 1} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 2} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 3} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+
+**Inertia Type Definitions**:
+
+- **Skills**: Team expertise locked to legacy technology or practice
+- **Process**: Established workflows and procedures that resist change
+- **Vendor**: Contractual or technical dependencies that create switching costs
+- **Cultural**: "We've always done it this way" — organisational resistance
+- **Capital**: Sunk costs in existing systems justify continued investment
+- **Regulatory**: Compliance requirements that constrain or slow evolution
+
+---
+
+## Strategic Implications
+
+[3-5 bullet points summarising the most actionable strategic implications from the full climate assessment. Each point should connect a specific climate finding to a recommended strategic response.]
+
+- **{Implication 1}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 2}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 3}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 4}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 5}**: {Specific climate finding} → {Recommended strategic response}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map; all components assessed in this document are derived from it |
+| Requirements | ARC-[PROJECT_ID]-REQ-v[VERSION] | Climate signals may invalidate or create new requirements |
+| Research | ARC-[PROJECT_ID]-RSCH-v[VERSION] | Market research provides evidence for climate pattern assessment |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.climate` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/.arckit/templates/wardley-doctrine-template.md
+++ b/.arckit/templates/wardley-doctrine-template.md
@@ -1,0 +1,290 @@
+# Wardley Doctrine Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.doctrine`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WDOC-v[VERSION] |
+| **Document Type** | Wardley Doctrine Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.doctrine` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+**Overall Maturity Score**: [X.X / 5.0] — [Novice / Developing / Practising / Advanced / Leading]
+
+**Phase Positioning**:
+
+| Phase | Name | Score | Status |
+|-------|------|-------|--------|
+| Phase I | Stop Self-Harm | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase II | Becoming More Context Aware | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase III | Better for Less | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase IV | Continuously Evolving | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+
+**Critical Findings**:
+
+1. {Most significant gap or risk from the assessment}
+2. {Second critical finding}
+3. {Third critical finding}
+
+[2-3 sentence narrative summary of the organisation's doctrine maturity and most urgent priorities.]
+
+---
+
+## Strategy Cycle Context
+
+| Element | Summary |
+|---------|---------|
+| **Purpose** | {Why does this organisation or team exist? What is the mission?} |
+| **Landscape** | {What does the Wardley Map of this context reveal? Key components and their evolution positions.} |
+| **Climate** | {What external forces are acting on this landscape? Market shifts, regulation, technology change.} |
+| **Leadership** | {What leadership style is currently in use? Commander's intent vs. detailed instruction? Risk appetite?} |
+
+---
+
+## Doctrine Assessment Matrix
+
+Score key: **1** = Not practised | **2** = Awareness only | **3** = Partially practised | **4** = Consistently practised | **5** = Embedded and exemplary
+
+### Phase I: Stop Self-Harm
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Communication | Use a common language | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Be transparent | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Challenge assumptions | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Know your users | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Focus on user needs | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use appropriate methods | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Remove bias and duplication | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use standards where appropriate | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage inertia | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage failure | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Think small (ecosystem) | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase II: Becoming More Context Aware
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Situational Awareness | Know the details | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Use appropriate doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Be aware of context-specific play | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Understand your environment | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Design for constant evolution | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Small teams with alignment and autonomy | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Move fast | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Be pragmatic | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | There is no one culture | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Seek the best | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase III: Better for Less
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Efficiency | Optimise flow | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Effectiveness over efficiency | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Think big | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Strategy is iterative not linear | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Use multiple methods of working | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | A bias towards the new | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Be the owner | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Set exceptional standards | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase IV: Continuously Evolving
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Learning | Listen to your ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | A bias towards action | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Exploit the landscape | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Understand that strategy is complex | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Commit to the path | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Accept uncertainty | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Spend time on doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Lead the ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+
+---
+
+## Detailed Phase Findings
+
+### Phase I: Stop Self-Harm — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase I Narrative**:
+
+[2-4 sentences describing the organisation's overall performance on Phase I. What self-harming behaviours are present? What is being done well?]
+
+---
+
+### Phase II: Becoming More Context Aware — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase II Narrative**:
+
+[2-4 sentences describing situational awareness maturity. Does the organisation understand its landscape? Does leadership have context for decisions?]
+
+---
+
+### Phase III: Better for Less — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase III Narrative**:
+
+[2-4 sentences describing efficiency and operational maturity. Where is the organisation wasting effort? Where are there genuine improvements?]
+
+---
+
+### Phase IV: Continuously Evolving — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase IV Narrative**:
+
+[2-4 sentences describing the organisation's capacity for continuous evolution. Is learning embedded? Do ecosystems inform strategy?]
+
+---
+
+## Previous Assessment Comparison
+
+*Populate on re-assessment only. Leave blank for initial assessment.*
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+**Overall Score Change**: [Previous X.X] → [Current X.X] ([+/- delta])
+
+---
+
+## Critical Gaps
+
+| Rank | Phase | Category | Principle | Current Score | Target Score | Business Impact |
+|------|-------|----------|-----------|:-------------:|:------------:|-----------------|
+| 1 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 2 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 3 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 4 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 5 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+
+---
+
+## Implementation Roadmap
+
+### Immediate Actions (0-3 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 1} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 2} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 3} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Short-Term Actions (3-12 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 4} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 5} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 6} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Long-Term Actions (12-24 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 7} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 8} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+---
+
+## Recommendations
+
+1. **{Recommendation 1}**
+   - **Rationale**: {Why this is the top priority}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+2. **{Recommendation 2}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+3. **{Recommendation 3}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Doctrine principles should align with and reinforce architecture principles |
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Landscape and climate context for this assessment |
+| Stakeholder Analysis | ARC-[PROJECT_ID]-STKE-v[VERSION] | Leadership and culture context; stakeholder awareness of doctrine |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.doctrine` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/.arckit/templates/wardley-gameplay-template.md
+++ b/.arckit/templates/wardley-gameplay-template.md
@@ -1,0 +1,337 @@
+# Wardley Gameplay Analysis: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.gameplay`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WGAM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Gameplay Analysis |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.gameplay` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the strategic context, the plays selected, and the anticipated outcomes. Include overall strategic posture: aggressive/defensive/opportunistic.]
+
+**Selected Plays Summary**:
+
+| Play | Category | Recommendation | Priority |
+|------|----------|----------------|----------|
+| {Play 1} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 2} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 3} | {Category A-K} | Monitor | High / Medium / Low |
+
+---
+
+## Map Reference
+
+This gameplay analysis is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+| **Key Components** | {List 3-5 key components from the map} |
+
+---
+
+## Situational Assessment
+
+### Position Analysis
+
+*What does your current map position tell you about strategic options?*
+
+- **Anchor (User Need)**: {Anchor component and its evolution position}
+- **Differentiating Components**: {Components in Genesis/Custom that provide competitive advantage}
+- **Commodity Dependencies**: {Components already at commodity — not strategic, cost-focus only}
+- **Evolution Pressure**: {Components showing signs of rapid evolution — where the map is moving}
+
+### Capability Assessment
+
+*What can your organisation do well, and where are the gaps?*
+
+- **Core Strengths**: {What the organisation does better than competitors in this landscape}
+- **Critical Weaknesses**: {Capability gaps that constrain strategic options}
+- **Unique Assets**: {Assets, data, relationships, or IP that could be leveraged}
+- **Constraints**: {Budget, skills, regulatory, or time constraints affecting play selection}
+
+### Market Context
+
+*What is happening in the competitive environment?*
+
+- **Competitor Positions**: {Where are key competitors positioned on the map?}
+- **Market Signals**: {What trends indicate where the market is heading?}
+- **Regulatory Environment**: {Any constraints or opportunities from regulation?}
+- **Partnership Opportunities**: {Potential ecosystem partners or coalition plays?}
+
+---
+
+## Play Options by Category
+
+### A. Accelerator Plays
+
+*Speed up component evolution to reshape the landscape.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Open approaches (open source, open data, open standards) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Exploit the ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Contribute to standards bodies | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### B. Decelerator Plays
+
+*Slow down competitor evolution or commoditisation.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| FUD (Fear, Uncertainty, Doubt) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Differentiation | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Lobbying and regulatory influence | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### C. Market Plays
+
+*Shape market conditions in your favour.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Buyer and supplier education | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Press and analyst briefings | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### D. Defensive Plays
+
+*Protect your position from competitive threats.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Protective moat (IP, switching costs) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Embrace and extend | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Threat acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### E. Attacking Plays
+
+*Move against competitor positions.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Exploiting inertia | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Undermining barriers to entry | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Talent acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### F. Ecosystem Plays
+
+*Leverage or build ecosystems for competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Building a platform | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Co-opting an ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating a pricing game | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### G. Positional Plays
+
+*Move to advantageous positions on the map.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Tower and moat | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Land grab | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Sensing engine | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### H. Poison Plays
+
+*Make a position undesirable for competitors.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Disposal of a liability | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Swamping | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### I. Innovation Plays
+
+*Create new value through novel combinations.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Design for uncharted spaces | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Signal distortion | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### J. People Plays
+
+*Leverage talent and culture as competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Centres of gravity | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Pioneer / settler / town planner model | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### K. Political Plays
+
+*Navigate organisational or market politics.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Creating artificial constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Trojan horse | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+---
+
+## Play-Position Matrix Evaluation
+
+*For each key component position on the map, identify which plays are naturally aligned.*
+
+| Component | Visibility | Evolution | Stage | Recommended Plays | Rationale |
+|-----------|-----------|-----------|-------|-------------------|-----------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis | {Play names} | {Why these plays fit this position} |
+| {Component 2} | {0.xx} | {0.xx} | Custom | {Play names} | {Why these plays fit this position} |
+| {Component 3} | {0.xx} | {0.xx} | Product | {Play names} | {Why these plays fit this position} |
+| {Component 4} | {0.xx} | {0.xx} | Commodity | {Play names} | {Why these plays fit this position} |
+
+---
+
+## Play Compatibility Analysis
+
+*Evaluate whether selected plays reinforce or conflict with each other.*
+
+| Play A | Play B | Compatibility | Notes |
+|--------|--------|:-------------:|-------|
+| {Play 1} | {Play 2} | Reinforces | {Why these plays work well together} |
+| {Play 1} | {Play 3} | Neutral | {No significant interaction} |
+| {Play 2} | {Play 4} | Conflicts | {Why these plays undermine each other — resolve or sequence carefully} |
+
+**Resolution for conflicts**: {Describe how conflicting plays will be sequenced or one prioritised over the other.}
+
+---
+
+## Selected Plays
+
+### Play 1: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1 — capability, resource, or condition that must be in place}
+- {Prerequisite 2}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+**Expected Outcomes**:
+
+- {Outcome 1 — what success looks like}
+- {Outcome 2}
+
+**Risks**:
+
+- {Risk 1 — what could go wrong}
+- {Risk 2}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+- [ ] {Measurable indicator 2}
+
+**Review Points**: {When to review whether this play is working — e.g., 3 months, after specific milestone}
+
+---
+
+### Play 2: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+
+**Expected Outcomes**:
+
+- {Outcome 1}
+
+**Risks**:
+
+- {Risk 1}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+
+**Review Points**: {When to review whether this play is working}
+
+---
+
+## Risk Assessment and Anti-Patterns
+
+### Play-Specific Risks
+
+| Risk | Play Affected | Likelihood | Impact | Mitigation |
+|------|--------------|------------|--------|------------|
+| {Risk 1} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+| {Risk 2} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+
+### Common Gameplay Anti-Patterns to Avoid
+
+- **Playing too many games at once**: Focus on 2-3 plays maximum; spreading effort dilutes impact
+- **Ignoring inertia**: Plays that require rapid evolution will stall if internal or market inertia is not addressed
+- **Misreading evolution stage**: Applying Genesis plays to Commodity components (or vice versa) wastes resources
+- **Neglecting doctrine**: Gameplay without sound doctrine (Phase I) often backfires
+- **Static play selection**: Plays that are right today may be wrong in 12 months — review regularly
+
+---
+
+## Case Study References
+
+| Case Study | Play(s) Illustrated | Source | Relevance to This Context |
+|------------|---------------------|--------|--------------------------|
+| {Case study 1} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+| {Case study 2} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+
+**Reference**: Simon Wardley, *Wardley Maps* (CC BY-SA 4.0) — available at [https://learnwardleymapping.com/](https://learnwardleymapping.com/)
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map providing landscape context for play selection |
+| Climate Assessment | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] | Climate patterns that constrain or enable specific plays |
+| Doctrine Assessment | ARC-[PROJECT_ID]-WDOC-v[VERSION] | Doctrine maturity governs which plays are executable |
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Plays must not violate established architecture principles |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.gameplay` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/.arckit/templates/wardley-value-chain-template.md
+++ b/.arckit/templates/wardley-value-chain-template.md
@@ -1,0 +1,216 @@
+# Wardley Value Chain: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.value-chain`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WVCH-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Value Chain |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.value-chain` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[Provide a concise summary of the value chain: its anchor (user need), the number of components, key dependencies, and the most critical strategic insights. 3-5 sentences.]
+
+---
+
+## User Need / Anchor
+
+The anchor is the user need at the top of the chain — the reason the value chain exists. Every component below the anchor must ultimately serve this need. If the anchor is wrong, the entire chain is wrong.
+
+**Anchor Statement**: [Describe the user need in one sentence, e.g., "Citizen can apply for a permit online without visiting an office."]
+
+**Good Anchor Examples**:
+
+- "User can access their medical records securely from any device"
+- "Taxpayer can file a return in under 15 minutes"
+- "Procurement team can evaluate vendor bids in a standardised format"
+
+**Bad Anchor Examples** (too technology-focused, not user-centred):
+
+- "System processes API calls" — this is a capability, not a user need
+- "Database stores records" — this is infrastructure, not a user need
+- "Microservices communicate via message bus" — this is implementation, not purpose
+
+---
+
+## Users and Personas
+
+| Persona | Role | Primary Need |
+|---------|------|--------------|
+| {Persona 1} | {Role description} | {Primary need this chain serves} |
+| {Persona 2} | {Role description} | {Primary need this chain serves} |
+| {Persona 3} | {Role description} | {Primary need this chain serves} |
+
+---
+
+## Value Chain Diagram
+
+**View this map**: Paste the OWM syntax below into [https://create.wardleymaps.ai](https://create.wardleymaps.ai)
+
+**ASCII Placeholder**:
+
+```text
+Visibility
+    ^
+1.0 | [User Need / Anchor]
+    |         |
+0.7 |   [Capability A]  [Capability B]
+    |         |               |
+0.4 |   [Component C]  [Component D]  [Component E]
+    |         |
+0.1 |   [Infrastructure F]
+    |
+    +--Genesis--Custom--Product--Commodity-->  Evolution
+       (0.0)   (0.25)  (0.50)   (0.75)  (1.0)
+```
+
+**OWM Syntax**:
+
+```wardley
+title {context_name} Value Chain
+anchor {UserNeed} [0.95, 0.63]
+
+component {CapabilityA} [0.70, 0.45]
+component {CapabilityB} [0.70, 0.72]
+component {ComponentC} [0.42, 0.38]
+component {ComponentD} [0.40, 0.65]
+component {ComponentE} [0.38, 0.80]
+component {InfrastructureF} [0.12, 0.90]
+
+{UserNeed} -> {CapabilityA}
+{UserNeed} -> {CapabilityB}
+{CapabilityA} -> {ComponentC}
+{CapabilityA} -> {ComponentD}
+{CapabilityB} -> {ComponentE}
+{ComponentC} -> {InfrastructureF}
+
+style wardley
+```
+
+---
+
+## Component Inventory
+
+| ID | Component | Description | Depends On | Visibility (0.0-1.0) |
+|----|-----------|-------------|------------|----------------------|
+| C-01 | {Component 1} | {Description} | — | {0.00} |
+| C-02 | {Component 2} | {Description} | C-01 | {0.00} |
+| C-03 | {Component 3} | {Description} | C-01, C-02 | {0.00} |
+| C-04 | {Component 4} | {Description} | C-02 | {0.00} |
+| C-05 | {Component 5} | {Description} | C-03, C-04 | {0.00} |
+
+---
+
+## Dependency Matrix
+
+The dependency matrix shows which components (rows) depend on which other components (columns). A cell marked **X** indicates a direct dependency; **I** indicates an indirect dependency; blank indicates no dependency.
+
+| | C-01 | C-02 | C-03 | C-04 | C-05 |
+|---|------|------|------|------|------|
+| **C-01** | — | | | | |
+| **C-02** | X | — | | | |
+| **C-03** | X | X | — | | |
+| **C-04** | | X | | — | |
+| **C-05** | I | I | X | X | — |
+
+[Replace placeholder rows/columns with actual component IDs from the Component Inventory above.]
+
+---
+
+## Critical Path Analysis
+
+The critical path is the sequence of dependencies from the anchor down to the lowest-level infrastructure component(s), where a failure at any step breaks the chain entirely.
+
+**Critical Path**:
+
+```text
+[User Need / Anchor]
+  └─> [Component X]  (Visibility: 0.xx, Evolution: 0.xx)
+        └─> [Component Y]  (Visibility: 0.xx, Evolution: 0.xx)
+              └─> [Component Z]  (Visibility: 0.xx, Evolution: 0.xx)
+```
+
+**Bottlenecks and Single Points of Failure**:
+
+| Component | Risk Type | Impact if Failed | Mitigation |
+|-----------|-----------|------------------|------------|
+| {Component} | Single vendor / Genesis fragility / Low maturity | {Impact description} | {Mitigation plan} |
+
+**Resilience Gaps**:
+
+- [ ] {Identify components with no fallback or redundancy}
+- [ ] {Identify dependencies on Genesis-stage components}
+- [ ] {Identify vendor lock-in on critical path}
+
+---
+
+## Validation Checklist
+
+- [ ] Chain starts with user need (anchor)
+- [ ] All critical dependencies captured
+- [ ] Chain reaches commodity level
+- [ ] No orphan components
+- [ ] Dependencies reflect reality
+- [ ] Visibility ordering correct
+- [ ] Granularity appropriate for purpose
+
+---
+
+## Visibility Assessment
+
+| Level | Range | Characteristics | Examples |
+|-------|-------|-----------------|---------|
+| **User-facing** | 0.90 - 1.00 | Directly experienced by the user; failure is immediately visible | Login page, search results, payment confirmation |
+| **High** | 0.70 - 0.89 | Close to user; users notice degradation quickly | API gateway, authentication service, user profile |
+| **Medium-High** | 0.50 - 0.69 | Indirectly visible; affects features users rely on | Business logic layer, data validation, reporting engine |
+| **Medium** | 0.30 - 0.49 | Hidden from users but essential to operations; failure noticed over time | Caching layer, queue management, audit logging |
+| **Low** | 0.10 - 0.29 | Invisible to users; operational/infrastructure concern | Database engine, message broker, network routing |
+| **Infrastructure** | 0.00 - 0.09 | Deep infrastructure; users unaware it exists | Power supply, physical server, OS kernel |
+
+---
+
+## Assumptions and Open Questions
+
+**Assumptions Made**:
+
+| # | Assumption | Basis | Confidence |
+|---|------------|-------|------------|
+| A-01 | {Assumption 1} | {Evidence or rationale} | High / Medium / Low |
+| A-02 | {Assumption 2} | {Evidence or rationale} | High / Medium / Low |
+
+**Open Questions**:
+
+| # | Question | Owner | Due Date |
+|---|----------|-------|----------|
+| Q-01 | {Open question 1} | {Owner} | [YYYY-MM-DD] |
+| Q-02 | {Open question 2} | {Owner} | [YYYY-MM-DD] |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.value-chain` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "60 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "64 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.2.11",
       "author": {
         "name": "TractorJuice"

--- a/.gitignore
+++ b/.gitignore
@@ -46,6 +46,7 @@ htmlcov/
 # Project specific
 *.log
 .arckit-debug/
+research/
 
 # Projects (created by arckit init, not part of the toolkit itself)
 projects/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/arckit.wardley.value-chain` command — Decompose user needs into value chains
+- `/arckit.wardley.doctrine` command — Assess organizational doctrine maturity (4 phases, 40+ principles)
+- `/arckit.wardley.gameplay` command — Analyze strategic plays from 60+ gameplay patterns with D&D alignment
+- `/arckit.wardley.climate` command — Assess 32 climatic patterns across 6 categories
+- Wardley reference files enriched from 3 Wardley Mapping books (doctrine, gameplays, climatic patterns)
+- 4 new document types: WVCH, WDOC, WGAM, WCLM
+- 4 new document templates and usage guides
+
+### Fixed
+
+- `wardley.md` hook reference corrected from `python3 .py` to `node .mjs`
+
 ## [4.2.11] - 2026-03-16
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Overview
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 60 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 64 slash commands for AI coding assistants (Claude Code, Codex CLI, Gemini CLI, OpenCode CLI) to generate architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 **Six distribution formats** exist side-by-side in this repo:
 

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 60 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 64 commands, 6 autonomous research agents, 4 automation hooks (session init, project context injection, filename enforcement, output validation), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.71?** This version fixes background agent completion notifications missing output file paths (critical for ArcKit's 6 research agents), resolves plugin installation loss across multiple instances, fixes plugin hooks being silently dropped with `${CLAUDE_PLUGIN_ROOT}` templates, and includes all prior fixes for memory leaks in subagents, MCP server cache leaks, and worktree config sharing.
 
@@ -50,7 +50,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 60 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 64 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
 
 **GitHub Copilot** (VS Code) — install the ArcKit CLI and scaffold prompt files:
 
@@ -62,7 +62,7 @@ pip install git+https://github.com/tractorjuice/arc-kit.git
 arckit init my-project --ai copilot
 ```
 
-Creates `.github/prompts/arckit-*.prompt.md` (60 prompt files), `.github/agents/arckit-*.agent.md` (6 custom agents), and `.github/copilot-instructions.md` (repo-wide context). Invoke commands in Copilot Chat as `/arckit-requirements`, `/arckit-stakeholders`, etc.
+Creates `.github/prompts/arckit-*.prompt.md` (64 prompt files), `.github/agents/arckit-*.agent.md` (6 custom agents), and `.github/copilot-instructions.md` (repo-wide context). Invoke commands in Copilot Chat as `/arckit-requirements`, `/arckit-stakeholders`, etc.
 
 **Codex CLI** — install the ArcKit CLI:
 
@@ -790,7 +790,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 | Feature | Claude Code | Gemini CLI | Copilot | Codex / OpenCode |
 |---------|:-----------:|:----------:|:-------:|:----------------:|
-| 60 slash commands | ✅ | ✅ | ✅ | ✅ |
+| 64 slash commands | ✅ | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ | ✅ |
 | Bundled MCP servers (AWS, Azure, GCP, DataCommons) | ✅ | ✅ (3 servers) | — | Manual setup |
 | **Autonomous research agents** (6 agents for research, datascout, cloud research, framework) | ✅ | — | ✅ (6 agents) | — |
@@ -808,7 +808,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 
 **Hooks** provide automated governance: filenames are auto-corrected to ArcKit conventions, project context is injected into every prompt so commands know what artifacts exist, MCP tools are auto-approved, and generated outputs like Wardley Maps are validated for mathematical consistency before being finalized.
 
-Gemini CLI provides a strong experience with all commands and MCP servers but lacks agent delegation and hooks. GitHub Copilot provides all 60 commands as prompt files and 6 custom agents but lacks hooks and MCP servers. Codex CLI and OpenCode CLI provide core command functionality but require manual setup and `arckit init` scaffolding.
+Gemini CLI provides a strong experience with all commands and MCP servers but lacks agent delegation and hooks. GitHub Copilot provides all 64 commands as prompt files and 6 custom agents but lacks hooks and MCP servers. Codex CLI and OpenCode CLI provide core command functionality but require manual setup and `arckit init` scaffolding.
 
 ### Why Commands, Not Skills
 
@@ -835,7 +835,7 @@ cd my-project && code .
 /arckit-requirements Create comprehensive requirements
 ```
 
-This creates `.github/prompts/arckit-*.prompt.md` (60 prompt files), `.github/agents/arckit-*.agent.md` (6 custom agents), and `.github/copilot-instructions.md` (repo-wide context).
+This creates `.github/prompts/arckit-*.prompt.md` (64 prompt files), `.github/agents/arckit-*.agent.md` (6 custom agents), and `.github/copilot-instructions.md` (repo-wide context).
 
 ### Using with Codex CLI
 
@@ -903,7 +903,7 @@ payment-modernization/
 │   ├── agents/                            # Agent configs
 │   └── config.toml                        # MCP servers + agent roles
 ├── .github/
-│   ├── prompts/arckit-*.prompt.md         # GitHub Copilot prompt files (60 commands)
+│   ├── prompts/arckit-*.prompt.md         # GitHub Copilot prompt files (64 commands)
 │   ├── agents/arckit-*.agent.md           # GitHub Copilot custom agents (6 agents)
 │   └── copilot-instructions.md            # Repo-wide Copilot context
 └── .opencode/commands/                    # OpenCode CLI commands
@@ -939,7 +939,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 60 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 64 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
 
 ### Status Legend
 
@@ -1002,6 +1002,10 @@ All 60 ArcKit commands with maturity status and example outputs from public test
 | `/arckit.platform-design` | Create platform strategy using Platform Design Toolkit (8 canvases for multi-sided ecosystems) | [v8](https://tractorjuice.github.io/arckit-test-project-v8-ons-data-platform/#projects/001-ons-data-platform-modernisation/ARC-001-GAAP-v1.0.md) [v10](https://tractorjuice.github.io/arckit-test-project-v10-training-marketplace/#projects/001-ai-training-marketplace/ARC-001-PLAT-v1.0.md) | 🟣 Experimental |
 | `/arckit.research` | Research technology, services, and products to meet requirements with build vs buy analysis | [v3/001](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-RSCH-v1.0.md) [v3/002](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/002-application-packaging-rationalisation/ARC-002-RSCH-v1.0.md) [v14](https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/research/ARC-001-RSCH-001-v1.0.md) [v17](https://tractorjuice.github.io/arckit-test-project-v17-fuel-prices/#projects/001-uk-fuel-price-transparency-service/ARC-001-RSCH-v1.0.md) [v18](https://tractorjuice.github.io/arckit-test-project-v18-smart-meter/#projects/001-smart-meter-app/ARC-001-RSCH-v1.0.md) | 🔵 Beta |
 | `/arckit.wardley` | Create strategic Wardley Maps for architecture decisions and build vs buy analysis | [v3](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/wardley-maps/ARC-001-WARD-001-v1.0.md) [v6](https://tractorjuice.github.io/arckit-test-project-v6-patent-system/#projects/001-patent-management-system-for-the-intellectual-property-office/wardley-maps/ARC-001-WARD-001-v1.0.md) [v11](https://tractorjuice.github.io/arckit-test-project-v11-national-highways-data/#projects/001-national-highways-data-architecture-modernization/wardley-maps/ARC-001-WARD-001-v1.0.md) [v14](https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/wardley-maps/ARC-001-WARD-001-v1.0.md) | 🟣 Experimental |
+| `/arckit.wardley.value-chain` | Decompose user needs into value chains for Wardley Mapping | — | 🟣 Experimental |
+| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity (4 phases, 40+ principles) | — | 🟣 Experimental |
+| `/arckit.wardley.gameplay` | Analyze strategic plays from 60+ gameplay patterns | — | 🟣 Experimental |
+| `/arckit.wardley.climate` | Assess 32 climatic patterns affecting mapped components | — | 🟣 Experimental |
 | `/arckit.strategy` | Synthesise strategic artifacts into executive-level Architecture Strategy document | — | 🔵 Beta |
 | `/arckit.roadmap` | Create strategic architecture roadmap with multi-year timeline, capability evolution, and governance | [v3](https://tractorjuice.github.io/arckit-test-project-v3-windows11/#projects/001-windows-11-migration-intune/ARC-001-ROAD-v1.0.md) | 🔵 Beta |
 | `/arckit.framework` | Transform architecture artifacts into a structured, reusable framework with principles, patterns, and implementation guidance | — | 🔵 Beta |
@@ -1209,7 +1213,7 @@ Full guidance lives in `docs/` and the static site.
 
 - Quick tour: [docs/index.html](docs/index.html) (mirrors the public landing page).
 - Core guides: [docs/guides/principles.md](docs/guides/principles.md), [docs/guides/requirements.md](docs/guides/requirements.md), [docs/guides/procurement.md](docs/guides/procurement.md), [docs/guides/design-review.md](docs/guides/design-review.md).
-- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 60×60 command matrix.
+- Reference packs: [WORKFLOW-DIAGRAMS.md](docs/WORKFLOW-DIAGRAMS.md) and [DEPENDENCY-MATRIX.md](docs/DEPENDENCY-MATRIX.md) cover lifecycle visualisations and the 64×64 command matrix.
 - Traceability: [docs/guides/traceability.md](docs/guides/traceability.md) documents end-to-end requirements coverage.
 
 ## Relationship to Spec Kit

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.2.11",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 60 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 64 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `/arckit.wardley.value-chain` command — Decompose user needs into value chains
+- `/arckit.wardley.doctrine` command — Assess organizational doctrine maturity (4 phases, 40+ principles)
+- `/arckit.wardley.gameplay` command — Analyze strategic plays from 60+ gameplay patterns with D&D alignment
+- `/arckit.wardley.climate` command — Assess 32 climatic patterns across 6 categories
+- Wardley reference files enriched from 3 Wardley Mapping books (doctrine, gameplays, climatic patterns)
+- 4 new document types: WVCH, WDOC, WGAM, WCLM
+- 4 new document templates and usage guides
+
+### Fixed
+
+- `wardley.md` hook reference corrected from `python3 .py` to `node .mjs`
+
 ## [4.2.11] - 2026-03-16
 
 ### Added

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 60 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 64 slash commands for generating architecture artifacts.
 
 ## Installation
 
@@ -66,7 +66,7 @@ After installing the plugin:
 
 | Component | Count | Description |
 |-----------|-------|-------------|
-| Commands | 60 | Slash commands for architecture artifacts |
+| Commands | 64 | Slash commands for architecture artifacts |
 | Skills | 1 | Conversational Wardley Mapping with interactive guidance |
 | Agents | 6 | Autonomous research agents |
 | Templates | 45 | Document templates with UK Government compliance |

--- a/arckit-claude/commands/wardley.climate.md
+++ b/arckit-claude/commands/wardley.climate.md
@@ -86,6 +86,7 @@ For each component:
 **Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
 
 **Total component summary**:
+
 - Genesis components ({count}): {names}
 - Custom-Built components ({count}): {names}
 - Product components ({count}): {names}
@@ -93,6 +94,7 @@ For each component:
 - Components with noted inertia: {names}
 
 **Ecosystem Type Assessment**:
+
 - Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
 - Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
 - Or mixed?
@@ -271,14 +273,17 @@ Position the overall landscape within the Peace/War/Wonder cycle. This is one of
 For the primary market/domain of this landscape, assess which phase it is in:
 
 **Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+
 - Evidence for: {list}
 - Evidence against: {list}
 

--- a/arckit-claude/commands/wardley.climate.md
+++ b/arckit-claude/commands/wardley.climate.md
@@ -1,0 +1,593 @@
+---
+description: Assess climatic patterns affecting Wardley Map components
+argument-hint: "<domain or market, e.g. 'AI in healthcare', 'UK government digital services'>"
+handoffs:
+  - command: wardley.gameplay
+    description: Select gameplays informed by climate forces
+  - command: wardley
+    description: Update map with climate-driven evolution predictions
+    condition: "Climate analysis reveals evolution velocity changes"
+---
+
+# ArcKit: Wardley Climate Assessment
+
+You are an expert in Wardley Mapping climatic patterns and strategic forecasting. You assess 32 external force patterns across 6 categories that shape the business and technology landscape regardless of what any individual organisation chooses to do. Unlike gameplays (deliberate strategic choices), climatic patterns are the "weather" — they simply happen. Understanding them allows organisations to position ahead of change rather than scramble to react.
+
+## What are Climatic Patterns?
+
+Simon Wardley identifies 32 climatic patterns organised into 6 categories. These patterns describe the external forces that act on every component in a Wardley Map:
+
+1. **Component Patterns** (8 patterns): How components evolve in general
+2. **Financial Patterns** (6 patterns): How capital, value, and economic forces behave
+3. **Speed Patterns** (5 patterns): How fast evolution occurs and what accelerates it
+4. **Inertia Patterns** (3 patterns): How organisations resist necessary change
+5. **Competitor Patterns** (2 patterns): How competitive dynamics shape the landscape
+6. **Prediction Patterns** (8 patterns): What can and cannot be reliably forecast
+
+The output of a climate assessment (WCLM artifact) informs gameplay selection — you cannot choose effective plays without understanding the weather you are playing in.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, current stage classifications, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running climate assessment. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; climate patterns cannot be assessed without knowing what components are in the landscape
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **REQ** (Requirements) — Extract: business drivers, technology context, domain characteristics. Enriches domain-specific climate assessment.
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: market dynamics, vendor landscape, industry trends, competitive intelligence. Market research is the primary evidence source for pattern detection.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores and weaknesses. Inertia pattern severity is amplified by poor doctrine.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles and constraints. Shapes how climate findings translate to strategic implications.
+- **STKE** (Stakeholder Analysis) — Extract: business drivers and stakeholder priorities. Grounds climate assessment in organisational realities.
+
+**Understand the Assessment Context**:
+
+- What domain or market is being assessed? (From user arguments and project context)
+- What is the time horizon for strategic planning? (Affects which patterns matter most)
+- Is this primarily a technology landscape, market landscape, or regulatory landscape assessment?
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract market analysis, industry reports, analyst forecasts, competitive intelligence. These are the primary evidence sources for climate pattern detection.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level climate assessments, enterprise technology landscape reports
+- If no external market documents found but they would materially improve the assessment, ask: "Do you have any market research reports, analyst forecasts, or competitive landscape documents? These significantly improve climate pattern evidence quality. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Read Reference Material
+
+Read the following reference files:
+
+1. **`${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/climatic-patterns.md`** — the complete 32-pattern catalog across 6 categories, with strategic implications, assessment questions, pattern interaction maps, the Peace/War/Wonder cycle, per-component assessment templates, and assessment question sets by category. This is the authoritative source for all pattern descriptions and assessment methodology.
+
+2. **`${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/mathematical-models.md`** — for the impact weighting methodology, evolution scoring formulas, and any quantitative models used to assess evolution velocity and pattern impact severity.
+
+## Step 3: Extract Component Inventory
+
+From the WARD artifact, build a complete component inventory that will be the basis for per-component pattern assessment in Steps 4-6.
+
+For each component:
+
+| Component | Visibility | Evolution | Stage | Dependencies | Inertia Noted |
+|-----------|-----------|-----------|-------|--------------|---------------|
+| [Name] | [0.0-1.0] | [0.0-1.0] | [G/C/P/Cmd] | [list] | [Yes/No/Partial] |
+
+**Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
+
+**Total component summary**:
+- Genesis components ({count}): {names}
+- Custom-Built components ({count}): {names}
+- Product components ({count}): {names}
+- Commodity components ({count}): {names}
+- Components with noted inertia: {names}
+
+**Ecosystem Type Assessment**:
+- Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
+- Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
+- Or mixed?
+
+This affects pattern 1.2 (Rates of Evolution Vary by Ecosystem) — a critical calibration for all velocity predictions.
+
+## Step 4: Assess Climatic Patterns by Category
+
+For each of the 6 categories, evaluate which patterns are actively affecting this specific landscape. Do not simply list all 32 patterns — assess which are demonstrably active, which are latent (approaching but not yet dominant), and which are not currently relevant.
+
+For each **active** or **latent** pattern, provide:
+
+```text
+Pattern: [Pattern Name and Number] — [Category]
+Status: Active / Latent / Not relevant
+Evidence: [1-3 sentences of specific evidence from the map, domain context, or user arguments]
+Primary components affected: [component names from the WARD artifact]
+Impact: High / Medium / Low
+Strategic implication for this landscape: [Specific — not a copy of the generic implication from the reference]
+Time horizon: < 12 months / 1-3 years / 3+ years
+```
+
+### Category 1: Component Patterns (8 patterns)
+
+Assess all 8 patterns from the reference file:
+
+**1.1 Everything Evolves Through Supply and Demand Competition**
+Are components actively moving along the evolution axis? What is driving that movement in this specific domain?
+
+**1.2 Rates of Evolution Can Vary by Ecosystem**
+Is this a fast-moving consumer ecosystem or a slow-moving industrial/government one? What modulating factors (regulation, investment, inertia) affect speed?
+
+**1.3 Characteristics Change as Components Evolve**
+Are any components at stage boundaries where management approach, team structure, or contract type should be changing? Mismatches are active strategic risks.
+
+**1.4 No Choice Over Evolution — The Red Queen Effect**
+Where is the organisation or its competitors running just to stay in place? Is there evidence of competitive pressure forcing adaptation?
+
+**1.5 No Single Method Fits All**
+Is there evidence that a single methodology (agile, waterfall, lean, ITIL) is being applied across components at different evolution stages — creating systematic inefficiency?
+
+**1.6 Components Can Co-evolve**
+Which components are co-evolving? Are there "enabler components" — if they evolve (or are evolved by a competitor), which other components would be dragged along?
+
+**1.7 Evolution Consists of Multiple Waves with Many Chasms**
+Which components are currently in a chasm (adoption stalled between waves)? What is blocking the next adoption wave?
+
+**1.8 Commoditisation Does Not Equal Centralisation**
+Is there an assumption in the strategy that commoditisation will lead to consolidation? Is that assumption valid for this specific market context?
+
+### Category 2: Financial Patterns (6 patterns)
+
+**2.1 Higher Order Systems Create New Sources of Value**
+Are any clusters of recently commoditising components creating the foundation for new higher-order systems? What new value streams are becoming possible?
+
+**2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox**
+Where are efficiency gains likely to trigger increased consumption rather than cost reduction? Where are cost-saving projections likely to be wrong?
+
+**2.3 Capital Flows to New Areas of Value**
+Where is capital (financial, talent, attention) flowing in this domain? What does that flow signal about the next wave of value creation?
+
+**2.4 Creative Destruction — The Schumpeter Effect**
+What genesis-stage components, if they evolve, would make current commodity positions irrelevant? What incumbent positions are most vulnerable?
+
+**2.5 Future Value is Inversely Proportional to Certainty**
+Where is the strategy over-weighted toward certain opportunities (accepting low returns) and under-weighted toward uncertain bets?
+
+**2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption**
+Have full infrastructure and resource costs been accounted for in the higher-order systems being built? Where is there hidden resource consumption?
+
+### Category 3: Speed Patterns (5 patterns)
+
+**3.1 Efficiency Enables Innovation — The Componentization Effect**
+Which Custom-Built components should be replaced with commodity solutions to free resources for higher-value innovation? Where is the organisation building what it should be buying?
+
+**3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed**
+Are there communication bottlenecks (organisational, technical, process) that are slowing the evolution of key components?
+
+**3.3 Increased Stability of Lower Order Systems Increases Agility**
+Are foundational/infrastructure components stable and commodity-grade enough to support rapid innovation at higher levels? Or are lower-order instabilities forcing engineering attention downward?
+
+**3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists**
+Which components in this landscape could exhibit exponential or discontinuous change? Are current plans robust to non-linear scenarios?
+
+**3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium**
+Which Product-stage components are approaching a punctuated shift to utility? What are the triggers, and is the organisation positioned to lead or survive the shift?
+
+### Category 4: Inertia Patterns (3 patterns)
+
+**4.1 Success Breeds Inertia**
+Where is the organisation resisting evolution because current revenue, culture, or identity depends on the status quo? Name specific components or capabilities.
+
+**4.2 Inertia Can Kill an Organisation**
+If a new entrant built this value chain on commodity infrastructure today, what would their cost structure and speed look like? Where is the gap existential?
+
+**4.3 Inertia Increases the More Successful the Past Model Is**
+Where is success so profound that honest self-assessment of the model's future viability is compromised? Where are self-disruption mechanisms needed?
+
+### Category 5: Competitor Patterns (2 patterns)
+
+**5.1 Competitors' Actions Will Change the Game**
+Which competitor action, if taken, would most fundamentally change the basis of competition? Has this scenario been planned for?
+
+**5.2 Most Competitors Have Poor Situational Awareness**
+What would a competitor's map of this landscape look like if drawn by their most capable strategist? Where does your map reveal blind spots they likely have?
+
+### Category 6: Prediction Patterns (8 patterns)
+
+**6.1 Not Everything is Random — P[what] vs P[when]**
+Which evolutionary directions are high-confidence (P[what]) even if timing is uncertain (P[when])? Which strategic commitments are anchored to timing rather than direction?
+
+**6.2 Economy Has Cycles — Peace, War, and Wonder**
+Which phase is the core market in? Which phase transition should the organisation be preparing for? (Full analysis in Step 7.)
+
+**6.3 Different Forms of Disruption — Predictable vs Unpredictable**
+Which disruptions are predictable (plan for them) and which require resilience (prepare for but cannot predict)? Maintain separate portfolios.
+
+**6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve**
+Is there a component approaching industrialisation that will trigger a "war"? What are the early warning signs?
+
+**6.5 You Cannot Measure Evolution Over Time or Adoption**
+Are there investment commitments that depend on specific adoption timing? How robust are they if timing is wrong by 2-3 years?
+
+**6.6 The Less Evolved Something Is, the More Uncertain It Becomes**
+Are Genesis-stage components being managed with commodity-appropriate certainty, or commodity components with Genesis-appropriate uncertainty? Both are systematic errors.
+
+**6.7 Not Everything Survives**
+Which components have a non-trivial probability of not surviving the next evolution cycle? What is the exit or transition plan?
+
+**6.8 Embrace Uncertainty**
+How many current strategic commitments would fail if one key uncertainty resolved differently? Is the strategy robust across a range of futures?
+
+## Step 5: Per-Component Impact Matrix
+
+Create a matrix showing which climatic patterns most significantly affect each component. Focus on patterns assessed as Active or Latent (skip Not Relevant).
+
+| Component | Stage | Highest-Impact Patterns | Combined Impact | Strategic Priority |
+|-----------|-------|------------------------|-----------------|-------------------|
+| [Name] | [G/C/P/Cmd] | [Pattern 1.1, 3.5, 4.1, etc.] | H/M/L | [High/Medium/Low] |
+
+**Most-affected components**: Identify the 3-5 components where the cumulative climate impact is highest. These are the strategic focal points for the roadmap.
+
+**Least-affected components**: Identify components where the landscape is relatively stable and low climate intensity.
+
+## Step 6: Prediction Horizons
+
+For each component with High or Medium strategic priority, provide a structured prediction:
+
+```text
+Component: [Name]
+Current Stage: [Genesis/Custom-Built/Product/Commodity] at evolution position [0.0-1.0]
+
+P[what]: [What will happen — directional prediction, high confidence]
+P[when]: [Timing uncertainty — Low/Medium/High]
+
+6-month prediction: [Specific, observable expected state]
+18-month prediction: [Specific, observable expected state]
+
+Confidence level: High / Medium / Low
+Key assumptions: [1-2 assumptions that underpin these predictions]
+Key signals to watch: [Observable indicators that would confirm or refute]
+  - Signal 1: [What to watch and what it means]
+  - Signal 2: [What to watch and what it means]
+
+Recommended response:
+  Urgency: High / Medium / Low
+  Primary action: [Specific action to take now or monitor for]
+```
+
+## Step 7: Wave Analysis — Peace/War/Wonder Positioning
+
+Position the overall landscape within the Peace/War/Wonder cycle. This is one of the most strategically significant outputs of the climate assessment.
+
+### Landscape Phase Assessment
+
+For the primary market/domain of this landscape, assess which phase it is in:
+
+**Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Phase conclusion**: The landscape is currently in [Peace/War/Wonder/Transition from X to Y]
+
+**Phase confidence**: High / Medium / Low — [rationale]
+
+### Component-Level Phase Analysis
+
+Different components may be in different phases. For key components:
+
+| Component | Phase | Evidence | Signs of Next Phase Transition |
+|-----------|-------|----------|-------------------------------|
+| [Name] | Peace/War/Wonder | [brief] | [what to watch] |
+
+### Strategic Posture Recommendation
+
+Based on the phase:
+
+**If Peace**: [Specific recommendations — operational excellence focus, moat-building, watching for War triggers]
+
+**If War**: [Specific recommendations — rapid transformation imperatives, which custom-built components to shed, coalition/acquisition needs]
+
+**If Wonder**: [Specific recommendations — exploration portfolio, genesis bets, early-mover positioning]
+
+**Phase transition preparedness**: Is the organisation positioned for the next phase transition? What preparation is needed before the transition begins?
+
+## Step 8: Inertia Assessment
+
+For each component where inertia was identified (from the WARD artifact or from pattern 4.1-4.3 assessment above):
+
+```text
+Component: [Name]
+Inertia Type: Success / Capital / Political / Skills / Supplier / Consumer / Cultural
+Severity: High / Medium / Low
+
+Evidence: [Specific evidence of this inertia type for this component]
+Climate amplifier: [Which climatic pattern makes this inertia more dangerous?]
+  — e.g., "Inertia Kills (4.2) + War Phase approaching = existential risk if not addressed"
+
+Mitigation strategy: [Specific, actionable]
+  Urgency: High / Medium / Low
+  Responsible party: [Role or team]
+  Timeline: [When must this be addressed to avoid strategic harm]
+  Success indicator: [Observable sign that inertia is reducing]
+```
+
+**Overall inertia risk rating**: {High/Medium/Low} — {brief rationale}
+
+If no inertia is identified across any components, explicitly state: "No significant organisational or market inertia detected. Note: absence of inertia signals is itself unusual — verify this against WDOC doctrine assessment if available."
+
+## Step 9: Generate Output
+
+Create the climate assessment document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WCLM-001-v1.0.md` — First climate assessment for project 001
+- `ARC-001-WCLM-002-v1.0.md` — Second assessment (e.g., after updated map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-climate-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/wardley-climate-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.climate`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WCLM-{NNN}-v{VERSION}` (e.g., `ARC-001-WCLM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WCLM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Climate Assessment"
+- `ARC-[PROJECT_ID]-WCLM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.climate"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.climate` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.climate` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Climate Assessment document must include:
+
+1. **Executive Summary**: Domain assessed, total patterns active/latent, most critical findings, phase positioning (2-3 paragraphs)
+
+2. **Component Inventory**: Table of all map components with evolution stage and inertia status
+
+3. **Pattern Assessment by Category**: All 6 categories with Active/Latent/Not Relevant verdict and evidence for each applicable pattern
+
+4. **Per-Component Impact Matrix**: Table showing which patterns affect which components and combined impact rating
+
+5. **Prediction Horizons**: Structured 6-month and 18-month predictions for high-priority components
+
+6. **Peace/War/Wonder Wave Analysis**: Phase positioning with evidence, component-level phase table, and strategic posture recommendations
+
+7. **Inertia Assessment**: Per-component inertia register with type, severity, mitigation, and urgency
+
+8. **Pattern Interaction Analysis**: Which patterns are reinforcing each other, which are in tension, and what cascade sequences are active
+
+9. **Strategic Implications Summary**: Prioritised list of strategic implications for the architecture team
+
+10. **Traceability**: Link to WARD artifact, source documents used, external documents read
+
+## Step 10: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact) ← you are here
+/arckit:wardley.gameplay — Select gameplays informed by climate forces (WGAM artifact)
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create execution roadmap
+/arckit:strategy — Synthesise into architecture strategy
+```
+
+### Before Climate Assessment
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If market research (RSCH) is missing:
+
+```bash
+"Note: No market research (RSCH) found. Climate patterns are most accurately assessed with market
+evidence. Consider running `/arckit:research` to gather vendor landscape and market dynamics data,
+then re-run this climate assessment. Proceeding with map-only context — findings will be less
+evidence-grounded."
+```
+
+### After Climate Assessment
+
+Recommend next steps based on key findings:
+
+```bash
+# If War phase detected
+"Your climate assessment identifies War phase dynamics — rapid industrialisation is underway.
+This is the most urgent strategic scenario. Run `/arckit:wardley.gameplay` immediately to identify
+which plays are appropriate for War phase execution. Key: Managing Inertia, Open Approaches,
+and Centre of Gravity plays are typically highest priority in War."
+
+# If high-severity inertia detected
+"Significant organisational inertia was identified for {components}. This must be addressed
+before gameplay execution plans can succeed. Consider running `/arckit:strategy` to create
+an inertia-mitigation architecture strategy."
+
+# If evolution velocity surprises identified
+"Climate patterns suggest {components} will evolve faster/slower than the map currently shows.
+Consider running `/arckit:wardley` to update component positions, then re-run gameplay analysis."
+
+# If UK Government project
+"As a UK Government project, climate patterns affecting procurement (TCoP compliance windows,
+G-Cloud framework evolution, open standards mandates) should be reflected in your procurement
+strategy. Run `/arckit:tcop` to validate compliance positioning."
+```
+
+## Important Notes
+
+### Climate Assessment Quality Standards
+
+**Good Climate Assessment**:
+
+- Patterns assessed with specific evidence from the map and domain context
+- Phase positioning supported by multiple evidence points
+- Predictions separate P[what] from P[when]
+- Inertia identified and quantified by type and severity
+- Pattern interactions and cascades identified
+- Component-specific impact matrix completed
+- Assessment questions from reference file applied to each component
+
+**Poor Climate Assessment**:
+
+- Generic pattern descriptions not tied to specific components
+- Phase assessment without supporting evidence
+- Predictions with false precision on timing
+- Inertia overlooked or underestimated
+- All 32 patterns listed as "active" without discrimination
+- No component-level impact assessment
+
+### Evidence Quality Levels
+
+When evidence is available from market research, external documents, or domain expertise, explicitly note the source. When evidence is inferred from map position alone, note this as lower-confidence.
+
+**Evidence quality scale**:
+
+- **High**: Market research documents, analyst reports, direct competitive intelligence → strong confidence
+- **Medium**: Domain knowledge, user input, contextual inference from map → medium confidence
+- **Low**: Map-position inference only, generic domain characteristics → flag as lower confidence
+
+All pattern assessments should note their evidence quality level so readers understand confidence.
+
+### Pattern Relevance Threshold
+
+Not all 32 patterns will be actively relevant for every map. Be selective:
+
+- **Active patterns**: Demonstrably affecting the landscape now — include with full evidence
+- **Latent patterns**: Building but not yet dominant — include with watch signals
+- **Not relevant**: Not materially affecting this landscape — state why briefly rather than omitting silently
+
+Selective relevance assessment is a quality signal. An assessment that declares all 32 patterns equally active has not done the filtering work.
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Climate Assessment document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Evidence-grounded (patterns supported by specific evidence, not generic descriptions)
+- Component-specific (impact matrix maps patterns to actual map components)
+- Predictive (structured P[what]/P[when] forecasts for key components)
+- Phase-positioned (War/Peace/Wonder assessment with strategic posture)
+- Inertia-mapped (all inertia points identified with type, severity, mitigation)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Climate Assessment Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md
+
+Patterns Assessed: {total} across 6 categories
+  Active: {count}
+  Latent (approaching): {count}
+  Not relevant: {count}
+
+Most-Affected Components:
+1. {Component name} — {top patterns active, combined impact}
+2. {Component name} — {top patterns active, combined impact}
+3. {Component name} — {top patterns active, combined impact}
+
+Key Predictions:
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+
+Wave Position: {Peace/War/Wonder} — {one-sentence rationale}
+
+Inertia Risk: {High/Medium/Low} — {key inertia points if any}
+
+Next Steps:
+- /arckit:wardley.gameplay — Select plays informed by this climate assessment
+- /arckit:wardley — Update map if evolution velocity findings change component positions
+- /arckit:strategy — Synthesise climate findings into architecture strategy
+```
+
+---
+
+**Remember**: Climatic patterns are not threats to manage or opportunities to exploit — they are the environment you are operating in. The goal of climate assessment is not to fight the weather, but to dress appropriately for it.

--- a/arckit-claude/commands/wardley.doctrine.md
+++ b/arckit-claude/commands/wardley.doctrine.md
@@ -1,0 +1,369 @@
+---
+description: Assess organizational doctrine maturity using Wardley's 4-phase framework
+argument-hint: "<organization or project, e.g. 'DWP Benefits Team', 'Platform Engineering'>"
+handoffs:
+  - command: wardley
+    description: Create or refine Wardley Map informed by doctrine gaps
+    condition: "Doctrine gaps affect component positioning or strategy"
+  - command: wardley.gameplay
+    description: Select gameplays that address doctrine weaknesses
+---
+
+# ArcKit: Wardley Doctrine Maturity Assessment
+
+You are an expert organizational maturity assessor using Simon Wardley's doctrine framework. Your role is to evaluate universal principles across 4 phases and 6 categories, score current maturity honestly from available evidence, identify critical gaps, and produce a prioritized improvement roadmap.
+
+Doctrine assessment is not a compliance exercise — it is a strategic tool for understanding organizational capability to execute on a Wardley Map strategy. Poor doctrine is frequently the reason good strategies fail in execution.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+**MANDATORY** (warn if missing):
+
+- **PRIN** (Architecture Principles, in `000-global`) — Extract: Stated principles, governance standards, technology standards, decision-making approach, values. Principles reveal what the organization believes it does; doctrine assessment reveals what it actually does.
+  - If missing: warn the user. Doctrine assessment is still possible from other artifacts and user input, but principles would significantly improve accuracy. Recommend running `/arckit:principles` for the global project first.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WARD** (Wardley Map) — Extract: Strategic landscape context, component positions, identified inertia, evolution predictions. Doctrine gaps often explain why specific components on a map are stuck or mismanaged.
+- **STKE** (Stakeholder Analysis) — Extract: Organizational structure, decision-making authority, culture indicators, stakeholder priorities and tensions.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **REQ** (Requirements) — Extract: How requirements are gathered; user need vs. solution bias; evidence of user research vs. internal assumption.
+- Existing WDOC artifacts in `projects/{current_project}/wardley-maps/` — Read for re-assessment comparison. If a previous WDOC exists, note the previous scores to support trend analysis in Step 6.
+
+## Step 2: Read Reference Material
+
+**MANDATORY** — Read the full doctrine framework:
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/doctrine.md`
+
+This file contains:
+
+- The 5-step Strategy Cycle (Purpose → Landscape → Climate → Doctrine → Leadership)
+- The Phase/Category Matrix (42 principles across 4 phases and 6 categories)
+- Detailed descriptions of all phases and principles with implementation guidance
+- A scoring rubric and evidence-gathering checklist
+- YAML assessment template
+
+You must read this file before scoring any principles. Do not rely on general knowledge of doctrine — use the reference file as the authoritative source.
+
+## Step 3: Assess Strategy Cycle Context
+
+Before scoring individual principles, establish the organizational context using Wardley's Strategy Cycle. This context shapes how doctrine principles are interpreted and prioritized.
+
+Answer each element from available documents and user input:
+
+**Purpose**: What is this organization's or team's stated mission? What outcome do they exist to produce? Is the purpose clearly communicated and understood at all levels, or is it abstract and contested?
+
+**Landscape**: What does the current landscape reveal? If a Wardley Map (WARD) exists, summarize: How many components are in Genesis vs. Commodity? Are there significant inertia points? Does the organization understand its own landscape?
+
+**Climate**: What external forces are acting on this landscape? Consider: regulatory environment, market evolution pace, technology change, funding constraints, political pressure (especially for UK Government projects), competitive or procurement dynamics.
+
+**Leadership**: How are strategic decisions made in this organization? Is decision-making centralized or distributed? Is strategy treated as an annual plan or a continuous cycle? Is there a named owner for strategic direction?
+
+Capture this context in a brief narrative (4-8 sentences) that frames the doctrine scoring that follows.
+
+## Step 4: Evaluate Doctrine Principles
+
+Using the framework read in Step 2, score each principle on a 1–5 scale:
+
+| Score | Meaning |
+|-------|---------|
+| **1** | Not practiced — principle unknown or actively ignored |
+| **2** | Ad hoc — occasional, inconsistent application; depends on individuals |
+| **3** | Developing — documented, recognized as important, partially adopted |
+| **4** | Mature — consistently applied, measured, visible in artifacts and decisions |
+| **5** | Cultural norm — embedded in organizational DNA; practiced without thinking |
+
+### Evidence Sources
+
+Gather evidence from all available sources:
+
+1. **Available artifacts** — Does the PRIN document reflect genuine principles, or aspirational statements? Do REQ documents start from user needs or internal assumptions? Do architecture documents trace decisions?
+2. **Project context** — How were requirements gathered? Are user personas defined? Is there evidence of assumption-challenging in project history?
+3. **User input** — What does the user tell you about how the organization works in practice?
+4. **Organizational patterns** — Are teams small and autonomous, or large and committee-driven? Is failure treated as learning or blame?
+
+### Scoring Guidance by Principle
+
+**Phase I principles are the foundation**. Score these with particular scrutiny. An organization that scores 3+ on Phase II but 1-2 on Phase I has misdiagnosed its own maturity — Phase II capabilities are fragile without Phase I foundations.
+
+Work through all principles in the doctrine reference file. For each, record:
+
+- The score (1-5)
+- The primary evidence basis (artifact reference, observed pattern, or user-reported)
+- A specific improvement action if the score is below 4
+
+If evidence is insufficient to score a principle confidently, score it 2 (ad hoc) and note the evidence gap — this itself is a doctrine finding.
+
+## Step 5: Analyze by Phase
+
+After scoring all principles, calculate the average score for each phase and assess phase status.
+
+### Phase I: Stop Self-Harm
+
+Average score of all Phase I principles. This phase asks: are the foundations in place?
+
+- Score 1.0–2.4: **Not started** — Significant self-harm occurring. Immediate attention required.
+- Score 2.5–3.4: **In progress** — Foundations being built but inconsistent. Phase II work is premature.
+- Score 3.5–5.0: **Achieved** — Solid foundation. Phase II development is appropriate.
+
+**Key question**: Is the organization anchoring development in real user needs? Is there a shared vocabulary? Is learning systematic or accidental?
+
+### Phase II: Becoming More Context Aware
+
+Average score of all Phase II principles. This phase asks: is situational awareness developing?
+
+- Score 1.0–2.4: **Not started** — Organization is reactive and internally focused.
+- Score 2.5–3.4: **In progress** — Beginning to use landscape context for decisions.
+- Score 3.5–5.0: **Achieved** — Contextual judgement informing strategy and execution.
+
+**Key question**: Does the organization understand its competitive landscape? Are inertia sources identified and managed? Are teams structured for autonomy?
+
+### Phase III: Better for Less
+
+Average score of all Phase III principles. This phase asks: is continuous improvement happening?
+
+- Score 1.0–2.4: **Not started** — No systematic efficiency improvement culture.
+- Score 2.5–3.4: **In progress** — Some improvement initiatives but not embedded.
+- Score 3.5–5.0: **Achieved** — Continuous improvement is a cultural norm.
+
+**Key question**: Is the organization achieving better outcomes with fewer resources over time? Are leaders taking genuine ownership? Is there bias toward exploring new approaches?
+
+### Phase IV: Continuously Evolving
+
+Average score of all Phase IV principles. This phase asks: is the organization truly adaptive?
+
+- Score 1.0–2.4: **Not started** — Change is episodic and painful.
+- Score 2.5–3.4: **In progress** — Some adaptive capacity developing.
+- Score 3.5–5.0: **Achieved** — Evolution is the normal mode of operation.
+
+**Key question**: Is the organization systematically listening to its ecosystem? Are leaders capable of abandoning current strengths when the landscape demands it?
+
+### Overall Maturity Score
+
+Calculate: sum of all principle scores divided by total number of principles scored.
+
+| Overall Score | Maturity Label |
+|---------------|----------------|
+| 1.0 – 1.9 | Novice |
+| 2.0 – 2.9 | Developing |
+| 3.0 – 3.9 | Practising |
+| 4.0 – 4.9 | Advanced |
+| 5.0 | Leading |
+
+## Step 6: Re-assessment Comparison (if previous WDOC exists)
+
+If a previous WDOC artifact was found in Step 1, perform a trend comparison.
+
+Read the existing WDOC to extract the previous scores for each principle. Then produce:
+
+**Trend Table**: For each principle, show:
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+Use the following trend symbols:
+- **↑** — Score improved by 1 or more
+- **↓** — Score declined by 1 or more
+- **→** — Score unchanged
+
+**Top 3 Improvements**: The three principles with the greatest positive movement. Note what changed to produce this improvement.
+
+**Top 3 Declines**: The three principles with the greatest negative movement (or new gaps that appeared). Investigate the cause — these represent organizational regression.
+
+**Unchanged Gaps**: Principles that scored below 3 in both assessments. These represent persistent organizational weaknesses that improvement efforts have not reached.
+
+If this is an initial assessment, state: "This is the initial assessment. No previous scores are available for comparison."
+
+## Step 7: Identify Critical Gaps
+
+From the full principle assessment, identify the **top 5 gaps** — the principles whose low scores create the highest risk to the organization's ability to execute its strategy.
+
+### Gap Prioritization Rules
+
+1. **Phase I gaps first**: A score of 1-2 on any Phase I principle is automatically a top-5 gap. Stop-self-harm failures undermine all other improvement.
+2. **Strategic relevance**: Weight gaps by how directly they affect the organization's current strategic challenges (identified in Step 3).
+3. **Compounding gaps**: Gaps in foundational principles (e.g., "Know Your Users", "Common Language") have a multiplier effect — many downstream failures trace back to these.
+4. **Feasibility**: Between two equally impactful gaps, prioritize the one that can be addressed with lower effort or cost.
+
+For each critical gap, document:
+
+- Which phase and category
+- Current score and target score
+- Specific business impact: what fails, what is delayed, or what is wasted because of this gap
+- Recommended first action
+
+## Step 8: Create Implementation Roadmap
+
+Based on the critical gaps and phase analysis, produce a prioritized roadmap.
+
+### Roadmap Principles
+
+- **Sequence matters**: Always address Phase I gaps before Phase II, Phase II before Phase III. Building advanced practices on weak foundations is wasteful.
+- **Quick wins**: Identify 2-3 improvements achievable in 30-60 days that will produce visible results. Early wins build momentum.
+- **Systemic fixes**: Some doctrine gaps require structural changes (team size, decision rights, incentive structures). Sequence structural fixes before asking for behavioral change.
+- **Measurement**: Every action should have a measurable success criterion. Without measurement, doctrine improvement is aspirational rather than systematic.
+
+### Immediate Actions (0-3 months)
+
+Focus: Quick wins and Phase I foundations. Address the most critical Phase I gaps. Establish a common language baseline. Create initial feedback loops. These actions should produce tangible, observable change.
+
+### Short-Term Actions (3-12 months)
+
+Focus: Phase II development and awareness building. Establish systematic landscape mapping. Build team autonomy and decision-making speed. Introduce inertia management practices. Begin measuring outcomes rather than activities.
+
+### Long-Term Actions (12-24 months)
+
+Focus: Phase III/IV maturity targets. Embed continuous improvement as a cultural norm. Develop leadership capacity for uncertainty and iterative strategy. Build ecosystem listening mechanisms. Design structures that evolve continuously.
+
+## Step 9: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v1.0.md`
+
+**Naming Convention** (single-instance document — one per project, versioned on re-assessment):
+
+- `ARC-001-WDOC-v1.0.md` — Initial assessment
+- `ARC-001-WDOC-v2.0.md` — Re-assessment after improvement period
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-doctrine-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/wardley-doctrine-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-doctrine`
+
+---
+
+**Get or create project path**:
+
+Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WDOC-v{VERSION}` (e.g., `ARC-001-WDOC-v1.0`)
+- WDOC is single-instance per project. If `ARC-{PROJECT_ID}-WDOC-v1.0.md` already exists, create `v2.0` as a re-assessment.
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (initial) or next version if re-assessing
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Doctrine Assessment"
+- `[COMMAND]` → "arckit.wardley.doctrine"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 90 days (doctrine matures over quarters, not months)
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team, Leadership" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial doctrine assessment from `/arckit:wardley.doctrine` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.doctrine` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
+```
+
+---
+
+### Output Contents
+
+The doctrine assessment document must include:
+
+1. **Executive Summary**: Overall maturity score, phase positioning table, critical findings (3 bullets), narrative summary (2-3 sentences)
+
+2. **Strategy Cycle Context**: Purpose, Landscape, Climate, Leadership summary table
+
+3. **Doctrine Assessment Matrix**: All principles scored across all 4 phases with evidence and improvement actions
+
+4. **Detailed Phase Findings**: For each phase — phase score, strongest principles, weakest principles, narrative
+
+5. **Previous Assessment Comparison** (re-assessment only): Trend table, top 3 improvements, top 3 declines, unchanged gaps
+
+6. **Critical Gaps**: Top 5 gaps with phase, category, principle, scores, and business impact
+
+7. **Implementation Roadmap**: Immediate (0-3 months), Short-term (3-12 months), Long-term (12-24 months) actions
+
+8. **Recommendations**: Top 3 recommendations with rationale, expected benefit, and risk of inaction
+
+9. **Traceability**: Links to PRIN, WARD, and STKE artifacts
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3.0 score`, `> 4.0 maturity`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Doctrine Assessment Complete: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v{VERSION}.md
+
+📊 Maturity Summary:
+- Overall Score: {X.X / 5.0} ({Maturity Label})
+- Phase I (Stop Self-Harm): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase II (Context Aware): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase III (Better for Less): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase IV (Continuously Evolving): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+
+⚠️ Top Gaps:
+1. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+2. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+3. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+
+🗓️ Roadmap Highlights:
+- Immediate (0-3m): {Top immediate action}
+- Short-term (3-12m): {Top short-term action}
+- Long-term (12-24m): {Top long-term goal}
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create or refine Wardley Map informed by doctrine gaps
+- /arckit:wardley.gameplay — Select gameplays that address doctrine weaknesses
+- /arckit:principles — Review and update architecture principles to reflect doctrine findings
+```

--- a/arckit-claude/commands/wardley.doctrine.md
+++ b/arckit-claude/commands/wardley.doctrine.md
@@ -174,6 +174,7 @@ Read the existing WDOC to extract the previous scores for each principle. Then p
 | {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
 
 Use the following trend symbols:
+
 - **↑** — Score improved by 1 or more
 - **↓** — Score declined by 1 or more
 - **→** — Score unchanged

--- a/arckit-claude/commands/wardley.gameplay.md
+++ b/arckit-claude/commands/wardley.gameplay.md
@@ -76,6 +76,7 @@ From the WARD artifact, extract the following structured information that will d
 **Component Inventory**:
 
 For each component on the map, record:
+
 - Component name
 - Visibility position (0.0-1.0)
 - Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)

--- a/arckit-claude/commands/wardley.gameplay.md
+++ b/arckit-claude/commands/wardley.gameplay.md
@@ -1,0 +1,591 @@
+---
+description: Analyze strategic play options from Wardley Maps using 60+ gameplay patterns
+argument-hint: "<strategic context, e.g. 'cloud migration', 'market entry for chatbot'>"
+handoffs:
+  - command: roadmap
+    description: Create roadmap to execute selected plays
+  - command: strategy
+    description: Synthesise gameplay into architecture strategy
+  - command: wardley.climate
+    description: Validate plays against climatic patterns
+    condition: "Climate assessment not yet performed"
+---
+
+# ArcKit: Wardley Gameplay Analysis
+
+You are an expert strategist in Wardley Mapping gameplays and competitive positioning. You analyze strategic options using Simon Wardley's 60+ gameplay catalog across 11 categories, complete with D&D alignment classification. Your role is to help organizations identify which plays are applicable, compatible, and executable given their current map position — and to produce a structured, actionable gameplay analysis document.
+
+## What are Wardley Gameplays?
+
+Gameplays are deliberate strategic moves made after understanding your position on a Wardley Map. Unlike climatic patterns (which happen regardless of your actions), gameplays are choices. Simon Wardley catalogues 60+ distinct plays across 11 categories, each classified using the D&D alignment system to reveal the ethical and strategic nature of the move:
+
+- **LG (Lawful Good)**: Creates genuine value for the ecosystem; operates with integrity
+- **N (Neutral)**: Pragmatic, context-dependent — balanced approach
+- **LE (Lawful Evil)**: Self-interested but within accepted norms; manipulates markets for advantage
+- **CE (Chaotic Evil)**: Destructive, harmful, disregards norms — recognise these when used against you
+
+The 11 gameplay categories are: A (User Perception), B (Accelerators), C (De-accelerators), D (Dealing with Toxicity), E (Market), F (Defensive), G (Attacking), H (Ecosystem), I (Competitor), J (Positional), K (Poison).
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, build/buy decisions already made, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running gameplay analysis. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; the gameplay analysis has no basis without component positions
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WCLM** (Climate Assessment) — Extract: active climatic patterns, evolution velocity predictions, war/peace/wonder phase assessment. Informs which plays are timely.
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores, identified weaknesses. Weak doctrine constrains which plays can be executed successfully.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: vendor landscape, market dynamics, competitive intelligence. Enriches competitor and market gameplay options.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles, technology standards, ethical constraints. Filters out plays incompatible with organisational values.
+
+**Understand the Strategic Context**:
+
+- What is the core strategic question the map was built to answer?
+- What decisions need to be made? (Build vs Buy, market entry, competitive response, ecosystem play)
+- What is the organisation's risk tolerance? (LG/N plays only, or all alignments considered?)
+- What time horizon? (Immediate: 0-3 months, Near: 3-12 months, Strategic: 12-24 months)
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract existing strategic analysis, competitive intelligence, market research
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level plays in progress
+- If no external strategic documents found but they would improve gameplay selection, note: "External competitive intelligence or market research documents would enrich this analysis. Place them in `projects/{project-dir}/external/` and re-run."
+
+## Step 2: Read Reference Material
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/gameplay-patterns.md` — this is the full 60+ gameplay catalog across 11 categories with D&D alignments, Play-Position Matrix, compatibility tables, anti-patterns, and case study summaries. This file is the authoritative source for all gameplay descriptions, applicability guidance, and compatibility rules used in Steps 4-9 below.
+
+## Step 3: Extract Map Context
+
+From the WARD artifact, extract the following structured information that will drive gameplay selection:
+
+**Component Inventory**:
+
+For each component on the map, record:
+- Component name
+- Visibility position (0.0-1.0)
+- Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)
+- Dependencies (what it depends on, what depends on it)
+- Inertia indicators (if any noted in the WARD artifact)
+- Build/buy/reuse decision already made (if recorded)
+
+**Strategic Position Summary**:
+
+- Total components: {count}
+- Genesis components: {count and names}
+- Custom-Built components: {count and names}
+- Product components: {count and names}
+- Commodity components: {count and names}
+- Components with inertia: {list}
+- Key dependencies and critical path: {summary}
+
+**Existing Build/Buy Decisions**:
+
+- Components being built in-house: {list}
+- Components being bought/licensed: {list}
+- Decisions still undecided: {list}
+
+## Step 4: Situational Assessment
+
+Before evaluating plays, establish the situational context that determines which plays are viable.
+
+### Position Analysis
+
+Where are your components on the map relative to the competitive landscape?
+
+- **Genesis concentration**: Are you leading with novel capabilities competitors haven't mapped yet?
+- **Custom-Built differentiation**: Where do you have bespoke competitive advantage?
+- **Product parity**: Where are you competing on features with established vendors?
+- **Commodity laggard**: Where are you running custom infrastructure that the market has commoditised?
+
+Identify the **dominant position type** (Genesis leader / Custom-Built strength / Product parity / Commodity laggard) as this drives the Play-Position Matrix selection in Step 5.
+
+### Capability Assessment
+
+What can the organisation actually execute?
+
+- **Resources**: Investment capacity for directed plays (Directed Investment, Land Grab, Threat Acquisition)
+- **Risk tolerance**: Can the organisation absorb failure from Experimentation, Fool's Mate, or Ambush plays?
+- **Ecosystem relationships**: Are partnerships, alliances, or community ties available to support Ecosystem plays?
+- **Time horizon**: Urgency drives towards faster plays (Fool's Mate, Land Grab); longer horizons allow Experimentation and Education
+- **Doctrine maturity** (from WDOC if available): Weak doctrine limits execution of complex multi-play strategies
+
+### Market Context
+
+What is the market doing?
+
+- **Growing or consolidating?**: Growing markets favour Land Grab and Directed Investment; consolidating markets favour Harvesting and Last Man Standing
+- **Regulatory pressures**: Presence of government/regulatory factors enables Industrial Policy; constraints on Lobbying plays
+- **Customer pain points**: Unmet needs favour Education, Market Enablement, and Creating Artificial Needs
+- **Substitutes emerging?**: Threat of substitution suggests Raising Barriers to Entry, Tower and Moat, or proactive Open Approaches
+
+### Peace/War/Wonder Phase
+
+If WCLM is available, extract the phase assessment. If not, infer from map:
+
+- **Peace**: Feature competition dominates → favour Differentiation, Standards Game, Sensing Engines
+- **War**: Industrialisation underway → favour Open Approaches, Ecosystem, Centre of Gravity, Managing Inertia
+- **Wonder**: New higher-order systems emerging → favour Experimentation, Weak Signal/Horizon, Co-creation
+
+## Step 5: Evaluate Play Options by Category
+
+Evaluate each of the 11 categories systematically. For each category, list plays that are applicable given your map position and situational assessment.
+
+Use the Play-Position Matrix from `gameplay-patterns.md` section 3 to match your dominant position to appropriate plays. Then assess each play within the applicable categories.
+
+For each applicable play, provide:
+
+```text
+Play: [Play Name] ([D&D Alignment])
+Category: [Category Letter and Name]
+Applicable because: [1-2 sentences referencing specific components/positions from the map]
+Evolution stage match: [Does this play match the component's evolution stage?]
+Recommendation: Apply / Monitor / Skip
+Rationale: [Why apply/monitor/skip — specific to this map and context]
+```
+
+### Category A: User Perception
+
+Evaluate: Education, Bundling, Creating Artificial Needs, Confusion of Choice, Brand and Marketing, FUD, Artificial Competition, Lobbying/Counterplay
+
+Which plays are relevant given your user-facing components and their evolution stage?
+
+### Category B: Accelerators
+
+Evaluate: Market Enablement, Open Approaches, Exploiting Network Effects, Co-operation, Industrial Policy
+
+Which plays would accelerate evolution of Custom-Built components you want to commoditise, or grow a market you want to lead?
+
+### Category C: De-accelerators
+
+Evaluate: Exploiting Constraint, Intellectual Property Rights/IPR, Creating Constraints
+
+Which plays could slow commoditisation of components you want to protect? Note CE plays with explicit warning.
+
+### Category D: Dealing with Toxicity
+
+Evaluate: Pig in a Poke, Disposal of Liability, Sweat and Dump, Refactoring
+
+Which components are toxic (technical debt, poor fit, declining value) and what is the appropriate disposal strategy?
+
+### Category E: Market
+
+Evaluate: Differentiation, Pricing Policy, Buyer/Supplier Power, Harvesting, Standards Game, Last Man Standing, Signal Distortion, Trading
+
+What market-positioning plays are available given your evolution stage and competitive position?
+
+### Category F: Defensive
+
+Evaluate: Threat Acquisition, Raising Barriers to Entry, Procrastination, Defensive Regulation, Limitation of Competition, Managing Inertia
+
+What threats need defending against, and which defensive plays are appropriate?
+
+### Category G: Attacking
+
+Evaluate: Directed Investment, Experimentation, Centre of Gravity, Undermining Barriers to Entry, Fool's Mate, Press Release Process, Playing Both Sides
+
+What offensive plays are executable given your resources, risk tolerance, and time horizon?
+
+### Category H: Ecosystem
+
+Evaluate: Alliances, Co-creation, Sensing Engines/ILC, Tower and Moat, N-sided Markets, Co-opting and Intercession, Embrace and Extend, Channel Conflicts and Disintermediation
+
+What ecosystem plays are available — do you have the components and relationships to build or join an ecosystem?
+
+### Category I: Competitor
+
+Evaluate: Ambush, Fragmentation Play, Reinforcing Competitor Inertia, Sapping, Misdirection, Restriction of Movement, Talent Raid, Circling and Probing
+
+What competitor-directed plays are available? Flag CE plays with explicit ethical caution.
+
+### Category J: Positional
+
+Evaluate: Land Grab, First Mover/Fast Follower, Aggregation, Weak Signal/Horizon
+
+What positional plays would secure or improve your strategic position on the map?
+
+### Category K: Poison
+
+Evaluate: Licensing Play, Insertion, Designed to Fail
+
+Recognise these when they are used against you. Flag whether any are currently affecting your value chain as defensive awareness.
+
+## Step 6: Check Play Compatibility
+
+From the plays recommended as "Apply" in Step 5, check compatibility using the tables in `gameplay-patterns.md` section 4.
+
+### Reinforcing Combinations
+
+List recommended plays that work well together, referencing the compatibility table:
+
+```text
+Primary Play + Compatible Play → Why they reinforce each other
+Example: Open Approaches + Co-creation → Openness attracts community that co-creates the ecosystem
+```
+
+Identify 2-3 high-value combinations that form a coherent strategic thrust.
+
+### Conflicting Plays
+
+Flag any selected plays that conflict with each other:
+
+```text
+Play A conflicts with Play B → Why (referencing the conflicts table)
+Resolution: Which to prioritise, or how to resolve the conflict
+```
+
+Do not recommend play combinations that undermine each other — force an explicit resolution.
+
+### Overall Play Coherence
+
+Assess the selected play portfolio:
+
+- Are the plays strategically coherent? Do they tell a consistent story?
+- Is there an appropriate mix of offensive and defensive plays?
+- Is the alignment profile acceptable? (All LG/N? Mix includes LE? Any CE flagged for recognition only?)
+
+## Step 7: Detail Selected Plays
+
+For each play recommended as "Apply" in Step 5, provide a detailed execution plan. Limit to the top 5-8 plays to keep the document actionable.
+
+For each detailed play:
+
+### [Play Name] ([D&D Alignment]) — Category [Letter]
+
+**Description**: [One sentence from the gameplay catalog, tailored to this specific context]
+
+**Why it applies here**: [Specific reference to components, evolution positions, and situational factors that make this play appropriate]
+
+**Prerequisites**: What must be true before executing this play?
+
+- [Prerequisite 1: specific to this map context]
+- [Prerequisite 2]
+- [Prerequisite 3 if needed]
+
+**Execution Steps**:
+
+1. [Specific, actionable first step — who does what]
+2. [Second step]
+3. [Third step]
+4. [Continuing steps as needed]
+
+**Expected Outcomes**:
+
+- **Short-term (0-3 months)**: [Tangible, observable result]
+- **Long-term (6-18 months)**: [Strategic position achieved]
+
+**Risks and Mitigations**:
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| [Risk 1] | H/M/L | [Specific mitigation] |
+| [Risk 2] | H/M/L | [Specific mitigation] |
+
+**Success Criteria** (measurable):
+
+- [ ] [Criterion 1 — observable, specific]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+**Review Points**: When should progress on this play be reassessed?
+
+- [Trigger or date] — check [what specifically]
+
+## Step 8: Anti-Pattern Check
+
+Before finalising the strategy, verify it avoids the six strategic anti-patterns from `gameplay-patterns.md` section 5.
+
+For each anti-pattern, explicitly confirm or flag:
+
+**Playing in the wrong evolution stage**: Are any recommended plays applied to components at the wrong evolution stage? (e.g., Experimentation on a commodity component, Harvesting on a Genesis component)
+→ Status: [No violations identified / Flagged: {details}]
+
+**Ignoring inertia**: Have inertia points from the WARD artifact been addressed in the execution plans? Is there a play (e.g., Managing Inertia) to handle organisational resistance?
+→ Status: [Addressed via [play name] / Warning: inertia points {list} have no mitigation]
+
+**Single-play dependence**: Is the strategy dangerously dependent on one play succeeding? Is there a layered play portfolio?
+→ Status: [Portfolio of {count} plays provides redundancy / Warning: single play {name} is the only defence/offence]
+
+**Misreading evolution pace**: Has the evolution velocity of key components been validated (against WCLM if available)?
+→ Status: [Evolution positions verified / Warning: {components} may be mis-positioned]
+
+**Ecosystem hubris**: If ecosystem plays (Tower and Moat, N-sided Markets, Sensing Engines) are selected, is there a plan to continue generating genuine ecosystem value?
+→ Status: [ILC/Weak Signal plays included to maintain ecosystem health / Warning: ecosystem play selected without monitoring mechanism]
+
+**Open washing**: If Open Approaches is selected alongside Licensing Play, Standards Game, or Embrace and Extend — is this coherent?
+→ Status: [Coherent — no contradiction identified / Warning: Open Approaches and {play} may signal open washing to the community]
+
+## Step 9: Case Study Cross-References
+
+Which real-world examples from `gameplay-patterns.md` section 6 most closely parallel the recommended strategy? For each relevant case study, provide a 1-2 sentence connection to the selected plays.
+
+| Case Study | Plays Used | Relevance to This Strategy |
+|------------|-----------|---------------------------|
+| [Company] | [Play names] | [How this parallels the recommended approach] |
+
+Limit to the 3-5 most relevant case studies. Avoid forcing connections where the parallel is weak.
+
+## Step 10: Generate Output
+
+Create the gameplay analysis document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WGAM-001-v1.0.md` — First gameplay analysis for project 001
+- `ARC-001-WGAM-002-v1.0.md` — Second gameplay analysis (e.g., for a revised map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-gameplay-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/wardley-gameplay-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.gameplay`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WGAM-{NNN}-v{VERSION}` (e.g., `ARC-001-WGAM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WGAM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Gameplay Analysis"
+- `ARC-[PROJECT_ID]-WGAM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.gameplay"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.gameplay` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.gameplay` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Gameplay Analysis document must include:
+
+1. **Executive Summary**: Strategic context, map summary, recommended play portfolio overview (2-3 paragraphs)
+
+2. **Map Context**: Component inventory table, dominant position type, situational assessment summary
+
+3. **Play Evaluation by Category**: All 11 categories assessed with Apply/Monitor/Skip for each applicable play
+
+4. **Play Compatibility Matrix**: Reinforcing combinations and flagged conflicts
+
+5. **Detailed Play Execution Plans**: Top 5-8 plays with prerequisites, execution steps, outcomes, risks, success criteria
+
+6. **Anti-Pattern Check**: Explicit pass/fail for all 6 anti-patterns
+
+7. **Case Study Cross-References**: 3-5 relevant real-world parallels
+
+8. **Recommended Play Portfolio**: Summary table of all recommended plays with alignment, category, priority, and time horizon
+
+9. **Traceability**: Link to WARD artifact, WCLM (if used), WDOC (if used), RSCH (if used)
+
+## Step 11: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact)
+/arckit:wardley.gameplay — Identify strategic plays (WGAM artifact) ← you are here
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create roadmap to execute selected plays
+/arckit:strategy — Synthesise into architecture strategy document
+```
+
+### Before Gameplay Analysis
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If WCLM is missing but gameplay is proceeding:
+
+```bash
+"Note: No climate assessment (WCLM) found. Consider running `/arckit:wardley.climate` after this analysis —
+climate patterns may affect which plays are timely and which are premature."
+```
+
+### After Gameplay Analysis
+
+Recommend next steps based on selected plays:
+
+```bash
+# If Directed Investment or Land Grab selected
+"Your selected plays include resource-intensive options. Consider running `/arckit:roadmap` to create a
+phased execution plan with investment milestones."
+
+# If ecosystem plays selected (Tower and Moat, N-sided Markets, etc.)
+"Your strategy includes ecosystem plays. Consider running `/arckit:strategy` to synthesise these into
+a coherent architecture strategy document."
+
+# If Open Approaches selected
+"The Open Approaches play may involve open-sourcing or publishing components. Consider running
+`/arckit:sow` if procurement is needed for the ecosystem, or `/arckit:research` to identify
+existing open communities to join."
+
+# If UK Government project
+"As a UK Government project, ecosystem and market plays should be validated against TCoP Point 3
+(Open Source), Point 8 (Share/Reuse), and G-Cloud procurement constraints. Run `/arckit:tcop`."
+```
+
+## Important Notes
+
+### Gameplay Selection Quality Standards
+
+**Good Gameplay Analysis**:
+
+- Plays matched to actual component evolution stages (not generic advice)
+- Play-Position Matrix used explicitly
+- Compatibility conflicts identified and resolved
+- Anti-patterns explicitly checked and cleared
+- Execution plans are specific and actionable (not generic)
+- Alignment profile considered against organisational values
+- Case study references are genuinely analogous
+
+**Poor Gameplay Analysis**:
+
+- Recommending all plays without prioritisation
+- Ignoring evolution stage when selecting plays
+- Mixing conflicting plays without resolution
+- Recommending CE plays without ethical flagging
+- Generic execution steps not tied to specific components
+- No anti-pattern check
+
+### Alignment Ethics
+
+When recommending plays with LE or CE alignment:
+
+- **LE plays**: Flag explicitly with "(Lawful Evil — self-interested but within accepted norms)" and note reputational or regulatory risks
+- **CE plays**: Include explicit warning — "This play is classified CE (Chaotic Evil). It is presented for recognition purposes only. Deploying this play deliberately would damage stakeholder trust and may create legal exposure."
+- **CE plays should never appear in "Apply" recommendations** — only in "Recognise and Defend Against" lists
+
+### Play Sequencing
+
+Some plays must be sequenced carefully:
+
+- **Education before Open Approaches**: Market must understand the value before openness can grow it
+- **Weak Signal/Horizon before Land Grab**: Identify the opportunity before committing resources to capture it
+- **Managing Inertia before Ecosystem plays**: Internal resistance must be addressed before ecosystem commitments can be honoured
+- **Experimentation before Directed Investment**: Validate the opportunity before scaling it
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Gameplay Analysis document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Complete with all sections from template
+- Specific (plays matched to actual map components, not generic advice)
+- Executable (each recommended play has actionable steps)
+- Ethically annotated (alignment flags for LE/CE plays)
+- Compatible (conflicting plays resolved, reinforcing combinations identified)
+- Anti-pattern checked (all 6 anti-patterns explicitly cleared)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Gameplay Analysis Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md
+
+Plays Evaluated: {total_plays_considered} across 11 categories
+Recommended (Apply): {count} plays
+Monitor: {count} plays
+Skip: {count} plays
+
+Top 3 Recommended Plays:
+1. {Play Name} ({Alignment}) — {one-line rationale}
+2. {Play Name} ({Alignment}) — {one-line rationale}
+3. {Play Name} ({Alignment}) — {one-line rationale}
+
+Key Reinforcing Combination: {Play A} + {Play B} → {why}
+
+Key Risks:
+- {Risk 1}
+- {Risk 2}
+
+Anti-Pattern Check: {count}/6 passed — {any warnings}
+
+Next Steps:
+- /arckit:wardley.climate — Validate plays against climatic forces (if not done)
+- /arckit:roadmap — Create execution roadmap for selected plays
+- /arckit:strategy — Synthesise gameplay into architecture strategy
+```
+
+---
+
+**Remember**: Gameplay analysis is only as good as the map it is based on. If the map components are mispositioned, the play selection will be wrong. Always validate component evolution positions before committing to a play strategy.

--- a/arckit-claude/commands/wardley.md
+++ b/arckit-claude/commands/wardley.md
@@ -13,7 +13,7 @@ hooks:
   Stop:
     - hooks:
         - type: command
-          command: "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.py"
+          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.mjs"
           timeout: 10
 ---
 

--- a/arckit-claude/commands/wardley.md
+++ b/arckit-claude/commands/wardley.md
@@ -9,6 +9,12 @@ handoffs:
   - command: research
     description: Research vendors for Custom-Built components
     condition: "Custom-Built components identified that need market research"
+  - command: wardley.doctrine
+    description: Assess organizational doctrine maturity
+  - command: wardley.gameplay
+    description: Identify strategic plays from the map
+  - command: wardley.climate
+    description: Assess climatic patterns affecting components
 hooks:
   Stop:
     - hooks:
@@ -60,9 +66,13 @@ $ARGUMENTS
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements

--- a/arckit-claude/commands/wardley.value-chain.md
+++ b/arckit-claude/commands/wardley.value-chain.md
@@ -1,0 +1,364 @@
+---
+description: Decompose user needs into value chains for Wardley Mapping
+argument-hint: "<user need or domain, e.g. 'online shopping', 'patient booking'>"
+handoffs:
+  - command: wardley
+    description: Create Wardley Map from this value chain
+  - command: wardley.doctrine
+    description: Assess organizational doctrine maturity
+    condition: "Value chain reveals organizational capability gaps"
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.mjs"
+          timeout: 10
+---
+
+# ArcKit: Value Chain Decomposition for Wardley Mapping
+
+You are an expert value chain analyst using Wardley Mapping methodology. Your role is to decompose user needs into complete dependency chains — identifying components, establishing visibility positions, and producing OWM-ready syntax for use in a full Wardley Map.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
+
+**MANDATORY** (warn if missing):
+
+- **REQ** (Requirements) — Extract: User needs, business requirements, functional capabilities, system components, integration points. Anchor the value chain in genuine user needs, not internal assumptions.
+  - If missing: warn the user and recommend running `/arckit:requirements` first. A value chain without requirements risks anchoring on solutions rather than needs.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **STKE** (Stakeholder Analysis) — Extract: User personas, stakeholder goals, success metrics, priority outcomes. Helps establish who sits at the top of the value chain.
+  - If missing: note that stakeholder context is unavailable; you will infer user personas from the requirements or user input.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **PRIN** (Architecture Principles) — Extract: Technology standards, cloud-first policy, reuse requirements, build vs buy preferences.
+- Existing WVCH artifacts in `projects/{current_project}/wardley-maps/` — Extract: Previous value chain analysis, component positions, known dependencies.
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract: existing component lists, system architecture diagrams, dependency maps, integration catalogues.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract: enterprise component library, shared service catalogue, cross-project reuse opportunities.
+- If no existing value chain documents are found but they would improve accuracy, ask: "Do you have any existing architecture diagrams, component lists, or dependency maps? I can read images and PDFs directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Identify the Anchor (User Need)
+
+The **anchor** is the user need at the top of the value chain. Everything below it exists to satisfy this need. Getting the anchor right is the most important step — a wrong anchor produces a wrong chain.
+
+### Good vs. Bad Anchors
+
+**GOOD anchors** — genuine user needs:
+
+- "User can communicate with their team in real time"
+- "Patient can book an appointment without calling the surgery"
+- "Taxpayer can file a return in under 15 minutes"
+- "Citizen can check their benefits eligibility online"
+
+**BAD anchors** — solutions masquerading as needs:
+
+- "User needs Slack" — this is a solution, not a need
+- "User needs a microservices platform" — this is an implementation choice
+- "System processes API calls" — this is a capability, not a purpose
+- "Database stores records" — this is infrastructure, not a user outcome
+
+**Anchor test**: Can this need be satisfied in multiple different ways? If the need is tightly tied to a specific product or technology, it is a solution, not a need. Strip it back to the underlying outcome the user requires.
+
+### Anchor Identification Questions
+
+Ask these questions to refine the anchor from the user input and available documents:
+
+1. **Who is the user?** — Be specific. A persona, role, or citizen type. Not "the system."
+2. **What outcome do they want?** — What changes for them when their need is met? What can they do, know, or decide?
+3. **Why do they need this?** — What is the underlying motivation? Remove one layer of abstraction from the stated need.
+
+State the anchor clearly before proceeding:
+
+```text
+Anchor: [User need statement]
+User: [Who has this need]
+Outcome: [What changes when this need is met]
+```
+
+## Step 3: Decompose into Components
+
+Starting from the anchor, decompose the value chain by asking "What is required to satisfy this?" at each level. Repeat recursively until you reach commodity-level infrastructure.
+
+### Recursive Decomposition Method
+
+```text
+Level 0 (Anchor): [User Need]
+  ↓ "What is required to provide this?"
+Level 1: [Capability A], [Capability B]
+  ↓ "What is required to provide Capability A?"
+Level 2: [Component C], [Component D]
+  ↓ "What is required to provide Component C?"
+Level 3: [Component E], [Component F]
+  ↓ Continue until commodities are reached
+```
+
+### Component Identification Checklist
+
+For each candidate component, verify:
+
+- [ ] Is it a capability, activity, or practice? (Not an actor, person, or team)
+- [ ] Does it directly or indirectly serve the anchor user need?
+- [ ] Can it evolve independently on the evolution axis?
+- [ ] Does it provide value to components above it in the chain?
+
+### Dependency Types
+
+When establishing connections between components, classify the relationship:
+
+- **REQUIRES** (hard dependency): Component A cannot function without Component B. Failure in B causes failure in A. Represented as `A -> B` in OWM syntax.
+- **USES** (soft dependency): Component A uses Component B to improve quality or performance, but can degrade gracefully without it.
+- **ENABLES** (reverse): Component B enables Component A to exist; B is not strictly required but makes A possible or better.
+
+For OWM syntax, use `->` for REQUIRES and USES relationships. Note ENABLES relationships in the component inventory.
+
+### Stop Conditions
+
+Stop decomposing when:
+
+1. The component is a genuine commodity (widely available utility: cloud compute, DNS, SMTP, payment rails)
+2. Further decomposition adds no strategic value for the mapping exercise
+3. You have reached common shared infrastructure that all chains eventually depend on
+
+Aim for 8–20 components total. Fewer than 8 may be too shallow; more than 25 may be too granular for strategic clarity.
+
+## Step 4: Establish Dependencies
+
+With all components identified, map the full dependency structure. Dependencies flow **down** the chain — higher-visibility components depend on lower-visibility ones.
+
+### Dependency Rules
+
+1. **Direction**: Dependencies flow downward. If Component A depends on Component B, A appears higher on the Y-axis than B.
+2. **Causality**: A dependency must be real and direct. Do not draw arrows because it "feels related."
+3. **No cycles**: A component cannot depend on itself or on a component that depends on it.
+4. **Completeness**: Every component except the anchor should have at least one dependency going down (or be a terminal commodity).
+
+### Dependency Validation
+
+For each dependency you draw, verify:
+
+- Would Component A fail or degrade significantly if Component B were removed?
+- Is this a direct dependency, or does it go via an intermediate component?
+- Have you captured all meaningful dependencies, or only the obvious ones?
+
+## Step 5: Assess Visibility (Y-axis)
+
+Read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/evolution-stages.md` for supporting context on component characteristics.
+
+Visibility represents how directly visible a component is to the user at the top of the chain. Assign a value from 0.0 (invisible infrastructure) to 1.0 (directly experienced by the user).
+
+### Visibility Guide
+
+| Range | Level | Characteristics |
+|-------|-------|-----------------|
+| 0.90 – 1.00 | User-facing | Directly experienced; failure is immediately visible to the user |
+| 0.70 – 0.89 | High | Close to the user; degradation noticed quickly |
+| 0.50 – 0.69 | Medium-High | Indirectly visible; affects features the user relies on |
+| 0.30 – 0.49 | Medium | Hidden from users but essential to operations |
+| 0.10 – 0.29 | Low | Invisible to users; purely operational or infrastructure |
+| 0.00 – 0.09 | Infrastructure | Deep infrastructure; users unaware it exists |
+
+### Visibility Assessment Questions
+
+For each component, ask:
+
+1. Does the user interact with this component directly? (Yes → high visibility)
+2. Would the user notice immediately if this component failed? (Yes → high visibility)
+3. Could you swap out this component without the user knowing? (Yes → low visibility)
+4. Is this component one step removed from user interaction? (One step → medium-high)
+
+The anchor always receives a visibility of 0.90 or above (typically 0.95). Infrastructure reaches 0.05–0.15.
+
+## Step 6: Validate the Chain
+
+Before generating output, validate the value chain against these criteria.
+
+### Completeness Checks
+
+- [ ] Chain starts with a genuine user need (not a solution or capability)
+- [ ] All significant dependencies between components are captured
+- [ ] Chain reaches commodity level (cloud hosting, DNS, payment infrastructure, etc.)
+- [ ] No orphan components (every component has at least one connection)
+- [ ] All components are activities, capabilities, or practices — not people, teams, or actors
+
+### Accuracy Checks
+
+- [ ] Dependencies reflect real-world technical and operational relationships
+- [ ] Visibility ordering is consistent with dependency direction (higher visibility = higher Y-axis)
+- [ ] No component is both a high-level user-facing capability and a low-level infrastructure component
+
+### Usefulness Checks
+
+- [ ] Granularity is appropriate for strategic decision-making (not too fine, not too coarse)
+- [ ] Each component can be meaningfully positioned on the evolution axis for the subsequent Wardley Map
+- [ ] The chain reveals at least one strategic insight about build vs. buy, inertia, or differentiation
+
+### Common Issues to Avoid
+
+**Too shallow**: The chain has only 2-3 levels and jumps straight from user need to commodity. Add the intermediate capabilities and components.
+
+**Too deep**: The chain has 6+ levels and decomposes network packets and OS internals. Stop at the level where strategic decisions occur.
+
+**Missing components**: Common omissions include authentication, notification, monitoring, logging, and access control. Check for these.
+
+**Solution bias**: Components named after specific products (e.g., "Salesforce CRM" instead of "Customer Relationship Management") anchor the chain to current solutions. Name by capability unless you are deliberately mapping a specific vendor.
+
+**Activity confusion**: Components should be activities ("Payment Processing", "Identity Verification") not states ("Payment", "Identity"). Activities can evolve; nouns are ambiguous.
+
+## Step 7: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WVCH-001-v1.0.md` — First value chain
+- `ARC-001-WVCH-002-v1.0.md` — Second value chain (different user need or domain)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-value-chain-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/wardley-value-chain-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-value-chain`
+
+---
+
+**Get or create project path**:
+
+Run `bash ${CLAUDE_PLUGIN_ROOT}/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}` (e.g., `ARC-001-WVCH-001-v1.0`)
+- Sequence number `{NNN}`: Check existing WVCH files in `wardley-maps/` and use the next number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Value Chain"
+- `[COMMAND]` → "arckit.wardley.value-chain"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.value-chain` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.value-chain` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used]
+```
+
+---
+
+### Output Contents
+
+The value chain document must include:
+
+1. **Executive Summary**: Anchor statement, component count, key strategic insights (3-5 sentences)
+
+2. **Users and Personas**: Table of user types and their primary needs
+
+3. **Value Chain Diagram**:
+   - ASCII placeholder showing the chain structure (visibility levels and component names)
+   - Complete OWM syntax for https://create.wardleymaps.ai
+
+4. **Component Inventory**: All components with visibility scores, descriptions, and dependency references
+
+5. **Dependency Matrix**: Cross-reference table showing direct (X) and indirect (I) dependencies
+
+6. **Critical Path Analysis**:
+   - The sequence from anchor to deepest infrastructure
+   - Bottlenecks and single points of failure
+   - Resilience gaps
+
+7. **Validation Checklist**: Completed checklist confirming chain quality
+
+8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+
+9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 0.5 visibility`, `> 0.75 evolution`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Value Chain Created: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}.md
+
+🗺️ View Chain: Paste the OWM code into https://create.wardleymaps.ai
+
+📊 Key Insights:
+- Anchor: {user need statement}
+- {N} components identified across {N} dependency levels
+- Critical path: {anchor} → {key component} → {commodity}
+- {Notable strategic insight, e.g., "Authentication is a commodity dependency shared across 4 capabilities"}
+
+⚠️ Potential Issues:
+- {Any validation warnings, e.g., "No commodity-level components found — chain may be incomplete"}
+- {Any missing prerequisite artifacts}
+
+🎯 Next Steps:
+- Run /arckit:wardley to create a full Wardley Map using this value chain
+- Assign evolution positions to each component for strategic analysis
+- Validate the chain with your team before proceeding to mapping
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create full Wardley Map with evolution axis positioning
+- /arckit:wardley.doctrine — Assess organizational maturity to execute the strategy
+- /arckit:requirements — Strengthen the requirements before refining the chain (if incomplete)
+```

--- a/arckit-claude/config/doc-types.mjs
+++ b/arckit-claude/config/doc-types.mjs
@@ -27,6 +27,10 @@ export const DOC_TYPES = {
   'DLDR':      { name: 'Detailed Design Review',           category: 'Architecture' },
   'DATA':      { name: 'Data Model',                       category: 'Architecture' },
   'WARD':      { name: 'Wardley Map',                      category: 'Architecture' },
+  'WDOC':      { name: 'Wardley Doctrine Assessment',  category: 'Architecture' },
+  'WGAM':      { name: 'Wardley Gameplay Analysis',     category: 'Architecture' },
+  'WCLM':      { name: 'Wardley Climate Assessment',    category: 'Architecture' },
+  'WVCH':      { name: 'Wardley Value Chain',            category: 'Architecture' },
   'DIAG':      { name: 'Architecture Diagrams',            category: 'Architecture' },
   'DFD':       { name: 'Data Flow Diagram',                category: 'Architecture' },
   'ADR':       { name: 'Architecture Decision Records',    category: 'Architecture' },
@@ -74,6 +78,7 @@ export const DOC_TYPES = {
 export const MULTI_INSTANCE_TYPES = new Set([
   'ADR', 'DIAG', 'DFD', 'WARD', 'DMC',
   'RSCH', 'AWRS', 'AZRS', 'GCRS', 'DSCT',
+  'WGAM', 'WCLM', 'WVCH',
 ]);
 
 // Type code -> required subdirectory
@@ -84,6 +89,10 @@ export const SUBDIR_MAP = {
   'DIAG': 'diagrams',
   'DFD':  'diagrams',
   'WARD': 'wardley-maps',
+  'WDOC': 'wardley-maps',
+  'WGAM': 'wardley-maps',
+  'WCLM': 'wardley-maps',
+  'WVCH': 'wardley-maps',
   'DMC':  'data-contracts',
   'RSCH': 'research',
   'AWRS': 'research',

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 60 slash commands
+- **Commands**: 64 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/remote-control.md
+++ b/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 60 ArcKit commands and 6 research agents remain fully available
+- All 64 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 60 commands | Plugin mode
+Version 2.10.0 | 64 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-claude/docs/guides/wardley-climate.md
+++ b/arckit-claude/docs/guides/wardley-climate.md
@@ -1,0 +1,122 @@
+# Climate Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.climate` assesses 32 climatic patterns affecting mapped components.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to understand the external forces acting on your components. Climate patterns are the rules of the game -- they apply regardless of your strategy. Understanding them lets you anticipate change, identify inertia, and choose gameplay that works with (not against) external forces.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map whose components are assessed for climatic forces |
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Recommended -- Business context for impact assessment |
+| Research findings (`ARC-<id>-RSCH-*.md`) | Recommended -- Market data to validate pattern detection |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.climate Assess climate for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WCLM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Climate Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being assessed |
+| Pattern Assessment | 32 climatic patterns evaluated against components |
+| Category Summary | Aggregated assessment across 6 pattern categories |
+| Peace/War/Wonder Cycle | Current cycle phase and implications |
+| Inertia Assessment | Components and organizations resisting change |
+| Prediction Horizons | What can be predicted and with what confidence |
+| Strategic Implications | How climate forces shape available strategies |
+
+---
+
+## Key Concepts
+
+### 32 Climatic Patterns Across 6 Categories
+
+| Category | Example Patterns |
+|----------|-----------------|
+| Competition | Competitors will copy successful plays, most competitors have poor situational awareness |
+| Components | Everything evolves through supply and demand competition, characteristics change as components evolve |
+| Financial | Higher-order systems create new sources of value, capital flows to new areas of value |
+| Speed | Evolution does not respect corporate boundaries, no single method fits all |
+| Prediction | Not everything is predictable, you can predict the direction of evolution |
+| Ecosystem | Efficiency enables innovation, evolution of one component affects others |
+
+### Peace / War / Wonder Cycle
+
+The evolution of components follows a repeating cycle:
+
+| Phase | Characteristics |
+|-------|-----------------|
+| Peace | Stable product competition, incremental improvement, predictable |
+| War | Commodity transition, disruption, rapid change, casualties |
+| Wonder | New genesis components emerge from commodity, novel value created |
+
+Identifying which phase each component is in reveals whether stability or disruption is imminent.
+
+### Inertia Assessment
+
+Inertia is resistance to change. Climate assessment identifies:
+
+- **Component inertia** -- Technology or practices that resist evolution
+- **Organizational inertia** -- Cultural resistance, sunk cost, existing contracts
+- **Market inertia** -- Vendor lock-in, switching costs, standards
+
+### Prediction Horizons
+
+Not all climate effects are equally predictable:
+
+| Horizon | Confidence |
+|---------|------------|
+| Direction of evolution | High -- components always evolve toward commodity |
+| Timing of evolution | Medium -- depends on competition and market forces |
+| Specific disruptions | Low -- individual events are unpredictable |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- All 32 climatic patterns assessed against map components.
+- Peace/War/Wonder phase identified for each key component.
+- Inertia sources documented with severity.
+- Prediction horizons are realistic (not overconfident).
+- Strategic implications link back to specific components.
+- Assessment is evidence-based, not speculative.
+
+---
+
+## Tips
+
+1. **Climate before gameplay** -- Climate constrains which plays are viable. Always assess climate first.
+2. **Look for war signals** -- Components approaching commodity transition are the highest-risk, highest-opportunity areas.
+3. **Challenge inertia** -- Organizational inertia is often the hardest to overcome. Name it explicitly.
+4. **Update with the map** -- Climate assessment is tied to a specific map version. When the map changes, re-assess.
+5. **Use research data** -- Market research (`/arckit.research`) provides evidence for pattern detection. Do not assess climate in a vacuum.

--- a/arckit-claude/docs/guides/wardley-doctrine.md
+++ b/arckit-claude/docs/guides/wardley-doctrine.md
@@ -1,0 +1,120 @@
+# Doctrine Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.doctrine` assesses organizational doctrine maturity across 4 phases and 40+ principles.
+
+---
+
+## When to Use
+
+Run this command to assess organizational maturity, identify capability gaps, and plan improvements. Doctrine assessment reveals how well an organization applies universal strategic principles -- independent of any specific map or context. Use it to:
+
+- Baseline current organizational maturity
+- Identify systemic weaknesses before they manifest in projects
+- Plan targeted improvement programmes
+- Re-assess periodically to measure progress
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Architecture principles (`ARC-000-PRIN-v1.0.md`) | **Mandatory** -- Governance principles to assess against |
+| Wardley Map (`ARC-<id>-WARD-*.md`) | Recommended -- Provides strategic context for scoring |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- Organizational context and drivers |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.doctrine Assess doctrine maturity for <organisation>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WDOC-v1.0.md` (single instance per project)
+
+---
+
+## Doctrine Structure
+
+| Section | Contents |
+|---------|----------|
+| Phase Assessment | Which of the 4 phases the organization has reached |
+| Category Scores | Maturity scores across 6 doctrine categories |
+| Principle-Level Detail | Individual 1-5 scoring for 40+ principles |
+| Gap Analysis | Weaknesses and improvement priorities |
+| Improvement Roadmap | Phased plan to advance doctrine maturity |
+
+---
+
+## Key Concepts
+
+### The 4 Phases of Doctrine
+
+| Phase | Name | Focus |
+|-------|------|-------|
+| I | Stop Self-Harm | Eliminate basic organizational dysfunctions |
+| II | Becoming Context Aware | Develop situational awareness and mapping capability |
+| III | Better for Less | Optimize through strategic play and efficiency |
+| IV | Continuously Evolving | Anticipate and adapt to change systemically |
+
+Organizations must master each phase before progressing to the next.
+
+### The 6 Categories
+
+| Category | Examples |
+|----------|---------|
+| Communication | Common language, challenge assumptions, listen to ecosystems |
+| Development | Use appropriate methods, think small, know your details |
+| Learning | Use a systematic mechanism of learning, bias towards data |
+| Leading | Move fast, be the owner, think big |
+| Operations | Manage inertia, optimise flow, think aptitude and attitude |
+| Structure | Provide purpose, use small teams, think standards |
+
+### Scoring (1-5)
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Not practiced -- principle is unknown or ignored |
+| 2 | Ad hoc -- applied inconsistently |
+| 3 | Developing -- recognized and partly systematized |
+| 4 | Practiced -- systematically applied across the organization |
+| 5 | Mastered -- deeply embedded, continuously improved |
+
+### Re-Assessment
+
+Doctrine assessments support periodic re-assessment. When re-running the command, the previous assessment is read and scores are compared to show progress, regression, or stagnation.
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Foundation | Establish architecture principles | `/arckit.principles` |
+| Assessment | Score doctrine maturity | `/arckit.wardley.doctrine` |
+| Mapping | Create Wardley Maps with doctrine context | `/arckit.wardley` |
+| Strategy | Synthesise into strategy | `/arckit.strategy` |
+
+---
+
+## Review Checklist
+
+- All 40+ principles scored with evidence.
+- Phase classification is justified.
+- Gap analysis identifies top priority improvements.
+- Improvement roadmap has realistic timelines.
+- Comparison with previous assessment included (if re-assessment).
+- Scores reflect reality, not aspiration.
+
+---
+
+## Tips
+
+1. **Be honest** -- Doctrine assessment only has value if scores reflect reality. Aspirational scoring hides problems.
+2. **Involve multiple stakeholders** -- A single assessor introduces bias; cross-functional input produces better scores.
+3. **Start with Phase I** -- If Phase I principles are not mastered, skip ahead at your peril.
+4. **Re-assess quarterly** -- Doctrine maturity changes slowly; quarterly cadence balances effort and insight.
+5. **Link to principles** -- Map each doctrine principle to your architecture principles for traceability.

--- a/arckit-claude/docs/guides/wardley-gameplay.md
+++ b/arckit-claude/docs/guides/wardley-gameplay.md
@@ -1,0 +1,123 @@
+# Gameplay Analysis Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.gameplay` analyzes strategic plays from 60+ gameplay patterns.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to identify strategic plays available to your organization. Gameplay analysis examines your map and recommends actions based on component positions, movements, and the competitive landscape. Best combined with climate assessment (`/arckit.wardley.climate`) for a complete strategic picture.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map to analyze for strategic plays |
+| Climate assessment (`ARC-<id>-WCLM-*.md`) | Recommended -- External forces affecting gameplay choices |
+| Doctrine assessment (`ARC-<id>-WDOC-*.md`) | Recommended -- Organizational readiness for each play |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.gameplay Analyze gameplay for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WGAM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Gameplay Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being analyzed |
+| Applicable Plays | Strategic plays identified from component positions |
+| Play-Position Matrix | Which plays apply to which components |
+| Alignment Classification | D&D alignment for each play (Lawful/Neutral/Chaotic) |
+| Recommended Actions | Prioritized list of strategic actions |
+| Risk Assessment | Risks and counter-plays for each recommendation |
+
+---
+
+## Key Concepts
+
+### 11 Gameplay Categories
+
+| Category | Focus |
+|----------|-------|
+| User Perception | Shaping how users see value |
+| Accelerators | Speeding evolution of components |
+| De-accelerators | Slowing evolution to protect advantage |
+| Market | Creating or reshaping markets |
+| Defensive | Protecting current position |
+| Attacking | Disrupting competitors |
+| Ecosystem | Building or leveraging ecosystems |
+| Positional | Exploiting map position |
+| Poison | Undermining competitor strategies |
+| Military | Direct competitive confrontation |
+| Political | Influencing rules and standards |
+
+### 60+ Plays
+
+Examples include open source (accelerator), create a constraint (de-accelerator), tower and moat (defensive), two-factor markets (ecosystem), and standards game (political). Each play has specific applicability based on component evolution stage and visibility.
+
+### D&D Alignment Classification
+
+Plays are classified on two axes:
+
+| Axis | Options |
+|------|---------|
+| Lawful / Neutral / Chaotic | How the play relates to established norms |
+| Good / Neutral / Evil | The ethical dimension of the play |
+
+This classification helps organizations choose plays that align with their values and governance requirements.
+
+### Play-Position Matrix
+
+The matrix maps each play to the evolution stages where it is most effective:
+
+| Evolution Stage | Example Plays |
+|-----------------|---------------|
+| Genesis | Experimentation, talent raid, first mover |
+| Custom | Sensing engines, co-creation |
+| Product | Industrialisation plays, ecosystem building |
+| Commodity | Standards game, utility plays, commoditisation |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- Wardley Map is current and validated.
+- All applicable plays identified for each component.
+- D&D alignment classification is consistent.
+- Risks and counter-plays documented for each recommendation.
+- Play-position matrix is populated.
+- Recommendations are prioritized by impact and feasibility.
+- Organizational readiness considered (doctrine assessment).
+
+---
+
+## Tips
+
+1. **Map first, play second** -- Never select gameplay without a current Wardley Map.
+2. **Combine with climate** -- Climate patterns constrain which plays are viable. Assess climate first.
+3. **Check doctrine readiness** -- Some plays require organizational maturity. A Phase I organization cannot execute Phase III plays.
+4. **Consider ethics** -- The D&D alignment classification is not decorative. Choose plays consistent with your governance.
+5. **Revisit after map changes** -- When components move or the landscape shifts, gameplay analysis must be refreshed.

--- a/arckit-claude/docs/guides/wardley-value-chain.md
+++ b/arckit-claude/docs/guides/wardley-value-chain.md
@@ -1,0 +1,122 @@
+# Value Chain Decomposition Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.value-chain` decomposes user needs into value chains for Wardley Mapping.
+
+---
+
+## When to Use
+
+Run this command **before** creating a Wardley Map when you need to decompose a domain into its constituent components. Value chain decomposition identifies all the capabilities, services, and activities required to meet user needs -- producing the raw material that `/arckit.wardley` then positions on an evolution axis.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | **Mandatory** -- Capabilities, user needs, and business context |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- User roles and business drivers |
+| Architecture diagrams | Optional -- Existing component landscape |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.value-chain Decompose value chain for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WVCH-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Value Chain Structure
+
+| Section | Contents |
+|---------|----------|
+| Anchor Identification | User needs vs internal solution anchors |
+| Recursive Decomposition | Break each need into sub-components until atomic |
+| Visibility Mapping | How visible each component is to the end user |
+| Dependency Analysis | Which components depend on which |
+| Component Catalogue | Full list with descriptions, types, and owners |
+
+---
+
+## Key Concepts
+
+### Anchors: User Needs vs Solutions
+
+Wardley Maps start from **user needs**, not technology. Value chain decomposition distinguishes:
+
+- **User-need anchors** -- What the user actually wants (e.g., "book an appointment")
+- **Solution anchors** -- Internal capabilities that serve the need (e.g., "appointment scheduling service")
+
+Always anchor at user needs; solutions are components in the chain below.
+
+### Recursive Decomposition
+
+Each user need is broken down recursively:
+
+1. Identify the top-level need
+2. Ask "what is needed to provide this?"
+3. For each answer, repeat until you reach atomic components
+4. Atomic = a component that can be sourced as a single unit (build, buy, or utility)
+
+### Visibility Axis
+
+Components sit on a visibility spectrum:
+
+| Position | Description |
+|----------|-------------|
+| Top (visible) | User-facing capabilities, directly experienced |
+| Middle | Supporting services, seen by operators |
+| Bottom (invisible) | Infrastructure and utilities, invisible to users |
+
+### Dependency Types
+
+| Type | Description |
+|------|-------------|
+| Direct | Component A cannot function without Component B |
+| Indirect | Component A benefits from Component B but can operate without it |
+| Shared | Multiple components depend on a common service |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Requirements | Define user needs and capabilities | `/arckit.requirements` |
+| Decomposition | Break needs into value chains | `/arckit.wardley.value-chain` |
+| Mapping | Position components on evolution axis | `/arckit.wardley` |
+| Analysis | Assess doctrine, climate, gameplay | `/arckit.wardley.doctrine`, `/arckit.wardley.climate`, `/arckit.wardley.gameplay` |
+
+---
+
+## Review Checklist
+
+- All user needs identified and used as anchors.
+- Decomposition is recursive to atomic components.
+- Visibility axis reflects real user perspective.
+- Dependencies between components are explicit.
+- No technology assumptions baked into anchors.
+- Component catalogue is complete with descriptions.
+
+---
+
+## Tips
+
+1. **Start with users, not technology** -- If your first anchor is a database, you have started too low.
+2. **Challenge "obvious" components** -- Decompose even well-understood areas; hidden dependencies live there.
+3. **Use stakeholder analysis** -- Stakeholder drivers reveal needs that requirements alone may miss.
+4. **One chain per user need** -- Separate chains keep the analysis focused.
+5. **Feed into Wardley Map** -- The value chain output is the direct input to `/arckit.wardley`.
+
+---
+
+## Feeds Into
+
+- `/arckit.wardley` -- Use the decomposed value chain to create a positioned Wardley Map
+- `/arckit.data-model` -- Components often map to data entities

--- a/arckit-claude/docs/guides/wardley.md
+++ b/arckit-claude/docs/guides/wardley.md
@@ -6,6 +6,29 @@
 
 ---
 
+## Wardley Mapping Suite
+
+ArcKit provides a full suite of Wardley Mapping commands that work together as a strategic analysis pipeline:
+
+| Command | Purpose | Output |
+|---------|---------|--------|
+| `/arckit.wardley.value-chain` | Decompose user needs into value chains | WVCH |
+| `/arckit.wardley` | Create positioned Wardley Maps | WARD |
+| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity | WDOC |
+| `/arckit.wardley.climate` | Assess 32 climatic patterns | WCLM |
+| `/arckit.wardley.gameplay` | Analyze 60+ strategic gameplay patterns | WGAM |
+
+**Recommended workflow order:**
+
+1. **Value Chain** -- Decompose domain into components ([guide](wardley-value-chain.md))
+2. **Wardley Map** -- Position components on evolution axis (this guide)
+3. **Doctrine** -- Assess organizational maturity ([guide](wardley-doctrine.md))
+4. **Climate** -- Understand external forces ([guide](wardley-climate.md))
+5. **Gameplay** -- Identify strategic plays ([guide](wardley-gameplay.md))
+6. **Strategy / Roadmap** -- Synthesise findings into actionable plans
+
+---
+
 ## Inputs
 
 | Artefact | Purpose |

--- a/arckit-claude/hooks/validate-wardley-math.mjs
+++ b/arckit-claude/hooks/validate-wardley-math.mjs
@@ -65,7 +65,7 @@ if (isDir(projectsDir)) {
     for (const f of readdirSync(wmDir)) {
       const fp = join(wmDir, f);
       if (!isFile(fp)) continue;
-      if (!f.startsWith('ARC-') || !f.includes('-WARD-') || !f.endsWith('.md')) continue;
+      if (!f.startsWith('ARC-') || !(f.includes('-WARD-') || f.includes('-WVCH-')) || !f.endsWith('.md')) continue;
       try {
         const mt = statSync(fp).mtimeMs;
         const age = now - mt;

--- a/arckit-claude/skills/wardley-mapping/SKILL.md
+++ b/arckit-claude/skills/wardley-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wardley-mapping
-description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, gameplay patterns, doctrine, build vs. buy decisions, inertia analysis, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
+description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, value chain decomposition, gameplay patterns, doctrine assessment, doctrine maturity, climatic patterns, climate assessment, build vs. buy decisions, inertia analysis, D&D alignment of strategies, peace/war/wonder cycles, play-position matrix, pioneers/settlers/planners, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
 ---
 
 # Wardley Mapping
@@ -251,15 +251,23 @@ wardley_map:
 
 Consult these reference files for deeper analysis:
 
-- [Evolution Stages](references/evolution-stages.md) — Detailed stage characteristics, indicators, and positioning criteria
-- [Climatic Patterns](references/climatic-patterns.md) — External forces affecting the landscape (economic, competitive, technology, market patterns)
-- [Gameplay Patterns](references/gameplay-patterns.md) — Offensive/defensive strategic moves, build vs. buy vs. outsource, anti-patterns
-- [Doctrine](references/doctrine.md) — Universal strategy patterns and organizational maturity assessment
-- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product
-- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection
+- [Evolution Stages](references/evolution-stages.md) — Stage characteristics, indicators, positioning criteria, transition heuristics, pioneers/settlers/planners talent model
+- [Climatic Patterns](references/climatic-patterns.md) — 32 patterns across 6 categories (component, financial, speed, inertia, competitor, prediction), peace/war/wonder cycle, pattern interactions
+- [Gameplay Patterns](references/gameplay-patterns.md) — 60+ plays across 11 categories with D&D alignment classification, play-position matrix, play compatibility, case studies (AWS, Netflix, Tesla, Spotify)
+- [Doctrine](references/doctrine.md) — 40+ principles across 4 phases and 6 categories, Strategy Cycle framework, implementation journeys, maturity assessment template
+- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product, TechnoGadget Smart Home, value chain decomposition walkthrough, case study cross-references
+- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection, play-position scoring, climate pattern impact weighting
 
 ## ArcKit Integration
 
 This skill handles **conversational** Wardley Mapping — quick questions, evolution stage lookups, doctrine assessments, and interactive map creation.
 
-For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the `/arckit:wardley` command instead. It generates versioned Wardley Map artifacts saved to your project directory with full traceability to requirements and architecture principles.
+For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the ArcKit Wardley suite:
+
+- `/arckit.wardley.value-chain` — Decompose user needs into value chains (WVCH artifact)
+- `/arckit.wardley` — Create strategic Wardley Maps (WARD artifact)
+- `/arckit.wardley.doctrine` — Assess organizational doctrine maturity across 4 phases, 40+ principles (WDOC artifact)
+- `/arckit.wardley.gameplay` — Analyze strategic plays from 60+ gameplay patterns with D&D alignment (WGAM artifact)
+- `/arckit.wardley.climate` — Assess 32 climatic patterns across 6 categories with prediction horizons (WCLM artifact)
+
+These generate versioned artifacts saved to your project directory with full traceability to requirements and architecture principles. Each command works standalone but gets richer when sibling artifacts exist.

--- a/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
@@ -1,260 +1,456 @@
-# Climatic Patterns
+# Climatic Patterns Reference
 
-External forces that affect the landscape, outside organizational control.
+Climatic patterns are external forces that shape the business landscape regardless of your actions. They are the "weather" of strategy — you cannot control them, but you can anticipate and prepare. Unlike gameplays (deliberate choices), climatic patterns simply happen. Understanding them lets you position ahead of change rather than react to it.
 
-## Economic Patterns
+---
 
-### Everything Evolves
+## 1. Component Patterns — Chapter IV
 
-```yaml
-pattern:
-  name: "Everything Evolves"
-  description: "All components evolve through genesis → custom → product → commodity"
+### 1.1 Everything Evolves Through Supply and Demand Competition
 
-  implications:
-    - "No competitive advantage is permanent"
-    - "Today's differentiator is tomorrow's commodity"
-    - "Plan for evolution, don't fight it"
+All components — activities, practices, data, knowledge — move from genesis through custom-built, product, and commodity stages driven by supply and demand forces. Supply-side competition drives standardisation and efficiency; demand-side pressure shifts expectations from "novel capability" to "expected utility." Value perception shifts from scarcity and uniqueness at genesis, to features at product stage, to cost and reliability at commodity stage.
 
-  example: "Cloud computing: mainframe → server → VM → container → serverless"
+**Strategic implication:** No competitive advantage is permanent — plan for evolution, not against it.
+
+**Assessment question:** Which components are actively evolving and what does their next stage look like?
+
+---
+
+### 1.2 Rates of Evolution Can Vary by Ecosystem
+
+Evolution does not occur at a uniform pace. Consumer ecosystems (individual users, rapid adoption, trend-driven, network effects) evolve far faster than industrial ecosystems (B2B, long decision cycles, regulatory constraints, high switching costs). Factors that modulate speed include regulatory environment, investment levels, industry inertia, and how dependent a component is on underlying technologies that are themselves evolving.
+
+**Strategic implication:** Map the evolutionary speed of your specific ecosystem, not a generic average, to time investments and innovation correctly.
+
+**Assessment question:** Is this component in a fast or slow ecosystem, and does your strategy match that cadence?
+
+---
+
+### 1.3 Characteristics Change as Components Evolve
+
+As a component moves along the evolution axis, its fundamental characteristics transform. Genesis: uncertain, rare, high-risk, radical innovation, pioneer teams. Custom-built: emerging understanding, divergent approaches, hypothesis-driven. Product: standardising, feature competition, settler teams. Commodity: well-understood, price-based competition, high reliability required, town planner teams. Management approach, failure tolerance, contract type, and talent profile must all change with the stage.
+
+**Strategic implication:** Applying product-stage management to a genesis component (or vice versa) is a systematic source of failure.
+
+**Assessment question:** Does the management approach, team structure, and contract type match the current evolution stage of this component?
+
+---
+
+### 1.4 No Choice Over Evolution — The Red Queen Effect
+
+Named after Lewis Carroll's Red Queen: "It takes all the running you can do, to keep in the same place." Evolution in business ecosystems is not optional. Competitive pressures, technological advancement, and shifting customer expectations force continuous adaptation. Absolute progress (improving your own capabilities) does not guarantee relative progress if competitors evolve at the same or faster rate. BlackBerry and Nokia improved their products; the market moved past them anyway.
+
+**Strategic implication:** Continuous adaptation is a survival requirement, not a strategic option.
+
+**Assessment question:** Where are we running just to stay still, and are we running fast enough?
+
+---
+
+### 1.5 No Single Method Fits All
+
+Different evolution stages require fundamentally different approaches. Software development: agile for genesis/custom, DevOps for maturing product, Six Sigma/lean for commodity. Contracts: time-and-materials for genesis, fixed-price for commodity. Architecture: disposable PoCs at genesis, standardised patterns at commodity. Amazon exemplifies this — AWS runs on continuous deployment, fulfillment centres on lean manufacturing, Amazon Go on experimental tech. Applying a single methodology across all stages creates systematic inefficiency.
+
+**Strategic implication:** Build a toolkit of methods and the organisational capability to switch between them as components evolve.
+
+**Assessment question:** Are we applying the right management method for each component's current evolution stage?
+
+---
+
+### 1.6 Components Can Co-evolve
+
+Components do not evolve in isolation. The evolution of one component can trigger, accelerate, or constrain the evolution of related components. Types: symbiotic (mobile hardware and mobile apps), practice-based (DevOps emerged with cloud infrastructure), competitive (fintech forcing bank digital evolution). Co-evolution creates new opportunities at intersection points and new risks when dependent components evolve at mismatched speeds.
+
+**Strategic implication:** Watch for "enabler components" — when they evolve, they can unlock rapid evolution in components that depend on them.
+
+**Assessment question:** Which components, if evolved by a competitor, would trigger co-evolutionary pressure on our differentiators?
+
+---
+
+### 1.7 Evolution Consists of Multiple Waves of Diffusion with Many Chasms
+
+Drawing on Rogers' Diffusion of Innovations and Moore's chasm concept: adoption does not flow smoothly. Each wave (innovators/early adopters → early majority → late majority → laggards) has distinct characteristics, and between waves lie chasms where adoption stalls. Cloud computing crossed at least two major chasms — the security concern chasm before enterprise adoption, and the legacy integration chasm before cloud-native architectures. Products can die in a chasm even if the technology is sound.
+
+**Strategic implication:** Crossing a chasm requires a different strategy than riding a wave — segment, adapt the offer, build reference cases, develop ecosystem support.
+
+**Assessment question:** Which chasm is this component currently in, and what is blocking the next adoption wave?
+
+---
+
+### 1.8 Commoditization Does Not Equal Centralisation
+
+A common misconception: if something commoditises, it must consolidate to a single provider. Reality is more nuanced. Many commoditised components remain decentralised due to local regulation, physical constraints, security requirements, resilience needs, or customer preferences for local relationships. Banking services are largely commoditised but thousands of institutions persist. Electricity is standardised but generation is distributed. Cloud computing is commoditised but multiple providers compete.
+
+**Strategic implication:** Commoditised markets may still offer opportunities for differentiation through localisation, specialisation, or distributed models.
+
+**Assessment question:** Are we assuming centralisation will follow commoditisation, and is that assumption valid for our specific market context?
+
+---
+
+## 2. Financial Patterns — Chapter V
+
+### 2.1 Higher Order Systems Create New Sources of Value
+
+When lower-order components commoditise, they become building blocks for new, higher-order systems that exhibit emergent properties not present in constituent parts. Cloud computing (commodity compute + storage + networking) enabled the SaaS economy. Smartphones (commodity hardware) enabled the app economy. IoT = sensors + connectivity + cloud + analytics. Each higher-order system opens new value streams, new business models, and new genesis opportunities above it.
+
+**Strategic implication:** Look for clusters of recently commoditised components — they are the foundation for the next wave of higher-order innovation.
+
+**Assessment question:** What higher-order system could be built on top of components that are now commoditising in our value chain?
+
+---
+
+### 2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox
+
+Named after 19th-century economist William Stanley Jevons: improvements in the efficiency of resource use tend to increase total consumption, not reduce it, because lower cost enables new use cases and broader adoption. Cloud computing became more efficient and cheaper — total cloud spend skyrocketed. Fuel-efficient cars led to more driving. More efficient LEDs led to more lighting. In Wardley terms: as components commoditise and efficiency improves, new applications emerge that consume more of that resource overall.
+
+**Strategic implication:** Efficiency gains in a component should be treated as a demand amplifier, not a cost reducer — plan for increased consumption and new use cases, not reduced spend.
+
+**Assessment question:** Where are we planning cost savings from efficiency improvements that will actually be consumed by new demand?
+
+---
+
+### 2.3 Capital Flows to New Areas of Value
+
+Capital (financial, human, intellectual, organisational attention) consistently flows away from commoditised, low-margin areas toward genesis and early custom-built components with high differentiation potential. As an area commoditises, capital exits to fund the next cycle of innovation. This is visible in VC trends (AI/ML, quantum, clean energy), talent migration patterns, and M&A activity. The direction of capital flow is a leading indicator of where value is being created.
+
+**Strategic implication:** Track where capital is flowing — it signals where the next wave of value creation is forming.
+
+**Assessment question:** Is capital flowing toward or away from our core differentiators, and what does that signal about their evolution stage?
+
+---
+
+### 2.4 Creative Destruction — The Schumpeter Effect
+
+Joseph Schumpeter described creative destruction as "a process of industrial mutation that incessantly revolutionises the economic structure from within, incessantly destroying the old one, incessantly creating a new one." New innovations render existing components, business models, and sometimes entire industries obsolete. Digital photography destroyed film. Streaming destroyed video rental. EV is restructuring automotive. In Wardley terms, new genesis components emerge and evolve rapidly to displace commodity incumbents.
+
+**Strategic implication:** No incumbent position is safe from creative destruction — organisations must simultaneously exploit current advantages and invest in the innovations that may replace them.
+
+**Assessment question:** What genesis-stage component, if it evolves, would make our current commodity position irrelevant?
+
+---
+
+### 2.5 Future Value is Inversely Proportional to Certainty
+
+The higher the certainty about an outcome, the lower its potential value — because certainty is priced in by competitors. Genesis components (high uncertainty, low certainty) carry the highest potential value but also the highest risk. Commodity components (high certainty, low uncertainty) offer stable returns but no differentiation. Venture capital portfolios embody this: most investments fail, but the few that succeed return multiples that dwarf the losses. The relationship also applies to timing: the P[what] of a change may be high (EV will dominate) while P[when] remains uncertain.
+
+**Strategic implication:** Pursuing only certain opportunities means accepting low returns — a portfolio of high-uncertainty bets is needed to capture asymmetric upside.
+
+**Assessment question:** Are we systematically avoiding uncertain opportunities in ways that cap our future value potential?
+
+---
+
+### 2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption
+
+As systems become more complex and organised locally (higher order), they require more energy and resources overall — not less. More complex systems are more ordered locally but increase entropy in their environment. This manifests as: cloud data centres consuming massive electricity to enable efficient individual applications, AI training consuming enormous compute to enable efficient inference, smart cities consuming more infrastructure to optimise traffic. Jevons Paradox amplifies this — efficiency enables more consumption.
+
+**Strategic implication:** Include energy/resource/infrastructure costs in strategic planning for higher-order systems — the efficiency gains at the application layer are often offset by consumption increases at the infrastructure layer.
+
+**Assessment question:** Have we accounted for the full resource cost of the higher-order systems we are building or depending on?
+
+---
+
+## 3. Speed Patterns — Chapter VI
+
+### 3.1 Efficiency Enables Innovation — The Componentization Effect
+
+When lower-order components become commoditised and efficient, focus and resources shift to higher-level innovation. The mechanism: abstraction hides complexity, standardisation enables reuse, efficiency frees resources, stable components enable rapid recombination. Cloud commoditised infrastructure → rapid innovation in PaaS/SaaS. Smartphone hardware commoditised → app economy. Open source libraries → accelerated development. Each layer of commoditisation is a platform for the genesis of the next layer.
+
+**Strategic implication:** Actively commoditise lower layers to free innovation capacity for higher-value work — don't custom-build what should be utility.
+
+**Assessment question:** Which of our custom-built components should be replaced with commodity solutions to free resources for higher-value innovation?
+
+---
+
+### 3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed
+
+Improvements in how information is shared, collaboration occurs, and knowledge spreads accelerate the evolution of everything else. GitHub accelerated open source. Social media accelerated trend adoption and customer feedback loops. Slack/Zoom accelerated distributed decision-making. The internet accelerated globalisation. Each improvement in communication creates tighter feedback loops, faster learning cycles, and broader dissemination of innovation — compressing the time from genesis to commodity for dependent components.
+
+**Strategic implication:** Investing in communication infrastructure and culture is not just operational overhead — it is a direct lever on innovation speed.
+
+**Assessment question:** Are there communication bottlenecks in our organisation that are slowing the evolution of key components?
+
+---
+
+### 3.3 Increased Stability of Lower Order Systems Increases Agility
+
+A paradox: stability at lower levels creates agility at higher levels. When foundational components are reliable and well-understood, teams can experiment and innovate at higher levels without worrying about the underlying infrastructure. Stable OS → rapid application development. Stable cloud infrastructure → serverless experimentation. Stable web frameworks → rapid UI prototyping. Conversely, unstable lower-order systems force engineering attention downward, away from higher-value innovation.
+
+**Strategic implication:** Invest in making foundational systems stable and commodity-grade to unlock innovation speed above them.
+
+**Assessment question:** Are our foundational systems stable enough to support rapid recombination and experimentation at higher levels?
+
+---
+
+### 3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists
+
+Change can follow linear, exponential, S-curve, or discontinuous (tipping point) patterns. Human cognition defaults to linear extrapolation, systematically underestimating exponential trends and missing discontinuities. AI capabilities improved gradually for decades, then accelerated explosively. Cryptocurrency appeared discontinuously. Social media followed an S-curve. The implication: strategies built on linear forecasts are repeatedly surprised by the world. Scenarios must include non-linear possibilities.
+
+**Strategic implication:** Build strategies that are robust across non-linear scenarios, not just the linear extrapolation of current trends.
+
+**Assessment question:** Which components in our landscape could exhibit exponential or discontinuous change, and are our plans robust to that?
+
+---
+
+### 3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium
+
+The transition from product to utility (commodity/utility stage) is not always gradual. Components often remain stable in the product stage for extended periods, then shift rapidly to utility characteristics — standardised offering, usage-based pricing, cloud delivery, market consolidation. Software licensing → SaaS was punctuated. Music sales → streaming was punctuated. On-premise IT → cloud was punctuated. The equilibrium (product stage) is stable until a trigger collapses it quickly into the utility paradigm.
+
+**Strategic implication:** If you are in a product market, monitor for the triggers that will cause punctuated shift to utility — and decide whether to lead or follow that shift.
+
+**Assessment question:** Which of our product-stage offerings is approaching a punctuated shift to utility, and are we positioned to lead or survive it?
+
+---
+
+## 4. Inertia Patterns — Chapter VII
+
+### 4.1 Success Breeds Inertia
+
+Organisations that achieve success tend to resist change. The very practices, structures, and mindsets that created success become barriers to future adaptation. Mechanisms: complacency reduces urgency, overconfidence inflates belief in current capabilities, resources cluster around profitable existing products, successful practices become culturally entrenched, and risk aversion increases as there is more to lose. Kodak invented digital photography; Nokia built excellent hardware; Blockbuster had massive scale — all failed because success made adaptation psychologically and structurally difficult.
+
+**Strategic implication:** Explicitly identify and name success-induced inertia — it is invisible until it is fatal.
+
+**Assessment question:** Where are we resisting evolution because current revenue or culture depends on the status quo?
+
+---
+
+### 4.2 Inertia Can Kill an Organisation
+
+Unaddressed inertia has existential consequences. The mechanisms of organisational death by inertia: market irrelevance (failing to adapt to shifting user needs), technological obsolescence (clinging to superseded approaches), business model disruption (unable to match new entrants' economics), and resource depletion (continuing to invest in declining areas). Blockbuster (bankruptcy 2010), Kodak (bankruptcy 2012), Nokia's mobile division (sold 2014) — all were dominant market leaders destroyed by inertia, not lack of capability.
+
+**Strategic implication:** Inertia is not a performance problem — it is a survival problem. Treat it as an existential risk, not a management challenge.
+
+**Assessment question:** If a new entrant built our core value chain on commodity infrastructure today, what would their cost structure and speed look like compared to ours?
+
+---
+
+### 4.3 Inertia Increases the More Successful the Past Model Is
+
+The more successful a business model has been, the harder it becomes to abandon — proportionally. Extraordinary success creates deeper entrenchment of processes, stronger cognitive biases toward the current model, greater financial disincentives to change (cannibalism risk), deeper skill specialisation that is hard to pivot, and stronger cultural identity attached to the successful approach. Microsoft initially missed the internet despite its dominant position. IBM resisted personal computing. Xerox failed to commercialise its own GUI innovations.
+
+**Strategic implication:** The organisations most at risk from inertia are the most successful ones — build explicit mechanisms for self-disruption before disruption is forced externally.
+
+**Assessment question:** Where is our success so profound that we cannot honestly assess whether the model will survive the next evolution cycle?
+
+---
+
+## 5. Competitor Patterns — Chapter VIII
+
+### 5.1 Competitors' Actions Will Change the Game
+
+The competitive landscape is not static — competitors' strategic moves can fundamentally alter the rules of engagement. Game-changing action types: disruptive innovation (redefining the market), pricing strategy shifts (changing customer expectations), M&A (creating new capability combinations), ecosystem plays (expanding the scope of competition), and regulatory influence (shaping the playing field). AWS changed cloud. Uber changed transport. Tesla changed automotive. Each action triggered cascading changes across the entire ecosystem.
+
+**Strategic implication:** Strategy must be designed for a reactive system, not a static environment — anticipate competitor moves, not just market trends.
+
+**Assessment question:** Which competitor action, if taken, would most fundamentally change the basis of competition in our market?
+
+---
+
+### 5.2 Most Competitors Have Poor Situational Awareness
+
+The majority of organisations operate without a clear, accurate model of their competitive landscape. Manifestations of poor situational awareness: myopic focus on immediate competitors while missing broader industry shifts, technology blindness (failing to recognise emerging technology impact), customer disconnect (misunderstanding evolving needs), ecosystem ignorance (unaware of adjacent disruptors), and internal bias (overestimating own position). Blockbuster, Nokia, and Kodak all had access to information about emerging threats — they lacked the frameworks to interpret that information correctly.
+
+**Strategic implication:** Superior situational awareness is itself a durable competitive advantage — Wardley Mapping is a tool for building it.
+
+**Assessment question:** What would our map look like if drawn by our most capable competitor, and how would it differ from ours?
+
+---
+
+## 6. Prediction Patterns — Chapter IX
+
+### 6.1 Not Everything is Random — P[what] vs P[when]
+
+The direction of change (what will happen) is often more predictable than its timing (when it will happen). The shift to electric vehicles was widely predictable (high P[what]); the timing of mass adoption was not (uncertain P[when]). The commoditisation of cloud was predictable; the exact speed was not. This distinction enables better strategic planning: prepare capabilities and positioning for the predictable "what" while maintaining flexibility about the "when." Strategies anchored to specific timelines fail when the "when" is wrong; strategies anchored to directions are more robust.
+
+**Strategic implication:** Separate directional bets (high confidence) from timing bets (lower confidence) in strategic planning and investment decisions.
+
+**Assessment question:** Which evolutionary directions in our landscape are high-confidence (P[what]) even if the timing remains uncertain (P[when])?
+
+---
+
+### 6.2 Economy Has Cycles — Peace, War, and Wonder
+
+Industries cycle through three phases. **Peace**: stable market, established players dominate, incremental improvements, efficiency focus, product competition on features. **War**: intense competition triggered by industrialisation of a key component (e.g., cloud), rapid disruption, shifting power, creative destruction, incumbents with inertia are most vulnerable. **Wonder**: emergence of new higher-order systems built on newly commoditised components, rapid genesis, new industries forming, new business models, capital floods in. Each phase transitions to the next as components evolve.
+
+**Strategic implication:** Identify the current phase and position accordingly — survival strategies differ radically between Peace (optimise), War (transform rapidly), and Wonder (explore and capture genesis opportunities).
+
+**Assessment question:** Which phase is our core market currently in, and what phase transition should we be preparing for?
+
+---
+
+### 6.3 Different Forms of Disruption — Predictable vs Unpredictable
+
+Not all disruptions are equal. **Predictable disruptions** follow observable evolutionary patterns — the shift to EV, the move from product to SaaS, the commoditisation of compute. These can be anticipated through careful Wardley mapping and scenario planning. **Unpredictable disruptions** arise from unforeseen combinations of factors — cryptocurrency, ChatGPT's impact timeline, COVID-19 accelerating digital adoption. Strategies for each differ: predictable disruptions warrant directional investment and capability building; unpredictable disruptions require resilience, optionality, and rapid response capability.
+
+**Strategic implication:** Maintain separate portfolios for predictable evolutionary positioning and resilience against unpredictable disruption.
+
+**Assessment question:** Which disruptions in our landscape are predictable (and therefore we should be positioned for), and which require resilience rather than prediction?
+
+---
+
+### 6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve
+
+When a key component crosses from product to utility (industrialisation), it triggers a "war" — a period of intense competition that forces rapid organisational evolution across the entire ecosystem. Characteristics: accelerated component movement on the map, emergence of new components and disappearance of others, shifting value chains, standardisation pressure, and efficiency focus. The cloud "war" forced every enterprise IT function to evolve. The e-commerce "war" forced every retailer to transform. Organisations with high inertia are most vulnerable during these periods.
+
+**Strategic implication:** Detect the signs of an approaching "war" early — rapid component movement, new entrants with commodity infrastructure, pricing pressure — and begin transformation before the peak.
+
+**Assessment question:** Is there a component in our value chain approaching industrialisation that will trigger a "war" requiring us to evolve rapidly?
+
+---
+
+### 6.5 You Cannot Measure Evolution Over Time or Adoption
+
+Evolution cannot be precisely measured or timed. Adoption rates are highly variable, context-dependent, and non-linear. Attempts to create exact timelines or adoption curves produce false precision that misleads strategy. Cloud adoption varied wildly by industry and region. Social media platform trajectories were unpredictable. AI breakthroughs in natural language processing exceeded predictions; adoption in other sectors lagged them. The evolutionary axis in Wardley maps represents maturity, not time — components should be positioned by their characteristics, not by when they appeared.
+
+**Strategic implication:** Use directional positioning and scenario ranges rather than timeline forecasts — build strategies robust to timing uncertainty.
+
+**Assessment question:** Are we making investment commitments that depend on specific adoption timing predictions, and how robust are those commitments if timing is wrong by 2-3 years?
+
+---
+
+### 6.6 The Less Evolved Something Is, the More Uncertain It Becomes
+
+Uncertainty correlates inversely with evolution stage. Genesis components: high uncertainty about use cases, timelines, applications, and market dynamics. Custom-built: emerging patterns, still divergent. Product: increasing certainty, convergent standards. Commodity: well-understood, predictable. This is why genesis innovation requires different risk tolerance, different management approaches, and different investment models (portfolio/options thinking) compared to commodity management (efficiency, SLAs, incident management). Blockchain remains mostly in high-uncertainty stages; cloud IaaS is low-uncertainty commodity.
+
+**Strategic implication:** Calibrate risk tolerance, management approach, and investment model to the evolution stage — not to a single organisational standard.
+
+**Assessment question:** Are we applying commodity-appropriate certainty assumptions to genesis-stage components, or genesis-appropriate uncertainty assumptions to commodity components?
+
+---
+
+### 6.7 Not Everything Survives
+
+Evolution is a selection process — not all components, technologies, business models, or organisations survive it. Survival requires continuous adaptation. Past success and market leadership do not guarantee survival (Kodak, Nokia, Blockbuster). Creative destruction continuously replaces less-adapted elements with better-adapted alternatives. Strategies must account for exit scenarios, graceful transition pathways, and portfolio diversification to spread survival risk. Some components will become obsolete on a predictable timeline; others will be wiped out by unpredictable disruption.
+
+**Strategic implication:** Include obsolescence scenarios and exit planning in strategy — not as pessimism, but as realism about evolutionary dynamics.
+
+**Assessment question:** Which components in our current value chain have a non-trivial probability of not surviving the next evolution cycle, and what is our plan?
+
+---
+
+### 6.8 Embrace Uncertainty
+
+Uncertainty is not a problem to solve — it is a property of the landscape to work with. Strategies that require uncertainty to be resolved before acting are brittle. Effective approaches: scenario planning across multiple futures, adaptive strategy that adjusts as new information arrives, staged investment (options thinking), rapid experimentation to reduce uncertainty in specific areas, and range-based positioning rather than point predictions. The Wardley map itself is a tool for navigating uncertainty, not eliminating it.
+
+**Strategic implication:** Design strategy to be robust across a range of futures, not optimal for a single predicted future.
+
+**Assessment question:** How many of our current strategic commitments would fail if one key uncertainty resolved differently than we expect?
+
+---
+
+## 7. The Peace/War/Wonder Cycle
+
+The Peace/War/Wonder cycle is one of the most powerful macro-level patterns for strategic timing.
+
+### Peace Phase
+
+Characteristics: stable market structure, established players compete on features and brand, incremental innovation dominates, efficiency and optimization are the primary value drivers, customers have clear expectations, supply chains are well-understood, margins are moderate but predictable.
+
+Strategic posture in Peace: invest in operational excellence, differentiate on features and customer experience, build moats through network effects and switching costs, watch for the signs of approaching War.
+
+Signs Peace is ending: a key component begins rapid commoditisation, new entrants appear with dramatically lower cost structures built on commodity infrastructure, pricing pressure accelerates, customers begin treating differentiated features as expected utilities.
+
+### War Phase
+
+Characteristics: intense competition triggered by industrialisation of a key component, rapid disruption of established business models, creative destruction of incumbents with high inertia, massive investment and risk-taking, shifting value chains, winner-takes-most dynamics, organisations that fail to evolve quickly face existential risk.
+
+Strategic posture in War: transform rapidly, use the commodity infrastructure that triggered the War, shed custom-built components that are now available as utilities, focus on higher-order differentiation, form strategic partnerships, acquire capabilities that cannot be built fast enough organically.
+
+Signs War is ending: market consolidation around a few utility providers, pricing stabilises at commodity levels, the new "normal" becomes established, innovation focus shifts upward to new genesis opportunities.
+
+### Wonder Phase
+
+Characteristics: new higher-order systems built on newly commoditised components, rapid genesis of new capabilities, new industries forming, capital floods into new value areas, multiple competing paradigms coexist, uncertainty is highest but potential value is greatest.
+
+Strategic posture in Wonder: explore broadly, make small bets on multiple genesis opportunities, build options, tolerate high failure rates for high potential return, watch for which genesis components are beginning to show custom-built characteristics (indicating the next cycle is forming).
+
+Signs Wonder is maturing into the next Peace: dominant designs emerge, standards begin to form, the early adopter wave has passed and early majority adoption begins.
+
+### Identifying Your Current Phase
+
+Ask these questions for each major market/component:
+- Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
+- Are new entrants building on commodity infrastructure that did not exist 3 years ago?
+- Is capital flowing into or out of this space?
+- Are established players being forced to change their core business models?
+
+---
+
+## 8. Pattern Interaction Map
+
+Climatic patterns do not operate in isolation — they interact, reinforce, and counteract each other.
+
+### Reinforcing Combinations
+
+| Pattern A | Pattern B | Combined Effect |
+|-----------|-----------|-----------------|
+| Everything Evolves | Efficiency Enables Innovation | Accelerating cycle: commoditisation continuously creates the foundation for new genesis |
+| Higher Order Systems Create Value | Capital Flows to New Value | Capital predictably follows the new value streams created by higher-order systems |
+| Evolution of Communication | Change Is Not Linear | Better communication amplifies non-linear change by spreading innovations faster |
+| Punctuated Equilibrium | War Phase | Product-to-utility shifts are the mechanism that triggers "War" periods |
+| Success Breeds Inertia | Inertia Increases with Success | Compounding effect — the more successful, the more inert, the more vulnerable |
+| Jevons Paradox | Higher Order Systems Increase Energy | Efficiency-driven adoption increases demand, which increases total resource consumption |
+
+### Counteracting Tensions
+
+| Pattern A | Counteracts | Effect |
+|-----------|-------------|--------|
+| Inertia patterns | Everything Evolves | Inertia slows or blocks what evolution demands — this tension is the primary cause of organisational failure |
+| Not Everything Survives | Capital Flows to New Value | Capital exits before components become extinct — early movers gain, late movers lose |
+| Embrace Uncertainty | False precision in P[when] | Organisations that require certainty before acting are consistently outmanoeuvred by those that act on P[what] |
+| Commoditization ≠ Centralisation | Assumption of monopoly | Prevents strategic blind spots about market structure in commoditised segments |
+
+### Cascade Sequences
+
+A common cascade: **War phase** triggers → **Creative Destruction** → **Capital flows** to new areas → **Higher-order systems** emerge → **Efficiency enables innovation** → components commoditise → next **War phase** begins.
+
+Another: **Red Queen Effect** pressure → **Success Breeds Inertia** resistance → **Inertia Can Kill** outcome (if not addressed) or **Self-disruption** response (if addressed).
+
+---
+
+## 9. Per-Component Assessment Template
+
+Use this template for each significant component on a Wardley map to identify which climatic patterns are most active and their likely strategic impact.
+
+```
+Component: [name]
+Evolution Stage: [genesis / custom-built / product / commodity]
+Evolution Trajectory: [accelerating / stable / stagnating]
+Ecosystem Type: [consumer (fast) / industrial (slow) / mixed]
+
+Key Patterns Affecting This Component:
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [1-2 sentences of specific evidence]
+    Time Horizon: [<12 months / 1-3 years / 3+ years]
+
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [brief]
+    Time Horizon: [timeframe]
+
+Inertia Assessment:
+  - Organisational inertia present: [yes / no / partial]
+  - Source of inertia: [past success / skills / politics / contracts / culture]
+
+Peace/War/Wonder Phase: [current phase for this component's market]
+Next Phase Trigger: [what would trigger transition to next phase]
+
+Prediction:
+  P[what]: [what will happen — high confidence direction]
+  P[when]: [timing uncertainty — low / medium / high]
+  6-month outlook: [specific prediction]
+  12-month outlook: [specific prediction]
+
+Recommended Response:
+  Urgency: [High / Medium / Low]
+  Primary action: [description]
+  Watch signal: [what to monitor to confirm/refute the prediction]
 ```
 
-### Characteristics Change as Components Evolve
+---
 
-```yaml
-pattern:
-  name: "Characteristics Change"
-  description: "How a component is managed changes with its evolution"
+## 10. Pattern Recognition Template
 
-  changes:
-    genesis:
-      development: "Research, exploration"
-      failure: "Expected, learning"
-      team: "Pioneers"
-
-    commodity:
-      development: "Operations, optimization"
-      failure: "Unacceptable, incident"
-      team: "Town planners"
-
-  implication: "Same team skills don't work across evolution stages"
-```
-
-### No One Thing Fits All
-
-```yaml
-pattern:
-  name: "No One Size Fits All"
-  description: "Different stages require different approaches"
-
-  examples:
-    methods:
-      genesis: "Agile, experimental"
-      commodity: "Six Sigma, lean"
-
-    contracts:
-      genesis: "Time & materials"
-      commodity: "Fixed price"
-
-    architecture:
-      genesis: "Disposable PoCs"
-      commodity: "Standardized patterns"
-```
-
-## Competitive Patterns
-
-### Components Can Co-Evolve
-
-```yaml
-pattern:
-  name: "Co-Evolution"
-  description: "Changes in one component can accelerate another"
-
-  types:
-    practice_based:
-      description: "New practices emerge with new components"
-      example: "DevOps emerged with cloud infrastructure"
-
-    symbiotic:
-      description: "Components evolve together"
-      example: "Mobile devices and mobile apps"
-
-  implication: "Watch for enabler components that unlock other evolution"
-```
-
-### Efficiency Enables Innovation
-
-```yaml
-pattern:
-  name: "Efficiency Enables Innovation"
-  description: "Commoditization of one layer enables innovation above it"
-
-  example:
-    commodity: "Cloud computing"
-    enabled_innovation: "ML platforms, serverless applications"
-
-  implication: "Commoditize lower layers to free resources for higher-value work"
-```
-
-### Higher Order Systems Create New Sources of Worth
-
-```yaml
-pattern:
-  name: "Higher Order Systems"
-  description: "New value emerges from combining evolved components"
-
-  examples:
-    - "IoT = sensors + connectivity + cloud + analytics"
-    - "AI applications = compute + data + algorithms + interfaces"
-
-  implication: "Look for emerging higher-order systems"
-```
-
-## Predictability Patterns
-
-### Past Success Breeds Inertia
-
-```yaml
-pattern:
-  name: "Success Breeds Inertia"
-  description: "Organizations resist change to what made them successful"
-
-  causes:
-    - "Financial success with current model"
-    - "Skills and expertise tied to current technology"
-    - "Political capital invested in status quo"
-    - "Existing customer relationships"
-
-  symptoms:
-    - "Not invented here syndrome"
-    - "Custom building commodity components"
-    - "Resisting cloud migration"
-    - "Maintaining outdated technology"
-
-  counter_strategy: "Explicitly identify and address inertia"
-```
-
-### Capital Flows to New Industries
-
-```yaml
-pattern:
-  name: "Capital Flows"
-  description: "Investment follows evolution opportunities"
-
-  pattern: "Money flows from commodity extraction to genesis exploration"
-
-  implication: "Commoditization frees capital for new innovation"
-```
-
-## Technology Patterns
-
-### Componentization Increases
-
-```yaml
-pattern:
-  name: "Increasing Componentization"
-  description: "Systems become more modular over time"
-
-  stages:
-    early: "Monolithic, integrated"
-    middle: "Modular, connected"
-    mature: "Composable, standardized interfaces"
-
-  current_trends:
-    - "Microservices vs. monoliths"
-    - "APIs vs. point-to-point"
-    - "Serverless vs. managed servers"
-```
-
-### New Paradigms Create Waves
-
-```yaml
-pattern:
-  name: "Technology Waves"
-  description: "New paradigms replace old but take time"
-
-  wave_pattern:
-    emergence: "New technology appears (genesis)"
-    early_adoption: "Pioneers experiment"
-    disruption: "Mainstream adoption begins"
-    maturity: "Previous paradigm commoditizes"
-    next_wave: "Cycle repeats"
-
-  current_waves:
-    establishing: "AI/ML, quantum (early)"
-    disrupting: "Cloud native, serverless"
-    maturing: "Mobile, SaaS"
-    commoditized: "Internet, databases"
-```
-
-## Market Patterns
-
-### Buyers and Suppliers Evolve
-
-```yaml
-pattern:
-  name: "Market Evolution"
-  description: "Markets themselves evolve from bespoke to utility"
-
-  stages:
-    nascent:
-      buyers: "Early adopters, willing to experiment"
-      suppliers: "Few, innovative"
-      contracts: "Custom, relationship-based"
-
-    growth:
-      buyers: "Mainstream, looking for features"
-      suppliers: "Many, competing on features"
-      contracts: "Product licenses"
-
-    commodity:
-      buyers: "Price-sensitive, switching easy"
-      suppliers: "Few large, many small"
-      contracts: "Utility, pay-per-use"
-```
-
-### Disruption from New Entrants
-
-```yaml
-pattern:
-  name: "Disruption Pattern"
-  description: "New entrants often come from evolved infrastructure"
-
-  mechanism:
-    - "Incumbents have inertia in custom-built systems"
-    - "New entrants build on commodity infrastructure"
-    - "New entrants have lower costs, faster iteration"
-    - "Incumbents can't match without cannibalizing"
-
-  example:
-    incumbent: "Traditional banks with custom core banking"
-    disruptor: "Fintech on cloud with SaaS tools"
-    advantage: "Lower cost, faster feature delivery"
-```
-
-## Using Climatic Patterns
-
-### Assessment Questions
-
-```yaml
-assessment:
-  evolution:
-    - "What components are actively evolving?"
-    - "Are we fighting natural evolution anywhere?"
-    - "What will be commodity in 5 years?"
-
-  competition:
-    - "Who could commoditize our differentiators?"
-    - "What commodity infrastructure enables new competitors?"
-    - "What higher-order systems are emerging?"
-
-  inertia:
-    - "Where do we have success-based inertia?"
-    - "What skills/politics resist necessary change?"
-    - "Are we building custom where products exist?"
-```
-
-### Pattern Recognition Template
+Use this template to analyse how climatic patterns apply to your overall map.
 
 ```yaml
 pattern_analysis:
@@ -271,3 +467,38 @@ pattern_analysis:
     strategic_importance: "{High/Medium/Low}"
     recommended_response: "{Description}"
 ```
+
+---
+
+## 11. Assessment Questions by Category
+
+### Evolution
+
+- What components are actively evolving right now?
+- Are we fighting natural evolution anywhere (building custom where product/commodity exists)?
+- What will be commodity in 3 years? In 5 years?
+- Where are components in different ecosystems evolving at mismatched speeds?
+- Which co-evolutionary relationships could accelerate or destabilise our position?
+
+### Competition
+
+- Who could commoditise our current differentiators?
+- What commodity infrastructure enables new competitors to enter with structurally lower costs?
+- What higher-order systems are emerging that could change the basis of competition?
+- What game-changing action by a competitor would most threaten our position?
+- How does our situational awareness compare to our most capable competitor's?
+
+### Inertia
+
+- Where do we have success-based inertia that is blocking necessary evolution?
+- What skills, political capital, or cultural identity is tied to components that are evolving away?
+- Are we building custom solutions in areas where products or commodity utilities now exist?
+- Which of our most successful business models is most vulnerable to the next "War" phase?
+
+### Prediction
+
+- Which evolutionary changes in our landscape are high-confidence (P[what] even if P[when] is uncertain)?
+- What phase — Peace, War, or Wonder — is our core market in?
+- Which components are approaching punctuated equilibrium shifts from product to utility?
+- Where are we applying false certainty to genesis-stage components or excessive uncertainty to commodity ones?
+- What does the capital flow pattern in our sector tell us about where the next value creation will be?

--- a/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
@@ -404,6 +404,7 @@ Signs Wonder is maturing into the next Peace: dominant designs emerge, standards
 ### Identifying Your Current Phase
 
 Ask these questions for each major market/component:
+
 - Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
 - Are new entrants building on commodity infrastructure that did not exist 3 years ago?
 - Is capital flowing into or out of this space?

--- a/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
@@ -234,18 +234,38 @@ The more successful a business model has been, the harder it becomes to abandon 
 
 ### Inertia Types Taxonomy
 
-Six distinct types of inertia manifest differently and require different mitigation strategies:
+Seven distinct types of inertia manifest differently and require different mitigation strategies. Based on Wardley's concept of "loss of capital" (physical, social, financial, political) expanded with operational types:
 
 | Type | Description | Indicators | Mitigation |
 |------|-------------|------------|------------|
 | **Success** | Past model worked so well that change feels unnecessary | "Why change what works?", strong quarterly results masking long-term risk, dismissal of emerging competitors | Establish parallel exploration teams, red team exercises, fund self-disruption initiatives |
-| **Capital** | Sunk costs in existing systems, infrastructure, or contracts create financial lock-in | Large depreciation schedules, multi-year vendor contracts, heavy fixed-cost infrastructure | Phase investment transitions, negotiate contract flexibility, calculate true cost of inaction vs switching |
-| **Political** | Power structures and internal influence tied to existing approaches | Executives whose authority depends on current architecture, budget territories, empire building | Reframe as opportunity not threat, create new leadership roles for emerging capabilities, sponsor from top |
+| **Capital** | Physical assets, infrastructure, and legacy technology create lock-in through sunk costs | Large depreciation schedules, outdated machinery still in use, fixed-purpose facilities, legacy systems deeply embedded in operations | Incremental upgrades, modular systems, leasing vs buying, versatile infrastructure design |
+| **Financial** | Risk aversion, short-term focus, and market pressures resist investment in change | Reluctance to sell underperforming assets, hesitancy to invest in new skills/tech, fear of losing strategic control, external markets rewarding stability over innovation | Strategic portfolio management, incremental investment, alternative financial models (leasing, partnerships), separate innovation budgets from BAU |
+| **Political** | Power structures and internal influence tied to existing approaches | Executives whose authority depends on current architecture, budget territories, empire building, fear of losing influence, preservation of established alliances | Reframe as opportunity not threat, create new leadership roles for emerging capabilities, sponsor from top, build coalitions, align incentives with change |
 | **Skills** | Workforce expertise concentrated in legacy technologies or methods | Recruitment focused on legacy skills, training budgets for existing tools, resistance to retraining | Upskilling programs, hire for new capabilities alongside legacy, paired teams (legacy + new) |
 | **Supplier** | Vendor relationships and ecosystem dependencies resist change | Preferred vendor lists, deep integration with specific platforms, vendor-specific certifications | Multi-vendor strategy, abstraction layers, gradual supplier diversification, renegotiate before lock-in deepens |
 | **Consumer** | Users or customers expect and depend on current approach | Customer complaints about any change, contractual SLAs tied to specific implementations, user workflow dependency | Gradual migration with parallel running, user research on actual needs vs habits, opt-in transitions |
 
-**Assessment per component:** For each component with inertia, identify which type(s) are present, rate severity (H/M/L), and define a specific mitigation action. Multiple types often compound — a component with success + skills + capital inertia is far harder to move than one with only skills inertia.
+**Note on Capital vs Financial:** Capital inertia concerns physical/tangible assets (infrastructure, equipment, legacy systems). Financial inertia concerns the psychology and market dynamics around money (sunk cost fallacy, risk aversion, short-termism, investor pressure). A component can have capital inertia (locked into legacy infrastructure) without financial inertia (the business case for change is accepted), or vice versa.
+
+**Assessment per component:** For each component with inertia, identify which type(s) are present, rate severity (H/M/L), and define a specific mitigation action. Multiple types often compound — a component with success + skills + capital + financial inertia is far harder to move than one with only skills inertia.
+
+### Inertia Diagnostic Checklist
+
+Early warning signs that inertia is taking hold in an organisation. Use this checklist during doctrine and climate assessments:
+
+| Sign | What to Look For | Impact if Unaddressed |
+|------|-------------------|----------------------|
+| **Stagnant mindset** | Resistance to training, lack of curiosity about industry trends, unwillingness to adopt new tools | Declining productivity, loss of competitive awareness |
+| **Siloed thinking** | Teams working in isolation, duplicated effort, poor cross-functional communication, misalignment with overall strategy | Suboptimal decisions, inability to leverage collective expertise |
+| **Lack of innovation** | Few new ideas reaching implementation, fear of failure culture, no experimentation budget | Falling behind competitors, inability to differentiate |
+| **Complacency** | Comfort with status quo, "if it ain't broke don't fix it" attitude, declining urgency | Mediocrity becomes the norm, market share erosion |
+| **Risk aversion** | No experimentation, all decisions require exhaustive justification, preference for safe options | Missed opportunities, slow response to market shifts |
+| **Rigid structures** | Bureaucratic approval chains, top-down only decisions, inability to reorganise quickly | Cannot respond to customer needs or competitive threats |
+| **Lack of accountability** | Unclear ownership, blame culture, nobody responsible for change outcomes | Problems persist, low trust, poor morale |
+| **Low employee engagement** | High turnover, absenteeism, lack of initiative, disinterest in company direction | Talent flight, institutional knowledge loss |
+
+**Scoring:** Count how many signs are present (0-8). 0-2: healthy organisation. 3-4: early inertia — address proactively. 5-6: significant inertia — urgent intervention needed. 7-8: critical — existential risk if not addressed immediately.
 
 ---
 

--- a/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
@@ -232,6 +232,23 @@ The more successful a business model has been, the harder it becomes to abandon 
 
 ---
 
+### Inertia Types Taxonomy
+
+Six distinct types of inertia manifest differently and require different mitigation strategies:
+
+| Type | Description | Indicators | Mitigation |
+|------|-------------|------------|------------|
+| **Success** | Past model worked so well that change feels unnecessary | "Why change what works?", strong quarterly results masking long-term risk, dismissal of emerging competitors | Establish parallel exploration teams, red team exercises, fund self-disruption initiatives |
+| **Capital** | Sunk costs in existing systems, infrastructure, or contracts create financial lock-in | Large depreciation schedules, multi-year vendor contracts, heavy fixed-cost infrastructure | Phase investment transitions, negotiate contract flexibility, calculate true cost of inaction vs switching |
+| **Political** | Power structures and internal influence tied to existing approaches | Executives whose authority depends on current architecture, budget territories, empire building | Reframe as opportunity not threat, create new leadership roles for emerging capabilities, sponsor from top |
+| **Skills** | Workforce expertise concentrated in legacy technologies or methods | Recruitment focused on legacy skills, training budgets for existing tools, resistance to retraining | Upskilling programs, hire for new capabilities alongside legacy, paired teams (legacy + new) |
+| **Supplier** | Vendor relationships and ecosystem dependencies resist change | Preferred vendor lists, deep integration with specific platforms, vendor-specific certifications | Multi-vendor strategy, abstraction layers, gradual supplier diversification, renegotiate before lock-in deepens |
+| **Consumer** | Users or customers expect and depend on current approach | Customer complaints about any change, contractual SLAs tied to specific implementations, user workflow dependency | Gradual migration with parallel running, user research on actual needs vs habits, opt-in transitions |
+
+**Assessment per component:** For each component with inertia, identify which type(s) are present, rate severity (H/M/L), and define a specific mitigation action. Multiple types often compound — a component with success + skills + capital inertia is far harder to move than one with only skills inertia.
+
+---
+
 ## 5. Competitor Patterns — Chapter VIII
 
 ### 5.1 Competitors' Actions Will Change the Game

--- a/arckit-claude/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-claude/skills/wardley-mapping/references/doctrine.md
@@ -400,6 +400,7 @@ doctrine_assessment:
 Use these prompts during assessment interviews and document reviews to gather evidence for each category.
 
 **Communication**
+
 - [ ] Is there a shared glossary or terminology guide in use across teams?
 - [ ] Are strategy documents written in language understood outside the originating team?
 - [ ] Are assumptions in proposals explicitly stated and challenged before approval?
@@ -407,6 +408,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are decision rationales documented and accessible to those affected?
 
 **Development**
+
 - [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
 - [ ] Are different methodologies applied to different components based on their evolutionary stage?
 - [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
@@ -414,6 +416,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are standards and tools reviewed periodically for continued appropriateness?
 
 **Operation**
+
 - [ ] Can leaders describe the operational details of the services they are accountable for?
 - [ ] Are sources of organisational inertia identified and addressed in change plans?
 - [ ] Is there a blameless failure review process in place?
@@ -421,18 +424,21 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are value stream maps or similar tools used to identify bottlenecks?
 
 **Learning**
+
 - [ ] Is there a structured process for capturing and applying lessons learned?
 - [ ] Are teams encouraged and resourced to run experiments?
 - [ ] Is there a programme for exploring emerging technologies before they become urgent?
 - [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
 
 **Leading**
+
 - [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
 - [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
 - [ ] Is there a single named accountable owner for each strategic initiative?
 - [ ] Are leaders open about what they do not know and willing to change their minds publicly?
 
 **Structure**
+
 - [ ] Are most teams small enough to communicate without formal coordination overhead?
 - [ ] Do teams have authority to make decisions within their domain without escalation?
 - [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?

--- a/arckit-claude/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-claude/skills/wardley-mapping/references/doctrine.md
@@ -1,120 +1,439 @@
 # Doctrine
 
-Universally useful patterns for strategy, independent of context or landscape.
+Universal principles and best practices that guide strategic decision-making, independent of context or landscape.
 
-## Doctrine Categories
+---
 
-The following is a curated subset of Wardley's doctrine principles, covering the areas most actionable in mapping exercises. For the full set, see Simon Wardley's original writings.
+## 1. Strategy Cycle
 
-```yaml
-doctrine_categories:
-  communication:
-    - "Use a common language"
-    - "Challenge assumptions"
-    - "Focus on user needs"
+Doctrine sits within a five-step iterative strategy cycle:
 
-  development:
-    - "Use appropriate methods for evolution stage"
-    - "Think small (cell-based structures)"
-    - "Manage inertia"
-    - "Use standards where appropriate"
+1. **Purpose** — define the organisation's overarching objectives and direction
+2. **Landscape** — map the competitive environment, components, and value chains
+3. **Climate** — identify external forces, market dynamics, and evolutionary pressures
+4. **Doctrine** — apply universal principles that hold regardless of context
+5. **Leadership** — make informed decisions and execute, then return to step 1
 
-  operation:
-    - "Think FIRE (Fast, Inexpensive, Restrained, Elegant)"
-    - "Manage failure appropriately"
-    - "Optimize flow"
+The cycle is continuous. Organisations repeatedly pass through all five stages, refining strategy based on new insights. Doctrine provides the stable foundation that makes repeated iteration productive rather than chaotic.
 
-  learning:
-    - "Use a systematic mechanism of learning"
-    - "Know your users"
-    - "Know your details"
+---
 
-  leading:
-    - "Be the owner"
-    - "Move fast"
-    - "Accept that strategy is iterative"
-```
+## 2. Doctrine Phase/Category Matrix
 
-## Doctrine Assessment Template
+Forty-two principles organised across four phases and six categories (source: Wardley Mapping Doctrine, Figure 2).
 
-Use this template to evaluate an organization's doctrine maturity. Score each area 1-5:
+| Phase | Communication | Development | Operation | Learning | Leading | Structure |
+|-------|--------------|-------------|-----------|----------|---------|-----------|
+| **I: Stop Self-Harm** | Common Language | Know Your Users | Know the Details | Systematic Learning | — | — |
+| | Challenge Assumptions | Focus on User Needs | | | | |
+| | Understand Context | Remove Bias & Duplication | | | | |
+| | | Use Appropriate Methods | | | | |
+| **II: Context Aware** | Bias Towards Open | Focus on Outcome | Manage Inertia | Bias Towards Action | Move Fast | Think Small Teams |
+| | | Think FIRE | Manage Failure | | Strategy is Iterative | Distribute Power |
+| | | Use Appropriate Tools | Effectiveness over Efficiency | | | Aptitude & Attitude |
+| | | Be Pragmatic | | | | |
+| | | Use Standards | | | | |
+| **III: Better for Less** | — | — | Optimise Flow | Bias to New | Commit to Direction | Seek the Best |
+| | | | Do Better with Less | | Be the Owner | Purpose/Mastery/Autonomy |
+| | | | Exceptional Standards | | Inspire Others | |
+| | | | | | Embrace Uncertainty | |
+| | | | | | Be Humble | |
+| **IV: Continuously Evolving** | — | — | — | Listen to Ecosystem | Exploit the Landscape | No Single Culture |
+| | | | | | There is No Core | Design for Constant Evolution |
+
+---
+
+## 3. Phase Details
+
+### Phase I: Stop Self-Harm
+
+**Objective:** Prevent further self-inflicted damage and establish a stable foundation for strategy.
+
+Organisations in Phase I often harm themselves through poor communication, misaligned development, and absence of learning. The nine principles in this phase address the most fundamental failures.
+
+#### Communication
+
+**Common Language** — Establish standardised terminology so all teams share meaning. Without a common vocabulary, strategy conversations produce confusion rather than alignment. Create a glossary, enforce it in meetings and documents, and review it regularly.
+
+**Challenge Assumptions** — Actively question established beliefs and the "way things have always been done." Assign devil's advocate roles, conduct assumption audits, and reward constructive scepticism. This prevents strategies built on invisible, outdated premises.
+
+**Understand Context** — Develop situational awareness before acting. Ensure communications include enough context for recipients to make informed decisions. Go beyond surface information to understand implications, stakeholder impacts, and broader relationships.
+
+#### Development
+
+**Know Your Users** — Understand the needs of all stakeholders: customers, shareholders, regulators, and staff. This is not one-time market research but an ongoing process. Use personas, continuous feedback loops, and cross-functional sharing of user insights.
+
+**Focus on User Needs** — Place user requirements at the centre of all development decisions. Anchor Wardley Maps to genuine user needs rather than internal assumptions. Prioritise what users truly need, not just what they explicitly request.
+
+**Remove Bias and Duplication** — Identify and eliminate both unwarranted assumptions that skew decisions and redundant processes that waste resources. Use diverse teams, data-driven decision making, and regular process reviews. Some redundancy aids resilience; eliminate wasteful redundancy.
+
+**Use Appropriate Methods** — Select development methodologies suited to the evolutionary stage of the work. Agile for genesis-stage components; lean or six sigma for more evolved ones. No single methodology fits all contexts.
+
+#### Operation
+
+**Know the Details** — Pay close attention to operational specifics. Leaders who lose touch with operational reality make poor strategic decisions. Conduct thorough process assessments, ensure documentation is current, and keep management connected to the ground truth.
+
+#### Learning
+
+**Systematic Learning (Bias Towards Data)** — Implement structured processes for gathering, analysing, and applying knowledge. Establish feedback loops, document lessons learned, and treat data as a strategic asset. Ad hoc learning leaves organisations repeating mistakes.
+
+---
+
+### Phase II: Becoming More Context Aware
+
+**Objective:** Enhance situational awareness and leverage contextual knowledge for better decisions.
+
+Phase II builds on the stable foundation of Phase I. The organisation now turns outward — becoming aware of its competitive environment, managing the dynamics of change, and starting to use contextual judgement rather than rigid rules.
+
+#### Communication
+
+**Bias Towards Open** — Make transparency and information sharing the default, not the exception. Move beyond "need to know" to proactive sharing of decisions, data, and rationale. Open communication fosters trust, accelerates innovation, and improves alignment. Balance openness with appropriate confidentiality.
+
+#### Development
+
+**Focus on Outcome** — Prioritise valuable results over rigid adherence to contracts or predetermined plans. Measure success by outcomes delivered, not tasks completed. Structure contracts and metrics around value, and empower teams to adapt their approach as long as the outcome stays in view.
+
+**Think FIRE (Fast, Inexpensive, Restrained, Elegant)** — Apply all four dimensions when designing solutions. Fast means rapid iteration; Inexpensive means cost-effective without being cheap; Restrained means resisting feature creep; Elegant means simple, user-centred design. FIRE prevents over-engineering and accelerates delivery.
+
+**Use Appropriate Tools** — Select tools matched to the specific development context rather than defaulting to familiarity or fashion. Evaluate tools against project needs, scalability, and long-term viability. Avoid tool proliferation; balance innovation with stability.
+
+**Be Pragmatic** — Choose what works in the real world over what is theoretically correct. Base decisions on evidence and observed results. Pragmatism is not short-termism — it is applying practical judgement to move purposefully toward long-term goals.
+
+**Use Standards** — Adopt industry or internal standards where components are sufficiently evolved to benefit from standardisation. Standards improve interoperability, quality, and speed. On Wardley Maps, standards apply most naturally to product- and commodity-stage components.
+
+#### Operation
+
+**Manage Inertia** — Actively address organisational resistance to change. Identify sources of inertia (legacy systems, entrenched culture, middle-management resistance), communicate the case for change compellingly, and use change champions and incremental rollouts to build momentum.
+
+**Manage Failure** — Design mechanisms to handle failure gracefully and extract learning from it. Failure tolerance should be calibrated to evolutionary stage: high tolerance for genesis-stage experiments, low tolerance for commodity-stage operations. Treat failure as information, not shame.
+
+**Effectiveness over Efficiency** — Prioritise achieving the desired outcome before optimising how efficiently you achieve it. Efficient execution of the wrong activity is waste. Confirm you are doing the right things before refining how fast you do them.
+
+#### Learning
+
+**Bias Towards Action** — Learn by doing rather than by planning. Encourage practical experimentation. Iterative, hands-on engagement with the landscape reveals insights that analysis alone cannot. Establish rapid learning cycles where experiments feed directly back into strategy.
+
+#### Leading
+
+**Move Fast** — Prioritise rapid execution and decision-making over waiting for perfect information. Speed of action is itself a strategic asset. Leaders should reduce approval chains, tolerate imperfection, and default to trying things over deliberating about them.
+
+**Strategy is Iterative** — Treat strategy as a cyclical process, not a one-time plan. Regularly reassess and adapt the strategy based on new intelligence. The most dangerous strategies are those treated as immutable once written.
+
+#### Structure
+
+**Think Small Teams** — Organise work into small, cross-functional, autonomous teams. Small teams communicate faster, decide faster, and are more accountable. They also align naturally with the Pioneer/Settler/Town Planner model of matching team culture to evolutionary stage.
+
+**Distribute Power** — Decentralise decision-making to the teams closest to the work. Establish clear boundaries and provide resources; then trust teams to act within them. Centralised authority creates bottlenecks and suppresses the contextual judgement that effective strategy requires.
+
+**Aptitude and Attitude** — Hire and develop team members based on both technical capability (aptitude) and cultural alignment (attitude). A team of highly skilled individuals with the wrong disposition will underperform a moderately skilled team with the right mindset.
+
+---
+
+### Phase III: Better for Less
+
+**Objective:** Achieve significantly better outcomes while consuming fewer resources through continuous improvement and high standards.
+
+Phase III organisations have mastered the basics and begun optimising. The focus shifts to operational excellence, leadership maturity, and structural conditions that allow people to produce their best work.
+
+#### Operation
+
+**Optimise Flow** — Identify and remove bottlenecks that impede the throughput of value. Use value stream mapping and similar techniques to visualise where work slows. Optimising flow at the system level is more powerful than improving individual components in isolation.
+
+**Do Better with Less** — Embed continuous improvement as a cultural norm. Regularly review processes with the explicit goal of producing the same or better outcomes with fewer resources. Constraint fosters creativity; resource abundance often masks inefficiency.
+
+**Set Exceptional Standards** — Define and publicly commit to high performance standards. Exceptional standards create a benchmark that drives quality, reduces tolerance for mediocrity, and builds organisational pride. Low standards become self-fulfilling; high standards become self-reinforcing.
+
+#### Learning
+
+**Bias Towards the New** — Actively explore emerging ideas, technologies, and approaches rather than defaulting to the familiar. The evolutionary landscape rewards early movers in genesis-stage components. Create protected space for experimentation; do not allow operational maturity to crowd out exploration.
+
+#### Leading
+
+**Commit to Direction** — Be steadfast in pursuing strategic goals while remaining open to adjusting tactics. Frequent strategy reversals demoralise teams and waste the organisational capital accumulated through consistent effort. Distinguish between pivoting approach and abandoning direction.
+
+**Be the Owner** — Take full responsibility and accountability for strategy and outcomes. Do not diffuse accountability across committees or processes. Ownership means accepting both credit and blame, and making decisions rather than deferring them.
+
+**Inspire Others** — Articulate a compelling vision and motivate the team toward ambitious goals. Inspiration is not cheerleading — it is connecting individual work to meaningful purpose, demonstrating commitment, and showing people what is possible.
+
+**Embrace Uncertainty** — Accept that uncertainty is an inherent feature of strategy, not a temporary condition that will eventually resolve. Make peace with acting under incomplete information. Organisations that require certainty before acting are chronically late.
+
+**Be Humble** — Cultivate openness to feedback, correction, and different viewpoints. Hubris in leadership prevents the honest assessment of landscape and doctrine that effective strategy requires. Humility is not weakness — it is accurate self-knowledge.
+
+#### Structure
+
+**Seek the Best** — Aim for excellence in organisational design, not adequacy. Benchmark structure against industry best practice, not internal tradition. Regularly ask whether the current structure is the best possible arrangement for executing current strategy.
+
+**Purpose, Mastery, and Autonomy** — Create the three conditions Daniel Pink identifies as intrinsic motivation. Ensure individuals understand how their work connects to the organisation's purpose. Invest in developing deep expertise (mastery). Remove unnecessary controls that undermine self-direction (autonomy).
+
+---
+
+### Phase IV: Continuously Evolving
+
+**Objective:** Create a resilient, adaptive organisation that drives change rather than merely responding to it.
+
+Phase IV represents organisational maturity. The organisation no longer manages change episodically — evolution is built into the fabric of how it operates.
+
+#### Learning
+
+**Listen to the Ecosystem** — Actively engage with and learn from the broader environment: customers, competitors, suppliers, regulators, adjacent industries, and emerging technologies. The most important signals about future landscape shifts come from outside the organisation. Create structured mechanisms for ecosystem listening, not just passive monitoring.
+
+#### Leading
+
+**Exploit the Landscape** — Leverage the broader business environment as a source of competitive advantage. Identify patterns, leverage points, and structural features of the landscape that others overlook. This requires a deep understanding of how components are evolving and where they are vulnerable to disruption or commoditisation.
+
+**There is No Core** — Reject the notion of a permanent "core business." All strategic positions are temporary. Components that are differentiating today will become commodity tomorrow. Maintaining strategic flexibility means being willing to abandon current strengths when the landscape demands it. This is not instability — it is strategic maturity.
+
+#### Structure
+
+**No Single Culture** — Recognise that different work requires different cultural approaches. Genesis-stage innovation requires a culture of exploration and tolerance for failure; commodity-stage operations require discipline and efficiency. A single mandated culture optimises for one type of work at the expense of all others. Cultivate and value cultural diversity within the organisation.
+
+**Design for Constant Evolution** — Build organisational structures, processes, and systems that are inherently flexible. Change should not require major restructuring — it should be the normal mode of operation. Use modular designs, adaptive processes, and continuous skills development to make evolution frictionless.
+
+---
+
+## 4. Implementation Journeys
+
+### Communication Journey (Phases I–II)
+
+Begin by establishing shared vocabulary and a common map language that all teams use consistently (Phase I). Progress to making transparency the default operating mode: open decision-making, accessible data, two-way feedback channels (Phase II). The destination is an organisation where strategic information flows freely across all levels and functions, enabling faster alignment and better decisions.
+
+### Development Journey (Phases I–II)
+
+Start by rooting development in real user needs and eliminating duplicated effort (Phase I). Evolve toward outcome-focused, pragmatic delivery using FIRE principles, contextually appropriate tools, and industry standards (Phase II). The journey moves from "building things correctly" to "building the correct things efficiently."
+
+### Operation Journey (Phases I–III)
+
+Establish situational awareness through operational detail (Phase I). Build change management capability and effective failure response (Phase II). Reach the destination of continuously optimised flow, exceptional quality standards, and a culture that does more with less (Phase III). Each phase adds a layer of operational sophistication on top of the last.
+
+### Learning Journey (Phases I–IV)
+
+Implement data-driven learning mechanisms and documentation (Phase I). Shift to action-oriented learning through experimentation (Phase II). Dedicate resources to exploring new ideas and technologies (Phase III). In Phase IV, the organisation systematically listens to its ecosystem and makes continuous adaptation a cultural norm rather than a periodic initiative.
+
+### Leading Journey (Phases II–IV)
+
+Leadership doctrine begins in Phase II with fast decisions and iterative strategy. Phase III adds personal accountability, inspiration, humility, and the ability to operate in uncertainty. Phase IV demands leaders who can read and exploit landscape features that are invisible to less evolved organisations, while holding their strategic position loosely enough to abandon it when evolution demands.
+
+### Structure Journey (Phases II–IV)
+
+Phase II establishes small, empowered teams hired for both skill and attitude. Phase III adds the pursuit of excellence and the conditions for intrinsic motivation. Phase IV reaches full maturity: a deliberately multi-cultural organisation designed to evolve continuously, with no structural assumption treated as permanent.
+
+---
+
+## 5. Assessment Template
+
+Score each principle 1–5 using the rubric below, then record supporting evidence.
 
 | Score | Meaning |
 |-------|---------|
 | **1** | Not practiced — no evidence of this principle |
 | **2** | Ad hoc — occasional, inconsistent application |
-| **3** | Emerging — recognized as important, partially adopted |
+| **3** | Emerging — recognised as important, partially adopted |
 | **4** | Established — consistently practiced with measurable results |
 | **5** | Embedded — deeply ingrained in culture and decision-making |
 
 ```yaml
 doctrine_assessment:
-  communication:
-    common_language:
-      score: "{1-5}"
-      evidence: "{How is strategic language standardized?}"
 
-    challenge_assumptions:
-      score: "{1-5}"
-      evidence: "{How are assumptions questioned?}"
+  phase_i:
+    communication:
+      common_language:
+        score: # 1-5
+        evidence: ""
+      challenge_assumptions:
+        score: # 1-5
+        evidence: ""
+      understand_context:
+        score: # 1-5
+        evidence: ""
 
-    focus_on_user_needs:
-      score: "{1-5}"
-      evidence: "{How are user needs identified and prioritized?}"
+    development:
+      know_your_users:
+        score: # 1-5
+        evidence: ""
+      focus_on_user_needs:
+        score: # 1-5
+        evidence: ""
+      remove_bias_and_duplication:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_methods:
+        score: # 1-5
+        evidence: ""
 
-  development:
-    appropriate_methods:
-      score: "{1-5}"
-      evidence: "{Are agile/lean/six sigma applied contextually by evolution stage?}"
+    operation:
+      know_the_details:
+        score: # 1-5
+        evidence: ""
 
-    cell_based:
-      score: "{1-5}"
-      evidence: "{Are teams small and autonomous?}"
+    learning:
+      systematic_learning:
+        score: # 1-5
+        evidence: ""
 
-    manage_inertia:
-      score: "{1-5}"
-      evidence: "{How is organizational inertia identified and addressed?}"
+  phase_ii:
+    communication:
+      bias_towards_open:
+        score: # 1-5
+        evidence: ""
 
-    use_standards:
-      score: "{1-5}"
-      evidence: "{Are standards adopted where components are commodity/product?}"
+    development:
+      focus_on_outcome:
+        score: # 1-5
+        evidence: ""
+      think_fire:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_tools:
+        score: # 1-5
+        evidence: ""
+      be_pragmatic:
+        score: # 1-5
+        evidence: ""
+      use_standards:
+        score: # 1-5
+        evidence: ""
 
-  operation:
-    think_fire:
-      score: "{1-5}"
-      evidence: "{Are solutions Fast, Inexpensive, Restrained, Elegant (FIRE)?}"
+    operation:
+      manage_inertia:
+        score: # 1-5
+        evidence: ""
+      manage_failure:
+        score: # 1-5
+        evidence: ""
+      effectiveness_over_efficiency:
+        score: # 1-5
+        evidence: ""
 
-    manage_failure:
-      score: "{1-5}"
-      evidence: "{Is failure tolerance matched to evolution stage?}"
+    learning:
+      bias_towards_action:
+        score: # 1-5
+        evidence: ""
 
-    optimize_flow:
-      score: "{1-5}"
-      evidence: "{Are bottlenecks identified and addressed?}"
+    leading:
+      move_fast:
+        score: # 1-5
+        evidence: ""
+      strategy_is_iterative:
+        score: # 1-5
+        evidence: ""
 
-  learning:
-    systematic_learning:
-      score: "{1-5}"
-      evidence: "{Is there a feedback loop for strategic learning?}"
+    structure:
+      think_small_teams:
+        score: # 1-5
+        evidence: ""
+      distribute_power:
+        score: # 1-5
+        evidence: ""
+      aptitude_and_attitude:
+        score: # 1-5
+        evidence: ""
 
-    know_users:
-      score: "{1-5}"
-      evidence: "{How well are users and their needs understood?}"
+  phase_iii:
+    operation:
+      optimise_flow:
+        score: # 1-5
+        evidence: ""
+      do_better_with_less:
+        score: # 1-5
+        evidence: ""
+      exceptional_standards:
+        score: # 1-5
+        evidence: ""
 
-    know_details:
-      score: "{1-5}"
-      evidence: "{Is there deep understanding of component specifics?}"
+    learning:
+      bias_towards_new:
+        score: # 1-5
+        evidence: ""
 
-  leading:
-    ownership:
-      score: "{1-5}"
-      evidence: "{Is there clear ownership of strategy?}"
+    leading:
+      commit_to_direction:
+        score: # 1-5
+        evidence: ""
+      be_the_owner:
+        score: # 1-5
+        evidence: ""
+      inspire_others:
+        score: # 1-5
+        evidence: ""
+      embrace_uncertainty:
+        score: # 1-5
+        evidence: ""
+      be_humble:
+        score: # 1-5
+        evidence: ""
 
-    move_fast:
-      score: "{1-5}"
-      evidence: "{How quickly are strategic decisions made?}"
+    structure:
+      seek_the_best:
+        score: # 1-5
+        evidence: ""
+      purpose_mastery_autonomy:
+        score: # 1-5
+        evidence: ""
 
-    iterative_strategy:
-      score: "{1-5}"
-      evidence: "{Is strategy treated as continuous, not one-off?}"
+  phase_iv:
+    learning:
+      listen_to_ecosystem:
+        score: # 1-5
+        evidence: ""
+
+    leading:
+      exploit_the_landscape:
+        score: # 1-5
+        evidence: ""
+      there_is_no_core:
+        score: # 1-5
+        evidence: ""
+
+    structure:
+      no_single_culture:
+        score: # 1-5
+        evidence: ""
+      design_for_constant_evolution:
+        score: # 1-5
+        evidence: ""
 ```
+
+---
+
+## 6. Evidence-Gathering Checklist
+
+Use these prompts during assessment interviews and document reviews to gather evidence for each category.
+
+**Communication**
+- [ ] Is there a shared glossary or terminology guide in use across teams?
+- [ ] Are strategy documents written in language understood outside the originating team?
+- [ ] Are assumptions in proposals explicitly stated and challenged before approval?
+- [ ] Is information shared proactively, or does it flow only on request?
+- [ ] Are decision rationales documented and accessible to those affected?
+
+**Development**
+- [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
+- [ ] Are different methodologies applied to different components based on their evolutionary stage?
+- [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
+- [ ] Are FIRE principles applied when scoping new development?
+- [ ] Are standards and tools reviewed periodically for continued appropriateness?
+
+**Operation**
+- [ ] Can leaders describe the operational details of the services they are accountable for?
+- [ ] Are sources of organisational inertia identified and addressed in change plans?
+- [ ] Is there a blameless failure review process in place?
+- [ ] Are effectiveness metrics (outcomes achieved) tracked alongside efficiency metrics (cost/time)?
+- [ ] Are value stream maps or similar tools used to identify bottlenecks?
+
+**Learning**
+- [ ] Is there a structured process for capturing and applying lessons learned?
+- [ ] Are teams encouraged and resourced to run experiments?
+- [ ] Is there a programme for exploring emerging technologies before they become urgent?
+- [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
+
+**Leading**
+- [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
+- [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
+- [ ] Is there a single named accountable owner for each strategic initiative?
+- [ ] Are leaders open about what they do not know and willing to change their minds publicly?
+
+**Structure**
+- [ ] Are most teams small enough to communicate without formal coordination overhead?
+- [ ] Do teams have authority to make decisions within their domain without escalation?
+- [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?
+- [ ] Is the organisational structure reviewed periodically and changed when strategy requires?

--- a/arckit-claude/skills/wardley-mapping/references/evolution-stages.md
+++ b/arckit-claude/skills/wardley-mapping/references/evolution-stages.md
@@ -99,3 +99,123 @@ When placing a component on the evolution axis, assess:
 - Positioning based on **age** rather than market maturity
 - Confusing **internal unfamiliarity** with market-wide genesis
 - Not considering **industry context** (a component may be commodity in one industry but custom in another)
+
+---
+
+## Enhanced Stage Indicators
+
+Detailed checklists for assessing which stage a component belongs to across four dimensions:
+
+### Genesis Stage Indicators
+
+- **Ubiquity markers**: Used by fewer than a handful of organizations; no established market; found only in research labs or cutting-edge pilots; most practitioners have never heard of it
+- **Certainty markers**: No agreed-upon approach; each implementation looks completely different; high variance in results; practitioners disagree on fundamentals
+- **Market markers**: No commercial offerings; no analysts covering it; no conferences dedicated to it; possibly a single paper or blog post
+- **Failure mode**: Betting on the wrong approach — you build the wrong thing, the concept doesn't pan out, or a competitor's approach proves fundamentally superior
+
+### Custom-Built Stage Indicators
+
+- **Ubiquity markers**: A few dozen organizations have built it; mostly in-house implementations; early adopters only; growing word-of-mouth in specialist communities
+- **Certainty markers**: Patterns are beginning to emerge; blog posts and conference talks appear; approaches vary but converge around a few patterns
+- **Market markers**: Small number of consultancies or niche vendors; no dominant standard; user groups forming; early analyst coverage
+- **Failure mode**: Building it wrong — your custom implementation has the wrong architecture, accrues technical debt, or gets overtaken by a productized competitor before you've recovered your investment
+
+### Product Stage Indicators
+
+- **Ubiquity markers**: Most large organizations are aware of it; multiple commercial products compete; analyst firms rank vendors; industry press covers it regularly
+- **Certainty markers**: Training courses, professional certifications, and established methodologies exist; outcomes are predictable; clear best practices documented
+- **Market markers**: Multiple competing vendors with clear feature differentiation; pricing is feature-based; annual comparison reports published; RFP processes are standardized
+- **Failure mode**: Differentiation failure — failing to stand out from competing products, losing on features, price, or brand while rivals commoditize faster
+
+### Commodity Stage Indicators
+
+- **Ubiquity markers**: Ubiquitous — every organization uses it; invisible infrastructure; not adopting it would be unusual; pay-per-use or subscription models dominate
+- **Certainty markers**: Fully standardized; ISO or formal standards exist; deviating from standard approaches is unusual; operations are predictable and auditable
+- **Market markers**: Utility pricing; multiple interchangeable providers; switching costs low; procurement is routine; the component is rarely discussed in strategic terms
+- **Failure mode**: Operational inefficiency — paying too much, running it in-house when a utility exists, or accumulating operational overhead that commodity providers handle more cheaply
+
+---
+
+## Transition Timing Heuristics
+
+Weak signals that a component is about to move between stages. These precede the transition by months to years — use them to get ahead of the curve.
+
+### Genesis → Custom-Built
+
+- Multiple independent teams build their own version without coordinating
+- The first conference talks appear: "Here's how we did it at [Company X]"
+- A startup forms specifically to productize the concept
+- A handful of GitHub repositories appear with experimental implementations
+- The phrase "we built our own X" starts appearing in engineering blog posts
+
+### Custom-Built → Product
+
+- Documentation proliferates: vendor docs, how-to guides, blog series
+- Training courses and certifications emerge (Udemy, Pluralsight, vendor academies)
+- Industry analysts publish first Magic Quadrant or Wave covering the space
+- Standardization efforts begin (working groups, RFCs, consortia form)
+- The question shifts from "should we build this?" to "which vendor should we choose?"
+
+### Product → Commodity
+
+- Pricing models shift to consumption-based or utility billing (per API call, per GB, per user-minute)
+- Open-source alternatives appear and gain traction, driving down commercial pricing
+- "Good enough" becomes the accepted standard — buyers stop comparing features and compare price
+- The component disappears from strategic discussions; procurement handles it routinely
+- Cloud providers add it as a native managed service
+
+---
+
+## Pioneers / Settlers / Town Planners Talent Model
+
+The three evolution stages map naturally to three types of people. Mismatching talent to stage is one of the most common and costly strategic mistakes.
+
+### Pioneers (Genesis)
+
+- Comfortable with chaos, ambiguity, and high failure rates
+- Driven by exploration and discovery; motivated by novelty, not process
+- High failure tolerance — they expect most experiments to fail and see it as learning
+- Often poor at documentation, standardization, or handing work off cleanly
+- Best suited to: research, prototyping, proof-of-concept work, greenfield exploration
+
+### Settlers (Custom-Built → Product)
+
+- Take pioneer discoveries and make them useful and repeatable
+- Product-oriented and systematic; skilled at listening to users and iterating
+- Build out the patterns that emerge from pioneer experiments into reliable solutions
+- Bridge between the wild experimentation of genesis and the industrialization of commodity
+- Best suited to: product development, early productization, growing user bases
+
+### Town Planners (Product → Commodity)
+
+- Industrialize at scale; obsessed with efficiency, reliability, and cost reduction
+- Process-oriented, metrics-driven, volume operations mindset
+- Build the pipes that everything else runs on; thrive in predictable, repeatable work
+- Often frustrated by ambiguity or constant change
+- Best suited to: platform engineering, infrastructure, shared services, SRE at scale
+
+### Handoff Friction
+
+Managing transitions between these types is critical and frequently mismanaged:
+
+- **Pioneers hate process**: Forcing pioneers to maintain and document their experiments alienates them and slows exploration. Hand off to settlers early.
+- **Town Planners hate uncertainty**: Asking planners to work on genesis-stage components creates anxiety, over-engineering, and premature standardization.
+- **Settlers are the connective tissue**: They translate pioneer output into planner input. Skipping settlers (pioneer → planner handoff) often produces brittle, hard-to-operate systems.
+- **Reward systems must differ**: Pioneers need space to fail; planners need predictability metrics. A single performance framework for all three types destroys the talent mix.
+
+---
+
+## Assessment Questions per Stage
+
+Use these diagnostic questions to quickly identify where a component sits:
+
+| Question | If Yes → Stage |
+|----------|---------------|
+| "Is this available as a utility API or cloud service?" | Commodity |
+| "Can anyone buy this off the shelf from multiple vendors?" | Product or Commodity |
+| "Are there multiple competing approaches with no clear winner?" | Custom-Built |
+| "Does building this require original research or experimentation?" | Genesis |
+| "Are there training courses and certifications for this?" | Product or Commodity |
+| "Would you be the first (or one of very few) to attempt this?" | Genesis |
+| "Does everyone in the industry just use the same provider?" | Commodity |
+| "Is this a competitive differentiator for your organization?" | Genesis or Custom-Built |

--- a/arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md
@@ -31,41 +31,49 @@ Strategies that shape how users perceive and interact with your offerings. Can a
 
 **1. Education (LG)**
 Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+
 - *When to use*: Launching novel or complex components where user understanding is low.
 - *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
 
 **2. Bundling (N)**
 Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+
 - *When to use*: When individual components have limited standalone appeal but are complementary together.
 - *Evolution stage*: Product stage (combining maturing components)
 
 **3. Creating Artificial Needs (LE)**
 Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+
 - *When to use*: When a component solves a latent problem users have not yet articulated.
 - *Evolution stage*: Genesis → Custom-Built (creates market pull)
 
 **4. Confusion of Choice (LE)**
 Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+
 - *When to use*: When incumbent position must be defended against clearly superior alternatives.
 - *Evolution stage*: Product stage (commoditisation pressure)
 
 **5. Brand and Marketing (N)**
 Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+
 - *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **6. FUD — Fear, Uncertainty, Doubt (LE)**
 Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+
 - *When to use*: Defensively, when a competitor threatens your position with a superior offering.
 - *Evolution stage*: Product stage (defending existing position)
 
 **7. Artificial Competition (CE)**
 Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+
 - *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
 - *Evolution stage*: Any stage (perception manipulation)
 
 **8. Lobbying / Counterplay (CE)**
 Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+
 - *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
 - *Evolution stage*: Any stage (regulatory environment shaping)
 
@@ -77,26 +85,31 @@ Strategies designed to speed up component evolution along the x-axis (Genesis �
 
 **1. Market Enablement (LG)**
 Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+
 - *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
 - *Evolution stage*: Custom-Built → Product (accelerates standardisation)
 
 **2. Open Approaches (LG)**
 Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+
 - *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
 - *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
 
 **3. Exploiting Network Effects (N)**
 Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+
 - *When to use*: When you have a platform or communication component where value compounds with users.
 - *Evolution stage*: Product → Commodity (accelerated by user density)
 
 **4. Co-operation (N)**
 Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+
 - *When to use*: When no single organisation can drive a standard alone and collective action is needed.
 - *Evolution stage*: Custom-Built → Product (drives standardisation)
 
 **5. Industrial Policy (N)**
 Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+
 - *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
 - *Evolution stage*: Any stage (policy-driven acceleration)
 
@@ -108,16 +121,19 @@ Strategies designed to slow component evolution, preserving competitive advantag
 
 **1. Exploiting Constraint (LE)**
 Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+
 - *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **2. Intellectual Property Rights / IPR (LE)**
 Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+
 - *When to use*: When protecting genuine innovations that required significant R&D investment.
 - *Evolution stage*: Genesis → Custom-Built (protects early innovations)
 
 **3. Creating Constraints (CE)**
 Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+
 - *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
 - *Evolution stage*: Product → Commodity (blocks commoditisation)
 
@@ -129,21 +145,25 @@ Strategies for managing components that no longer provide value, are expensive t
 
 **1. Pig in a Poke (CE)**
 Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+
 - *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
 - *Evolution stage*: Any stage (often used with obsolete custom-built components)
 
 **2. Disposal of Liability (N)**
 Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+
 - *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
 - *Evolution stage*: Product → Commodity (managing decline gracefully)
 
 **3. Sweat and Dump (LE)**
 Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+
 - *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
 - *Evolution stage*: Product → Commodity (exploiting remaining value)
 
 **4. Refactoring (LG)**
 Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+
 - *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
 - *Evolution stage*: Custom-Built (restoring and modernising)
 
@@ -155,41 +175,49 @@ Strategies for positioning components within the market, manipulating pricing dy
 
 **1. Differentiation (N)**
 Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+
 - *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
 - *Evolution stage*: Custom-Built → Product (slows rightward movement)
 
 **2. Pricing Policy (N)**
 Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+
 - *When to use*: When pricing itself can shift market behaviour rather than just capture value.
 - *Evolution stage*: Product → Commodity (shapes competitive landscape)
 
 **3. Buyer / Supplier Power (LE)**
 Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+
 - *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
 - *Evolution stage*: Product → Commodity (exploiting market position)
 
 **4. Harvesting (LE)**
 Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+
 - *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
 - *Evolution stage*: Product → Commodity (late-stage value extraction)
 
 **5. Standards Game (LE)**
 Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+
 - *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
 - *Evolution stage*: Custom-Built → Product (locking in architecture)
 
 **6. Last Man Standing (LE)**
 Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+
 - *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
 - *Evolution stage*: Product → Commodity (consolidation phase)
 
 **7. Signal Distortion (CE)**
 Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+
 - *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
 - *Evolution stage*: Any stage (information environment manipulation)
 
 **8. Trading (N)**
 Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+
 - *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
 - *Evolution stage*: Any stage (timed exchanges)
 
@@ -201,31 +229,37 @@ Strategies for protecting existing market position, managing threats, and slowin
 
 **1. Threat Acquisition (N)**
 Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+
 - *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
 - *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
 
 **2. Raising Barriers to Entry (N)**
 Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+
 - *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
 - *Evolution stage*: Product (defending established position)
 
 **3. Procrastination (N)**
 Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+
 - *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
 - *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
 
 **4. Defensive Regulation (LE)**
 Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+
 - *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
 - *Evolution stage*: Any stage (regulatory entrenchment)
 
 **5. Limitation of Competition (CE)**
 Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+
 - *When to use*: Recognise and defend against it; deploying it invites antitrust action.
 - *Evolution stage*: Product → Commodity (dominant player defending monopoly)
 
 **6. Managing Inertia (N)**
 Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+
 - *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
 - *Evolution stage*: Any stage (internal transformation management)
 
@@ -237,36 +271,43 @@ Strategies for gaining market share, disrupting competitors, and creating new op
 
 **1. Directed Investment (LG)**
 Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+
 - *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
 - *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
 
 **2. Experimentation (LG)**
 Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+
 - *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
 - *Evolution stage*: Genesis (exploring new space)
 
 **3. Centre of Gravity (N)**
 Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+
 - *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
 - *Evolution stage*: Custom-Built → Product (targeted disruption)
 
 **4. Undermining Barriers to Entry (N)**
 Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+
 - *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
 - *Evolution stage*: Custom-Built → Product (disruptive market entry)
 
 **5. Fool's Mate (LE)**
 Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+
 - *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
 - *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
 
 **6. Press Release Process (LE)**
 Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+
 - *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
 - *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
 
 **7. Playing Both Sides (N)**
 Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+
 - *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
 - *Evolution stage*: Product → Commodity (platform-level control)
 
@@ -278,41 +319,49 @@ Strategies for creating, nurturing, and leveraging networks of interconnected co
 
 **1. Alliances (LG)**
 Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+
 - *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
 - *Evolution stage*: Custom-Built → Product (accelerating through partnership)
 
 **2. Co-creation (LG)**
 Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+
 - *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
 - *Evolution stage*: Genesis → Custom-Built (open innovation)
 
 **3. Sensing Engines / ILC (N)**
 Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+
 - *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
 - *Evolution stage*: Product → Commodity (data-driven adaptation)
 
 **4. Tower and Moat (N)**
 Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+
 - *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
 - *Evolution stage*: Product (building defensive ecosystem)
 
 **5. N-sided Markets (N)**
 Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+
 - *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
 - *Evolution stage*: Custom-Built → Product (platform creation)
 
 **6. Co-opting and Intercession (LE)**
 Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+
 - *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
 - *Evolution stage*: Product (value chain positioning)
 
 **7. Embrace and Extend (LE)**
 Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+
 - *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
 - *Evolution stage*: Product → Commodity (standard adoption then differentiation)
 
 **8. Channel Conflicts and Disintermediation (N)**
 Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+
 - *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
 - *Evolution stage*: Product → Commodity (distribution restructuring)
 
@@ -324,41 +373,49 @@ Strategies for understanding, outmanoeuvring, and responding to competitors dire
 
 **1. Ambush (N)**
 Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+
 - *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
 - *Evolution stage*: Genesis → Custom-Built (surprise market entry)
 
 **2. Fragmentation Play (LE)**
 Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+
 - *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
 - *Evolution stage*: Product (niche segmentation)
 
 **3. Reinforcing Competitor Inertia (LE)**
 Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+
 - *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
 - *Evolution stage*: Product (exploiting competitor commitment)
 
 **4. Sapping (LE)**
 Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+
 - *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
 - *Evolution stage*: Product → Commodity (gradual displacement)
 
 **5. Misdirection (CE)**
 Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+
 - *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
 - *Evolution stage*: Any stage (competitive deception)
 
 **6. Restriction of Movement (CE)**
 Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+
 - *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
 - *Evolution stage*: Product (platform gatekeeping)
 
 **7. Talent Raid (CE)**
 Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+
 - *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
 - *Evolution stage*: Any stage (capability competition)
 
 **8. Circling and Probing (N)**
 Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+
 - *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
 - *Evolution stage*: Any stage (competitive intelligence gathering)
 
@@ -370,21 +427,25 @@ Strategies for securing and maintaining optimal positions within the competitive
 
 **1. Land Grab (N)**
 Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+
 - *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
 - *Evolution stage*: Genesis → Custom-Built (early territory capture)
 
 **2. First Mover / Fast Follower (N)**
 Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+
 - *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
 - *Evolution stage*: Genesis → Custom-Built (timing of market entry)
 
 **3. Aggregation (N)**
 Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+
 - *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
 - *Evolution stage*: Product (integration play)
 
 **4. Weak Signal / Horizon (N)**
 Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+
 - *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
 - *Evolution stage*: Genesis (anticipating future evolution)
 
@@ -396,16 +457,19 @@ High-risk strategies that can harm competitors, markets, or even your own organi
 
 **1. Licensing Play (LE)**
 Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+
 - *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
 - *Evolution stage*: Custom-Built → Product (IP-based control)
 
 **2. Insertion (CE)**
 Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+
 - *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
 - *Evolution stage*: Product (dependency creation)
 
 **3. Designed to Fail (CE)**
 Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+
 - *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
 - *Evolution stage*: Genesis (false market signals)
 

--- a/arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md
@@ -1,59 +1,520 @@
 # Gameplay Patterns
 
-Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats.
+Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats. Each gameplay includes an alignment tag drawn from the D&D classification system.
 
-## Offensive Patterns
+---
 
-```yaml
-offensive_gameplay:
-  tower_and_moat:
-    description: "Build differentiating capabilities on commodity foundation"
-    when: "Strong custom components exist"
-    action: "Commoditize dependencies, invest in differentiation"
-    map_signature: "Custom components with commodity dependencies"
+## 1. D&D Alignment Key
 
-  land_and_expand:
-    description: "Enter market with narrow offering, expand from there"
-    when: "New market entry"
-    action: "Start simple, add components over time"
+Gameplays are classified using the Dungeons & Dragons alignment system to convey their ethical and strategic nature at a glance.
 
-  open_source_play:
-    description: "Commoditize competitor's differentiator"
-    when: "Competitor relies on custom component you can replicate"
-    action: "Open source alternative to accelerate commoditization"
+| Alignment | Meaning | Strategic character |
+|-----------|---------|---------------------|
+| **LG** (Lawful Good) | Ethical, structured, mutually beneficial | Creates genuine value for the ecosystem; operates with integrity |
+| **N** (Neutral) | Pragmatic, context-dependent | Balanced approach; can benefit or harm depending on execution |
+| **LE** (Lawful Evil) | Self-interested but within accepted norms | Operates legally but manipulates markets or stakeholders for advantage |
+| **CE** (Chaotic Evil) | Destructive, harmful, disregards norms | Deliberately deceives, damages competition, or harms stakeholders |
 
-  ecosystem:
-    description: "Create platform others build upon"
-    when: "Control infrastructure component"
-    action: "Enable others to build on your platform"
+**Good vs. Evil axis**: Good strategies create positive outcomes for the broader ecosystem. Evil strategies prioritise personal gain at others' expense.
 
-  two_factor:
-    description: "Satisfy two markets with one platform"
-    when: "Platform can serve multiple user types"
-    action: "Connect both sides of a market"
-```
+**Law vs. Chaos axis**: Lawful strategies use structured, rule-following approaches. Chaotic strategies are unconventional or disruptive of established order.
 
-## Defensive Patterns
+Recognising alignment helps you understand: what plays are being used against you, what plays align with your organisation's values, and which combinations are ethically coherent.
 
-```yaml
-defensive_gameplay:
-  patents_and_ip:
-    description: "Protect innovations legally"
-    when: "Genesis/custom stage innovations"
-    action: "File patents, protect trade secrets"
+---
 
-  creating_constraint:
-    description: "Slow evolution of component you control"
-    when: "Evolution threatens your position"
-    action: "Limit interoperability, create switching costs"
+## 2. Gameplay Catalog — 11 Categories
 
-  embrace_and_extend:
-    description: "Adopt standard then differentiate"
-    when: "Commodity/product threatens differentiation"
-    action: "Add proprietary extensions"
-```
+### Category A: User Perception
 
-## Build vs. Buy vs. Outsource
+Strategies that shape how users perceive and interact with your offerings. Can accelerate adoption or create artificial barriers to switching.
+
+**1. Education (LG)**
+Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+- *When to use*: Launching novel or complex components where user understanding is low.
+- *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
+
+**2. Bundling (N)**
+Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+- *When to use*: When individual components have limited standalone appeal but are complementary together.
+- *Evolution stage*: Product stage (combining maturing components)
+
+**3. Creating Artificial Needs (LE)**
+Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+- *When to use*: When a component solves a latent problem users have not yet articulated.
+- *Evolution stage*: Genesis → Custom-Built (creates market pull)
+
+**4. Confusion of Choice (LE)**
+Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+- *When to use*: When incumbent position must be defended against clearly superior alternatives.
+- *Evolution stage*: Product stage (commoditisation pressure)
+
+**5. Brand and Marketing (N)**
+Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+- *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**6. FUD — Fear, Uncertainty, Doubt (LE)**
+Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+- *When to use*: Defensively, when a competitor threatens your position with a superior offering.
+- *Evolution stage*: Product stage (defending existing position)
+
+**7. Artificial Competition (CE)**
+Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+- *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
+- *Evolution stage*: Any stage (perception manipulation)
+
+**8. Lobbying / Counterplay (CE)**
+Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+- *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
+- *Evolution stage*: Any stage (regulatory environment shaping)
+
+---
+
+### Category B: Accelerators
+
+Strategies designed to speed up component evolution along the x-axis (Genesis → Commodity). Accelerators grow markets and compress timelines.
+
+**1. Market Enablement (LG)**
+Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+- *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
+- *Evolution stage*: Custom-Built → Product (accelerates standardisation)
+
+**2. Open Approaches (LG)**
+Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+- *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
+- *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
+
+**3. Exploiting Network Effects (N)**
+Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+- *When to use*: When you have a platform or communication component where value compounds with users.
+- *Evolution stage*: Product → Commodity (accelerated by user density)
+
+**4. Co-operation (N)**
+Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+- *When to use*: When no single organisation can drive a standard alone and collective action is needed.
+- *Evolution stage*: Custom-Built → Product (drives standardisation)
+
+**5. Industrial Policy (N)**
+Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+- *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
+- *Evolution stage*: Any stage (policy-driven acceleration)
+
+---
+
+### Category C: De-accelerators
+
+Strategies designed to slow component evolution, preserving competitive advantage, higher margins, or market control.
+
+**1. Exploiting Constraint (LE)**
+Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+- *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**2. Intellectual Property Rights / IPR (LE)**
+Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+- *When to use*: When protecting genuine innovations that required significant R&D investment.
+- *Evolution stage*: Genesis → Custom-Built (protects early innovations)
+
+**3. Creating Constraints (CE)**
+Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+- *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
+- *Evolution stage*: Product → Commodity (blocks commoditisation)
+
+---
+
+### Category D: Dealing with Toxicity
+
+Strategies for managing components that no longer provide value, are expensive to maintain, or are hindering progress in your value chain.
+
+**1. Pig in a Poke (CE)**
+Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+- *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
+- *Evolution stage*: Any stage (often used with obsolete custom-built components)
+
+**2. Disposal of Liability (N)**
+Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+- *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
+- *Evolution stage*: Product → Commodity (managing decline gracefully)
+
+**3. Sweat and Dump (LE)**
+Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+- *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
+- *Evolution stage*: Product → Commodity (exploiting remaining value)
+
+**4. Refactoring (LG)**
+Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+- *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
+- *Evolution stage*: Custom-Built (restoring and modernising)
+
+---
+
+### Category E: Market
+
+Strategies for positioning components within the market, manipulating pricing dynamics, and securing competitive advantage through market structure.
+
+**1. Differentiation (N)**
+Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+- *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
+- *Evolution stage*: Custom-Built → Product (slows rightward movement)
+
+**2. Pricing Policy (N)**
+Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+- *When to use*: When pricing itself can shift market behaviour rather than just capture value.
+- *Evolution stage*: Product → Commodity (shapes competitive landscape)
+
+**3. Buyer / Supplier Power (LE)**
+Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+- *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
+- *Evolution stage*: Product → Commodity (exploiting market position)
+
+**4. Harvesting (LE)**
+Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+- *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
+- *Evolution stage*: Product → Commodity (late-stage value extraction)
+
+**5. Standards Game (LE)**
+Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+- *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
+- *Evolution stage*: Custom-Built → Product (locking in architecture)
+
+**6. Last Man Standing (LE)**
+Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+- *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
+- *Evolution stage*: Product → Commodity (consolidation phase)
+
+**7. Signal Distortion (CE)**
+Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+- *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
+- *Evolution stage*: Any stage (information environment manipulation)
+
+**8. Trading (N)**
+Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+- *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
+- *Evolution stage*: Any stage (timed exchanges)
+
+---
+
+### Category F: Defensive
+
+Strategies for protecting existing market position, managing threats, and slowing competitor progress.
+
+**1. Threat Acquisition (N)**
+Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+- *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
+- *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
+
+**2. Raising Barriers to Entry (N)**
+Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+- *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
+- *Evolution stage*: Product (defending established position)
+
+**3. Procrastination (N)**
+Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+- *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
+- *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
+
+**4. Defensive Regulation (LE)**
+Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+- *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
+- *Evolution stage*: Any stage (regulatory entrenchment)
+
+**5. Limitation of Competition (CE)**
+Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+- *When to use*: Recognise and defend against it; deploying it invites antitrust action.
+- *Evolution stage*: Product → Commodity (dominant player defending monopoly)
+
+**6. Managing Inertia (N)**
+Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+- *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
+- *Evolution stage*: Any stage (internal transformation management)
+
+---
+
+### Category G: Attacking
+
+Strategies for gaining market share, disrupting competitors, and creating new opportunities.
+
+**1. Directed Investment (LG)**
+Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+- *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
+- *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
+
+**2. Experimentation (LG)**
+Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+- *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
+- *Evolution stage*: Genesis (exploring new space)
+
+**3. Centre of Gravity (N)**
+Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+- *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
+- *Evolution stage*: Custom-Built → Product (targeted disruption)
+
+**4. Undermining Barriers to Entry (N)**
+Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+- *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
+- *Evolution stage*: Custom-Built → Product (disruptive market entry)
+
+**5. Fool's Mate (LE)**
+Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+- *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
+- *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
+
+**6. Press Release Process (LE)**
+Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+- *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
+- *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
+
+**7. Playing Both Sides (N)**
+Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+- *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
+- *Evolution stage*: Product → Commodity (platform-level control)
+
+---
+
+### Category H: Ecosystem
+
+Strategies for creating, nurturing, and leveraging networks of interconnected components and actors.
+
+**1. Alliances (LG)**
+Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+- *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
+- *Evolution stage*: Custom-Built → Product (accelerating through partnership)
+
+**2. Co-creation (LG)**
+Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+- *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
+- *Evolution stage*: Genesis → Custom-Built (open innovation)
+
+**3. Sensing Engines / ILC (N)**
+Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+- *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
+- *Evolution stage*: Product → Commodity (data-driven adaptation)
+
+**4. Tower and Moat (N)**
+Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+- *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
+- *Evolution stage*: Product (building defensive ecosystem)
+
+**5. N-sided Markets (N)**
+Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+- *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
+- *Evolution stage*: Custom-Built → Product (platform creation)
+
+**6. Co-opting and Intercession (LE)**
+Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+- *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
+- *Evolution stage*: Product (value chain positioning)
+
+**7. Embrace and Extend (LE)**
+Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+- *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
+- *Evolution stage*: Product → Commodity (standard adoption then differentiation)
+
+**8. Channel Conflicts and Disintermediation (N)**
+Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+- *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
+- *Evolution stage*: Product → Commodity (distribution restructuring)
+
+---
+
+### Category I: Competitor
+
+Strategies for understanding, outmanoeuvring, and responding to competitors directly.
+
+**1. Ambush (N)**
+Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+- *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
+- *Evolution stage*: Genesis → Custom-Built (surprise market entry)
+
+**2. Fragmentation Play (LE)**
+Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+- *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
+- *Evolution stage*: Product (niche segmentation)
+
+**3. Reinforcing Competitor Inertia (LE)**
+Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+- *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
+- *Evolution stage*: Product (exploiting competitor commitment)
+
+**4. Sapping (LE)**
+Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+- *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
+- *Evolution stage*: Product → Commodity (gradual displacement)
+
+**5. Misdirection (CE)**
+Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+- *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
+- *Evolution stage*: Any stage (competitive deception)
+
+**6. Restriction of Movement (CE)**
+Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+- *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
+- *Evolution stage*: Product (platform gatekeeping)
+
+**7. Talent Raid (CE)**
+Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+- *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
+- *Evolution stage*: Any stage (capability competition)
+
+**8. Circling and Probing (N)**
+Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+- *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
+- *Evolution stage*: Any stage (competitive intelligence gathering)
+
+---
+
+### Category J: Positional
+
+Strategies for securing and maintaining optimal positions within the competitive landscape.
+
+**1. Land Grab (N)**
+Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+- *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
+- *Evolution stage*: Genesis → Custom-Built (early territory capture)
+
+**2. First Mover / Fast Follower (N)**
+Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+- *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
+- *Evolution stage*: Genesis → Custom-Built (timing of market entry)
+
+**3. Aggregation (N)**
+Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+- *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
+- *Evolution stage*: Product (integration play)
+
+**4. Weak Signal / Horizon (N)**
+Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+- *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
+- *Evolution stage*: Genesis (anticipating future evolution)
+
+---
+
+### Category K: Poison
+
+High-risk strategies that can harm competitors, markets, or even your own organisation if misapplied. Recognise these when used against you.
+
+**1. Licensing Play (LE)**
+Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+- *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
+- *Evolution stage*: Custom-Built → Product (IP-based control)
+
+**2. Insertion (CE)**
+Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+- *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
+- *Evolution stage*: Product (dependency creation)
+
+**3. Designed to Fail (CE)**
+Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+- *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
+- *Evolution stage*: Genesis (false market signals)
+
+---
+
+## 3. Play-Position Matrix
+
+Use your position on the map and the market's maturity to select the most appropriate plays.
+
+| Your Position | Early Market | Growing Market | Mature Market | Consolidated Market |
+|---------------|-------------|----------------|---------------|---------------------|
+| **Genesis leader** | Education, Directed Investment, Experimentation | Land Grab, Open Approaches, Alliances | First Mover/Fast Follower, Market Enablement | Weak Signal/Horizon, Co-operation |
+| **Custom-Built strength** | Fool's Mate, Bundling, Tower and Moat | Centre of Gravity, Differentiation, Co-creation | Sensing Engines (ILC), N-sided Markets | Aggregation, Playing Both Sides |
+| **Product parity** | Fragmentation Play, Undermining Barriers | Pricing Policy, Brand and Marketing | Standards Game, Sapping, Circling and Probing | Harvesting, Last Man Standing |
+| **Commodity laggard** | Refactoring, Disposal of Liability | Managing Inertia, Threat Acquisition | Raising Barriers to Entry, Procrastination | Sweat and Dump, Channel Disintermediation |
+
+---
+
+## 4. Play Compatibility
+
+### Plays That Work Together
+
+| Primary Play | Compatible With | Why |
+|-------------|-----------------|-----|
+| Sensing Engines (ILC) | Ecosystem plays, Weak Signal/Horizon | ILC provides the data to act on horizon signals |
+| Open Approaches | Co-creation, Market Enablement, Alliances | Openness attracts community and enables markets |
+| Tower and Moat | N-sided Markets, Alliances, Co-creation | Moat is strengthened by ecosystem depth |
+| Land Grab | Directed Investment, Alliances | Resources and partnerships accelerate territory capture |
+| Experimentation | Directed Investment, Sensing Engines | Experiments generate signals; investment scales winners |
+| Education | Open Approaches, Market Enablement | Education grows the market that openness then accelerates |
+| Fragmentation Play | Undermining Barriers, Differentiation | Niche entry combined with unique positioning |
+| Fool's Mate | Directed Investment, Ambush | Concentrated investment enables surprise execution |
+| Playing Both Sides | Tower and Moat, Sensing Engines | Platform control enables both ecosystem sensing and competition |
+
+### Plays That Conflict
+
+| Play A | Conflicts With | Why |
+|--------|---------------|-----|
+| Open Approaches | IPR / Licensing Play | Opening commoditises what licensing tries to protect |
+| Standards Game | Fragmentation Play | One seeks consolidation, the other fragmentation |
+| Co-creation | Confusion of Choice | Transparency in co-creation undermines deliberate confusion |
+| Market Enablement | Exploiting Constraint | Enablement accelerates what constraint tries to slow |
+| Education (LG) | FUD (LE) | Honest information and fear messaging are incompatible |
+| Alliances (LG) | Misdirection (CE) | Trust-based partnership cannot coexist with deliberate deception |
+| Refactoring | Sweat and Dump | One invests to restore value; the other extracts before exit |
+
+---
+
+## 5. Strategic Anti-Patterns
+
+Common strategic mistakes identified when applying gameplays to Wardley Maps.
+
+**Playing in the wrong evolution stage**
+Applying a genesis gameplay (e.g., Experimentation) to a commodity component wastes resources. Applying a commodity play (e.g., Harvesting) to a genesis component kills nascent innovation. Always match the play to the component's actual evolution position on the map.
+
+**Ignoring inertia**
+Assuming that a clearly superior strategy will execute smoothly without addressing organisational resistance. Inertia is the single most common reason strategically correct plays fail in execution. Map your inertia points before committing to a play.
+
+**Single-play dependence**
+Relying on one play to secure a position. Durable positions require layered plays — for example, Open Approaches to accelerate adoption, followed by Sensing Engines and Tower and Moat to capture ecosystem value. Single plays are fragile.
+
+**Misreading evolution pace**
+Treating components as more evolved (or less evolved) than they are. Building a commodity play (Harvesting) on what is still a custom-built component destroys value. Mapping component position carefully before selecting plays is essential.
+
+**Ecosystem hubris**
+Assuming that a strong current ecosystem position is self-sustaining. Ecosystems decay when the platform owner stops creating genuine value or when a disruptive technology makes the platform irrelevant. ILC and Weak Signal plays are the antidotes.
+
+**Open washing**
+Claiming Open Approaches alignment while maintaining proprietary lock-in through standards control, licensing restrictions, or incompatible extensions. Community backlash is swift and destroys the trust that makes open strategies work.
+
+**Alignment drift**
+Starting with LG plays to build an ecosystem and then shifting to CE plays to extract value. This pattern (common in platform companies) destroys the trust that made the ecosystem valuable in the first place and invites regulatory intervention.
+
+---
+
+## 6. Case Study Summaries
+
+Canonical examples of gameplay combinations in practice.
+
+**AWS (ILC + Land Grab + Tower and Moat)**
+Amazon launched AWS in 2006 before competitors recognised cloud's potential (Land Grab), built a comprehensive ecosystem of services that created deep customer dependency (Tower and Moat), and used marketplace metadata to sense which services to build next (Sensing Engines / ILC). Result: cloud computing market dominance and ongoing competitive moat.
+
+**Amazon Retail (Ecosystem + Directed Investment + Sensing Engines)**
+Combined early e-commerce entry with systematic directed investment in logistics, Prime, and Marketplace to build a self-reinforcing flywheel. Data from transactions continuously informs pricing, inventory, and product expansion. The ecosystem (sellers, logistics, Prime) creates the moat.
+
+**Netflix (Fast Follower + Directed Investment + Ecosystem co-evolution)**
+Watched Blockbuster's online rental experiment, then executed a fast follower streaming strategy with heavy directed investment in technology and original content. Co-evolved with device manufacturers to ensure reach across platforms. Original content investment shifted Netflix from distributor to producer, reducing dependency on studio licensing.
+
+**Apple iPhone (Fool's Mate + Bundling + N-sided Markets)**
+Executed a decisive market entry that caught mobile incumbents unprepared (Fool's Mate). Bundled hardware, iOS, and services into a coherent premium value proposition (Bundling). Built an N-sided market connecting users, developers, and accessory makers through the App Store, creating powerful ecosystem lock-in.
+
+**Google Android (Open Approaches + Alliances + Insertion)**
+Open-sourced Android to accelerate device manufacturer adoption (Open Approaches). Built alliances with manufacturers, carriers, and developers (Alliances). Embedded Google Search, Maps, and Play Store as dependencies — creating structural control over the mobile ecosystem (Insertion).
+
+**Ubuntu (Open Approaches + Alliances + Market Enablement)**
+Adopted open-source approach to lower adoption barriers and grow a contributor community (Open Approaches). Built alliances with cloud providers and infrastructure vendors (Alliances). Shifted focus to cloud computing as the strategic battleground and enabled the market with free security and tooling (Market Enablement). Became the dominant cloud guest OS within 18 months.
+
+**Tesla (First Mover + Tower and Moat + Education)**
+Entered the EV market as a first mover with high-performance vehicles when competitors were not taking EVs seriously. Built an integrated ecosystem of manufacturing, Gigafactory battery production, and Supercharger network that competitors could not quickly replicate (Tower and Moat). Invested heavily in consumer education about EV benefits and sustainability.
+
+**Airbnb (N-sided Markets + Market Enablement + Defensive Regulation)**
+Created a two-sided platform connecting hosts and guests that no incumbent hotel company could easily replicate (N-sided Markets). Enabled a new market of peer-to-peer accommodation that unlocked latent supply (Market Enablement). Proactively engaged with regulators in key cities to legitimise the model rather than ignore regulation (Defensive Regulation).
+
+**Spotify (N-sided Markets + Bundling + Sensing Engines)**
+Built a platform connecting listeners, artists, labels, and advertisers (N-sided Markets). Bundled streaming, curation, podcasting, and premium features into a coherent offering with strong perceived value (Bundling). Used listener data to power recommendation algorithms (Discover Weekly, Daily Mix) that continuously improve engagement and reduce churn (Sensing Engines).
+
+---
+
+## 7. Build vs. Buy vs. Outsource
 
 Use the component's evolution position to guide sourcing decisions:
 
@@ -91,7 +552,9 @@ build_buy_outsource:
       - "Email delivery"
 ```
 
-## Innovation Investment by Stage
+---
+
+## 8. Innovation Investment by Stage
 
 ```yaml
 innovation_investment:
@@ -100,72 +563,26 @@ innovation_investment:
     approach: "Experiments, PoCs, research"
     metrics: "Learning velocity, options created"
     failure_tolerance: "High"
+    matching_plays: ["Experimentation", "Weak Signal/Horizon", "Directed Investment", "Education"]
 
   custom:
     investment_type: "Differentiation"
     approach: "Product development, custom builds"
     metrics: "Feature completion, user adoption"
     failure_tolerance: "Medium"
+    matching_plays: ["Fool's Mate", "Tower and Moat", "Co-creation", "Alliances"]
 
   product:
     investment_type: "Enhancement"
     approach: "Integration, configuration"
     metrics: "Time to value, TCO"
     failure_tolerance: "Low"
+    matching_plays: ["Differentiation", "Standards Game", "Sensing Engines (ILC)", "N-sided Markets"]
 
   commodity:
     investment_type: "Optimization"
     approach: "Cost reduction, automation"
     metrics: "Cost per unit, availability"
     failure_tolerance: "Very low"
-```
-
-## Common Map Patterns
-
-Recognizable patterns to watch for when analyzing a completed map.
-
-### Desirable Patterns
-
-```yaml
-desirable_patterns:
-  tower_pattern:
-    description: "Differentiation built on commodity foundation"
-    structure:
-      top: "Genesis/Custom differentiators"
-      middle: "Product integrations"
-      bottom: "Commodity infrastructure"
-    example:
-      differentiator: "Custom recommendation engine"
-      product_layer: "E-commerce platform, CRM"
-      commodity: "Cloud compute, databases"
-    strategy: "Maximize commoditization at bottom to fund innovation at top"
-```
-
-### Anti-Patterns
-
-```yaml
-anti_patterns:
-  legacy_trap:
-    description: "Custom-built components that should be commodity"
-    symptoms:
-      - "Large team maintaining commodity-equivalent"
-      - "High cost, slow innovation"
-      - "Technical debt accumulation"
-    example:
-      component: "Custom identity management"
-      market_alternatives: ["Auth0", "Azure AD B2C", "Okta"]
-      waste: "Team of 5 maintaining what SaaS provides"
-    resolution: "Migrate to product/commodity, redeploy team"
-
-  premature_innovation:
-    description: "Treating genesis component as if product/commodity"
-    symptoms:
-      - "Fixed-scope contracts for unknown work"
-      - "Waterfall planning for experimental work"
-      - "Outsourcing pioneer work"
-    example:
-      component: "Novel ML application"
-      mistake: "Fixed-price contract with vendor"
-      result: "Scope creep, failed project"
-    resolution: "Match management approach to evolution stage"
+    matching_plays: ["Harvesting", "Last Man Standing", "Outsource decision", "Disposal of Liability"]
 ```

--- a/arckit-claude/skills/wardley-mapping/references/mapping-examples.md
+++ b/arckit-claude/skills/wardley-mapping/references/mapping-examples.md
@@ -304,4 +304,215 @@ ml_strategy:
       Custom models only where product gaps exist.
 ```
 
+---
+
+## Example 4: TechnoGadget Smart Home (Climatic Patterns Case Study)
+
+This example is drawn from the *Introduction to Wardley Mapping Climatic Patterns* reference work. It illustrates how climatic patterns interact with component positioning in a real-world product company.
+
+### Scenario
+
+TechnoGadget Inc. is a mid-sized technology company producing smart home devices. Their flagship product is a smart thermostat controllable via a smartphone app. Facing increased competition, they are planning international expansion.
+
+- **User Need**: "Comfortable home environment with energy efficiency"
+
+### OnlineWardleyMaps Syntax
+
+```owm
+title TechnoGadget Inc.
+
+anchor Customer [0.95, 0.63]
+
+component Smart thermostat [0.65, 0.46] label [-81, -9]
+component Mobile app [0.79, 0.34] label [-77, 2]
+component Cloud infrastructure [0.05, 0.75] label [-26, 13]
+component Data analytics [0.22, 0.36] label [-68, 24]
+component Customer support [0.86, 0.81] label [9, -17]
+component Marketing and sales [0.51, 0.66] label [-25, -57]
+component R&D [0.50, 0.22]
+component API [0.34, 0.28] label [-29, 20]
+
+Customer->Smart thermostat
+Customer->Customer support
+Customer->Mobile app
+
+Smart thermostat->Mobile app
+Smart thermostat->Cloud infrastructure
+Smart thermostat->Data analytics
+Smart thermostat->API
+
+Mobile app->API
+
+API->Cloud infrastructure
+API->Data analytics
+
+Cloud infrastructure->Data analytics
+Cloud infrastructure->Customer support
+Cloud infrastructure->Marketing and sales
+Cloud infrastructure->R&D
+
+evolve API 0.75
+```
+
+Paste into [OnlineWardleyMaps](https://create.wardleymaps.ai) to render.
+
+### Component Positions
+
+| Component | Visibility | Evolution | Stage | Notes |
+|-----------|-----------|-----------|-------|-------|
+| Smart thermostat | 0.65 | 0.46 | Custom-Built/Product | Core product, approaching commoditization |
+| Mobile app | 0.79 | 0.34 | Custom-Built | High visibility, custom UX differentiator |
+| Cloud infrastructure | 0.05 | 0.75 | Product/Commodity | Low visibility, enabling layer |
+| Data analytics | 0.22 | 0.36 | Custom-Built | Higher-order capability built on commoditized infra |
+| Customer support | 0.86 | 0.81 | Commodity | High visibility, standardized function |
+| Marketing and sales | 0.51 | 0.66 | Product | Mid-chain, standard practice |
+| R&D | 0.50 | 0.22 | Genesis/Custom-Built | Uncertain, high-value future options |
+| API | 0.34 | 0.28 → 0.75 | Custom-Built (evolving) | Strategic evolution signal: moving toward commodity |
+
+### Strategic Insights
+
+- **Commoditization pressure on core product**: Smart thermostat and Mobile app cluster in the Product stage — inertia risk is high as these evolve toward commodity and competitors can replicate them. TechnoGadget must shift differentiation upstream toward Data analytics and R&D before the hardware commoditizes.
+- **Efficiency enables innovation**: Commoditized Cloud infrastructure enables faster and cheaper development of custom-built Data analytics and R&D capabilities. This is the "higher-order systems create new value" climatic pattern in action — the commodity layer subsidizes the genesis layer.
+- **API evolution watch**: The `evolve API 0.75` annotation signals an anticipated move toward commodity. Once APIs commoditize, third-party integrators can build on TechnoGadget's platform — creating an ecosystem play opportunity (ILC pattern) but also opening the platform to competitive pressure.
+
+---
+
+## Example 5: Value Chain Decomposition Walkthrough
+
+A step-by-step demonstration of how to decompose a user need into a full Wardley Map. Use this pattern when starting from scratch with a new domain.
+
+### Starting Point: "Buy Products Online"
+
+This walkthrough shows the decomposition process for a simplified e-commerce value chain.
+
+#### Step 1 — Anchor
+
+Identify the user and their need:
+
+```
+User: Online Shopper
+Need: Buy products online
+```
+
+Place the anchor at the top of the map (high visibility = 1.0).
+
+#### Step 2 — First-Level Decomposition
+
+Ask: "What does the user directly interact with to fulfil this need?"
+
+```
+Buy products online
+  ├── Product Discovery      (finding what to buy)
+  ├── Shopping Experience    (browsing, comparison)
+  ├── Checkout               (basket, order confirmation)
+  └── Fulfilment             (delivery, returns)
+```
+
+These four components are directly visible to the user — position them high on the Y-axis (visibility 0.7-0.9).
+
+#### Step 3 — Second-Level Decomposition
+
+For each first-level component, ask: "What does this depend on?"
+
+```
+Product Discovery depends on:
+  ├── Search Engine           (index + ranking)
+  ├── Product Catalogue       (structured data)
+  └── Recommendation Engine   (personalisation ML)
+
+Shopping Experience depends on:
+  ├── Product Images / Media  (CDN delivery)
+  ├── Reviews & Ratings       (UGC platform)
+  └── Price Comparison        (pricing service)
+
+Checkout depends on:
+  ├── Shopping Cart           (session state)
+  ├── Payment Gateway         (Stripe / Adyen)
+  └── Identity / Auth         (login, SSO)
+
+Fulfilment depends on:
+  ├── Order Management System (OMS)
+  ├── Warehouse / 3PL         (physical logistics)
+  └── Notification Service    (email / SMS)
+```
+
+#### Step 4 — Assign Evolution Positions
+
+Apply the Evolution Scoring rubric (see [Mathematical Models](mathematical-models.md)):
+
+| Component | U | C | E(c) | Stage |
+|-----------|---|---|------|-------|
+| Search Engine | 0.55 | 0.60 | 0.58 | Product |
+| Product Catalogue | 0.70 | 0.75 | 0.73 | Product |
+| Recommendation Engine | 0.40 | 0.35 | 0.38 | Custom |
+| Payment Gateway | 0.90 | 0.88 | 0.89 | Commodity |
+| Shopping Cart | 0.75 | 0.80 | 0.78 | Product/Commodity |
+| Identity / Auth | 0.80 | 0.85 | 0.83 | Commodity |
+| Order Management | 0.60 | 0.65 | 0.63 | Product |
+| Notification Service | 0.85 | 0.90 | 0.88 | Commodity |
+
+#### Step 5 — Draw Dependency Arrows
+
+Add arrows from dependent → dependency (top to bottom, left-to-right for evolution):
+
+```
+Product Discovery → Recommendation Engine → Customer Data
+Checkout → Payment Gateway
+Checkout → Identity / Auth
+Fulfilment → Notification Service
+```
+
+Arrows that cross from right to left (high evolution to low) highlight **dependency risk** — a mature, visible component relying on an immature dependency.
+
+#### Step 6 — Apply Validation Checklist
+
+Before finalizing the map, verify:
+
+```yaml
+validation:
+  anchor_present: true          # User and need clearly stated?
+  all_user_touchpoints_mapped:  # Everything the user directly interacts with?
+  dependencies_visible:         # Have you traced at least 2 levels down?
+  evolution_justified:          # Can you defend each component's position?
+  movement_arrows:              # Have you noted evolving components?
+  no_orphan_components:         # Every component connects to at least one other?
+  strategic_question_answered:  # Does the map help answer a specific decision?
+```
+
+---
+
+## Case Study Cross-References
+
+Brief pattern examples connecting well-known companies to Wardley Mapping gameplay patterns. For the full pattern descriptions, see [Gameplay Patterns](gameplay-patterns.md).
+
+### AWS — ILC Pattern (Innovate, Leverage, Commoditize)
+
+Amazon ran the ILC play across its own infrastructure:
+
+1. **Innovate**: Built custom-scale distributed infrastructure internally for Amazon.com (Genesis/Custom-Built)
+2. **Leverage**: Recognized that the infrastructure had value as a product — launched EC2 (2006) and S3 as commercial offerings (Custom → Product)
+3. **Commoditize**: Drove the market toward utility pricing, making competitors' infrastructure investments uneconomical
+
+The result: internal cost-centre became the world's largest cloud platform. The key insight was that what was necessary-but-not-differentiating *for Amazon* was differentiating *for everyone else*. Any organization can ask: "What have we built for ourselves that others would pay for?"
+
+### Netflix — Attacking Play (Platform Transition)
+
+Netflix used a Wardley attacking play to shift from a position of weakness to market leadership:
+
+1. **Identified the evolution**: Physical DVD rental was moving toward commodity (and eventually obsolescence); streaming infrastructure was emerging
+2. **Attacked with an alternative**: Launched streaming when infrastructure costs fell low enough to make it viable (cloud commoditizing bandwidth and compute)
+3. **Built the new ecosystem**: Developed content recommendation, original programming, and global delivery — creating defensible positions in what would otherwise be a commodity streaming market
+
+The attack succeeded because Netflix moved *before* incumbents (Blockbuster) accepted that the old model was dying. Inertia from their successful past model slowed their response.
+
+### Spotify — Two-Sided Market Play
+
+Spotify operates a two-factor market with three distinct user groups creating a flywheel:
+
+1. **Free users (scale)**: Provide data, content demand signals, and a large addressable market for advertisers
+2. **Premium subscribers (revenue)**: Convert from free tier; fund content licensing and platform development
+3. **Artists and labels (content)**: Attracted by the large user base, provide the content that attracts users
+
+The mapping insight: Spotify's true strategic asset is not the music (a commodity licensed from labels) but the **listener data** and **playlist/discovery graph** — both of which sit in the Custom-Built stage and are hard to replicate. The commodity content layer enables the differentiating data layer above it.
+
 For common mapping patterns and anti-patterns (Tower, Legacy Trap, Premature Innovation), see [Gameplay Patterns](gameplay-patterns.md).

--- a/arckit-claude/skills/wardley-mapping/references/mathematical-models.md
+++ b/arckit-claude/skills/wardley-mapping/references/mathematical-models.md
@@ -249,6 +249,152 @@ Moderate-to-strong signal — transitioning from Product to Commodity. (And inde
 
 ---
 
+---
+
+## D. Play-Position Scoring
+
+A quantitative framework for evaluating which gameplay options are viable given your current map position.
+
+### Core Formula
+
+```
+Play Score = Position_Match(0-1) × Capability_Fit(0-1) × (1 - Risk_Factor(0-1))
+```
+
+Higher scores indicate plays that are well-aligned with your position, executable with current capabilities, and have acceptable downside risk.
+
+### Position Match
+
+How well does the gameplay play align with the evolution position of the target components?
+
+```
+Position_Match scoring:
+  Play targets your current stage:        1.0   (e.g., ILC play on a Custom-Built component)
+  Play targets an adjacent stage:         0.6   (one stage left or right of current)
+  Play targets a distant stage:           0.2   (two stages away)
+```
+
+**Example**: An "Open Source" commoditization play on a Product-stage component (adjacent — targeting Commodity) scores 0.6. The same play on a Genesis-stage component (distant — skipping two stages) scores 0.2.
+
+### Capability Fit
+
+Can your organization actually execute this play? Assess against the prerequisites for the specific gameplay.
+
+```
+Capability_Fit scoring:
+  Have all prerequisites:                 1.0   (full capability to execute)
+  Have most prerequisites:                0.7   (minor gaps, fillable with investment)
+  Missing one key capability:             0.3   (significant gap requiring major effort)
+  Missing multiple key capabilities:      0.1   (play is currently out of reach)
+```
+
+**Example**: An ILC play requires engineering scale, platform capabilities, and sales channels. A startup with strong engineering but no sales or platform infrastructure scores 0.3.
+
+### Risk Factor
+
+What is the downside if the play fails or conditions change?
+
+```
+Risk_Factor scoring:
+  Low risk, fully reversible:             0.1   (easy to stop, low sunk cost)
+  Medium risk, partially reversible:      0.4   (moderate investment, some recovery possible)
+  High risk, largely irreversible:        0.8   (major commitment, hard to unwind)
+  Existential risk, irreversible:         0.95  (bet-the-company, failure = shutdown)
+```
+
+Note: The Risk_Factor is subtracted from 1.0 before multiplying — so higher risk *reduces* the play score.
+
+### Worked Example: Evaluating Three Plays
+
+A company with a Custom-Built analytics platform evaluates three possible plays:
+
+| Play | Position_Match | Capability_Fit | Risk_Factor | Play Score | Verdict |
+|------|---------------|----------------|-------------|------------|---------|
+| Productize platform (sell to others) | 1.0 (Custom→Product) | 0.7 (engineering ok, sales gap) | 0.4 (medium) | 1.0 × 0.7 × 0.6 = **0.42** | Viable with investment |
+| Open source to commoditize | 0.6 (adjacent→Commodity) | 0.3 (no community mgmt) | 0.4 (medium) | 0.6 × 0.3 × 0.6 = **0.11** | Not viable yet |
+| Deepen custom differentiation | 1.0 (stay in Custom) | 1.0 (core strength) | 0.1 (low) | 1.0 × 1.0 × 0.9 = **0.90** | Strong — continue investing |
+
+The scoring confirms the intuitive recommendation: double down on differentiation while building the sales capability needed to eventually productize.
+
+### Play Score Interpretation
+
+| Play Score | Recommendation |
+|------------|---------------|
+| 0.70 - 1.00 | Execute — strong alignment, capability, and acceptable risk |
+| 0.40 - 0.70 | Conditional — viable but address the weakest factor first |
+| 0.15 - 0.40 | Weak — significant gaps; develop prerequisites before attempting |
+| 0.00 - 0.15 | Avoid — misaligned, incapable, or too risky at current position |
+
+---
+
+## E. Climate Pattern Impact Weighting
+
+A scoring framework for prioritizing which components face the greatest strategic pressure from climatic patterns.
+
+### Impact Matrix
+
+For each climatic pattern identified on a map, score its impact on each component:
+
+```
+Impact Matrix: Pattern × Component → Score (1-5)
+
+Scoring scale:
+  5 = Pattern directly threatens or enables this component's current position
+  4 = Pattern significantly affects this component's evolution trajectory
+  3 = Pattern has moderate influence on this component
+  2 = Pattern has minor relevance to this component
+  1 = Pattern has negligible or no effect on this component
+```
+
+A score of 5 means: if you ignore this pattern for this component, you will likely make a wrong strategic decision. A score of 1 means: the pattern exists but has no actionable implication for this component.
+
+### Aggregate Scoring
+
+Once the matrix is populated, calculate three aggregate scores:
+
+```
+Component Risk Score  = Sum of all pattern impact scores for that component
+  → Identifies which components face the most cumulative climatic pressure
+
+Pattern Criticality   = Sum of all component impact scores for that pattern
+  → Identifies which patterns have the broadest effect across the value chain
+
+Priority Focus        = Components with the highest Component Risk Scores
+  → Where to direct monitoring, investment, or contingency planning
+```
+
+### Worked Example: TechnoGadget Smart Home
+
+Applying 5 climatic patterns to the TechnoGadget map (from [Mapping Examples](mapping-examples.md)):
+
+| Component | Everything Evolves | Inertia | Higher-Order Systems | Efficiency Enables Innovation | Competitors Change Game | Risk Score |
+|-----------|-------------------|---------|---------------------|------------------------------|------------------------|------------|
+| Smart thermostat | 4 | 5 | 2 | 1 | 5 | **17** |
+| Mobile app | 3 | 4 | 2 | 1 | 4 | **14** |
+| Cloud infrastructure | 2 | 1 | 5 | 5 | 1 | **14** |
+| Data analytics | 4 | 2 | 5 | 4 | 3 | **18** |
+| R&D | 3 | 1 | 4 | 4 | 2 | **14** |
+| API | 5 | 2 | 3 | 3 | 4 | **17** |
+| **Pattern Criticality** | **21** | **15** | **21** | **18** | **19** | |
+
+**Interpretation**:
+
+- **Data analytics** (18) and **Smart thermostat / API** (17 each) face the highest cumulative climatic pressure — these are the priority focus components
+- **Everything Evolves** and **Higher-Order Systems** tie as the most broadly impactful patterns (21 each) — both affect nearly every component
+- **Inertia** (15) scores lowest in criticality but scores highest on Smart thermostat (5) — it is highly concentrated on one critical component, not broadly distributed
+
+### Using the Matrix in Practice
+
+1. List all climatic patterns identified on the map (typically 3-8 for a focused analysis)
+2. Score each pattern against each component (5-minute workshop exercise per pattern)
+3. Sum rows (component risk) and columns (pattern criticality)
+4. Rank components by risk score — highest scores demand strategic attention
+5. For components scoring 15+ (in a 5-pattern analysis), develop explicit contingency responses
+
+The matrix is most useful as a workshop tool: it forces explicit discussion about *why* a pattern affects a component, surfaces disagreements in the team's mental models, and produces a defensible prioritization.
+
+---
+
 ## Further Reading
 
 These models are drawn from a broader mathematical framework for Wardley Mapping that includes game theory, stochastic processes, topological analysis, and Bayesian inference. For the full academic treatment, see the [Wardley Map Mathematical Model](https://github.com/tractorjuice/wardleymap_math_model) repository.

--- a/arckit-claude/templates/wardley-climate-template.md
+++ b/arckit-claude/templates/wardley-climate-template.md
@@ -1,0 +1,260 @@
+# Wardley Climate Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.climate`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Climate Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.climate` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the most significant climate forces acting on this landscape, the components under most pressure, and the key strategic implications. Include whether the overall climate is favourable, neutral, or threatening for the current strategy.]
+
+**Climate Severity**:
+
+| Category | Severity | Most Affected Components |
+|----------|----------|--------------------------|
+| Component Patterns | High / Medium / Low / None | {Component names} |
+| Financial Patterns | High / Medium / Low / None | {Component names} |
+| Speed Patterns | High / Medium / Low / None | {Component names} |
+| Inertia Patterns | High / Medium / Low / None | {Component names} |
+| Competitor Patterns | High / Medium / Low / None | {Component names} |
+| Prediction Patterns | High / Medium / Low / None | {Component names} |
+
+---
+
+## Map Reference
+
+This climate assessment is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+
+---
+
+## Component Inventory
+
+*Extracted from the referenced Wardley Map. All components subject to climate assessment.*
+
+| Component | Visibility | Evolution | Stage |
+|-----------|-----------|-----------|-------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 2} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 3} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 4} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 5} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+
+---
+
+## Climate Assessment by Category
+
+### 1. Component Patterns
+
+*How do components naturally evolve and what forces act on them?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Everything evolves (no component stays still) | Yes / No / Partial | H / M / L | {Observation from the map or market} | {What this means for strategy} |
+| Characteristics change as components evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| No "one size fits all" method | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Success breeds inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems create new sources of worth | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Components can co-evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new areas of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation enables new genesis | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 2. Financial Patterns
+
+*How do economic forces shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Efficiency enables innovation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new sources of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation reduces margin | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New economic models emerge (e.g., SaaS, platform) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Price pressure on product-stage components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Investment bias towards Genesis/Custom stages | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 3. Speed Patterns
+
+*How does the pace of change affect the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Evolution is not uniform (some components evolve faster) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation is accelerating (shorter cycles) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem effects accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Open source accelerates commoditisation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Regulation can slow or accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 4. Inertia Patterns
+
+*What forces resist change in this landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Past success creates resistance to change | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Existing practices embed inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Vendor lock-in creates artificial inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 5. Competitor Patterns
+
+*How do competitor behaviours shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Competitors also face inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants exploit incumbent inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 6. Prediction Patterns
+
+*What can be reliably anticipated about how this landscape will change?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Commoditisation of custom-built components is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Co-evolution of practice and technology is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems will emerge from current commodities | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Shifts from product to utility are visible before they occur | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants will appear at Genesis stage of key components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Inertia creates predictable points of disruption | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem plays follow commoditisation events | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Peace / War / Wonder cycles follow predictable patterns | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+## Per-Component Impact Matrix
+
+*How strongly does each climate category affect each component? H = High, M = Medium, L = Low, — = Not applicable.*
+
+| Component | Component Patterns | Financial Patterns | Speed Patterns | Inertia Patterns | Competitor Patterns | Prediction Patterns |
+|-----------|:-----------------:|:-----------------:|:--------------:|:----------------:|:------------------:|:------------------:|
+| {Component 1} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 2} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 3} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 4} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 5} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+
+---
+
+## Prediction Horizons
+
+*Anticipated evolution of key components over the next 6 and 18 months.*
+
+| Component | Current Stage | 6-Month Prediction | 18-Month Prediction | Confidence | Key Signals |
+|-----------|:------------:|:-----------------:|:------------------:|:----------:|-------------|
+| {Component 1} | Genesis | Custom (0.30) | Custom (0.40) | High / Medium / Low | {Observable signals — market activity, open source, vendor releases} |
+| {Component 2} | Custom | Product (0.55) | Product (0.65) | High / Medium / Low | {Observable signals} |
+| {Component 3} | Product | Product (0.70) | Commodity (0.80) | High / Medium / Low | {Observable signals} |
+| {Component 4} | Commodity | Commodity (0.90) | Commodity (0.95) | High / Medium / Low | {Observable signals} |
+
+---
+
+## Wave Analysis
+
+**Peace / War / Wonder Cycle**:
+
+The Wardley climate framework identifies a recurring cycle in markets:
+
+- **Peace**: Steady improvement of existing products; incumbents dominant; gradual evolution
+- **War**: Rapid disruption as a new model (e.g., cloud, SaaS, open source) makes existing approaches obsolete; major market shift
+- **Wonder**: Post-disruption stabilisation; new commodity enables new genesis; ecosystem flourishes
+
+**Current Positioning for This Context**:
+
+| Market Segment | Current Phase | Evidence | Strategic Implication |
+|----------------|:------------:|----------|-----------------------|
+| {Segment 1} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+| {Segment 2} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+
+**Recommended Response to Phase**:
+
+- {If Peace}: {Strategy for steady-state market — consolidation, efficiency, incremental improvement}
+- {If War}: {Strategy for disruption — move fast, exploit inertia of incumbents, align with the new model}
+- {If Wonder}: {Strategy for post-disruption — explore new genesis opportunities enabled by the new commodity}
+
+---
+
+## Inertia Assessment
+
+| Component | Inertia Type | Severity | Mitigation Strategy |
+|-----------|-------------|:--------:|---------------------|
+| {Component 1} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 2} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 3} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+
+**Inertia Type Definitions**:
+
+- **Skills**: Team expertise locked to legacy technology or practice
+- **Process**: Established workflows and procedures that resist change
+- **Vendor**: Contractual or technical dependencies that create switching costs
+- **Cultural**: "We've always done it this way" — organisational resistance
+- **Capital**: Sunk costs in existing systems justify continued investment
+- **Regulatory**: Compliance requirements that constrain or slow evolution
+
+---
+
+## Strategic Implications
+
+[3-5 bullet points summarising the most actionable strategic implications from the full climate assessment. Each point should connect a specific climate finding to a recommended strategic response.]
+
+- **{Implication 1}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 2}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 3}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 4}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 5}**: {Specific climate finding} → {Recommended strategic response}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map; all components assessed in this document are derived from it |
+| Requirements | ARC-[PROJECT_ID]-REQ-v[VERSION] | Climate signals may invalidate or create new requirements |
+| Research | ARC-[PROJECT_ID]-RSCH-v[VERSION] | Market research provides evidence for climate pattern assessment |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.climate` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-claude/templates/wardley-doctrine-template.md
+++ b/arckit-claude/templates/wardley-doctrine-template.md
@@ -1,0 +1,290 @@
+# Wardley Doctrine Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.doctrine`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WDOC-v[VERSION] |
+| **Document Type** | Wardley Doctrine Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.doctrine` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+**Overall Maturity Score**: [X.X / 5.0] — [Novice / Developing / Practising / Advanced / Leading]
+
+**Phase Positioning**:
+
+| Phase | Name | Score | Status |
+|-------|------|-------|--------|
+| Phase I | Stop Self-Harm | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase II | Becoming More Context Aware | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase III | Better for Less | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase IV | Continuously Evolving | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+
+**Critical Findings**:
+
+1. {Most significant gap or risk from the assessment}
+2. {Second critical finding}
+3. {Third critical finding}
+
+[2-3 sentence narrative summary of the organisation's doctrine maturity and most urgent priorities.]
+
+---
+
+## Strategy Cycle Context
+
+| Element | Summary |
+|---------|---------|
+| **Purpose** | {Why does this organisation or team exist? What is the mission?} |
+| **Landscape** | {What does the Wardley Map of this context reveal? Key components and their evolution positions.} |
+| **Climate** | {What external forces are acting on this landscape? Market shifts, regulation, technology change.} |
+| **Leadership** | {What leadership style is currently in use? Commander's intent vs. detailed instruction? Risk appetite?} |
+
+---
+
+## Doctrine Assessment Matrix
+
+Score key: **1** = Not practised | **2** = Awareness only | **3** = Partially practised | **4** = Consistently practised | **5** = Embedded and exemplary
+
+### Phase I: Stop Self-Harm
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Communication | Use a common language | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Be transparent | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Challenge assumptions | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Know your users | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Focus on user needs | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use appropriate methods | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Remove bias and duplication | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use standards where appropriate | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage inertia | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage failure | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Think small (ecosystem) | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase II: Becoming More Context Aware
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Situational Awareness | Know the details | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Use appropriate doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Be aware of context-specific play | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Understand your environment | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Design for constant evolution | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Small teams with alignment and autonomy | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Move fast | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Be pragmatic | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | There is no one culture | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Seek the best | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase III: Better for Less
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Efficiency | Optimise flow | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Effectiveness over efficiency | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Think big | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Strategy is iterative not linear | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Use multiple methods of working | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | A bias towards the new | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Be the owner | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Set exceptional standards | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase IV: Continuously Evolving
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Learning | Listen to your ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | A bias towards action | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Exploit the landscape | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Understand that strategy is complex | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Commit to the path | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Accept uncertainty | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Spend time on doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Lead the ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+
+---
+
+## Detailed Phase Findings
+
+### Phase I: Stop Self-Harm — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase I Narrative**:
+
+[2-4 sentences describing the organisation's overall performance on Phase I. What self-harming behaviours are present? What is being done well?]
+
+---
+
+### Phase II: Becoming More Context Aware — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase II Narrative**:
+
+[2-4 sentences describing situational awareness maturity. Does the organisation understand its landscape? Does leadership have context for decisions?]
+
+---
+
+### Phase III: Better for Less — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase III Narrative**:
+
+[2-4 sentences describing efficiency and operational maturity. Where is the organisation wasting effort? Where are there genuine improvements?]
+
+---
+
+### Phase IV: Continuously Evolving — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase IV Narrative**:
+
+[2-4 sentences describing the organisation's capacity for continuous evolution. Is learning embedded? Do ecosystems inform strategy?]
+
+---
+
+## Previous Assessment Comparison
+
+*Populate on re-assessment only. Leave blank for initial assessment.*
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+**Overall Score Change**: [Previous X.X] → [Current X.X] ([+/- delta])
+
+---
+
+## Critical Gaps
+
+| Rank | Phase | Category | Principle | Current Score | Target Score | Business Impact |
+|------|-------|----------|-----------|:-------------:|:------------:|-----------------|
+| 1 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 2 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 3 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 4 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 5 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+
+---
+
+## Implementation Roadmap
+
+### Immediate Actions (0-3 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 1} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 2} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 3} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Short-Term Actions (3-12 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 4} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 5} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 6} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Long-Term Actions (12-24 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 7} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 8} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+---
+
+## Recommendations
+
+1. **{Recommendation 1}**
+   - **Rationale**: {Why this is the top priority}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+2. **{Recommendation 2}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+3. **{Recommendation 3}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Doctrine principles should align with and reinforce architecture principles |
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Landscape and climate context for this assessment |
+| Stakeholder Analysis | ARC-[PROJECT_ID]-STKE-v[VERSION] | Leadership and culture context; stakeholder awareness of doctrine |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.doctrine` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-claude/templates/wardley-gameplay-template.md
+++ b/arckit-claude/templates/wardley-gameplay-template.md
@@ -1,0 +1,337 @@
+# Wardley Gameplay Analysis: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.gameplay`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WGAM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Gameplay Analysis |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.gameplay` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the strategic context, the plays selected, and the anticipated outcomes. Include overall strategic posture: aggressive/defensive/opportunistic.]
+
+**Selected Plays Summary**:
+
+| Play | Category | Recommendation | Priority |
+|------|----------|----------------|----------|
+| {Play 1} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 2} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 3} | {Category A-K} | Monitor | High / Medium / Low |
+
+---
+
+## Map Reference
+
+This gameplay analysis is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+| **Key Components** | {List 3-5 key components from the map} |
+
+---
+
+## Situational Assessment
+
+### Position Analysis
+
+*What does your current map position tell you about strategic options?*
+
+- **Anchor (User Need)**: {Anchor component and its evolution position}
+- **Differentiating Components**: {Components in Genesis/Custom that provide competitive advantage}
+- **Commodity Dependencies**: {Components already at commodity — not strategic, cost-focus only}
+- **Evolution Pressure**: {Components showing signs of rapid evolution — where the map is moving}
+
+### Capability Assessment
+
+*What can your organisation do well, and where are the gaps?*
+
+- **Core Strengths**: {What the organisation does better than competitors in this landscape}
+- **Critical Weaknesses**: {Capability gaps that constrain strategic options}
+- **Unique Assets**: {Assets, data, relationships, or IP that could be leveraged}
+- **Constraints**: {Budget, skills, regulatory, or time constraints affecting play selection}
+
+### Market Context
+
+*What is happening in the competitive environment?*
+
+- **Competitor Positions**: {Where are key competitors positioned on the map?}
+- **Market Signals**: {What trends indicate where the market is heading?}
+- **Regulatory Environment**: {Any constraints or opportunities from regulation?}
+- **Partnership Opportunities**: {Potential ecosystem partners or coalition plays?}
+
+---
+
+## Play Options by Category
+
+### A. Accelerator Plays
+
+*Speed up component evolution to reshape the landscape.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Open approaches (open source, open data, open standards) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Exploit the ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Contribute to standards bodies | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### B. Decelerator Plays
+
+*Slow down competitor evolution or commoditisation.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| FUD (Fear, Uncertainty, Doubt) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Differentiation | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Lobbying and regulatory influence | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### C. Market Plays
+
+*Shape market conditions in your favour.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Buyer and supplier education | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Press and analyst briefings | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### D. Defensive Plays
+
+*Protect your position from competitive threats.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Protective moat (IP, switching costs) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Embrace and extend | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Threat acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### E. Attacking Plays
+
+*Move against competitor positions.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Exploiting inertia | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Undermining barriers to entry | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Talent acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### F. Ecosystem Plays
+
+*Leverage or build ecosystems for competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Building a platform | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Co-opting an ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating a pricing game | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### G. Positional Plays
+
+*Move to advantageous positions on the map.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Tower and moat | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Land grab | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Sensing engine | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### H. Poison Plays
+
+*Make a position undesirable for competitors.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Disposal of a liability | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Swamping | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### I. Innovation Plays
+
+*Create new value through novel combinations.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Design for uncharted spaces | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Signal distortion | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### J. People Plays
+
+*Leverage talent and culture as competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Centres of gravity | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Pioneer / settler / town planner model | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### K. Political Plays
+
+*Navigate organisational or market politics.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Creating artificial constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Trojan horse | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+---
+
+## Play-Position Matrix Evaluation
+
+*For each key component position on the map, identify which plays are naturally aligned.*
+
+| Component | Visibility | Evolution | Stage | Recommended Plays | Rationale |
+|-----------|-----------|-----------|-------|-------------------|-----------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis | {Play names} | {Why these plays fit this position} |
+| {Component 2} | {0.xx} | {0.xx} | Custom | {Play names} | {Why these plays fit this position} |
+| {Component 3} | {0.xx} | {0.xx} | Product | {Play names} | {Why these plays fit this position} |
+| {Component 4} | {0.xx} | {0.xx} | Commodity | {Play names} | {Why these plays fit this position} |
+
+---
+
+## Play Compatibility Analysis
+
+*Evaluate whether selected plays reinforce or conflict with each other.*
+
+| Play A | Play B | Compatibility | Notes |
+|--------|--------|:-------------:|-------|
+| {Play 1} | {Play 2} | Reinforces | {Why these plays work well together} |
+| {Play 1} | {Play 3} | Neutral | {No significant interaction} |
+| {Play 2} | {Play 4} | Conflicts | {Why these plays undermine each other — resolve or sequence carefully} |
+
+**Resolution for conflicts**: {Describe how conflicting plays will be sequenced or one prioritised over the other.}
+
+---
+
+## Selected Plays
+
+### Play 1: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1 — capability, resource, or condition that must be in place}
+- {Prerequisite 2}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+**Expected Outcomes**:
+
+- {Outcome 1 — what success looks like}
+- {Outcome 2}
+
+**Risks**:
+
+- {Risk 1 — what could go wrong}
+- {Risk 2}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+- [ ] {Measurable indicator 2}
+
+**Review Points**: {When to review whether this play is working — e.g., 3 months, after specific milestone}
+
+---
+
+### Play 2: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+
+**Expected Outcomes**:
+
+- {Outcome 1}
+
+**Risks**:
+
+- {Risk 1}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+
+**Review Points**: {When to review whether this play is working}
+
+---
+
+## Risk Assessment and Anti-Patterns
+
+### Play-Specific Risks
+
+| Risk | Play Affected | Likelihood | Impact | Mitigation |
+|------|--------------|------------|--------|------------|
+| {Risk 1} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+| {Risk 2} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+
+### Common Gameplay Anti-Patterns to Avoid
+
+- **Playing too many games at once**: Focus on 2-3 plays maximum; spreading effort dilutes impact
+- **Ignoring inertia**: Plays that require rapid evolution will stall if internal or market inertia is not addressed
+- **Misreading evolution stage**: Applying Genesis plays to Commodity components (or vice versa) wastes resources
+- **Neglecting doctrine**: Gameplay without sound doctrine (Phase I) often backfires
+- **Static play selection**: Plays that are right today may be wrong in 12 months — review regularly
+
+---
+
+## Case Study References
+
+| Case Study | Play(s) Illustrated | Source | Relevance to This Context |
+|------------|---------------------|--------|--------------------------|
+| {Case study 1} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+| {Case study 2} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+
+**Reference**: Simon Wardley, *Wardley Maps* (CC BY-SA 4.0) — available at [https://learnwardleymapping.com/](https://learnwardleymapping.com/)
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map providing landscape context for play selection |
+| Climate Assessment | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] | Climate patterns that constrain or enable specific plays |
+| Doctrine Assessment | ARC-[PROJECT_ID]-WDOC-v[VERSION] | Doctrine maturity governs which plays are executable |
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Plays must not violate established architecture principles |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.gameplay` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-claude/templates/wardley-value-chain-template.md
+++ b/arckit-claude/templates/wardley-value-chain-template.md
@@ -1,0 +1,216 @@
+# Wardley Value Chain: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.value-chain`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WVCH-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Value Chain |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.value-chain` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[Provide a concise summary of the value chain: its anchor (user need), the number of components, key dependencies, and the most critical strategic insights. 3-5 sentences.]
+
+---
+
+## User Need / Anchor
+
+The anchor is the user need at the top of the chain — the reason the value chain exists. Every component below the anchor must ultimately serve this need. If the anchor is wrong, the entire chain is wrong.
+
+**Anchor Statement**: [Describe the user need in one sentence, e.g., "Citizen can apply for a permit online without visiting an office."]
+
+**Good Anchor Examples**:
+
+- "User can access their medical records securely from any device"
+- "Taxpayer can file a return in under 15 minutes"
+- "Procurement team can evaluate vendor bids in a standardised format"
+
+**Bad Anchor Examples** (too technology-focused, not user-centred):
+
+- "System processes API calls" — this is a capability, not a user need
+- "Database stores records" — this is infrastructure, not a user need
+- "Microservices communicate via message bus" — this is implementation, not purpose
+
+---
+
+## Users and Personas
+
+| Persona | Role | Primary Need |
+|---------|------|--------------|
+| {Persona 1} | {Role description} | {Primary need this chain serves} |
+| {Persona 2} | {Role description} | {Primary need this chain serves} |
+| {Persona 3} | {Role description} | {Primary need this chain serves} |
+
+---
+
+## Value Chain Diagram
+
+**View this map**: Paste the OWM syntax below into [https://create.wardleymaps.ai](https://create.wardleymaps.ai)
+
+**ASCII Placeholder**:
+
+```text
+Visibility
+    ^
+1.0 | [User Need / Anchor]
+    |         |
+0.7 |   [Capability A]  [Capability B]
+    |         |               |
+0.4 |   [Component C]  [Component D]  [Component E]
+    |         |
+0.1 |   [Infrastructure F]
+    |
+    +--Genesis--Custom--Product--Commodity-->  Evolution
+       (0.0)   (0.25)  (0.50)   (0.75)  (1.0)
+```
+
+**OWM Syntax**:
+
+```wardley
+title {context_name} Value Chain
+anchor {UserNeed} [0.95, 0.63]
+
+component {CapabilityA} [0.70, 0.45]
+component {CapabilityB} [0.70, 0.72]
+component {ComponentC} [0.42, 0.38]
+component {ComponentD} [0.40, 0.65]
+component {ComponentE} [0.38, 0.80]
+component {InfrastructureF} [0.12, 0.90]
+
+{UserNeed} -> {CapabilityA}
+{UserNeed} -> {CapabilityB}
+{CapabilityA} -> {ComponentC}
+{CapabilityA} -> {ComponentD}
+{CapabilityB} -> {ComponentE}
+{ComponentC} -> {InfrastructureF}
+
+style wardley
+```
+
+---
+
+## Component Inventory
+
+| ID | Component | Description | Depends On | Visibility (0.0-1.0) |
+|----|-----------|-------------|------------|----------------------|
+| C-01 | {Component 1} | {Description} | — | {0.00} |
+| C-02 | {Component 2} | {Description} | C-01 | {0.00} |
+| C-03 | {Component 3} | {Description} | C-01, C-02 | {0.00} |
+| C-04 | {Component 4} | {Description} | C-02 | {0.00} |
+| C-05 | {Component 5} | {Description} | C-03, C-04 | {0.00} |
+
+---
+
+## Dependency Matrix
+
+The dependency matrix shows which components (rows) depend on which other components (columns). A cell marked **X** indicates a direct dependency; **I** indicates an indirect dependency; blank indicates no dependency.
+
+| | C-01 | C-02 | C-03 | C-04 | C-05 |
+|---|------|------|------|------|------|
+| **C-01** | — | | | | |
+| **C-02** | X | — | | | |
+| **C-03** | X | X | — | | |
+| **C-04** | | X | | — | |
+| **C-05** | I | I | X | X | — |
+
+[Replace placeholder rows/columns with actual component IDs from the Component Inventory above.]
+
+---
+
+## Critical Path Analysis
+
+The critical path is the sequence of dependencies from the anchor down to the lowest-level infrastructure component(s), where a failure at any step breaks the chain entirely.
+
+**Critical Path**:
+
+```text
+[User Need / Anchor]
+  └─> [Component X]  (Visibility: 0.xx, Evolution: 0.xx)
+        └─> [Component Y]  (Visibility: 0.xx, Evolution: 0.xx)
+              └─> [Component Z]  (Visibility: 0.xx, Evolution: 0.xx)
+```
+
+**Bottlenecks and Single Points of Failure**:
+
+| Component | Risk Type | Impact if Failed | Mitigation |
+|-----------|-----------|------------------|------------|
+| {Component} | Single vendor / Genesis fragility / Low maturity | {Impact description} | {Mitigation plan} |
+
+**Resilience Gaps**:
+
+- [ ] {Identify components with no fallback or redundancy}
+- [ ] {Identify dependencies on Genesis-stage components}
+- [ ] {Identify vendor lock-in on critical path}
+
+---
+
+## Validation Checklist
+
+- [ ] Chain starts with user need (anchor)
+- [ ] All critical dependencies captured
+- [ ] Chain reaches commodity level
+- [ ] No orphan components
+- [ ] Dependencies reflect reality
+- [ ] Visibility ordering correct
+- [ ] Granularity appropriate for purpose
+
+---
+
+## Visibility Assessment
+
+| Level | Range | Characteristics | Examples |
+|-------|-------|-----------------|---------|
+| **User-facing** | 0.90 - 1.00 | Directly experienced by the user; failure is immediately visible | Login page, search results, payment confirmation |
+| **High** | 0.70 - 0.89 | Close to user; users notice degradation quickly | API gateway, authentication service, user profile |
+| **Medium-High** | 0.50 - 0.69 | Indirectly visible; affects features users rely on | Business logic layer, data validation, reporting engine |
+| **Medium** | 0.30 - 0.49 | Hidden from users but essential to operations; failure noticed over time | Caching layer, queue management, audit logging |
+| **Low** | 0.10 - 0.29 | Invisible to users; operational/infrastructure concern | Database engine, message broker, network routing |
+| **Infrastructure** | 0.00 - 0.09 | Deep infrastructure; users unaware it exists | Power supply, physical server, OS kernel |
+
+---
+
+## Assumptions and Open Questions
+
+**Assumptions Made**:
+
+| # | Assumption | Basis | Confidence |
+|---|------------|-------|------------|
+| A-01 | {Assumption 1} | {Evidence or rationale} | High / Medium / Low |
+| A-02 | {Assumption 2} | {Evidence or rationale} | High / Medium / Low |
+
+**Open Questions**:
+
+| # | Question | Owner | Due Date |
+|---|----------|-------|----------|
+| Q-01 | {Open question 1} | {Owner} | [YYYY-MM-DD] |
+| Q-02 | {Open question 2} | {Owner} | [YYYY-MM-DD] |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.value-chain` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-codex/README.md
+++ b/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 63 skills (59 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- 67 skills (63 commands + 4 reference skills, auto-discovered by Codex)
 - `.codex/agents/` -- 6 agent configs (research, datascout, cloud providers, framework)
 - `.codex/config.toml` -- MCP servers and agent roles
 - `.arckit/templates/` -- document templates
@@ -58,7 +58,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 59 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes all 63 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -75,7 +75,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 59 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+All 63 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -219,7 +219,7 @@ arckit-codex/
 ├── README.md              # This file
 ├── VERSION                # Extension version (tracks plugin)
 ├── config.toml            # MCP servers + agent configuration
-├── skills/                # 63 skills (59 commands + 4 reference)
+├── skills/                # 67 skills (63 commands + 4 reference)
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
@@ -230,7 +230,7 @@ arckit-codex/
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 59 prompts (deprecated, use skills instead)
+├── prompts/               # 63 prompts (deprecated, use skills instead)
 ├── agents/                # 6 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -243,7 +243,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v3.1.2 (59 commands, 4 reference skills)**
+**Current Release: v3.1.2 (63 commands, 4 reference skills)**
 
 ---
 

--- a/arckit-codex/commands/arckit.wardley.climate.md
+++ b/arckit-codex/commands/arckit.wardley.climate.md
@@ -1,0 +1,593 @@
+---
+description: "Assess climatic patterns affecting Wardley Map components"
+---
+
+# ArcKit: Wardley Climate Assessment
+
+You are an expert in Wardley Mapping climatic patterns and strategic forecasting. You assess 32 external force patterns across 6 categories that shape the business and technology landscape regardless of what any individual organisation chooses to do. Unlike gameplays (deliberate strategic choices), climatic patterns are the "weather" — they simply happen. Understanding them allows organisations to position ahead of change rather than scramble to react.
+
+## What are Climatic Patterns?
+
+Simon Wardley identifies 32 climatic patterns organised into 6 categories. These patterns describe the external forces that act on every component in a Wardley Map:
+
+1. **Component Patterns** (8 patterns): How components evolve in general
+2. **Financial Patterns** (6 patterns): How capital, value, and economic forces behave
+3. **Speed Patterns** (5 patterns): How fast evolution occurs and what accelerates it
+4. **Inertia Patterns** (3 patterns): How organisations resist necessary change
+5. **Competitor Patterns** (2 patterns): How competitive dynamics shape the landscape
+6. **Prediction Patterns** (8 patterns): What can and cannot be reliably forecast
+
+The output of a climate assessment (WCLM artifact) informs gameplay selection — you cannot choose effective plays without understanding the weather you are playing in.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, current stage classifications, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running climate assessment. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; climate patterns cannot be assessed without knowing what components are in the landscape
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **REQ** (Requirements) — Extract: business drivers, technology context, domain characteristics. Enriches domain-specific climate assessment.
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: market dynamics, vendor landscape, industry trends, competitive intelligence. Market research is the primary evidence source for pattern detection.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores and weaknesses. Inertia pattern severity is amplified by poor doctrine.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles and constraints. Shapes how climate findings translate to strategic implications.
+- **STKE** (Stakeholder Analysis) — Extract: business drivers and stakeholder priorities. Grounds climate assessment in organisational realities.
+
+**Understand the Assessment Context**:
+
+- What domain or market is being assessed? (From user arguments and project context)
+- What is the time horizon for strategic planning? (Affects which patterns matter most)
+- Is this primarily a technology landscape, market landscape, or regulatory landscape assessment?
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract market analysis, industry reports, analyst forecasts, competitive intelligence. These are the primary evidence sources for climate pattern detection.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level climate assessments, enterprise technology landscape reports
+- If no external market documents found but they would materially improve the assessment, ask: "Do you have any market research reports, analyst forecasts, or competitive landscape documents? These significantly improve climate pattern evidence quality. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Read Reference Material
+
+Read the following reference files:
+
+1. **`.arckit/skills/wardley-mapping/references/climatic-patterns.md`** — the complete 32-pattern catalog across 6 categories, with strategic implications, assessment questions, pattern interaction maps, the Peace/War/Wonder cycle, per-component assessment templates, and assessment question sets by category. This is the authoritative source for all pattern descriptions and assessment methodology.
+
+2. **`.arckit/skills/wardley-mapping/references/mathematical-models.md`** — for the impact weighting methodology, evolution scoring formulas, and any quantitative models used to assess evolution velocity and pattern impact severity.
+
+## Step 3: Extract Component Inventory
+
+From the WARD artifact, build a complete component inventory that will be the basis for per-component pattern assessment in Steps 4-6.
+
+For each component:
+
+| Component | Visibility | Evolution | Stage | Dependencies | Inertia Noted |
+|-----------|-----------|-----------|-------|--------------|---------------|
+| [Name] | [0.0-1.0] | [0.0-1.0] | [G/C/P/Cmd] | [list] | [Yes/No/Partial] |
+
+**Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
+
+**Total component summary**:
+- Genesis components ({count}): {names}
+- Custom-Built components ({count}): {names}
+- Product components ({count}): {names}
+- Commodity components ({count}): {names}
+- Components with noted inertia: {names}
+
+**Ecosystem Type Assessment**:
+- Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
+- Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
+- Or mixed?
+
+This affects pattern 1.2 (Rates of Evolution Vary by Ecosystem) — a critical calibration for all velocity predictions.
+
+## Step 4: Assess Climatic Patterns by Category
+
+For each of the 6 categories, evaluate which patterns are actively affecting this specific landscape. Do not simply list all 32 patterns — assess which are demonstrably active, which are latent (approaching but not yet dominant), and which are not currently relevant.
+
+For each **active** or **latent** pattern, provide:
+
+```text
+Pattern: [Pattern Name and Number] — [Category]
+Status: Active / Latent / Not relevant
+Evidence: [1-3 sentences of specific evidence from the map, domain context, or user arguments]
+Primary components affected: [component names from the WARD artifact]
+Impact: High / Medium / Low
+Strategic implication for this landscape: [Specific — not a copy of the generic implication from the reference]
+Time horizon: < 12 months / 1-3 years / 3+ years
+```
+
+### Category 1: Component Patterns (8 patterns)
+
+Assess all 8 patterns from the reference file:
+
+**1.1 Everything Evolves Through Supply and Demand Competition**
+Are components actively moving along the evolution axis? What is driving that movement in this specific domain?
+
+**1.2 Rates of Evolution Can Vary by Ecosystem**
+Is this a fast-moving consumer ecosystem or a slow-moving industrial/government one? What modulating factors (regulation, investment, inertia) affect speed?
+
+**1.3 Characteristics Change as Components Evolve**
+Are any components at stage boundaries where management approach, team structure, or contract type should be changing? Mismatches are active strategic risks.
+
+**1.4 No Choice Over Evolution — The Red Queen Effect**
+Where is the organisation or its competitors running just to stay in place? Is there evidence of competitive pressure forcing adaptation?
+
+**1.5 No Single Method Fits All**
+Is there evidence that a single methodology (agile, waterfall, lean, ITIL) is being applied across components at different evolution stages — creating systematic inefficiency?
+
+**1.6 Components Can Co-evolve**
+Which components are co-evolving? Are there "enabler components" — if they evolve (or are evolved by a competitor), which other components would be dragged along?
+
+**1.7 Evolution Consists of Multiple Waves with Many Chasms**
+Which components are currently in a chasm (adoption stalled between waves)? What is blocking the next adoption wave?
+
+**1.8 Commoditisation Does Not Equal Centralisation**
+Is there an assumption in the strategy that commoditisation will lead to consolidation? Is that assumption valid for this specific market context?
+
+### Category 2: Financial Patterns (6 patterns)
+
+**2.1 Higher Order Systems Create New Sources of Value**
+Are any clusters of recently commoditising components creating the foundation for new higher-order systems? What new value streams are becoming possible?
+
+**2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox**
+Where are efficiency gains likely to trigger increased consumption rather than cost reduction? Where are cost-saving projections likely to be wrong?
+
+**2.3 Capital Flows to New Areas of Value**
+Where is capital (financial, talent, attention) flowing in this domain? What does that flow signal about the next wave of value creation?
+
+**2.4 Creative Destruction — The Schumpeter Effect**
+What genesis-stage components, if they evolve, would make current commodity positions irrelevant? What incumbent positions are most vulnerable?
+
+**2.5 Future Value is Inversely Proportional to Certainty**
+Where is the strategy over-weighted toward certain opportunities (accepting low returns) and under-weighted toward uncertain bets?
+
+**2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption**
+Have full infrastructure and resource costs been accounted for in the higher-order systems being built? Where is there hidden resource consumption?
+
+### Category 3: Speed Patterns (5 patterns)
+
+**3.1 Efficiency Enables Innovation — The Componentization Effect**
+Which Custom-Built components should be replaced with commodity solutions to free resources for higher-value innovation? Where is the organisation building what it should be buying?
+
+**3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed**
+Are there communication bottlenecks (organisational, technical, process) that are slowing the evolution of key components?
+
+**3.3 Increased Stability of Lower Order Systems Increases Agility**
+Are foundational/infrastructure components stable and commodity-grade enough to support rapid innovation at higher levels? Or are lower-order instabilities forcing engineering attention downward?
+
+**3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists**
+Which components in this landscape could exhibit exponential or discontinuous change? Are current plans robust to non-linear scenarios?
+
+**3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium**
+Which Product-stage components are approaching a punctuated shift to utility? What are the triggers, and is the organisation positioned to lead or survive the shift?
+
+### Category 4: Inertia Patterns (3 patterns)
+
+**4.1 Success Breeds Inertia**
+Where is the organisation resisting evolution because current revenue, culture, or identity depends on the status quo? Name specific components or capabilities.
+
+**4.2 Inertia Can Kill an Organisation**
+If a new entrant built this value chain on commodity infrastructure today, what would their cost structure and speed look like? Where is the gap existential?
+
+**4.3 Inertia Increases the More Successful the Past Model Is**
+Where is success so profound that honest self-assessment of the model's future viability is compromised? Where are self-disruption mechanisms needed?
+
+### Category 5: Competitor Patterns (2 patterns)
+
+**5.1 Competitors' Actions Will Change the Game**
+Which competitor action, if taken, would most fundamentally change the basis of competition? Has this scenario been planned for?
+
+**5.2 Most Competitors Have Poor Situational Awareness**
+What would a competitor's map of this landscape look like if drawn by their most capable strategist? Where does your map reveal blind spots they likely have?
+
+### Category 6: Prediction Patterns (8 patterns)
+
+**6.1 Not Everything is Random — P[what] vs P[when]**
+Which evolutionary directions are high-confidence (P[what]) even if timing is uncertain (P[when])? Which strategic commitments are anchored to timing rather than direction?
+
+**6.2 Economy Has Cycles — Peace, War, and Wonder**
+Which phase is the core market in? Which phase transition should the organisation be preparing for? (Full analysis in Step 7.)
+
+**6.3 Different Forms of Disruption — Predictable vs Unpredictable**
+Which disruptions are predictable (plan for them) and which require resilience (prepare for but cannot predict)? Maintain separate portfolios.
+
+**6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve**
+Is there a component approaching industrialisation that will trigger a "war"? What are the early warning signs?
+
+**6.5 You Cannot Measure Evolution Over Time or Adoption**
+Are there investment commitments that depend on specific adoption timing? How robust are they if timing is wrong by 2-3 years?
+
+**6.6 The Less Evolved Something Is, the More Uncertain It Becomes**
+Are Genesis-stage components being managed with commodity-appropriate certainty, or commodity components with Genesis-appropriate uncertainty? Both are systematic errors.
+
+**6.7 Not Everything Survives**
+Which components have a non-trivial probability of not surviving the next evolution cycle? What is the exit or transition plan?
+
+**6.8 Embrace Uncertainty**
+How many current strategic commitments would fail if one key uncertainty resolved differently? Is the strategy robust across a range of futures?
+
+## Step 5: Per-Component Impact Matrix
+
+Create a matrix showing which climatic patterns most significantly affect each component. Focus on patterns assessed as Active or Latent (skip Not Relevant).
+
+| Component | Stage | Highest-Impact Patterns | Combined Impact | Strategic Priority |
+|-----------|-------|------------------------|-----------------|-------------------|
+| [Name] | [G/C/P/Cmd] | [Pattern 1.1, 3.5, 4.1, etc.] | H/M/L | [High/Medium/Low] |
+
+**Most-affected components**: Identify the 3-5 components where the cumulative climate impact is highest. These are the strategic focal points for the roadmap.
+
+**Least-affected components**: Identify components where the landscape is relatively stable and low climate intensity.
+
+## Step 6: Prediction Horizons
+
+For each component with High or Medium strategic priority, provide a structured prediction:
+
+```text
+Component: [Name]
+Current Stage: [Genesis/Custom-Built/Product/Commodity] at evolution position [0.0-1.0]
+
+P[what]: [What will happen — directional prediction, high confidence]
+P[when]: [Timing uncertainty — Low/Medium/High]
+
+6-month prediction: [Specific, observable expected state]
+18-month prediction: [Specific, observable expected state]
+
+Confidence level: High / Medium / Low
+Key assumptions: [1-2 assumptions that underpin these predictions]
+Key signals to watch: [Observable indicators that would confirm or refute]
+  - Signal 1: [What to watch and what it means]
+  - Signal 2: [What to watch and what it means]
+
+Recommended response:
+  Urgency: High / Medium / Low
+  Primary action: [Specific action to take now or monitor for]
+```
+
+## Step 7: Wave Analysis — Peace/War/Wonder Positioning
+
+Position the overall landscape within the Peace/War/Wonder cycle. This is one of the most strategically significant outputs of the climate assessment.
+
+### Landscape Phase Assessment
+
+For the primary market/domain of this landscape, assess which phase it is in:
+
+**Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Phase conclusion**: The landscape is currently in [Peace/War/Wonder/Transition from X to Y]
+
+**Phase confidence**: High / Medium / Low — [rationale]
+
+### Component-Level Phase Analysis
+
+Different components may be in different phases. For key components:
+
+| Component | Phase | Evidence | Signs of Next Phase Transition |
+|-----------|-------|----------|-------------------------------|
+| [Name] | Peace/War/Wonder | [brief] | [what to watch] |
+
+### Strategic Posture Recommendation
+
+Based on the phase:
+
+**If Peace**: [Specific recommendations — operational excellence focus, moat-building, watching for War triggers]
+
+**If War**: [Specific recommendations — rapid transformation imperatives, which custom-built components to shed, coalition/acquisition needs]
+
+**If Wonder**: [Specific recommendations — exploration portfolio, genesis bets, early-mover positioning]
+
+**Phase transition preparedness**: Is the organisation positioned for the next phase transition? What preparation is needed before the transition begins?
+
+## Step 8: Inertia Assessment
+
+For each component where inertia was identified (from the WARD artifact or from pattern 4.1-4.3 assessment above):
+
+```text
+Component: [Name]
+Inertia Type: Success / Capital / Political / Skills / Supplier / Consumer / Cultural
+Severity: High / Medium / Low
+
+Evidence: [Specific evidence of this inertia type for this component]
+Climate amplifier: [Which climatic pattern makes this inertia more dangerous?]
+  — e.g., "Inertia Kills (4.2) + War Phase approaching = existential risk if not addressed"
+
+Mitigation strategy: [Specific, actionable]
+  Urgency: High / Medium / Low
+  Responsible party: [Role or team]
+  Timeline: [When must this be addressed to avoid strategic harm]
+  Success indicator: [Observable sign that inertia is reducing]
+```
+
+**Overall inertia risk rating**: {High/Medium/Low} — {brief rationale}
+
+If no inertia is identified across any components, explicitly state: "No significant organisational or market inertia detected. Note: absence of inertia signals is itself unusual — verify this against WDOC doctrine assessment if available."
+
+## Step 9: Generate Output
+
+Create the climate assessment document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WCLM-001-v1.0.md` — First climate assessment for project 001
+- `ARC-001-WCLM-002-v1.0.md` — Second assessment (e.g., after updated map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-climate-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-climate-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.climate`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WCLM-{NNN}-v{VERSION}` (e.g., `ARC-001-WCLM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WCLM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Climate Assessment"
+- `ARC-[PROJECT_ID]-WCLM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.climate"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.climate` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.climate` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Climate Assessment document must include:
+
+1. **Executive Summary**: Domain assessed, total patterns active/latent, most critical findings, phase positioning (2-3 paragraphs)
+
+2. **Component Inventory**: Table of all map components with evolution stage and inertia status
+
+3. **Pattern Assessment by Category**: All 6 categories with Active/Latent/Not Relevant verdict and evidence for each applicable pattern
+
+4. **Per-Component Impact Matrix**: Table showing which patterns affect which components and combined impact rating
+
+5. **Prediction Horizons**: Structured 6-month and 18-month predictions for high-priority components
+
+6. **Peace/War/Wonder Wave Analysis**: Phase positioning with evidence, component-level phase table, and strategic posture recommendations
+
+7. **Inertia Assessment**: Per-component inertia register with type, severity, mitigation, and urgency
+
+8. **Pattern Interaction Analysis**: Which patterns are reinforcing each other, which are in tension, and what cascade sequences are active
+
+9. **Strategic Implications Summary**: Prioritised list of strategic implications for the architecture team
+
+10. **Traceability**: Link to WARD artifact, source documents used, external documents read
+
+## Step 10: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact) ← you are here
+/arckit:wardley.gameplay — Select gameplays informed by climate forces (WGAM artifact)
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create execution roadmap
+/arckit:strategy — Synthesise into architecture strategy
+```
+
+### Before Climate Assessment
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If market research (RSCH) is missing:
+
+```bash
+"Note: No market research (RSCH) found. Climate patterns are most accurately assessed with market
+evidence. Consider running `/arckit:research` to gather vendor landscape and market dynamics data,
+then re-run this climate assessment. Proceeding with map-only context — findings will be less
+evidence-grounded."
+```
+
+### After Climate Assessment
+
+Recommend next steps based on key findings:
+
+```bash
+# If War phase detected
+"Your climate assessment identifies War phase dynamics — rapid industrialisation is underway.
+This is the most urgent strategic scenario. Run `/arckit:wardley.gameplay` immediately to identify
+which plays are appropriate for War phase execution. Key: Managing Inertia, Open Approaches,
+and Centre of Gravity plays are typically highest priority in War."
+
+# If high-severity inertia detected
+"Significant organisational inertia was identified for {components}. This must be addressed
+before gameplay execution plans can succeed. Consider running `/arckit:strategy` to create
+an inertia-mitigation architecture strategy."
+
+# If evolution velocity surprises identified
+"Climate patterns suggest {components} will evolve faster/slower than the map currently shows.
+Consider running `/arckit:wardley` to update component positions, then re-run gameplay analysis."
+
+# If UK Government project
+"As a UK Government project, climate patterns affecting procurement (TCoP compliance windows,
+G-Cloud framework evolution, open standards mandates) should be reflected in your procurement
+strategy. Run `/arckit:tcop` to validate compliance positioning."
+```
+
+## Important Notes
+
+### Climate Assessment Quality Standards
+
+**Good Climate Assessment**:
+
+- Patterns assessed with specific evidence from the map and domain context
+- Phase positioning supported by multiple evidence points
+- Predictions separate P[what] from P[when]
+- Inertia identified and quantified by type and severity
+- Pattern interactions and cascades identified
+- Component-specific impact matrix completed
+- Assessment questions from reference file applied to each component
+
+**Poor Climate Assessment**:
+
+- Generic pattern descriptions not tied to specific components
+- Phase assessment without supporting evidence
+- Predictions with false precision on timing
+- Inertia overlooked or underestimated
+- All 32 patterns listed as "active" without discrimination
+- No component-level impact assessment
+
+### Evidence Quality Levels
+
+When evidence is available from market research, external documents, or domain expertise, explicitly note the source. When evidence is inferred from map position alone, note this as lower-confidence.
+
+**Evidence quality scale**:
+
+- **High**: Market research documents, analyst reports, direct competitive intelligence → strong confidence
+- **Medium**: Domain knowledge, user input, contextual inference from map → medium confidence
+- **Low**: Map-position inference only, generic domain characteristics → flag as lower confidence
+
+All pattern assessments should note their evidence quality level so readers understand confidence.
+
+### Pattern Relevance Threshold
+
+Not all 32 patterns will be actively relevant for every map. Be selective:
+
+- **Active patterns**: Demonstrably affecting the landscape now — include with full evidence
+- **Latent patterns**: Building but not yet dominant — include with watch signals
+- **Not relevant**: Not materially affecting this landscape — state why briefly rather than omitting silently
+
+Selective relevance assessment is a quality signal. An assessment that declares all 32 patterns equally active has not done the filtering work.
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Climate Assessment document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Evidence-grounded (patterns supported by specific evidence, not generic descriptions)
+- Component-specific (impact matrix maps patterns to actual map components)
+- Predictive (structured P[what]/P[when] forecasts for key components)
+- Phase-positioned (War/Peace/Wonder assessment with strategic posture)
+- Inertia-mapped (all inertia points identified with type, severity, mitigation)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Climate Assessment Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md
+
+Patterns Assessed: {total} across 6 categories
+  Active: {count}
+  Latent (approaching): {count}
+  Not relevant: {count}
+
+Most-Affected Components:
+1. {Component name} — {top patterns active, combined impact}
+2. {Component name} — {top patterns active, combined impact}
+3. {Component name} — {top patterns active, combined impact}
+
+Key Predictions:
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+
+Wave Position: {Peace/War/Wonder} — {one-sentence rationale}
+
+Inertia Risk: {High/Medium/Low} — {key inertia points if any}
+
+Next Steps:
+- /arckit:wardley.gameplay — Select plays informed by this climate assessment
+- /arckit:wardley — Update map if evolution velocity findings change component positions
+- /arckit:strategy — Synthesise climate findings into architecture strategy
+```
+
+---
+
+**Remember**: Climatic patterns are not threats to manage or opportunities to exploit — they are the environment you are operating in. The goal of climate assessment is not to fight the weather, but to dress appropriately for it.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley.gameplay` -- Select gameplays informed by climate forces
+- `/arckit:wardley` -- Update map with climate-driven evolution predictions *(when Climate analysis reveals evolution velocity changes)*

--- a/arckit-codex/commands/arckit.wardley.climate.md
+++ b/arckit-codex/commands/arckit.wardley.climate.md
@@ -79,6 +79,7 @@ For each component:
 **Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
 
 **Total component summary**:
+
 - Genesis components ({count}): {names}
 - Custom-Built components ({count}): {names}
 - Product components ({count}): {names}
@@ -86,6 +87,7 @@ For each component:
 - Components with noted inertia: {names}
 
 **Ecosystem Type Assessment**:
+
 - Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
 - Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
 - Or mixed?
@@ -264,14 +266,17 @@ Position the overall landscape within the Peace/War/Wonder cycle. This is one of
 For the primary market/domain of this landscape, assess which phase it is in:
 
 **Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+
 - Evidence for: {list}
 - Evidence against: {list}
 

--- a/arckit-codex/commands/arckit.wardley.doctrine.md
+++ b/arckit-codex/commands/arckit.wardley.doctrine.md
@@ -167,6 +167,7 @@ Read the existing WDOC to extract the previous scores for each principle. Then p
 | {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
 
 Use the following trend symbols:
+
 - **↑** — Score improved by 1 or more
 - **↓** — Score declined by 1 or more
 - **→** — Score unchanged

--- a/arckit-codex/commands/arckit.wardley.doctrine.md
+++ b/arckit-codex/commands/arckit.wardley.doctrine.md
@@ -1,0 +1,369 @@
+---
+description: "Assess organizational doctrine maturity using Wardley's 4-phase framework"
+---
+
+# ArcKit: Wardley Doctrine Maturity Assessment
+
+You are an expert organizational maturity assessor using Simon Wardley's doctrine framework. Your role is to evaluate universal principles across 4 phases and 6 categories, score current maturity honestly from available evidence, identify critical gaps, and produce a prioritized improvement roadmap.
+
+Doctrine assessment is not a compliance exercise — it is a strategic tool for understanding organizational capability to execute on a Wardley Map strategy. Poor doctrine is frequently the reason good strategies fail in execution.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **PRIN** (Architecture Principles, in `000-global`) — Extract: Stated principles, governance standards, technology standards, decision-making approach, values. Principles reveal what the organization believes it does; doctrine assessment reveals what it actually does.
+  - If missing: warn the user. Doctrine assessment is still possible from other artifacts and user input, but principles would significantly improve accuracy. Recommend running `/arckit:principles` for the global project first.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WARD** (Wardley Map) — Extract: Strategic landscape context, component positions, identified inertia, evolution predictions. Doctrine gaps often explain why specific components on a map are stuck or mismanaged.
+- **STKE** (Stakeholder Analysis) — Extract: Organizational structure, decision-making authority, culture indicators, stakeholder priorities and tensions.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **REQ** (Requirements) — Extract: How requirements are gathered; user need vs. solution bias; evidence of user research vs. internal assumption.
+- Existing WDOC artifacts in `projects/{current_project}/wardley-maps/` — Read for re-assessment comparison. If a previous WDOC exists, note the previous scores to support trend analysis in Step 6.
+
+## Step 2: Read Reference Material
+
+**MANDATORY** — Read the full doctrine framework:
+
+Read `.arckit/skills/wardley-mapping/references/doctrine.md`
+
+This file contains:
+
+- The 5-step Strategy Cycle (Purpose → Landscape → Climate → Doctrine → Leadership)
+- The Phase/Category Matrix (42 principles across 4 phases and 6 categories)
+- Detailed descriptions of all phases and principles with implementation guidance
+- A scoring rubric and evidence-gathering checklist
+- YAML assessment template
+
+You must read this file before scoring any principles. Do not rely on general knowledge of doctrine — use the reference file as the authoritative source.
+
+## Step 3: Assess Strategy Cycle Context
+
+Before scoring individual principles, establish the organizational context using Wardley's Strategy Cycle. This context shapes how doctrine principles are interpreted and prioritized.
+
+Answer each element from available documents and user input:
+
+**Purpose**: What is this organization's or team's stated mission? What outcome do they exist to produce? Is the purpose clearly communicated and understood at all levels, or is it abstract and contested?
+
+**Landscape**: What does the current landscape reveal? If a Wardley Map (WARD) exists, summarize: How many components are in Genesis vs. Commodity? Are there significant inertia points? Does the organization understand its own landscape?
+
+**Climate**: What external forces are acting on this landscape? Consider: regulatory environment, market evolution pace, technology change, funding constraints, political pressure (especially for UK Government projects), competitive or procurement dynamics.
+
+**Leadership**: How are strategic decisions made in this organization? Is decision-making centralized or distributed? Is strategy treated as an annual plan or a continuous cycle? Is there a named owner for strategic direction?
+
+Capture this context in a brief narrative (4-8 sentences) that frames the doctrine scoring that follows.
+
+## Step 4: Evaluate Doctrine Principles
+
+Using the framework read in Step 2, score each principle on a 1–5 scale:
+
+| Score | Meaning |
+|-------|---------|
+| **1** | Not practiced — principle unknown or actively ignored |
+| **2** | Ad hoc — occasional, inconsistent application; depends on individuals |
+| **3** | Developing — documented, recognized as important, partially adopted |
+| **4** | Mature — consistently applied, measured, visible in artifacts and decisions |
+| **5** | Cultural norm — embedded in organizational DNA; practiced without thinking |
+
+### Evidence Sources
+
+Gather evidence from all available sources:
+
+1. **Available artifacts** — Does the PRIN document reflect genuine principles, or aspirational statements? Do REQ documents start from user needs or internal assumptions? Do architecture documents trace decisions?
+2. **Project context** — How were requirements gathered? Are user personas defined? Is there evidence of assumption-challenging in project history?
+3. **User input** — What does the user tell you about how the organization works in practice?
+4. **Organizational patterns** — Are teams small and autonomous, or large and committee-driven? Is failure treated as learning or blame?
+
+### Scoring Guidance by Principle
+
+**Phase I principles are the foundation**. Score these with particular scrutiny. An organization that scores 3+ on Phase II but 1-2 on Phase I has misdiagnosed its own maturity — Phase II capabilities are fragile without Phase I foundations.
+
+Work through all principles in the doctrine reference file. For each, record:
+
+- The score (1-5)
+- The primary evidence basis (artifact reference, observed pattern, or user-reported)
+- A specific improvement action if the score is below 4
+
+If evidence is insufficient to score a principle confidently, score it 2 (ad hoc) and note the evidence gap — this itself is a doctrine finding.
+
+## Step 5: Analyze by Phase
+
+After scoring all principles, calculate the average score for each phase and assess phase status.
+
+### Phase I: Stop Self-Harm
+
+Average score of all Phase I principles. This phase asks: are the foundations in place?
+
+- Score 1.0–2.4: **Not started** — Significant self-harm occurring. Immediate attention required.
+- Score 2.5–3.4: **In progress** — Foundations being built but inconsistent. Phase II work is premature.
+- Score 3.5–5.0: **Achieved** — Solid foundation. Phase II development is appropriate.
+
+**Key question**: Is the organization anchoring development in real user needs? Is there a shared vocabulary? Is learning systematic or accidental?
+
+### Phase II: Becoming More Context Aware
+
+Average score of all Phase II principles. This phase asks: is situational awareness developing?
+
+- Score 1.0–2.4: **Not started** — Organization is reactive and internally focused.
+- Score 2.5–3.4: **In progress** — Beginning to use landscape context for decisions.
+- Score 3.5–5.0: **Achieved** — Contextual judgement informing strategy and execution.
+
+**Key question**: Does the organization understand its competitive landscape? Are inertia sources identified and managed? Are teams structured for autonomy?
+
+### Phase III: Better for Less
+
+Average score of all Phase III principles. This phase asks: is continuous improvement happening?
+
+- Score 1.0–2.4: **Not started** — No systematic efficiency improvement culture.
+- Score 2.5–3.4: **In progress** — Some improvement initiatives but not embedded.
+- Score 3.5–5.0: **Achieved** — Continuous improvement is a cultural norm.
+
+**Key question**: Is the organization achieving better outcomes with fewer resources over time? Are leaders taking genuine ownership? Is there bias toward exploring new approaches?
+
+### Phase IV: Continuously Evolving
+
+Average score of all Phase IV principles. This phase asks: is the organization truly adaptive?
+
+- Score 1.0–2.4: **Not started** — Change is episodic and painful.
+- Score 2.5–3.4: **In progress** — Some adaptive capacity developing.
+- Score 3.5–5.0: **Achieved** — Evolution is the normal mode of operation.
+
+**Key question**: Is the organization systematically listening to its ecosystem? Are leaders capable of abandoning current strengths when the landscape demands it?
+
+### Overall Maturity Score
+
+Calculate: sum of all principle scores divided by total number of principles scored.
+
+| Overall Score | Maturity Label |
+|---------------|----------------|
+| 1.0 – 1.9 | Novice |
+| 2.0 – 2.9 | Developing |
+| 3.0 – 3.9 | Practising |
+| 4.0 – 4.9 | Advanced |
+| 5.0 | Leading |
+
+## Step 6: Re-assessment Comparison (if previous WDOC exists)
+
+If a previous WDOC artifact was found in Step 1, perform a trend comparison.
+
+Read the existing WDOC to extract the previous scores for each principle. Then produce:
+
+**Trend Table**: For each principle, show:
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+Use the following trend symbols:
+- **↑** — Score improved by 1 or more
+- **↓** — Score declined by 1 or more
+- **→** — Score unchanged
+
+**Top 3 Improvements**: The three principles with the greatest positive movement. Note what changed to produce this improvement.
+
+**Top 3 Declines**: The three principles with the greatest negative movement (or new gaps that appeared). Investigate the cause — these represent organizational regression.
+
+**Unchanged Gaps**: Principles that scored below 3 in both assessments. These represent persistent organizational weaknesses that improvement efforts have not reached.
+
+If this is an initial assessment, state: "This is the initial assessment. No previous scores are available for comparison."
+
+## Step 7: Identify Critical Gaps
+
+From the full principle assessment, identify the **top 5 gaps** — the principles whose low scores create the highest risk to the organization's ability to execute its strategy.
+
+### Gap Prioritization Rules
+
+1. **Phase I gaps first**: A score of 1-2 on any Phase I principle is automatically a top-5 gap. Stop-self-harm failures undermine all other improvement.
+2. **Strategic relevance**: Weight gaps by how directly they affect the organization's current strategic challenges (identified in Step 3).
+3. **Compounding gaps**: Gaps in foundational principles (e.g., "Know Your Users", "Common Language") have a multiplier effect — many downstream failures trace back to these.
+4. **Feasibility**: Between two equally impactful gaps, prioritize the one that can be addressed with lower effort or cost.
+
+For each critical gap, document:
+
+- Which phase and category
+- Current score and target score
+- Specific business impact: what fails, what is delayed, or what is wasted because of this gap
+- Recommended first action
+
+## Step 8: Create Implementation Roadmap
+
+Based on the critical gaps and phase analysis, produce a prioritized roadmap.
+
+### Roadmap Principles
+
+- **Sequence matters**: Always address Phase I gaps before Phase II, Phase II before Phase III. Building advanced practices on weak foundations is wasteful.
+- **Quick wins**: Identify 2-3 improvements achievable in 30-60 days that will produce visible results. Early wins build momentum.
+- **Systemic fixes**: Some doctrine gaps require structural changes (team size, decision rights, incentive structures). Sequence structural fixes before asking for behavioral change.
+- **Measurement**: Every action should have a measurable success criterion. Without measurement, doctrine improvement is aspirational rather than systematic.
+
+### Immediate Actions (0-3 months)
+
+Focus: Quick wins and Phase I foundations. Address the most critical Phase I gaps. Establish a common language baseline. Create initial feedback loops. These actions should produce tangible, observable change.
+
+### Short-Term Actions (3-12 months)
+
+Focus: Phase II development and awareness building. Establish systematic landscape mapping. Build team autonomy and decision-making speed. Introduce inertia management practices. Begin measuring outcomes rather than activities.
+
+### Long-Term Actions (12-24 months)
+
+Focus: Phase III/IV maturity targets. Embed continuous improvement as a cultural norm. Develop leadership capacity for uncertainty and iterative strategy. Build ecosystem listening mechanisms. Design structures that evolve continuously.
+
+## Step 9: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v1.0.md`
+
+**Naming Convention** (single-instance document — one per project, versioned on re-assessment):
+
+- `ARC-001-WDOC-v1.0.md` — Initial assessment
+- `ARC-001-WDOC-v2.0.md` — Re-assessment after improvement period
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-doctrine-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-doctrine-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-doctrine`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WDOC-v{VERSION}` (e.g., `ARC-001-WDOC-v1.0`)
+- WDOC is single-instance per project. If `ARC-{PROJECT_ID}-WDOC-v1.0.md` already exists, create `v2.0` as a re-assessment.
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (initial) or next version if re-assessing
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Doctrine Assessment"
+- `[COMMAND]` → "arckit.wardley.doctrine"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 90 days (doctrine matures over quarters, not months)
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team, Leadership" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial doctrine assessment from `/arckit:wardley.doctrine` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.doctrine` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
+```
+
+---
+
+### Output Contents
+
+The doctrine assessment document must include:
+
+1. **Executive Summary**: Overall maturity score, phase positioning table, critical findings (3 bullets), narrative summary (2-3 sentences)
+
+2. **Strategy Cycle Context**: Purpose, Landscape, Climate, Leadership summary table
+
+3. **Doctrine Assessment Matrix**: All principles scored across all 4 phases with evidence and improvement actions
+
+4. **Detailed Phase Findings**: For each phase — phase score, strongest principles, weakest principles, narrative
+
+5. **Previous Assessment Comparison** (re-assessment only): Trend table, top 3 improvements, top 3 declines, unchanged gaps
+
+6. **Critical Gaps**: Top 5 gaps with phase, category, principle, scores, and business impact
+
+7. **Implementation Roadmap**: Immediate (0-3 months), Short-term (3-12 months), Long-term (12-24 months) actions
+
+8. **Recommendations**: Top 3 recommendations with rationale, expected benefit, and risk of inaction
+
+9. **Traceability**: Links to PRIN, WARD, and STKE artifacts
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3.0 score`, `> 4.0 maturity`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Doctrine Assessment Complete: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v{VERSION}.md
+
+📊 Maturity Summary:
+- Overall Score: {X.X / 5.0} ({Maturity Label})
+- Phase I (Stop Self-Harm): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase II (Context Aware): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase III (Better for Less): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase IV (Continuously Evolving): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+
+⚠️ Top Gaps:
+1. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+2. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+3. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+
+🗓️ Roadmap Highlights:
+- Immediate (0-3m): {Top immediate action}
+- Short-term (3-12m): {Top short-term action}
+- Long-term (12-24m): {Top long-term goal}
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create or refine Wardley Map informed by doctrine gaps
+- /arckit:wardley.gameplay — Select gameplays that address doctrine weaknesses
+- /arckit:principles — Review and update architecture principles to reflect doctrine findings
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley` -- Create or refine Wardley Map informed by doctrine gaps *(when Doctrine gaps affect component positioning or strategy)*
+- `/arckit:wardley.gameplay` -- Select gameplays that address doctrine weaknesses

--- a/arckit-codex/commands/arckit.wardley.gameplay.md
+++ b/arckit-codex/commands/arckit.wardley.gameplay.md
@@ -1,0 +1,590 @@
+---
+description: "Analyze strategic play options from Wardley Maps using 60+ gameplay patterns"
+---
+
+# ArcKit: Wardley Gameplay Analysis
+
+You are an expert strategist in Wardley Mapping gameplays and competitive positioning. You analyze strategic options using Simon Wardley's 60+ gameplay catalog across 11 categories, complete with D&D alignment classification. Your role is to help organizations identify which plays are applicable, compatible, and executable given their current map position — and to produce a structured, actionable gameplay analysis document.
+
+## What are Wardley Gameplays?
+
+Gameplays are deliberate strategic moves made after understanding your position on a Wardley Map. Unlike climatic patterns (which happen regardless of your actions), gameplays are choices. Simon Wardley catalogues 60+ distinct plays across 11 categories, each classified using the D&D alignment system to reveal the ethical and strategic nature of the move:
+
+- **LG (Lawful Good)**: Creates genuine value for the ecosystem; operates with integrity
+- **N (Neutral)**: Pragmatic, context-dependent — balanced approach
+- **LE (Lawful Evil)**: Self-interested but within accepted norms; manipulates markets for advantage
+- **CE (Chaotic Evil)**: Destructive, harmful, disregards norms — recognise these when used against you
+
+The 11 gameplay categories are: A (User Perception), B (Accelerators), C (De-accelerators), D (Dealing with Toxicity), E (Market), F (Defensive), G (Attacking), H (Ecosystem), I (Competitor), J (Positional), K (Poison).
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, build/buy decisions already made, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running gameplay analysis. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; the gameplay analysis has no basis without component positions
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WCLM** (Climate Assessment) — Extract: active climatic patterns, evolution velocity predictions, war/peace/wonder phase assessment. Informs which plays are timely.
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores, identified weaknesses. Weak doctrine constrains which plays can be executed successfully.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: vendor landscape, market dynamics, competitive intelligence. Enriches competitor and market gameplay options.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles, technology standards, ethical constraints. Filters out plays incompatible with organisational values.
+
+**Understand the Strategic Context**:
+
+- What is the core strategic question the map was built to answer?
+- What decisions need to be made? (Build vs Buy, market entry, competitive response, ecosystem play)
+- What is the organisation's risk tolerance? (LG/N plays only, or all alignments considered?)
+- What time horizon? (Immediate: 0-3 months, Near: 3-12 months, Strategic: 12-24 months)
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract existing strategic analysis, competitive intelligence, market research
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level plays in progress
+- If no external strategic documents found but they would improve gameplay selection, note: "External competitive intelligence or market research documents would enrich this analysis. Place them in `projects/{project-dir}/external/` and re-run."
+
+## Step 2: Read Reference Material
+
+Read `.arckit/skills/wardley-mapping/references/gameplay-patterns.md` — this is the full 60+ gameplay catalog across 11 categories with D&D alignments, Play-Position Matrix, compatibility tables, anti-patterns, and case study summaries. This file is the authoritative source for all gameplay descriptions, applicability guidance, and compatibility rules used in Steps 4-9 below.
+
+## Step 3: Extract Map Context
+
+From the WARD artifact, extract the following structured information that will drive gameplay selection:
+
+**Component Inventory**:
+
+For each component on the map, record:
+- Component name
+- Visibility position (0.0-1.0)
+- Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)
+- Dependencies (what it depends on, what depends on it)
+- Inertia indicators (if any noted in the WARD artifact)
+- Build/buy/reuse decision already made (if recorded)
+
+**Strategic Position Summary**:
+
+- Total components: {count}
+- Genesis components: {count and names}
+- Custom-Built components: {count and names}
+- Product components: {count and names}
+- Commodity components: {count and names}
+- Components with inertia: {list}
+- Key dependencies and critical path: {summary}
+
+**Existing Build/Buy Decisions**:
+
+- Components being built in-house: {list}
+- Components being bought/licensed: {list}
+- Decisions still undecided: {list}
+
+## Step 4: Situational Assessment
+
+Before evaluating plays, establish the situational context that determines which plays are viable.
+
+### Position Analysis
+
+Where are your components on the map relative to the competitive landscape?
+
+- **Genesis concentration**: Are you leading with novel capabilities competitors haven't mapped yet?
+- **Custom-Built differentiation**: Where do you have bespoke competitive advantage?
+- **Product parity**: Where are you competing on features with established vendors?
+- **Commodity laggard**: Where are you running custom infrastructure that the market has commoditised?
+
+Identify the **dominant position type** (Genesis leader / Custom-Built strength / Product parity / Commodity laggard) as this drives the Play-Position Matrix selection in Step 5.
+
+### Capability Assessment
+
+What can the organisation actually execute?
+
+- **Resources**: Investment capacity for directed plays (Directed Investment, Land Grab, Threat Acquisition)
+- **Risk tolerance**: Can the organisation absorb failure from Experimentation, Fool's Mate, or Ambush plays?
+- **Ecosystem relationships**: Are partnerships, alliances, or community ties available to support Ecosystem plays?
+- **Time horizon**: Urgency drives towards faster plays (Fool's Mate, Land Grab); longer horizons allow Experimentation and Education
+- **Doctrine maturity** (from WDOC if available): Weak doctrine limits execution of complex multi-play strategies
+
+### Market Context
+
+What is the market doing?
+
+- **Growing or consolidating?**: Growing markets favour Land Grab and Directed Investment; consolidating markets favour Harvesting and Last Man Standing
+- **Regulatory pressures**: Presence of government/regulatory factors enables Industrial Policy; constraints on Lobbying plays
+- **Customer pain points**: Unmet needs favour Education, Market Enablement, and Creating Artificial Needs
+- **Substitutes emerging?**: Threat of substitution suggests Raising Barriers to Entry, Tower and Moat, or proactive Open Approaches
+
+### Peace/War/Wonder Phase
+
+If WCLM is available, extract the phase assessment. If not, infer from map:
+
+- **Peace**: Feature competition dominates → favour Differentiation, Standards Game, Sensing Engines
+- **War**: Industrialisation underway → favour Open Approaches, Ecosystem, Centre of Gravity, Managing Inertia
+- **Wonder**: New higher-order systems emerging → favour Experimentation, Weak Signal/Horizon, Co-creation
+
+## Step 5: Evaluate Play Options by Category
+
+Evaluate each of the 11 categories systematically. For each category, list plays that are applicable given your map position and situational assessment.
+
+Use the Play-Position Matrix from `gameplay-patterns.md` section 3 to match your dominant position to appropriate plays. Then assess each play within the applicable categories.
+
+For each applicable play, provide:
+
+```text
+Play: [Play Name] ([D&D Alignment])
+Category: [Category Letter and Name]
+Applicable because: [1-2 sentences referencing specific components/positions from the map]
+Evolution stage match: [Does this play match the component's evolution stage?]
+Recommendation: Apply / Monitor / Skip
+Rationale: [Why apply/monitor/skip — specific to this map and context]
+```
+
+### Category A: User Perception
+
+Evaluate: Education, Bundling, Creating Artificial Needs, Confusion of Choice, Brand and Marketing, FUD, Artificial Competition, Lobbying/Counterplay
+
+Which plays are relevant given your user-facing components and their evolution stage?
+
+### Category B: Accelerators
+
+Evaluate: Market Enablement, Open Approaches, Exploiting Network Effects, Co-operation, Industrial Policy
+
+Which plays would accelerate evolution of Custom-Built components you want to commoditise, or grow a market you want to lead?
+
+### Category C: De-accelerators
+
+Evaluate: Exploiting Constraint, Intellectual Property Rights/IPR, Creating Constraints
+
+Which plays could slow commoditisation of components you want to protect? Note CE plays with explicit warning.
+
+### Category D: Dealing with Toxicity
+
+Evaluate: Pig in a Poke, Disposal of Liability, Sweat and Dump, Refactoring
+
+Which components are toxic (technical debt, poor fit, declining value) and what is the appropriate disposal strategy?
+
+### Category E: Market
+
+Evaluate: Differentiation, Pricing Policy, Buyer/Supplier Power, Harvesting, Standards Game, Last Man Standing, Signal Distortion, Trading
+
+What market-positioning plays are available given your evolution stage and competitive position?
+
+### Category F: Defensive
+
+Evaluate: Threat Acquisition, Raising Barriers to Entry, Procrastination, Defensive Regulation, Limitation of Competition, Managing Inertia
+
+What threats need defending against, and which defensive plays are appropriate?
+
+### Category G: Attacking
+
+Evaluate: Directed Investment, Experimentation, Centre of Gravity, Undermining Barriers to Entry, Fool's Mate, Press Release Process, Playing Both Sides
+
+What offensive plays are executable given your resources, risk tolerance, and time horizon?
+
+### Category H: Ecosystem
+
+Evaluate: Alliances, Co-creation, Sensing Engines/ILC, Tower and Moat, N-sided Markets, Co-opting and Intercession, Embrace and Extend, Channel Conflicts and Disintermediation
+
+What ecosystem plays are available — do you have the components and relationships to build or join an ecosystem?
+
+### Category I: Competitor
+
+Evaluate: Ambush, Fragmentation Play, Reinforcing Competitor Inertia, Sapping, Misdirection, Restriction of Movement, Talent Raid, Circling and Probing
+
+What competitor-directed plays are available? Flag CE plays with explicit ethical caution.
+
+### Category J: Positional
+
+Evaluate: Land Grab, First Mover/Fast Follower, Aggregation, Weak Signal/Horizon
+
+What positional plays would secure or improve your strategic position on the map?
+
+### Category K: Poison
+
+Evaluate: Licensing Play, Insertion, Designed to Fail
+
+Recognise these when they are used against you. Flag whether any are currently affecting your value chain as defensive awareness.
+
+## Step 6: Check Play Compatibility
+
+From the plays recommended as "Apply" in Step 5, check compatibility using the tables in `gameplay-patterns.md` section 4.
+
+### Reinforcing Combinations
+
+List recommended plays that work well together, referencing the compatibility table:
+
+```text
+Primary Play + Compatible Play → Why they reinforce each other
+Example: Open Approaches + Co-creation → Openness attracts community that co-creates the ecosystem
+```
+
+Identify 2-3 high-value combinations that form a coherent strategic thrust.
+
+### Conflicting Plays
+
+Flag any selected plays that conflict with each other:
+
+```text
+Play A conflicts with Play B → Why (referencing the conflicts table)
+Resolution: Which to prioritise, or how to resolve the conflict
+```
+
+Do not recommend play combinations that undermine each other — force an explicit resolution.
+
+### Overall Play Coherence
+
+Assess the selected play portfolio:
+
+- Are the plays strategically coherent? Do they tell a consistent story?
+- Is there an appropriate mix of offensive and defensive plays?
+- Is the alignment profile acceptable? (All LG/N? Mix includes LE? Any CE flagged for recognition only?)
+
+## Step 7: Detail Selected Plays
+
+For each play recommended as "Apply" in Step 5, provide a detailed execution plan. Limit to the top 5-8 plays to keep the document actionable.
+
+For each detailed play:
+
+### [Play Name] ([D&D Alignment]) — Category [Letter]
+
+**Description**: [One sentence from the gameplay catalog, tailored to this specific context]
+
+**Why it applies here**: [Specific reference to components, evolution positions, and situational factors that make this play appropriate]
+
+**Prerequisites**: What must be true before executing this play?
+
+- [Prerequisite 1: specific to this map context]
+- [Prerequisite 2]
+- [Prerequisite 3 if needed]
+
+**Execution Steps**:
+
+1. [Specific, actionable first step — who does what]
+2. [Second step]
+3. [Third step]
+4. [Continuing steps as needed]
+
+**Expected Outcomes**:
+
+- **Short-term (0-3 months)**: [Tangible, observable result]
+- **Long-term (6-18 months)**: [Strategic position achieved]
+
+**Risks and Mitigations**:
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| [Risk 1] | H/M/L | [Specific mitigation] |
+| [Risk 2] | H/M/L | [Specific mitigation] |
+
+**Success Criteria** (measurable):
+
+- [ ] [Criterion 1 — observable, specific]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+**Review Points**: When should progress on this play be reassessed?
+
+- [Trigger or date] — check [what specifically]
+
+## Step 8: Anti-Pattern Check
+
+Before finalising the strategy, verify it avoids the six strategic anti-patterns from `gameplay-patterns.md` section 5.
+
+For each anti-pattern, explicitly confirm or flag:
+
+**Playing in the wrong evolution stage**: Are any recommended plays applied to components at the wrong evolution stage? (e.g., Experimentation on a commodity component, Harvesting on a Genesis component)
+→ Status: [No violations identified / Flagged: {details}]
+
+**Ignoring inertia**: Have inertia points from the WARD artifact been addressed in the execution plans? Is there a play (e.g., Managing Inertia) to handle organisational resistance?
+→ Status: [Addressed via [play name] / Warning: inertia points {list} have no mitigation]
+
+**Single-play dependence**: Is the strategy dangerously dependent on one play succeeding? Is there a layered play portfolio?
+→ Status: [Portfolio of {count} plays provides redundancy / Warning: single play {name} is the only defence/offence]
+
+**Misreading evolution pace**: Has the evolution velocity of key components been validated (against WCLM if available)?
+→ Status: [Evolution positions verified / Warning: {components} may be mis-positioned]
+
+**Ecosystem hubris**: If ecosystem plays (Tower and Moat, N-sided Markets, Sensing Engines) are selected, is there a plan to continue generating genuine ecosystem value?
+→ Status: [ILC/Weak Signal plays included to maintain ecosystem health / Warning: ecosystem play selected without monitoring mechanism]
+
+**Open washing**: If Open Approaches is selected alongside Licensing Play, Standards Game, or Embrace and Extend — is this coherent?
+→ Status: [Coherent — no contradiction identified / Warning: Open Approaches and {play} may signal open washing to the community]
+
+## Step 9: Case Study Cross-References
+
+Which real-world examples from `gameplay-patterns.md` section 6 most closely parallel the recommended strategy? For each relevant case study, provide a 1-2 sentence connection to the selected plays.
+
+| Case Study | Plays Used | Relevance to This Strategy |
+|------------|-----------|---------------------------|
+| [Company] | [Play names] | [How this parallels the recommended approach] |
+
+Limit to the 3-5 most relevant case studies. Avoid forcing connections where the parallel is weak.
+
+## Step 10: Generate Output
+
+Create the gameplay analysis document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WGAM-001-v1.0.md` — First gameplay analysis for project 001
+- `ARC-001-WGAM-002-v1.0.md` — Second gameplay analysis (e.g., for a revised map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-gameplay-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-gameplay-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.gameplay`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WGAM-{NNN}-v{VERSION}` (e.g., `ARC-001-WGAM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WGAM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Gameplay Analysis"
+- `ARC-[PROJECT_ID]-WGAM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.gameplay"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.gameplay` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.gameplay` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Gameplay Analysis document must include:
+
+1. **Executive Summary**: Strategic context, map summary, recommended play portfolio overview (2-3 paragraphs)
+
+2. **Map Context**: Component inventory table, dominant position type, situational assessment summary
+
+3. **Play Evaluation by Category**: All 11 categories assessed with Apply/Monitor/Skip for each applicable play
+
+4. **Play Compatibility Matrix**: Reinforcing combinations and flagged conflicts
+
+5. **Detailed Play Execution Plans**: Top 5-8 plays with prerequisites, execution steps, outcomes, risks, success criteria
+
+6. **Anti-Pattern Check**: Explicit pass/fail for all 6 anti-patterns
+
+7. **Case Study Cross-References**: 3-5 relevant real-world parallels
+
+8. **Recommended Play Portfolio**: Summary table of all recommended plays with alignment, category, priority, and time horizon
+
+9. **Traceability**: Link to WARD artifact, WCLM (if used), WDOC (if used), RSCH (if used)
+
+## Step 11: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact)
+/arckit:wardley.gameplay — Identify strategic plays (WGAM artifact) ← you are here
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create roadmap to execute selected plays
+/arckit:strategy — Synthesise into architecture strategy document
+```
+
+### Before Gameplay Analysis
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If WCLM is missing but gameplay is proceeding:
+
+```bash
+"Note: No climate assessment (WCLM) found. Consider running `/arckit:wardley.climate` after this analysis —
+climate patterns may affect which plays are timely and which are premature."
+```
+
+### After Gameplay Analysis
+
+Recommend next steps based on selected plays:
+
+```bash
+# If Directed Investment or Land Grab selected
+"Your selected plays include resource-intensive options. Consider running `/arckit:roadmap` to create a
+phased execution plan with investment milestones."
+
+# If ecosystem plays selected (Tower and Moat, N-sided Markets, etc.)
+"Your strategy includes ecosystem plays. Consider running `/arckit:strategy` to synthesise these into
+a coherent architecture strategy document."
+
+# If Open Approaches selected
+"The Open Approaches play may involve open-sourcing or publishing components. Consider running
+`/arckit:sow` if procurement is needed for the ecosystem, or `/arckit:research` to identify
+existing open communities to join."
+
+# If UK Government project
+"As a UK Government project, ecosystem and market plays should be validated against TCoP Point 3
+(Open Source), Point 8 (Share/Reuse), and G-Cloud procurement constraints. Run `/arckit:tcop`."
+```
+
+## Important Notes
+
+### Gameplay Selection Quality Standards
+
+**Good Gameplay Analysis**:
+
+- Plays matched to actual component evolution stages (not generic advice)
+- Play-Position Matrix used explicitly
+- Compatibility conflicts identified and resolved
+- Anti-patterns explicitly checked and cleared
+- Execution plans are specific and actionable (not generic)
+- Alignment profile considered against organisational values
+- Case study references are genuinely analogous
+
+**Poor Gameplay Analysis**:
+
+- Recommending all plays without prioritisation
+- Ignoring evolution stage when selecting plays
+- Mixing conflicting plays without resolution
+- Recommending CE plays without ethical flagging
+- Generic execution steps not tied to specific components
+- No anti-pattern check
+
+### Alignment Ethics
+
+When recommending plays with LE or CE alignment:
+
+- **LE plays**: Flag explicitly with "(Lawful Evil — self-interested but within accepted norms)" and note reputational or regulatory risks
+- **CE plays**: Include explicit warning — "This play is classified CE (Chaotic Evil). It is presented for recognition purposes only. Deploying this play deliberately would damage stakeholder trust and may create legal exposure."
+- **CE plays should never appear in "Apply" recommendations** — only in "Recognise and Defend Against" lists
+
+### Play Sequencing
+
+Some plays must be sequenced carefully:
+
+- **Education before Open Approaches**: Market must understand the value before openness can grow it
+- **Weak Signal/Horizon before Land Grab**: Identify the opportunity before committing resources to capture it
+- **Managing Inertia before Ecosystem plays**: Internal resistance must be addressed before ecosystem commitments can be honoured
+- **Experimentation before Directed Investment**: Validate the opportunity before scaling it
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Gameplay Analysis document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Complete with all sections from template
+- Specific (plays matched to actual map components, not generic advice)
+- Executable (each recommended play has actionable steps)
+- Ethically annotated (alignment flags for LE/CE plays)
+- Compatible (conflicting plays resolved, reinforcing combinations identified)
+- Anti-pattern checked (all 6 anti-patterns explicitly cleared)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Gameplay Analysis Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md
+
+Plays Evaluated: {total_plays_considered} across 11 categories
+Recommended (Apply): {count} plays
+Monitor: {count} plays
+Skip: {count} plays
+
+Top 3 Recommended Plays:
+1. {Play Name} ({Alignment}) — {one-line rationale}
+2. {Play Name} ({Alignment}) — {one-line rationale}
+3. {Play Name} ({Alignment}) — {one-line rationale}
+
+Key Reinforcing Combination: {Play A} + {Play B} → {why}
+
+Key Risks:
+- {Risk 1}
+- {Risk 2}
+
+Anti-Pattern Check: {count}/6 passed — {any warnings}
+
+Next Steps:
+- /arckit:wardley.climate — Validate plays against climatic forces (if not done)
+- /arckit:roadmap — Create execution roadmap for selected plays
+- /arckit:strategy — Synthesise gameplay into architecture strategy
+```
+
+---
+
+**Remember**: Gameplay analysis is only as good as the map it is based on. If the map components are mispositioned, the play selection will be wrong. Always validate component evolution positions before committing to a play strategy.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:roadmap` -- Create roadmap to execute selected plays
+- `/arckit:strategy` -- Synthesise gameplay into architecture strategy
+- `/arckit:wardley.climate` -- Validate plays against climatic patterns *(when Climate assessment not yet performed)*

--- a/arckit-codex/commands/arckit.wardley.gameplay.md
+++ b/arckit-codex/commands/arckit.wardley.gameplay.md
@@ -67,6 +67,7 @@ From the WARD artifact, extract the following structured information that will d
 **Component Inventory**:
 
 For each component on the map, record:
+
 - Component name
 - Visibility position (0.0-1.0)
 - Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)

--- a/arckit-codex/commands/arckit.wardley.md
+++ b/arckit-codex/commands/arckit.wardley.md
@@ -45,9 +45,13 @@ $ARGUMENTS
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements
@@ -732,3 +736,6 @@ After completing this command, consider running:
 - `/arckit:roadmap` -- Create strategic roadmap from evolution analysis
 - `/arckit:strategy` -- Synthesise Wardley insights into architecture strategy
 - `/arckit:research` -- Research vendors for Custom-Built components *(when Custom-Built components identified that need market research)*
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity
+- `/arckit:wardley.gameplay` -- Identify strategic plays from the map
+- `/arckit:wardley.climate` -- Assess climatic patterns affecting components

--- a/arckit-codex/commands/arckit.wardley.value-chain.md
+++ b/arckit-codex/commands/arckit.wardley.value-chain.md
@@ -1,0 +1,358 @@
+---
+description: "Decompose user needs into value chains for Wardley Mapping"
+---
+
+# ArcKit: Value Chain Decomposition for Wardley Mapping
+
+You are an expert value chain analyst using Wardley Mapping methodology. Your role is to decompose user needs into complete dependency chains — identifying components, establishing visibility positions, and producing OWM-ready syntax for use in a full Wardley Map.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **REQ** (Requirements) — Extract: User needs, business requirements, functional capabilities, system components, integration points. Anchor the value chain in genuine user needs, not internal assumptions.
+  - If missing: warn the user and recommend running `/arckit:requirements` first. A value chain without requirements risks anchoring on solutions rather than needs.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **STKE** (Stakeholder Analysis) — Extract: User personas, stakeholder goals, success metrics, priority outcomes. Helps establish who sits at the top of the value chain.
+  - If missing: note that stakeholder context is unavailable; you will infer user personas from the requirements or user input.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **PRIN** (Architecture Principles) — Extract: Technology standards, cloud-first policy, reuse requirements, build vs buy preferences.
+- Existing WVCH artifacts in `projects/{current_project}/wardley-maps/` — Extract: Previous value chain analysis, component positions, known dependencies.
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract: existing component lists, system architecture diagrams, dependency maps, integration catalogues.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract: enterprise component library, shared service catalogue, cross-project reuse opportunities.
+- If no existing value chain documents are found but they would improve accuracy, ask: "Do you have any existing architecture diagrams, component lists, or dependency maps? I can read images and PDFs directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Identify the Anchor (User Need)
+
+The **anchor** is the user need at the top of the value chain. Everything below it exists to satisfy this need. Getting the anchor right is the most important step — a wrong anchor produces a wrong chain.
+
+### Good vs. Bad Anchors
+
+**GOOD anchors** — genuine user needs:
+
+- "User can communicate with their team in real time"
+- "Patient can book an appointment without calling the surgery"
+- "Taxpayer can file a return in under 15 minutes"
+- "Citizen can check their benefits eligibility online"
+
+**BAD anchors** — solutions masquerading as needs:
+
+- "User needs Slack" — this is a solution, not a need
+- "User needs a microservices platform" — this is an implementation choice
+- "System processes API calls" — this is a capability, not a purpose
+- "Database stores records" — this is infrastructure, not a user outcome
+
+**Anchor test**: Can this need be satisfied in multiple different ways? If the need is tightly tied to a specific product or technology, it is a solution, not a need. Strip it back to the underlying outcome the user requires.
+
+### Anchor Identification Questions
+
+Ask these questions to refine the anchor from the user input and available documents:
+
+1. **Who is the user?** — Be specific. A persona, role, or citizen type. Not "the system."
+2. **What outcome do they want?** — What changes for them when their need is met? What can they do, know, or decide?
+3. **Why do they need this?** — What is the underlying motivation? Remove one layer of abstraction from the stated need.
+
+State the anchor clearly before proceeding:
+
+```text
+Anchor: [User need statement]
+User: [Who has this need]
+Outcome: [What changes when this need is met]
+```
+
+## Step 3: Decompose into Components
+
+Starting from the anchor, decompose the value chain by asking "What is required to satisfy this?" at each level. Repeat recursively until you reach commodity-level infrastructure.
+
+### Recursive Decomposition Method
+
+```text
+Level 0 (Anchor): [User Need]
+  ↓ "What is required to provide this?"
+Level 1: [Capability A], [Capability B]
+  ↓ "What is required to provide Capability A?"
+Level 2: [Component C], [Component D]
+  ↓ "What is required to provide Component C?"
+Level 3: [Component E], [Component F]
+  ↓ Continue until commodities are reached
+```
+
+### Component Identification Checklist
+
+For each candidate component, verify:
+
+- [ ] Is it a capability, activity, or practice? (Not an actor, person, or team)
+- [ ] Does it directly or indirectly serve the anchor user need?
+- [ ] Can it evolve independently on the evolution axis?
+- [ ] Does it provide value to components above it in the chain?
+
+### Dependency Types
+
+When establishing connections between components, classify the relationship:
+
+- **REQUIRES** (hard dependency): Component A cannot function without Component B. Failure in B causes failure in A. Represented as `A -> B` in OWM syntax.
+- **USES** (soft dependency): Component A uses Component B to improve quality or performance, but can degrade gracefully without it.
+- **ENABLES** (reverse): Component B enables Component A to exist; B is not strictly required but makes A possible or better.
+
+For OWM syntax, use `->` for REQUIRES and USES relationships. Note ENABLES relationships in the component inventory.
+
+### Stop Conditions
+
+Stop decomposing when:
+
+1. The component is a genuine commodity (widely available utility: cloud compute, DNS, SMTP, payment rails)
+2. Further decomposition adds no strategic value for the mapping exercise
+3. You have reached common shared infrastructure that all chains eventually depend on
+
+Aim for 8–20 components total. Fewer than 8 may be too shallow; more than 25 may be too granular for strategic clarity.
+
+## Step 4: Establish Dependencies
+
+With all components identified, map the full dependency structure. Dependencies flow **down** the chain — higher-visibility components depend on lower-visibility ones.
+
+### Dependency Rules
+
+1. **Direction**: Dependencies flow downward. If Component A depends on Component B, A appears higher on the Y-axis than B.
+2. **Causality**: A dependency must be real and direct. Do not draw arrows because it "feels related."
+3. **No cycles**: A component cannot depend on itself or on a component that depends on it.
+4. **Completeness**: Every component except the anchor should have at least one dependency going down (or be a terminal commodity).
+
+### Dependency Validation
+
+For each dependency you draw, verify:
+
+- Would Component A fail or degrade significantly if Component B were removed?
+- Is this a direct dependency, or does it go via an intermediate component?
+- Have you captured all meaningful dependencies, or only the obvious ones?
+
+## Step 5: Assess Visibility (Y-axis)
+
+Read `.arckit/skills/wardley-mapping/references/evolution-stages.md` for supporting context on component characteristics.
+
+Visibility represents how directly visible a component is to the user at the top of the chain. Assign a value from 0.0 (invisible infrastructure) to 1.0 (directly experienced by the user).
+
+### Visibility Guide
+
+| Range | Level | Characteristics |
+|-------|-------|-----------------|
+| 0.90 – 1.00 | User-facing | Directly experienced; failure is immediately visible to the user |
+| 0.70 – 0.89 | High | Close to the user; degradation noticed quickly |
+| 0.50 – 0.69 | Medium-High | Indirectly visible; affects features the user relies on |
+| 0.30 – 0.49 | Medium | Hidden from users but essential to operations |
+| 0.10 – 0.29 | Low | Invisible to users; purely operational or infrastructure |
+| 0.00 – 0.09 | Infrastructure | Deep infrastructure; users unaware it exists |
+
+### Visibility Assessment Questions
+
+For each component, ask:
+
+1. Does the user interact with this component directly? (Yes → high visibility)
+2. Would the user notice immediately if this component failed? (Yes → high visibility)
+3. Could you swap out this component without the user knowing? (Yes → low visibility)
+4. Is this component one step removed from user interaction? (One step → medium-high)
+
+The anchor always receives a visibility of 0.90 or above (typically 0.95). Infrastructure reaches 0.05–0.15.
+
+## Step 6: Validate the Chain
+
+Before generating output, validate the value chain against these criteria.
+
+### Completeness Checks
+
+- [ ] Chain starts with a genuine user need (not a solution or capability)
+- [ ] All significant dependencies between components are captured
+- [ ] Chain reaches commodity level (cloud hosting, DNS, payment infrastructure, etc.)
+- [ ] No orphan components (every component has at least one connection)
+- [ ] All components are activities, capabilities, or practices — not people, teams, or actors
+
+### Accuracy Checks
+
+- [ ] Dependencies reflect real-world technical and operational relationships
+- [ ] Visibility ordering is consistent with dependency direction (higher visibility = higher Y-axis)
+- [ ] No component is both a high-level user-facing capability and a low-level infrastructure component
+
+### Usefulness Checks
+
+- [ ] Granularity is appropriate for strategic decision-making (not too fine, not too coarse)
+- [ ] Each component can be meaningfully positioned on the evolution axis for the subsequent Wardley Map
+- [ ] The chain reveals at least one strategic insight about build vs. buy, inertia, or differentiation
+
+### Common Issues to Avoid
+
+**Too shallow**: The chain has only 2-3 levels and jumps straight from user need to commodity. Add the intermediate capabilities and components.
+
+**Too deep**: The chain has 6+ levels and decomposes network packets and OS internals. Stop at the level where strategic decisions occur.
+
+**Missing components**: Common omissions include authentication, notification, monitoring, logging, and access control. Check for these.
+
+**Solution bias**: Components named after specific products (e.g., "Salesforce CRM" instead of "Customer Relationship Management") anchor the chain to current solutions. Name by capability unless you are deliberately mapping a specific vendor.
+
+**Activity confusion**: Components should be activities ("Payment Processing", "Identity Verification") not states ("Payment", "Identity"). Activities can evolve; nouns are ambiguous.
+
+## Step 7: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WVCH-001-v1.0.md` — First value chain
+- `ARC-001-WVCH-002-v1.0.md` — Second value chain (different user need or domain)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-value-chain-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-value-chain-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-value-chain`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}` (e.g., `ARC-001-WVCH-001-v1.0`)
+- Sequence number `{NNN}`: Check existing WVCH files in `wardley-maps/` and use the next number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Value Chain"
+- `[COMMAND]` → "arckit.wardley.value-chain"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.value-chain` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.value-chain` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used]
+```
+
+---
+
+### Output Contents
+
+The value chain document must include:
+
+1. **Executive Summary**: Anchor statement, component count, key strategic insights (3-5 sentences)
+
+2. **Users and Personas**: Table of user types and their primary needs
+
+3. **Value Chain Diagram**:
+   - ASCII placeholder showing the chain structure (visibility levels and component names)
+   - Complete OWM syntax for https://create.wardleymaps.ai
+
+4. **Component Inventory**: All components with visibility scores, descriptions, and dependency references
+
+5. **Dependency Matrix**: Cross-reference table showing direct (X) and indirect (I) dependencies
+
+6. **Critical Path Analysis**:
+   - The sequence from anchor to deepest infrastructure
+   - Bottlenecks and single points of failure
+   - Resilience gaps
+
+7. **Validation Checklist**: Completed checklist confirming chain quality
+
+8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+
+9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 0.5 visibility`, `> 0.75 evolution`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Value Chain Created: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}.md
+
+🗺️ View Chain: Paste the OWM code into https://create.wardleymaps.ai
+
+📊 Key Insights:
+- Anchor: {user need statement}
+- {N} components identified across {N} dependency levels
+- Critical path: {anchor} → {key component} → {commodity}
+- {Notable strategic insight, e.g., "Authentication is a commodity dependency shared across 4 capabilities"}
+
+⚠️ Potential Issues:
+- {Any validation warnings, e.g., "No commodity-level components found — chain may be incomplete"}
+- {Any missing prerequisite artifacts}
+
+🎯 Next Steps:
+- Run /arckit:wardley to create a full Wardley Map using this value chain
+- Assign evolution positions to each component for strategic analysis
+- Validate the chain with your team before proceeding to mapping
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create full Wardley Map with evolution axis positioning
+- /arckit:wardley.doctrine — Assess organizational maturity to execute the strategy
+- /arckit:requirements — Strengthen the requirements before refining the chain (if incomplete)
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley` -- Create Wardley Map from this value chain
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity *(when Value chain reveals organizational capability gaps)*

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 60 slash commands
+- **Commands**: 64 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/remote-control.md
+++ b/arckit-codex/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 60 ArcKit commands and 6 research agents remain fully available
+- All 64 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 60 commands | Plugin mode
+Version 2.10.0 | 64 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/docs/guides/wardley-climate.md
+++ b/arckit-codex/docs/guides/wardley-climate.md
@@ -1,0 +1,122 @@
+# Climate Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.climate` assesses 32 climatic patterns affecting mapped components.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to understand the external forces acting on your components. Climate patterns are the rules of the game -- they apply regardless of your strategy. Understanding them lets you anticipate change, identify inertia, and choose gameplay that works with (not against) external forces.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map whose components are assessed for climatic forces |
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Recommended -- Business context for impact assessment |
+| Research findings (`ARC-<id>-RSCH-*.md`) | Recommended -- Market data to validate pattern detection |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.climate Assess climate for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WCLM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Climate Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being assessed |
+| Pattern Assessment | 32 climatic patterns evaluated against components |
+| Category Summary | Aggregated assessment across 6 pattern categories |
+| Peace/War/Wonder Cycle | Current cycle phase and implications |
+| Inertia Assessment | Components and organizations resisting change |
+| Prediction Horizons | What can be predicted and with what confidence |
+| Strategic Implications | How climate forces shape available strategies |
+
+---
+
+## Key Concepts
+
+### 32 Climatic Patterns Across 6 Categories
+
+| Category | Example Patterns |
+|----------|-----------------|
+| Competition | Competitors will copy successful plays, most competitors have poor situational awareness |
+| Components | Everything evolves through supply and demand competition, characteristics change as components evolve |
+| Financial | Higher-order systems create new sources of value, capital flows to new areas of value |
+| Speed | Evolution does not respect corporate boundaries, no single method fits all |
+| Prediction | Not everything is predictable, you can predict the direction of evolution |
+| Ecosystem | Efficiency enables innovation, evolution of one component affects others |
+
+### Peace / War / Wonder Cycle
+
+The evolution of components follows a repeating cycle:
+
+| Phase | Characteristics |
+|-------|-----------------|
+| Peace | Stable product competition, incremental improvement, predictable |
+| War | Commodity transition, disruption, rapid change, casualties |
+| Wonder | New genesis components emerge from commodity, novel value created |
+
+Identifying which phase each component is in reveals whether stability or disruption is imminent.
+
+### Inertia Assessment
+
+Inertia is resistance to change. Climate assessment identifies:
+
+- **Component inertia** -- Technology or practices that resist evolution
+- **Organizational inertia** -- Cultural resistance, sunk cost, existing contracts
+- **Market inertia** -- Vendor lock-in, switching costs, standards
+
+### Prediction Horizons
+
+Not all climate effects are equally predictable:
+
+| Horizon | Confidence |
+|---------|------------|
+| Direction of evolution | High -- components always evolve toward commodity |
+| Timing of evolution | Medium -- depends on competition and market forces |
+| Specific disruptions | Low -- individual events are unpredictable |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- All 32 climatic patterns assessed against map components.
+- Peace/War/Wonder phase identified for each key component.
+- Inertia sources documented with severity.
+- Prediction horizons are realistic (not overconfident).
+- Strategic implications link back to specific components.
+- Assessment is evidence-based, not speculative.
+
+---
+
+## Tips
+
+1. **Climate before gameplay** -- Climate constrains which plays are viable. Always assess climate first.
+2. **Look for war signals** -- Components approaching commodity transition are the highest-risk, highest-opportunity areas.
+3. **Challenge inertia** -- Organizational inertia is often the hardest to overcome. Name it explicitly.
+4. **Update with the map** -- Climate assessment is tied to a specific map version. When the map changes, re-assess.
+5. **Use research data** -- Market research (`/arckit.research`) provides evidence for pattern detection. Do not assess climate in a vacuum.

--- a/arckit-codex/docs/guides/wardley-doctrine.md
+++ b/arckit-codex/docs/guides/wardley-doctrine.md
@@ -1,0 +1,120 @@
+# Doctrine Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.doctrine` assesses organizational doctrine maturity across 4 phases and 40+ principles.
+
+---
+
+## When to Use
+
+Run this command to assess organizational maturity, identify capability gaps, and plan improvements. Doctrine assessment reveals how well an organization applies universal strategic principles -- independent of any specific map or context. Use it to:
+
+- Baseline current organizational maturity
+- Identify systemic weaknesses before they manifest in projects
+- Plan targeted improvement programmes
+- Re-assess periodically to measure progress
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Architecture principles (`ARC-000-PRIN-v1.0.md`) | **Mandatory** -- Governance principles to assess against |
+| Wardley Map (`ARC-<id>-WARD-*.md`) | Recommended -- Provides strategic context for scoring |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- Organizational context and drivers |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.doctrine Assess doctrine maturity for <organisation>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WDOC-v1.0.md` (single instance per project)
+
+---
+
+## Doctrine Structure
+
+| Section | Contents |
+|---------|----------|
+| Phase Assessment | Which of the 4 phases the organization has reached |
+| Category Scores | Maturity scores across 6 doctrine categories |
+| Principle-Level Detail | Individual 1-5 scoring for 40+ principles |
+| Gap Analysis | Weaknesses and improvement priorities |
+| Improvement Roadmap | Phased plan to advance doctrine maturity |
+
+---
+
+## Key Concepts
+
+### The 4 Phases of Doctrine
+
+| Phase | Name | Focus |
+|-------|------|-------|
+| I | Stop Self-Harm | Eliminate basic organizational dysfunctions |
+| II | Becoming Context Aware | Develop situational awareness and mapping capability |
+| III | Better for Less | Optimize through strategic play and efficiency |
+| IV | Continuously Evolving | Anticipate and adapt to change systemically |
+
+Organizations must master each phase before progressing to the next.
+
+### The 6 Categories
+
+| Category | Examples |
+|----------|---------|
+| Communication | Common language, challenge assumptions, listen to ecosystems |
+| Development | Use appropriate methods, think small, know your details |
+| Learning | Use a systematic mechanism of learning, bias towards data |
+| Leading | Move fast, be the owner, think big |
+| Operations | Manage inertia, optimise flow, think aptitude and attitude |
+| Structure | Provide purpose, use small teams, think standards |
+
+### Scoring (1-5)
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Not practiced -- principle is unknown or ignored |
+| 2 | Ad hoc -- applied inconsistently |
+| 3 | Developing -- recognized and partly systematized |
+| 4 | Practiced -- systematically applied across the organization |
+| 5 | Mastered -- deeply embedded, continuously improved |
+
+### Re-Assessment
+
+Doctrine assessments support periodic re-assessment. When re-running the command, the previous assessment is read and scores are compared to show progress, regression, or stagnation.
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Foundation | Establish architecture principles | `/arckit.principles` |
+| Assessment | Score doctrine maturity | `/arckit.wardley.doctrine` |
+| Mapping | Create Wardley Maps with doctrine context | `/arckit.wardley` |
+| Strategy | Synthesise into strategy | `/arckit.strategy` |
+
+---
+
+## Review Checklist
+
+- All 40+ principles scored with evidence.
+- Phase classification is justified.
+- Gap analysis identifies top priority improvements.
+- Improvement roadmap has realistic timelines.
+- Comparison with previous assessment included (if re-assessment).
+- Scores reflect reality, not aspiration.
+
+---
+
+## Tips
+
+1. **Be honest** -- Doctrine assessment only has value if scores reflect reality. Aspirational scoring hides problems.
+2. **Involve multiple stakeholders** -- A single assessor introduces bias; cross-functional input produces better scores.
+3. **Start with Phase I** -- If Phase I principles are not mastered, skip ahead at your peril.
+4. **Re-assess quarterly** -- Doctrine maturity changes slowly; quarterly cadence balances effort and insight.
+5. **Link to principles** -- Map each doctrine principle to your architecture principles for traceability.

--- a/arckit-codex/docs/guides/wardley-gameplay.md
+++ b/arckit-codex/docs/guides/wardley-gameplay.md
@@ -1,0 +1,123 @@
+# Gameplay Analysis Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.gameplay` analyzes strategic plays from 60+ gameplay patterns.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to identify strategic plays available to your organization. Gameplay analysis examines your map and recommends actions based on component positions, movements, and the competitive landscape. Best combined with climate assessment (`/arckit.wardley.climate`) for a complete strategic picture.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map to analyze for strategic plays |
+| Climate assessment (`ARC-<id>-WCLM-*.md`) | Recommended -- External forces affecting gameplay choices |
+| Doctrine assessment (`ARC-<id>-WDOC-*.md`) | Recommended -- Organizational readiness for each play |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.gameplay Analyze gameplay for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WGAM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Gameplay Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being analyzed |
+| Applicable Plays | Strategic plays identified from component positions |
+| Play-Position Matrix | Which plays apply to which components |
+| Alignment Classification | D&D alignment for each play (Lawful/Neutral/Chaotic) |
+| Recommended Actions | Prioritized list of strategic actions |
+| Risk Assessment | Risks and counter-plays for each recommendation |
+
+---
+
+## Key Concepts
+
+### 11 Gameplay Categories
+
+| Category | Focus |
+|----------|-------|
+| User Perception | Shaping how users see value |
+| Accelerators | Speeding evolution of components |
+| De-accelerators | Slowing evolution to protect advantage |
+| Market | Creating or reshaping markets |
+| Defensive | Protecting current position |
+| Attacking | Disrupting competitors |
+| Ecosystem | Building or leveraging ecosystems |
+| Positional | Exploiting map position |
+| Poison | Undermining competitor strategies |
+| Military | Direct competitive confrontation |
+| Political | Influencing rules and standards |
+
+### 60+ Plays
+
+Examples include open source (accelerator), create a constraint (de-accelerator), tower and moat (defensive), two-factor markets (ecosystem), and standards game (political). Each play has specific applicability based on component evolution stage and visibility.
+
+### D&D Alignment Classification
+
+Plays are classified on two axes:
+
+| Axis | Options |
+|------|---------|
+| Lawful / Neutral / Chaotic | How the play relates to established norms |
+| Good / Neutral / Evil | The ethical dimension of the play |
+
+This classification helps organizations choose plays that align with their values and governance requirements.
+
+### Play-Position Matrix
+
+The matrix maps each play to the evolution stages where it is most effective:
+
+| Evolution Stage | Example Plays |
+|-----------------|---------------|
+| Genesis | Experimentation, talent raid, first mover |
+| Custom | Sensing engines, co-creation |
+| Product | Industrialisation plays, ecosystem building |
+| Commodity | Standards game, utility plays, commoditisation |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- Wardley Map is current and validated.
+- All applicable plays identified for each component.
+- D&D alignment classification is consistent.
+- Risks and counter-plays documented for each recommendation.
+- Play-position matrix is populated.
+- Recommendations are prioritized by impact and feasibility.
+- Organizational readiness considered (doctrine assessment).
+
+---
+
+## Tips
+
+1. **Map first, play second** -- Never select gameplay without a current Wardley Map.
+2. **Combine with climate** -- Climate patterns constrain which plays are viable. Assess climate first.
+3. **Check doctrine readiness** -- Some plays require organizational maturity. A Phase I organization cannot execute Phase III plays.
+4. **Consider ethics** -- The D&D alignment classification is not decorative. Choose plays consistent with your governance.
+5. **Revisit after map changes** -- When components move or the landscape shifts, gameplay analysis must be refreshed.

--- a/arckit-codex/docs/guides/wardley-value-chain.md
+++ b/arckit-codex/docs/guides/wardley-value-chain.md
@@ -1,0 +1,122 @@
+# Value Chain Decomposition Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.value-chain` decomposes user needs into value chains for Wardley Mapping.
+
+---
+
+## When to Use
+
+Run this command **before** creating a Wardley Map when you need to decompose a domain into its constituent components. Value chain decomposition identifies all the capabilities, services, and activities required to meet user needs -- producing the raw material that `/arckit.wardley` then positions on an evolution axis.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | **Mandatory** -- Capabilities, user needs, and business context |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- User roles and business drivers |
+| Architecture diagrams | Optional -- Existing component landscape |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.value-chain Decompose value chain for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WVCH-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Value Chain Structure
+
+| Section | Contents |
+|---------|----------|
+| Anchor Identification | User needs vs internal solution anchors |
+| Recursive Decomposition | Break each need into sub-components until atomic |
+| Visibility Mapping | How visible each component is to the end user |
+| Dependency Analysis | Which components depend on which |
+| Component Catalogue | Full list with descriptions, types, and owners |
+
+---
+
+## Key Concepts
+
+### Anchors: User Needs vs Solutions
+
+Wardley Maps start from **user needs**, not technology. Value chain decomposition distinguishes:
+
+- **User-need anchors** -- What the user actually wants (e.g., "book an appointment")
+- **Solution anchors** -- Internal capabilities that serve the need (e.g., "appointment scheduling service")
+
+Always anchor at user needs; solutions are components in the chain below.
+
+### Recursive Decomposition
+
+Each user need is broken down recursively:
+
+1. Identify the top-level need
+2. Ask "what is needed to provide this?"
+3. For each answer, repeat until you reach atomic components
+4. Atomic = a component that can be sourced as a single unit (build, buy, or utility)
+
+### Visibility Axis
+
+Components sit on a visibility spectrum:
+
+| Position | Description |
+|----------|-------------|
+| Top (visible) | User-facing capabilities, directly experienced |
+| Middle | Supporting services, seen by operators |
+| Bottom (invisible) | Infrastructure and utilities, invisible to users |
+
+### Dependency Types
+
+| Type | Description |
+|------|-------------|
+| Direct | Component A cannot function without Component B |
+| Indirect | Component A benefits from Component B but can operate without it |
+| Shared | Multiple components depend on a common service |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Requirements | Define user needs and capabilities | `/arckit.requirements` |
+| Decomposition | Break needs into value chains | `/arckit.wardley.value-chain` |
+| Mapping | Position components on evolution axis | `/arckit.wardley` |
+| Analysis | Assess doctrine, climate, gameplay | `/arckit.wardley.doctrine`, `/arckit.wardley.climate`, `/arckit.wardley.gameplay` |
+
+---
+
+## Review Checklist
+
+- All user needs identified and used as anchors.
+- Decomposition is recursive to atomic components.
+- Visibility axis reflects real user perspective.
+- Dependencies between components are explicit.
+- No technology assumptions baked into anchors.
+- Component catalogue is complete with descriptions.
+
+---
+
+## Tips
+
+1. **Start with users, not technology** -- If your first anchor is a database, you have started too low.
+2. **Challenge "obvious" components** -- Decompose even well-understood areas; hidden dependencies live there.
+3. **Use stakeholder analysis** -- Stakeholder drivers reveal needs that requirements alone may miss.
+4. **One chain per user need** -- Separate chains keep the analysis focused.
+5. **Feed into Wardley Map** -- The value chain output is the direct input to `/arckit.wardley`.
+
+---
+
+## Feeds Into
+
+- `/arckit.wardley` -- Use the decomposed value chain to create a positioned Wardley Map
+- `/arckit.data-model` -- Components often map to data entities

--- a/arckit-codex/docs/guides/wardley.md
+++ b/arckit-codex/docs/guides/wardley.md
@@ -6,6 +6,29 @@
 
 ---
 
+## Wardley Mapping Suite
+
+ArcKit provides a full suite of Wardley Mapping commands that work together as a strategic analysis pipeline:
+
+| Command | Purpose | Output |
+|---------|---------|--------|
+| `/arckit.wardley.value-chain` | Decompose user needs into value chains | WVCH |
+| `/arckit.wardley` | Create positioned Wardley Maps | WARD |
+| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity | WDOC |
+| `/arckit.wardley.climate` | Assess 32 climatic patterns | WCLM |
+| `/arckit.wardley.gameplay` | Analyze 60+ strategic gameplay patterns | WGAM |
+
+**Recommended workflow order:**
+
+1. **Value Chain** -- Decompose domain into components ([guide](wardley-value-chain.md))
+2. **Wardley Map** -- Position components on evolution axis (this guide)
+3. **Doctrine** -- Assess organizational maturity ([guide](wardley-doctrine.md))
+4. **Climate** -- Understand external forces ([guide](wardley-climate.md))
+5. **Gameplay** -- Identify strategic plays ([guide](wardley-gameplay.md))
+6. **Strategy / Roadmap** -- Synthesise findings into actionable plans
+
+---
+
 ## Inputs
 
 | Artefact | Purpose |

--- a/arckit-codex/prompts/arckit.wardley.climate.md
+++ b/arckit-codex/prompts/arckit.wardley.climate.md
@@ -1,0 +1,593 @@
+---
+description: "Assess climatic patterns affecting Wardley Map components"
+---
+
+# ArcKit: Wardley Climate Assessment
+
+You are an expert in Wardley Mapping climatic patterns and strategic forecasting. You assess 32 external force patterns across 6 categories that shape the business and technology landscape regardless of what any individual organisation chooses to do. Unlike gameplays (deliberate strategic choices), climatic patterns are the "weather" — they simply happen. Understanding them allows organisations to position ahead of change rather than scramble to react.
+
+## What are Climatic Patterns?
+
+Simon Wardley identifies 32 climatic patterns organised into 6 categories. These patterns describe the external forces that act on every component in a Wardley Map:
+
+1. **Component Patterns** (8 patterns): How components evolve in general
+2. **Financial Patterns** (6 patterns): How capital, value, and economic forces behave
+3. **Speed Patterns** (5 patterns): How fast evolution occurs and what accelerates it
+4. **Inertia Patterns** (3 patterns): How organisations resist necessary change
+5. **Competitor Patterns** (2 patterns): How competitive dynamics shape the landscape
+6. **Prediction Patterns** (8 patterns): What can and cannot be reliably forecast
+
+The output of a climate assessment (WCLM artifact) informs gameplay selection — you cannot choose effective plays without understanding the weather you are playing in.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, current stage classifications, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running climate assessment. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; climate patterns cannot be assessed without knowing what components are in the landscape
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **REQ** (Requirements) — Extract: business drivers, technology context, domain characteristics. Enriches domain-specific climate assessment.
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: market dynamics, vendor landscape, industry trends, competitive intelligence. Market research is the primary evidence source for pattern detection.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores and weaknesses. Inertia pattern severity is amplified by poor doctrine.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles and constraints. Shapes how climate findings translate to strategic implications.
+- **STKE** (Stakeholder Analysis) — Extract: business drivers and stakeholder priorities. Grounds climate assessment in organisational realities.
+
+**Understand the Assessment Context**:
+
+- What domain or market is being assessed? (From user arguments and project context)
+- What is the time horizon for strategic planning? (Affects which patterns matter most)
+- Is this primarily a technology landscape, market landscape, or regulatory landscape assessment?
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract market analysis, industry reports, analyst forecasts, competitive intelligence. These are the primary evidence sources for climate pattern detection.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level climate assessments, enterprise technology landscape reports
+- If no external market documents found but they would materially improve the assessment, ask: "Do you have any market research reports, analyst forecasts, or competitive landscape documents? These significantly improve climate pattern evidence quality. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Read Reference Material
+
+Read the following reference files:
+
+1. **`.arckit/skills/wardley-mapping/references/climatic-patterns.md`** — the complete 32-pattern catalog across 6 categories, with strategic implications, assessment questions, pattern interaction maps, the Peace/War/Wonder cycle, per-component assessment templates, and assessment question sets by category. This is the authoritative source for all pattern descriptions and assessment methodology.
+
+2. **`.arckit/skills/wardley-mapping/references/mathematical-models.md`** — for the impact weighting methodology, evolution scoring formulas, and any quantitative models used to assess evolution velocity and pattern impact severity.
+
+## Step 3: Extract Component Inventory
+
+From the WARD artifact, build a complete component inventory that will be the basis for per-component pattern assessment in Steps 4-6.
+
+For each component:
+
+| Component | Visibility | Evolution | Stage | Dependencies | Inertia Noted |
+|-----------|-----------|-----------|-------|--------------|---------------|
+| [Name] | [0.0-1.0] | [0.0-1.0] | [G/C/P/Cmd] | [list] | [Yes/No/Partial] |
+
+**Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
+
+**Total component summary**:
+- Genesis components ({count}): {names}
+- Custom-Built components ({count}): {names}
+- Product components ({count}): {names}
+- Commodity components ({count}): {names}
+- Components with noted inertia: {names}
+
+**Ecosystem Type Assessment**:
+- Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
+- Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
+- Or mixed?
+
+This affects pattern 1.2 (Rates of Evolution Vary by Ecosystem) — a critical calibration for all velocity predictions.
+
+## Step 4: Assess Climatic Patterns by Category
+
+For each of the 6 categories, evaluate which patterns are actively affecting this specific landscape. Do not simply list all 32 patterns — assess which are demonstrably active, which are latent (approaching but not yet dominant), and which are not currently relevant.
+
+For each **active** or **latent** pattern, provide:
+
+```text
+Pattern: [Pattern Name and Number] — [Category]
+Status: Active / Latent / Not relevant
+Evidence: [1-3 sentences of specific evidence from the map, domain context, or user arguments]
+Primary components affected: [component names from the WARD artifact]
+Impact: High / Medium / Low
+Strategic implication for this landscape: [Specific — not a copy of the generic implication from the reference]
+Time horizon: < 12 months / 1-3 years / 3+ years
+```
+
+### Category 1: Component Patterns (8 patterns)
+
+Assess all 8 patterns from the reference file:
+
+**1.1 Everything Evolves Through Supply and Demand Competition**
+Are components actively moving along the evolution axis? What is driving that movement in this specific domain?
+
+**1.2 Rates of Evolution Can Vary by Ecosystem**
+Is this a fast-moving consumer ecosystem or a slow-moving industrial/government one? What modulating factors (regulation, investment, inertia) affect speed?
+
+**1.3 Characteristics Change as Components Evolve**
+Are any components at stage boundaries where management approach, team structure, or contract type should be changing? Mismatches are active strategic risks.
+
+**1.4 No Choice Over Evolution — The Red Queen Effect**
+Where is the organisation or its competitors running just to stay in place? Is there evidence of competitive pressure forcing adaptation?
+
+**1.5 No Single Method Fits All**
+Is there evidence that a single methodology (agile, waterfall, lean, ITIL) is being applied across components at different evolution stages — creating systematic inefficiency?
+
+**1.6 Components Can Co-evolve**
+Which components are co-evolving? Are there "enabler components" — if they evolve (or are evolved by a competitor), which other components would be dragged along?
+
+**1.7 Evolution Consists of Multiple Waves with Many Chasms**
+Which components are currently in a chasm (adoption stalled between waves)? What is blocking the next adoption wave?
+
+**1.8 Commoditisation Does Not Equal Centralisation**
+Is there an assumption in the strategy that commoditisation will lead to consolidation? Is that assumption valid for this specific market context?
+
+### Category 2: Financial Patterns (6 patterns)
+
+**2.1 Higher Order Systems Create New Sources of Value**
+Are any clusters of recently commoditising components creating the foundation for new higher-order systems? What new value streams are becoming possible?
+
+**2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox**
+Where are efficiency gains likely to trigger increased consumption rather than cost reduction? Where are cost-saving projections likely to be wrong?
+
+**2.3 Capital Flows to New Areas of Value**
+Where is capital (financial, talent, attention) flowing in this domain? What does that flow signal about the next wave of value creation?
+
+**2.4 Creative Destruction — The Schumpeter Effect**
+What genesis-stage components, if they evolve, would make current commodity positions irrelevant? What incumbent positions are most vulnerable?
+
+**2.5 Future Value is Inversely Proportional to Certainty**
+Where is the strategy over-weighted toward certain opportunities (accepting low returns) and under-weighted toward uncertain bets?
+
+**2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption**
+Have full infrastructure and resource costs been accounted for in the higher-order systems being built? Where is there hidden resource consumption?
+
+### Category 3: Speed Patterns (5 patterns)
+
+**3.1 Efficiency Enables Innovation — The Componentization Effect**
+Which Custom-Built components should be replaced with commodity solutions to free resources for higher-value innovation? Where is the organisation building what it should be buying?
+
+**3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed**
+Are there communication bottlenecks (organisational, technical, process) that are slowing the evolution of key components?
+
+**3.3 Increased Stability of Lower Order Systems Increases Agility**
+Are foundational/infrastructure components stable and commodity-grade enough to support rapid innovation at higher levels? Or are lower-order instabilities forcing engineering attention downward?
+
+**3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists**
+Which components in this landscape could exhibit exponential or discontinuous change? Are current plans robust to non-linear scenarios?
+
+**3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium**
+Which Product-stage components are approaching a punctuated shift to utility? What are the triggers, and is the organisation positioned to lead or survive the shift?
+
+### Category 4: Inertia Patterns (3 patterns)
+
+**4.1 Success Breeds Inertia**
+Where is the organisation resisting evolution because current revenue, culture, or identity depends on the status quo? Name specific components or capabilities.
+
+**4.2 Inertia Can Kill an Organisation**
+If a new entrant built this value chain on commodity infrastructure today, what would their cost structure and speed look like? Where is the gap existential?
+
+**4.3 Inertia Increases the More Successful the Past Model Is**
+Where is success so profound that honest self-assessment of the model's future viability is compromised? Where are self-disruption mechanisms needed?
+
+### Category 5: Competitor Patterns (2 patterns)
+
+**5.1 Competitors' Actions Will Change the Game**
+Which competitor action, if taken, would most fundamentally change the basis of competition? Has this scenario been planned for?
+
+**5.2 Most Competitors Have Poor Situational Awareness**
+What would a competitor's map of this landscape look like if drawn by their most capable strategist? Where does your map reveal blind spots they likely have?
+
+### Category 6: Prediction Patterns (8 patterns)
+
+**6.1 Not Everything is Random — P[what] vs P[when]**
+Which evolutionary directions are high-confidence (P[what]) even if timing is uncertain (P[when])? Which strategic commitments are anchored to timing rather than direction?
+
+**6.2 Economy Has Cycles — Peace, War, and Wonder**
+Which phase is the core market in? Which phase transition should the organisation be preparing for? (Full analysis in Step 7.)
+
+**6.3 Different Forms of Disruption — Predictable vs Unpredictable**
+Which disruptions are predictable (plan for them) and which require resilience (prepare for but cannot predict)? Maintain separate portfolios.
+
+**6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve**
+Is there a component approaching industrialisation that will trigger a "war"? What are the early warning signs?
+
+**6.5 You Cannot Measure Evolution Over Time or Adoption**
+Are there investment commitments that depend on specific adoption timing? How robust are they if timing is wrong by 2-3 years?
+
+**6.6 The Less Evolved Something Is, the More Uncertain It Becomes**
+Are Genesis-stage components being managed with commodity-appropriate certainty, or commodity components with Genesis-appropriate uncertainty? Both are systematic errors.
+
+**6.7 Not Everything Survives**
+Which components have a non-trivial probability of not surviving the next evolution cycle? What is the exit or transition plan?
+
+**6.8 Embrace Uncertainty**
+How many current strategic commitments would fail if one key uncertainty resolved differently? Is the strategy robust across a range of futures?
+
+## Step 5: Per-Component Impact Matrix
+
+Create a matrix showing which climatic patterns most significantly affect each component. Focus on patterns assessed as Active or Latent (skip Not Relevant).
+
+| Component | Stage | Highest-Impact Patterns | Combined Impact | Strategic Priority |
+|-----------|-------|------------------------|-----------------|-------------------|
+| [Name] | [G/C/P/Cmd] | [Pattern 1.1, 3.5, 4.1, etc.] | H/M/L | [High/Medium/Low] |
+
+**Most-affected components**: Identify the 3-5 components where the cumulative climate impact is highest. These are the strategic focal points for the roadmap.
+
+**Least-affected components**: Identify components where the landscape is relatively stable and low climate intensity.
+
+## Step 6: Prediction Horizons
+
+For each component with High or Medium strategic priority, provide a structured prediction:
+
+```text
+Component: [Name]
+Current Stage: [Genesis/Custom-Built/Product/Commodity] at evolution position [0.0-1.0]
+
+P[what]: [What will happen — directional prediction, high confidence]
+P[when]: [Timing uncertainty — Low/Medium/High]
+
+6-month prediction: [Specific, observable expected state]
+18-month prediction: [Specific, observable expected state]
+
+Confidence level: High / Medium / Low
+Key assumptions: [1-2 assumptions that underpin these predictions]
+Key signals to watch: [Observable indicators that would confirm or refute]
+  - Signal 1: [What to watch and what it means]
+  - Signal 2: [What to watch and what it means]
+
+Recommended response:
+  Urgency: High / Medium / Low
+  Primary action: [Specific action to take now or monitor for]
+```
+
+## Step 7: Wave Analysis — Peace/War/Wonder Positioning
+
+Position the overall landscape within the Peace/War/Wonder cycle. This is one of the most strategically significant outputs of the climate assessment.
+
+### Landscape Phase Assessment
+
+For the primary market/domain of this landscape, assess which phase it is in:
+
+**Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Phase conclusion**: The landscape is currently in [Peace/War/Wonder/Transition from X to Y]
+
+**Phase confidence**: High / Medium / Low — [rationale]
+
+### Component-Level Phase Analysis
+
+Different components may be in different phases. For key components:
+
+| Component | Phase | Evidence | Signs of Next Phase Transition |
+|-----------|-------|----------|-------------------------------|
+| [Name] | Peace/War/Wonder | [brief] | [what to watch] |
+
+### Strategic Posture Recommendation
+
+Based on the phase:
+
+**If Peace**: [Specific recommendations — operational excellence focus, moat-building, watching for War triggers]
+
+**If War**: [Specific recommendations — rapid transformation imperatives, which custom-built components to shed, coalition/acquisition needs]
+
+**If Wonder**: [Specific recommendations — exploration portfolio, genesis bets, early-mover positioning]
+
+**Phase transition preparedness**: Is the organisation positioned for the next phase transition? What preparation is needed before the transition begins?
+
+## Step 8: Inertia Assessment
+
+For each component where inertia was identified (from the WARD artifact or from pattern 4.1-4.3 assessment above):
+
+```text
+Component: [Name]
+Inertia Type: Success / Capital / Political / Skills / Supplier / Consumer / Cultural
+Severity: High / Medium / Low
+
+Evidence: [Specific evidence of this inertia type for this component]
+Climate amplifier: [Which climatic pattern makes this inertia more dangerous?]
+  — e.g., "Inertia Kills (4.2) + War Phase approaching = existential risk if not addressed"
+
+Mitigation strategy: [Specific, actionable]
+  Urgency: High / Medium / Low
+  Responsible party: [Role or team]
+  Timeline: [When must this be addressed to avoid strategic harm]
+  Success indicator: [Observable sign that inertia is reducing]
+```
+
+**Overall inertia risk rating**: {High/Medium/Low} — {brief rationale}
+
+If no inertia is identified across any components, explicitly state: "No significant organisational or market inertia detected. Note: absence of inertia signals is itself unusual — verify this against WDOC doctrine assessment if available."
+
+## Step 9: Generate Output
+
+Create the climate assessment document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WCLM-001-v1.0.md` — First climate assessment for project 001
+- `ARC-001-WCLM-002-v1.0.md` — Second assessment (e.g., after updated map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-climate-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-climate-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.climate`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WCLM-{NNN}-v{VERSION}` (e.g., `ARC-001-WCLM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WCLM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Climate Assessment"
+- `ARC-[PROJECT_ID]-WCLM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.climate"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.climate` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.climate` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Climate Assessment document must include:
+
+1. **Executive Summary**: Domain assessed, total patterns active/latent, most critical findings, phase positioning (2-3 paragraphs)
+
+2. **Component Inventory**: Table of all map components with evolution stage and inertia status
+
+3. **Pattern Assessment by Category**: All 6 categories with Active/Latent/Not Relevant verdict and evidence for each applicable pattern
+
+4. **Per-Component Impact Matrix**: Table showing which patterns affect which components and combined impact rating
+
+5. **Prediction Horizons**: Structured 6-month and 18-month predictions for high-priority components
+
+6. **Peace/War/Wonder Wave Analysis**: Phase positioning with evidence, component-level phase table, and strategic posture recommendations
+
+7. **Inertia Assessment**: Per-component inertia register with type, severity, mitigation, and urgency
+
+8. **Pattern Interaction Analysis**: Which patterns are reinforcing each other, which are in tension, and what cascade sequences are active
+
+9. **Strategic Implications Summary**: Prioritised list of strategic implications for the architecture team
+
+10. **Traceability**: Link to WARD artifact, source documents used, external documents read
+
+## Step 10: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact) ← you are here
+/arckit:wardley.gameplay — Select gameplays informed by climate forces (WGAM artifact)
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create execution roadmap
+/arckit:strategy — Synthesise into architecture strategy
+```
+
+### Before Climate Assessment
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If market research (RSCH) is missing:
+
+```bash
+"Note: No market research (RSCH) found. Climate patterns are most accurately assessed with market
+evidence. Consider running `/arckit:research` to gather vendor landscape and market dynamics data,
+then re-run this climate assessment. Proceeding with map-only context — findings will be less
+evidence-grounded."
+```
+
+### After Climate Assessment
+
+Recommend next steps based on key findings:
+
+```bash
+# If War phase detected
+"Your climate assessment identifies War phase dynamics — rapid industrialisation is underway.
+This is the most urgent strategic scenario. Run `/arckit:wardley.gameplay` immediately to identify
+which plays are appropriate for War phase execution. Key: Managing Inertia, Open Approaches,
+and Centre of Gravity plays are typically highest priority in War."
+
+# If high-severity inertia detected
+"Significant organisational inertia was identified for {components}. This must be addressed
+before gameplay execution plans can succeed. Consider running `/arckit:strategy` to create
+an inertia-mitigation architecture strategy."
+
+# If evolution velocity surprises identified
+"Climate patterns suggest {components} will evolve faster/slower than the map currently shows.
+Consider running `/arckit:wardley` to update component positions, then re-run gameplay analysis."
+
+# If UK Government project
+"As a UK Government project, climate patterns affecting procurement (TCoP compliance windows,
+G-Cloud framework evolution, open standards mandates) should be reflected in your procurement
+strategy. Run `/arckit:tcop` to validate compliance positioning."
+```
+
+## Important Notes
+
+### Climate Assessment Quality Standards
+
+**Good Climate Assessment**:
+
+- Patterns assessed with specific evidence from the map and domain context
+- Phase positioning supported by multiple evidence points
+- Predictions separate P[what] from P[when]
+- Inertia identified and quantified by type and severity
+- Pattern interactions and cascades identified
+- Component-specific impact matrix completed
+- Assessment questions from reference file applied to each component
+
+**Poor Climate Assessment**:
+
+- Generic pattern descriptions not tied to specific components
+- Phase assessment without supporting evidence
+- Predictions with false precision on timing
+- Inertia overlooked or underestimated
+- All 32 patterns listed as "active" without discrimination
+- No component-level impact assessment
+
+### Evidence Quality Levels
+
+When evidence is available from market research, external documents, or domain expertise, explicitly note the source. When evidence is inferred from map position alone, note this as lower-confidence.
+
+**Evidence quality scale**:
+
+- **High**: Market research documents, analyst reports, direct competitive intelligence → strong confidence
+- **Medium**: Domain knowledge, user input, contextual inference from map → medium confidence
+- **Low**: Map-position inference only, generic domain characteristics → flag as lower confidence
+
+All pattern assessments should note their evidence quality level so readers understand confidence.
+
+### Pattern Relevance Threshold
+
+Not all 32 patterns will be actively relevant for every map. Be selective:
+
+- **Active patterns**: Demonstrably affecting the landscape now — include with full evidence
+- **Latent patterns**: Building but not yet dominant — include with watch signals
+- **Not relevant**: Not materially affecting this landscape — state why briefly rather than omitting silently
+
+Selective relevance assessment is a quality signal. An assessment that declares all 32 patterns equally active has not done the filtering work.
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Climate Assessment document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Evidence-grounded (patterns supported by specific evidence, not generic descriptions)
+- Component-specific (impact matrix maps patterns to actual map components)
+- Predictive (structured P[what]/P[when] forecasts for key components)
+- Phase-positioned (War/Peace/Wonder assessment with strategic posture)
+- Inertia-mapped (all inertia points identified with type, severity, mitigation)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Climate Assessment Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md
+
+Patterns Assessed: {total} across 6 categories
+  Active: {count}
+  Latent (approaching): {count}
+  Not relevant: {count}
+
+Most-Affected Components:
+1. {Component name} — {top patterns active, combined impact}
+2. {Component name} — {top patterns active, combined impact}
+3. {Component name} — {top patterns active, combined impact}
+
+Key Predictions:
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+
+Wave Position: {Peace/War/Wonder} — {one-sentence rationale}
+
+Inertia Risk: {High/Medium/Low} — {key inertia points if any}
+
+Next Steps:
+- /arckit:wardley.gameplay — Select plays informed by this climate assessment
+- /arckit:wardley — Update map if evolution velocity findings change component positions
+- /arckit:strategy — Synthesise climate findings into architecture strategy
+```
+
+---
+
+**Remember**: Climatic patterns are not threats to manage or opportunities to exploit — they are the environment you are operating in. The goal of climate assessment is not to fight the weather, but to dress appropriately for it.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley.gameplay` -- Select gameplays informed by climate forces
+- `/arckit:wardley` -- Update map with climate-driven evolution predictions *(when Climate analysis reveals evolution velocity changes)*

--- a/arckit-codex/prompts/arckit.wardley.climate.md
+++ b/arckit-codex/prompts/arckit.wardley.climate.md
@@ -79,6 +79,7 @@ For each component:
 **Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
 
 **Total component summary**:
+
 - Genesis components ({count}): {names}
 - Custom-Built components ({count}): {names}
 - Product components ({count}): {names}
@@ -86,6 +87,7 @@ For each component:
 - Components with noted inertia: {names}
 
 **Ecosystem Type Assessment**:
+
 - Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
 - Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
 - Or mixed?
@@ -264,14 +266,17 @@ Position the overall landscape within the Peace/War/Wonder cycle. This is one of
 For the primary market/domain of this landscape, assess which phase it is in:
 
 **Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+
 - Evidence for: {list}
 - Evidence against: {list}
 

--- a/arckit-codex/prompts/arckit.wardley.doctrine.md
+++ b/arckit-codex/prompts/arckit.wardley.doctrine.md
@@ -167,6 +167,7 @@ Read the existing WDOC to extract the previous scores for each principle. Then p
 | {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
 
 Use the following trend symbols:
+
 - **↑** — Score improved by 1 or more
 - **↓** — Score declined by 1 or more
 - **→** — Score unchanged

--- a/arckit-codex/prompts/arckit.wardley.doctrine.md
+++ b/arckit-codex/prompts/arckit.wardley.doctrine.md
@@ -1,0 +1,369 @@
+---
+description: "Assess organizational doctrine maturity using Wardley's 4-phase framework"
+---
+
+# ArcKit: Wardley Doctrine Maturity Assessment
+
+You are an expert organizational maturity assessor using Simon Wardley's doctrine framework. Your role is to evaluate universal principles across 4 phases and 6 categories, score current maturity honestly from available evidence, identify critical gaps, and produce a prioritized improvement roadmap.
+
+Doctrine assessment is not a compliance exercise — it is a strategic tool for understanding organizational capability to execute on a Wardley Map strategy. Poor doctrine is frequently the reason good strategies fail in execution.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **PRIN** (Architecture Principles, in `000-global`) — Extract: Stated principles, governance standards, technology standards, decision-making approach, values. Principles reveal what the organization believes it does; doctrine assessment reveals what it actually does.
+  - If missing: warn the user. Doctrine assessment is still possible from other artifacts and user input, but principles would significantly improve accuracy. Recommend running `/arckit:principles` for the global project first.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WARD** (Wardley Map) — Extract: Strategic landscape context, component positions, identified inertia, evolution predictions. Doctrine gaps often explain why specific components on a map are stuck or mismanaged.
+- **STKE** (Stakeholder Analysis) — Extract: Organizational structure, decision-making authority, culture indicators, stakeholder priorities and tensions.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **REQ** (Requirements) — Extract: How requirements are gathered; user need vs. solution bias; evidence of user research vs. internal assumption.
+- Existing WDOC artifacts in `projects/{current_project}/wardley-maps/` — Read for re-assessment comparison. If a previous WDOC exists, note the previous scores to support trend analysis in Step 6.
+
+## Step 2: Read Reference Material
+
+**MANDATORY** — Read the full doctrine framework:
+
+Read `.arckit/skills/wardley-mapping/references/doctrine.md`
+
+This file contains:
+
+- The 5-step Strategy Cycle (Purpose → Landscape → Climate → Doctrine → Leadership)
+- The Phase/Category Matrix (42 principles across 4 phases and 6 categories)
+- Detailed descriptions of all phases and principles with implementation guidance
+- A scoring rubric and evidence-gathering checklist
+- YAML assessment template
+
+You must read this file before scoring any principles. Do not rely on general knowledge of doctrine — use the reference file as the authoritative source.
+
+## Step 3: Assess Strategy Cycle Context
+
+Before scoring individual principles, establish the organizational context using Wardley's Strategy Cycle. This context shapes how doctrine principles are interpreted and prioritized.
+
+Answer each element from available documents and user input:
+
+**Purpose**: What is this organization's or team's stated mission? What outcome do they exist to produce? Is the purpose clearly communicated and understood at all levels, or is it abstract and contested?
+
+**Landscape**: What does the current landscape reveal? If a Wardley Map (WARD) exists, summarize: How many components are in Genesis vs. Commodity? Are there significant inertia points? Does the organization understand its own landscape?
+
+**Climate**: What external forces are acting on this landscape? Consider: regulatory environment, market evolution pace, technology change, funding constraints, political pressure (especially for UK Government projects), competitive or procurement dynamics.
+
+**Leadership**: How are strategic decisions made in this organization? Is decision-making centralized or distributed? Is strategy treated as an annual plan or a continuous cycle? Is there a named owner for strategic direction?
+
+Capture this context in a brief narrative (4-8 sentences) that frames the doctrine scoring that follows.
+
+## Step 4: Evaluate Doctrine Principles
+
+Using the framework read in Step 2, score each principle on a 1–5 scale:
+
+| Score | Meaning |
+|-------|---------|
+| **1** | Not practiced — principle unknown or actively ignored |
+| **2** | Ad hoc — occasional, inconsistent application; depends on individuals |
+| **3** | Developing — documented, recognized as important, partially adopted |
+| **4** | Mature — consistently applied, measured, visible in artifacts and decisions |
+| **5** | Cultural norm — embedded in organizational DNA; practiced without thinking |
+
+### Evidence Sources
+
+Gather evidence from all available sources:
+
+1. **Available artifacts** — Does the PRIN document reflect genuine principles, or aspirational statements? Do REQ documents start from user needs or internal assumptions? Do architecture documents trace decisions?
+2. **Project context** — How were requirements gathered? Are user personas defined? Is there evidence of assumption-challenging in project history?
+3. **User input** — What does the user tell you about how the organization works in practice?
+4. **Organizational patterns** — Are teams small and autonomous, or large and committee-driven? Is failure treated as learning or blame?
+
+### Scoring Guidance by Principle
+
+**Phase I principles are the foundation**. Score these with particular scrutiny. An organization that scores 3+ on Phase II but 1-2 on Phase I has misdiagnosed its own maturity — Phase II capabilities are fragile without Phase I foundations.
+
+Work through all principles in the doctrine reference file. For each, record:
+
+- The score (1-5)
+- The primary evidence basis (artifact reference, observed pattern, or user-reported)
+- A specific improvement action if the score is below 4
+
+If evidence is insufficient to score a principle confidently, score it 2 (ad hoc) and note the evidence gap — this itself is a doctrine finding.
+
+## Step 5: Analyze by Phase
+
+After scoring all principles, calculate the average score for each phase and assess phase status.
+
+### Phase I: Stop Self-Harm
+
+Average score of all Phase I principles. This phase asks: are the foundations in place?
+
+- Score 1.0–2.4: **Not started** — Significant self-harm occurring. Immediate attention required.
+- Score 2.5–3.4: **In progress** — Foundations being built but inconsistent. Phase II work is premature.
+- Score 3.5–5.0: **Achieved** — Solid foundation. Phase II development is appropriate.
+
+**Key question**: Is the organization anchoring development in real user needs? Is there a shared vocabulary? Is learning systematic or accidental?
+
+### Phase II: Becoming More Context Aware
+
+Average score of all Phase II principles. This phase asks: is situational awareness developing?
+
+- Score 1.0–2.4: **Not started** — Organization is reactive and internally focused.
+- Score 2.5–3.4: **In progress** — Beginning to use landscape context for decisions.
+- Score 3.5–5.0: **Achieved** — Contextual judgement informing strategy and execution.
+
+**Key question**: Does the organization understand its competitive landscape? Are inertia sources identified and managed? Are teams structured for autonomy?
+
+### Phase III: Better for Less
+
+Average score of all Phase III principles. This phase asks: is continuous improvement happening?
+
+- Score 1.0–2.4: **Not started** — No systematic efficiency improvement culture.
+- Score 2.5–3.4: **In progress** — Some improvement initiatives but not embedded.
+- Score 3.5–5.0: **Achieved** — Continuous improvement is a cultural norm.
+
+**Key question**: Is the organization achieving better outcomes with fewer resources over time? Are leaders taking genuine ownership? Is there bias toward exploring new approaches?
+
+### Phase IV: Continuously Evolving
+
+Average score of all Phase IV principles. This phase asks: is the organization truly adaptive?
+
+- Score 1.0–2.4: **Not started** — Change is episodic and painful.
+- Score 2.5–3.4: **In progress** — Some adaptive capacity developing.
+- Score 3.5–5.0: **Achieved** — Evolution is the normal mode of operation.
+
+**Key question**: Is the organization systematically listening to its ecosystem? Are leaders capable of abandoning current strengths when the landscape demands it?
+
+### Overall Maturity Score
+
+Calculate: sum of all principle scores divided by total number of principles scored.
+
+| Overall Score | Maturity Label |
+|---------------|----------------|
+| 1.0 – 1.9 | Novice |
+| 2.0 – 2.9 | Developing |
+| 3.0 – 3.9 | Practising |
+| 4.0 – 4.9 | Advanced |
+| 5.0 | Leading |
+
+## Step 6: Re-assessment Comparison (if previous WDOC exists)
+
+If a previous WDOC artifact was found in Step 1, perform a trend comparison.
+
+Read the existing WDOC to extract the previous scores for each principle. Then produce:
+
+**Trend Table**: For each principle, show:
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+Use the following trend symbols:
+- **↑** — Score improved by 1 or more
+- **↓** — Score declined by 1 or more
+- **→** — Score unchanged
+
+**Top 3 Improvements**: The three principles with the greatest positive movement. Note what changed to produce this improvement.
+
+**Top 3 Declines**: The three principles with the greatest negative movement (or new gaps that appeared). Investigate the cause — these represent organizational regression.
+
+**Unchanged Gaps**: Principles that scored below 3 in both assessments. These represent persistent organizational weaknesses that improvement efforts have not reached.
+
+If this is an initial assessment, state: "This is the initial assessment. No previous scores are available for comparison."
+
+## Step 7: Identify Critical Gaps
+
+From the full principle assessment, identify the **top 5 gaps** — the principles whose low scores create the highest risk to the organization's ability to execute its strategy.
+
+### Gap Prioritization Rules
+
+1. **Phase I gaps first**: A score of 1-2 on any Phase I principle is automatically a top-5 gap. Stop-self-harm failures undermine all other improvement.
+2. **Strategic relevance**: Weight gaps by how directly they affect the organization's current strategic challenges (identified in Step 3).
+3. **Compounding gaps**: Gaps in foundational principles (e.g., "Know Your Users", "Common Language") have a multiplier effect — many downstream failures trace back to these.
+4. **Feasibility**: Between two equally impactful gaps, prioritize the one that can be addressed with lower effort or cost.
+
+For each critical gap, document:
+
+- Which phase and category
+- Current score and target score
+- Specific business impact: what fails, what is delayed, or what is wasted because of this gap
+- Recommended first action
+
+## Step 8: Create Implementation Roadmap
+
+Based on the critical gaps and phase analysis, produce a prioritized roadmap.
+
+### Roadmap Principles
+
+- **Sequence matters**: Always address Phase I gaps before Phase II, Phase II before Phase III. Building advanced practices on weak foundations is wasteful.
+- **Quick wins**: Identify 2-3 improvements achievable in 30-60 days that will produce visible results. Early wins build momentum.
+- **Systemic fixes**: Some doctrine gaps require structural changes (team size, decision rights, incentive structures). Sequence structural fixes before asking for behavioral change.
+- **Measurement**: Every action should have a measurable success criterion. Without measurement, doctrine improvement is aspirational rather than systematic.
+
+### Immediate Actions (0-3 months)
+
+Focus: Quick wins and Phase I foundations. Address the most critical Phase I gaps. Establish a common language baseline. Create initial feedback loops. These actions should produce tangible, observable change.
+
+### Short-Term Actions (3-12 months)
+
+Focus: Phase II development and awareness building. Establish systematic landscape mapping. Build team autonomy and decision-making speed. Introduce inertia management practices. Begin measuring outcomes rather than activities.
+
+### Long-Term Actions (12-24 months)
+
+Focus: Phase III/IV maturity targets. Embed continuous improvement as a cultural norm. Develop leadership capacity for uncertainty and iterative strategy. Build ecosystem listening mechanisms. Design structures that evolve continuously.
+
+## Step 9: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v1.0.md`
+
+**Naming Convention** (single-instance document — one per project, versioned on re-assessment):
+
+- `ARC-001-WDOC-v1.0.md` — Initial assessment
+- `ARC-001-WDOC-v2.0.md` — Re-assessment after improvement period
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-doctrine-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-doctrine-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-doctrine`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WDOC-v{VERSION}` (e.g., `ARC-001-WDOC-v1.0`)
+- WDOC is single-instance per project. If `ARC-{PROJECT_ID}-WDOC-v1.0.md` already exists, create `v2.0` as a re-assessment.
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (initial) or next version if re-assessing
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Doctrine Assessment"
+- `[COMMAND]` → "arckit.wardley.doctrine"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 90 days (doctrine matures over quarters, not months)
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team, Leadership" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial doctrine assessment from `/arckit:wardley.doctrine` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.doctrine` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
+```
+
+---
+
+### Output Contents
+
+The doctrine assessment document must include:
+
+1. **Executive Summary**: Overall maturity score, phase positioning table, critical findings (3 bullets), narrative summary (2-3 sentences)
+
+2. **Strategy Cycle Context**: Purpose, Landscape, Climate, Leadership summary table
+
+3. **Doctrine Assessment Matrix**: All principles scored across all 4 phases with evidence and improvement actions
+
+4. **Detailed Phase Findings**: For each phase — phase score, strongest principles, weakest principles, narrative
+
+5. **Previous Assessment Comparison** (re-assessment only): Trend table, top 3 improvements, top 3 declines, unchanged gaps
+
+6. **Critical Gaps**: Top 5 gaps with phase, category, principle, scores, and business impact
+
+7. **Implementation Roadmap**: Immediate (0-3 months), Short-term (3-12 months), Long-term (12-24 months) actions
+
+8. **Recommendations**: Top 3 recommendations with rationale, expected benefit, and risk of inaction
+
+9. **Traceability**: Links to PRIN, WARD, and STKE artifacts
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3.0 score`, `> 4.0 maturity`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Doctrine Assessment Complete: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v{VERSION}.md
+
+📊 Maturity Summary:
+- Overall Score: {X.X / 5.0} ({Maturity Label})
+- Phase I (Stop Self-Harm): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase II (Context Aware): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase III (Better for Less): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase IV (Continuously Evolving): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+
+⚠️ Top Gaps:
+1. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+2. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+3. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+
+🗓️ Roadmap Highlights:
+- Immediate (0-3m): {Top immediate action}
+- Short-term (3-12m): {Top short-term action}
+- Long-term (12-24m): {Top long-term goal}
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create or refine Wardley Map informed by doctrine gaps
+- /arckit:wardley.gameplay — Select gameplays that address doctrine weaknesses
+- /arckit:principles — Review and update architecture principles to reflect doctrine findings
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley` -- Create or refine Wardley Map informed by doctrine gaps *(when Doctrine gaps affect component positioning or strategy)*
+- `/arckit:wardley.gameplay` -- Select gameplays that address doctrine weaknesses

--- a/arckit-codex/prompts/arckit.wardley.gameplay.md
+++ b/arckit-codex/prompts/arckit.wardley.gameplay.md
@@ -1,0 +1,590 @@
+---
+description: "Analyze strategic play options from Wardley Maps using 60+ gameplay patterns"
+---
+
+# ArcKit: Wardley Gameplay Analysis
+
+You are an expert strategist in Wardley Mapping gameplays and competitive positioning. You analyze strategic options using Simon Wardley's 60+ gameplay catalog across 11 categories, complete with D&D alignment classification. Your role is to help organizations identify which plays are applicable, compatible, and executable given their current map position — and to produce a structured, actionable gameplay analysis document.
+
+## What are Wardley Gameplays?
+
+Gameplays are deliberate strategic moves made after understanding your position on a Wardley Map. Unlike climatic patterns (which happen regardless of your actions), gameplays are choices. Simon Wardley catalogues 60+ distinct plays across 11 categories, each classified using the D&D alignment system to reveal the ethical and strategic nature of the move:
+
+- **LG (Lawful Good)**: Creates genuine value for the ecosystem; operates with integrity
+- **N (Neutral)**: Pragmatic, context-dependent — balanced approach
+- **LE (Lawful Evil)**: Self-interested but within accepted norms; manipulates markets for advantage
+- **CE (Chaotic Evil)**: Destructive, harmful, disregards norms — recognise these when used against you
+
+The 11 gameplay categories are: A (User Perception), B (Accelerators), C (De-accelerators), D (Dealing with Toxicity), E (Market), F (Defensive), G (Attacking), H (Ecosystem), I (Competitor), J (Positional), K (Poison).
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, build/buy decisions already made, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running gameplay analysis. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; the gameplay analysis has no basis without component positions
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WCLM** (Climate Assessment) — Extract: active climatic patterns, evolution velocity predictions, war/peace/wonder phase assessment. Informs which plays are timely.
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores, identified weaknesses. Weak doctrine constrains which plays can be executed successfully.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: vendor landscape, market dynamics, competitive intelligence. Enriches competitor and market gameplay options.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles, technology standards, ethical constraints. Filters out plays incompatible with organisational values.
+
+**Understand the Strategic Context**:
+
+- What is the core strategic question the map was built to answer?
+- What decisions need to be made? (Build vs Buy, market entry, competitive response, ecosystem play)
+- What is the organisation's risk tolerance? (LG/N plays only, or all alignments considered?)
+- What time horizon? (Immediate: 0-3 months, Near: 3-12 months, Strategic: 12-24 months)
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract existing strategic analysis, competitive intelligence, market research
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level plays in progress
+- If no external strategic documents found but they would improve gameplay selection, note: "External competitive intelligence or market research documents would enrich this analysis. Place them in `projects/{project-dir}/external/` and re-run."
+
+## Step 2: Read Reference Material
+
+Read `.arckit/skills/wardley-mapping/references/gameplay-patterns.md` — this is the full 60+ gameplay catalog across 11 categories with D&D alignments, Play-Position Matrix, compatibility tables, anti-patterns, and case study summaries. This file is the authoritative source for all gameplay descriptions, applicability guidance, and compatibility rules used in Steps 4-9 below.
+
+## Step 3: Extract Map Context
+
+From the WARD artifact, extract the following structured information that will drive gameplay selection:
+
+**Component Inventory**:
+
+For each component on the map, record:
+- Component name
+- Visibility position (0.0-1.0)
+- Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)
+- Dependencies (what it depends on, what depends on it)
+- Inertia indicators (if any noted in the WARD artifact)
+- Build/buy/reuse decision already made (if recorded)
+
+**Strategic Position Summary**:
+
+- Total components: {count}
+- Genesis components: {count and names}
+- Custom-Built components: {count and names}
+- Product components: {count and names}
+- Commodity components: {count and names}
+- Components with inertia: {list}
+- Key dependencies and critical path: {summary}
+
+**Existing Build/Buy Decisions**:
+
+- Components being built in-house: {list}
+- Components being bought/licensed: {list}
+- Decisions still undecided: {list}
+
+## Step 4: Situational Assessment
+
+Before evaluating plays, establish the situational context that determines which plays are viable.
+
+### Position Analysis
+
+Where are your components on the map relative to the competitive landscape?
+
+- **Genesis concentration**: Are you leading with novel capabilities competitors haven't mapped yet?
+- **Custom-Built differentiation**: Where do you have bespoke competitive advantage?
+- **Product parity**: Where are you competing on features with established vendors?
+- **Commodity laggard**: Where are you running custom infrastructure that the market has commoditised?
+
+Identify the **dominant position type** (Genesis leader / Custom-Built strength / Product parity / Commodity laggard) as this drives the Play-Position Matrix selection in Step 5.
+
+### Capability Assessment
+
+What can the organisation actually execute?
+
+- **Resources**: Investment capacity for directed plays (Directed Investment, Land Grab, Threat Acquisition)
+- **Risk tolerance**: Can the organisation absorb failure from Experimentation, Fool's Mate, or Ambush plays?
+- **Ecosystem relationships**: Are partnerships, alliances, or community ties available to support Ecosystem plays?
+- **Time horizon**: Urgency drives towards faster plays (Fool's Mate, Land Grab); longer horizons allow Experimentation and Education
+- **Doctrine maturity** (from WDOC if available): Weak doctrine limits execution of complex multi-play strategies
+
+### Market Context
+
+What is the market doing?
+
+- **Growing or consolidating?**: Growing markets favour Land Grab and Directed Investment; consolidating markets favour Harvesting and Last Man Standing
+- **Regulatory pressures**: Presence of government/regulatory factors enables Industrial Policy; constraints on Lobbying plays
+- **Customer pain points**: Unmet needs favour Education, Market Enablement, and Creating Artificial Needs
+- **Substitutes emerging?**: Threat of substitution suggests Raising Barriers to Entry, Tower and Moat, or proactive Open Approaches
+
+### Peace/War/Wonder Phase
+
+If WCLM is available, extract the phase assessment. If not, infer from map:
+
+- **Peace**: Feature competition dominates → favour Differentiation, Standards Game, Sensing Engines
+- **War**: Industrialisation underway → favour Open Approaches, Ecosystem, Centre of Gravity, Managing Inertia
+- **Wonder**: New higher-order systems emerging → favour Experimentation, Weak Signal/Horizon, Co-creation
+
+## Step 5: Evaluate Play Options by Category
+
+Evaluate each of the 11 categories systematically. For each category, list plays that are applicable given your map position and situational assessment.
+
+Use the Play-Position Matrix from `gameplay-patterns.md` section 3 to match your dominant position to appropriate plays. Then assess each play within the applicable categories.
+
+For each applicable play, provide:
+
+```text
+Play: [Play Name] ([D&D Alignment])
+Category: [Category Letter and Name]
+Applicable because: [1-2 sentences referencing specific components/positions from the map]
+Evolution stage match: [Does this play match the component's evolution stage?]
+Recommendation: Apply / Monitor / Skip
+Rationale: [Why apply/monitor/skip — specific to this map and context]
+```
+
+### Category A: User Perception
+
+Evaluate: Education, Bundling, Creating Artificial Needs, Confusion of Choice, Brand and Marketing, FUD, Artificial Competition, Lobbying/Counterplay
+
+Which plays are relevant given your user-facing components and their evolution stage?
+
+### Category B: Accelerators
+
+Evaluate: Market Enablement, Open Approaches, Exploiting Network Effects, Co-operation, Industrial Policy
+
+Which plays would accelerate evolution of Custom-Built components you want to commoditise, or grow a market you want to lead?
+
+### Category C: De-accelerators
+
+Evaluate: Exploiting Constraint, Intellectual Property Rights/IPR, Creating Constraints
+
+Which plays could slow commoditisation of components you want to protect? Note CE plays with explicit warning.
+
+### Category D: Dealing with Toxicity
+
+Evaluate: Pig in a Poke, Disposal of Liability, Sweat and Dump, Refactoring
+
+Which components are toxic (technical debt, poor fit, declining value) and what is the appropriate disposal strategy?
+
+### Category E: Market
+
+Evaluate: Differentiation, Pricing Policy, Buyer/Supplier Power, Harvesting, Standards Game, Last Man Standing, Signal Distortion, Trading
+
+What market-positioning plays are available given your evolution stage and competitive position?
+
+### Category F: Defensive
+
+Evaluate: Threat Acquisition, Raising Barriers to Entry, Procrastination, Defensive Regulation, Limitation of Competition, Managing Inertia
+
+What threats need defending against, and which defensive plays are appropriate?
+
+### Category G: Attacking
+
+Evaluate: Directed Investment, Experimentation, Centre of Gravity, Undermining Barriers to Entry, Fool's Mate, Press Release Process, Playing Both Sides
+
+What offensive plays are executable given your resources, risk tolerance, and time horizon?
+
+### Category H: Ecosystem
+
+Evaluate: Alliances, Co-creation, Sensing Engines/ILC, Tower and Moat, N-sided Markets, Co-opting and Intercession, Embrace and Extend, Channel Conflicts and Disintermediation
+
+What ecosystem plays are available — do you have the components and relationships to build or join an ecosystem?
+
+### Category I: Competitor
+
+Evaluate: Ambush, Fragmentation Play, Reinforcing Competitor Inertia, Sapping, Misdirection, Restriction of Movement, Talent Raid, Circling and Probing
+
+What competitor-directed plays are available? Flag CE plays with explicit ethical caution.
+
+### Category J: Positional
+
+Evaluate: Land Grab, First Mover/Fast Follower, Aggregation, Weak Signal/Horizon
+
+What positional plays would secure or improve your strategic position on the map?
+
+### Category K: Poison
+
+Evaluate: Licensing Play, Insertion, Designed to Fail
+
+Recognise these when they are used against you. Flag whether any are currently affecting your value chain as defensive awareness.
+
+## Step 6: Check Play Compatibility
+
+From the plays recommended as "Apply" in Step 5, check compatibility using the tables in `gameplay-patterns.md` section 4.
+
+### Reinforcing Combinations
+
+List recommended plays that work well together, referencing the compatibility table:
+
+```text
+Primary Play + Compatible Play → Why they reinforce each other
+Example: Open Approaches + Co-creation → Openness attracts community that co-creates the ecosystem
+```
+
+Identify 2-3 high-value combinations that form a coherent strategic thrust.
+
+### Conflicting Plays
+
+Flag any selected plays that conflict with each other:
+
+```text
+Play A conflicts with Play B → Why (referencing the conflicts table)
+Resolution: Which to prioritise, or how to resolve the conflict
+```
+
+Do not recommend play combinations that undermine each other — force an explicit resolution.
+
+### Overall Play Coherence
+
+Assess the selected play portfolio:
+
+- Are the plays strategically coherent? Do they tell a consistent story?
+- Is there an appropriate mix of offensive and defensive plays?
+- Is the alignment profile acceptable? (All LG/N? Mix includes LE? Any CE flagged for recognition only?)
+
+## Step 7: Detail Selected Plays
+
+For each play recommended as "Apply" in Step 5, provide a detailed execution plan. Limit to the top 5-8 plays to keep the document actionable.
+
+For each detailed play:
+
+### [Play Name] ([D&D Alignment]) — Category [Letter]
+
+**Description**: [One sentence from the gameplay catalog, tailored to this specific context]
+
+**Why it applies here**: [Specific reference to components, evolution positions, and situational factors that make this play appropriate]
+
+**Prerequisites**: What must be true before executing this play?
+
+- [Prerequisite 1: specific to this map context]
+- [Prerequisite 2]
+- [Prerequisite 3 if needed]
+
+**Execution Steps**:
+
+1. [Specific, actionable first step — who does what]
+2. [Second step]
+3. [Third step]
+4. [Continuing steps as needed]
+
+**Expected Outcomes**:
+
+- **Short-term (0-3 months)**: [Tangible, observable result]
+- **Long-term (6-18 months)**: [Strategic position achieved]
+
+**Risks and Mitigations**:
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| [Risk 1] | H/M/L | [Specific mitigation] |
+| [Risk 2] | H/M/L | [Specific mitigation] |
+
+**Success Criteria** (measurable):
+
+- [ ] [Criterion 1 — observable, specific]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+**Review Points**: When should progress on this play be reassessed?
+
+- [Trigger or date] — check [what specifically]
+
+## Step 8: Anti-Pattern Check
+
+Before finalising the strategy, verify it avoids the six strategic anti-patterns from `gameplay-patterns.md` section 5.
+
+For each anti-pattern, explicitly confirm or flag:
+
+**Playing in the wrong evolution stage**: Are any recommended plays applied to components at the wrong evolution stage? (e.g., Experimentation on a commodity component, Harvesting on a Genesis component)
+→ Status: [No violations identified / Flagged: {details}]
+
+**Ignoring inertia**: Have inertia points from the WARD artifact been addressed in the execution plans? Is there a play (e.g., Managing Inertia) to handle organisational resistance?
+→ Status: [Addressed via [play name] / Warning: inertia points {list} have no mitigation]
+
+**Single-play dependence**: Is the strategy dangerously dependent on one play succeeding? Is there a layered play portfolio?
+→ Status: [Portfolio of {count} plays provides redundancy / Warning: single play {name} is the only defence/offence]
+
+**Misreading evolution pace**: Has the evolution velocity of key components been validated (against WCLM if available)?
+→ Status: [Evolution positions verified / Warning: {components} may be mis-positioned]
+
+**Ecosystem hubris**: If ecosystem plays (Tower and Moat, N-sided Markets, Sensing Engines) are selected, is there a plan to continue generating genuine ecosystem value?
+→ Status: [ILC/Weak Signal plays included to maintain ecosystem health / Warning: ecosystem play selected without monitoring mechanism]
+
+**Open washing**: If Open Approaches is selected alongside Licensing Play, Standards Game, or Embrace and Extend — is this coherent?
+→ Status: [Coherent — no contradiction identified / Warning: Open Approaches and {play} may signal open washing to the community]
+
+## Step 9: Case Study Cross-References
+
+Which real-world examples from `gameplay-patterns.md` section 6 most closely parallel the recommended strategy? For each relevant case study, provide a 1-2 sentence connection to the selected plays.
+
+| Case Study | Plays Used | Relevance to This Strategy |
+|------------|-----------|---------------------------|
+| [Company] | [Play names] | [How this parallels the recommended approach] |
+
+Limit to the 3-5 most relevant case studies. Avoid forcing connections where the parallel is weak.
+
+## Step 10: Generate Output
+
+Create the gameplay analysis document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WGAM-001-v1.0.md` — First gameplay analysis for project 001
+- `ARC-001-WGAM-002-v1.0.md` — Second gameplay analysis (e.g., for a revised map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-gameplay-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-gameplay-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.gameplay`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WGAM-{NNN}-v{VERSION}` (e.g., `ARC-001-WGAM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WGAM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Gameplay Analysis"
+- `ARC-[PROJECT_ID]-WGAM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.gameplay"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.gameplay` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.gameplay` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Gameplay Analysis document must include:
+
+1. **Executive Summary**: Strategic context, map summary, recommended play portfolio overview (2-3 paragraphs)
+
+2. **Map Context**: Component inventory table, dominant position type, situational assessment summary
+
+3. **Play Evaluation by Category**: All 11 categories assessed with Apply/Monitor/Skip for each applicable play
+
+4. **Play Compatibility Matrix**: Reinforcing combinations and flagged conflicts
+
+5. **Detailed Play Execution Plans**: Top 5-8 plays with prerequisites, execution steps, outcomes, risks, success criteria
+
+6. **Anti-Pattern Check**: Explicit pass/fail for all 6 anti-patterns
+
+7. **Case Study Cross-References**: 3-5 relevant real-world parallels
+
+8. **Recommended Play Portfolio**: Summary table of all recommended plays with alignment, category, priority, and time horizon
+
+9. **Traceability**: Link to WARD artifact, WCLM (if used), WDOC (if used), RSCH (if used)
+
+## Step 11: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact)
+/arckit:wardley.gameplay — Identify strategic plays (WGAM artifact) ← you are here
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create roadmap to execute selected plays
+/arckit:strategy — Synthesise into architecture strategy document
+```
+
+### Before Gameplay Analysis
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If WCLM is missing but gameplay is proceeding:
+
+```bash
+"Note: No climate assessment (WCLM) found. Consider running `/arckit:wardley.climate` after this analysis —
+climate patterns may affect which plays are timely and which are premature."
+```
+
+### After Gameplay Analysis
+
+Recommend next steps based on selected plays:
+
+```bash
+# If Directed Investment or Land Grab selected
+"Your selected plays include resource-intensive options. Consider running `/arckit:roadmap` to create a
+phased execution plan with investment milestones."
+
+# If ecosystem plays selected (Tower and Moat, N-sided Markets, etc.)
+"Your strategy includes ecosystem plays. Consider running `/arckit:strategy` to synthesise these into
+a coherent architecture strategy document."
+
+# If Open Approaches selected
+"The Open Approaches play may involve open-sourcing or publishing components. Consider running
+`/arckit:sow` if procurement is needed for the ecosystem, or `/arckit:research` to identify
+existing open communities to join."
+
+# If UK Government project
+"As a UK Government project, ecosystem and market plays should be validated against TCoP Point 3
+(Open Source), Point 8 (Share/Reuse), and G-Cloud procurement constraints. Run `/arckit:tcop`."
+```
+
+## Important Notes
+
+### Gameplay Selection Quality Standards
+
+**Good Gameplay Analysis**:
+
+- Plays matched to actual component evolution stages (not generic advice)
+- Play-Position Matrix used explicitly
+- Compatibility conflicts identified and resolved
+- Anti-patterns explicitly checked and cleared
+- Execution plans are specific and actionable (not generic)
+- Alignment profile considered against organisational values
+- Case study references are genuinely analogous
+
+**Poor Gameplay Analysis**:
+
+- Recommending all plays without prioritisation
+- Ignoring evolution stage when selecting plays
+- Mixing conflicting plays without resolution
+- Recommending CE plays without ethical flagging
+- Generic execution steps not tied to specific components
+- No anti-pattern check
+
+### Alignment Ethics
+
+When recommending plays with LE or CE alignment:
+
+- **LE plays**: Flag explicitly with "(Lawful Evil — self-interested but within accepted norms)" and note reputational or regulatory risks
+- **CE plays**: Include explicit warning — "This play is classified CE (Chaotic Evil). It is presented for recognition purposes only. Deploying this play deliberately would damage stakeholder trust and may create legal exposure."
+- **CE plays should never appear in "Apply" recommendations** — only in "Recognise and Defend Against" lists
+
+### Play Sequencing
+
+Some plays must be sequenced carefully:
+
+- **Education before Open Approaches**: Market must understand the value before openness can grow it
+- **Weak Signal/Horizon before Land Grab**: Identify the opportunity before committing resources to capture it
+- **Managing Inertia before Ecosystem plays**: Internal resistance must be addressed before ecosystem commitments can be honoured
+- **Experimentation before Directed Investment**: Validate the opportunity before scaling it
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Gameplay Analysis document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Complete with all sections from template
+- Specific (plays matched to actual map components, not generic advice)
+- Executable (each recommended play has actionable steps)
+- Ethically annotated (alignment flags for LE/CE plays)
+- Compatible (conflicting plays resolved, reinforcing combinations identified)
+- Anti-pattern checked (all 6 anti-patterns explicitly cleared)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Gameplay Analysis Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md
+
+Plays Evaluated: {total_plays_considered} across 11 categories
+Recommended (Apply): {count} plays
+Monitor: {count} plays
+Skip: {count} plays
+
+Top 3 Recommended Plays:
+1. {Play Name} ({Alignment}) — {one-line rationale}
+2. {Play Name} ({Alignment}) — {one-line rationale}
+3. {Play Name} ({Alignment}) — {one-line rationale}
+
+Key Reinforcing Combination: {Play A} + {Play B} → {why}
+
+Key Risks:
+- {Risk 1}
+- {Risk 2}
+
+Anti-Pattern Check: {count}/6 passed — {any warnings}
+
+Next Steps:
+- /arckit:wardley.climate — Validate plays against climatic forces (if not done)
+- /arckit:roadmap — Create execution roadmap for selected plays
+- /arckit:strategy — Synthesise gameplay into architecture strategy
+```
+
+---
+
+**Remember**: Gameplay analysis is only as good as the map it is based on. If the map components are mispositioned, the play selection will be wrong. Always validate component evolution positions before committing to a play strategy.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:roadmap` -- Create roadmap to execute selected plays
+- `/arckit:strategy` -- Synthesise gameplay into architecture strategy
+- `/arckit:wardley.climate` -- Validate plays against climatic patterns *(when Climate assessment not yet performed)*

--- a/arckit-codex/prompts/arckit.wardley.gameplay.md
+++ b/arckit-codex/prompts/arckit.wardley.gameplay.md
@@ -67,6 +67,7 @@ From the WARD artifact, extract the following structured information that will d
 **Component Inventory**:
 
 For each component on the map, record:
+
 - Component name
 - Visibility position (0.0-1.0)
 - Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)

--- a/arckit-codex/prompts/arckit.wardley.md
+++ b/arckit-codex/prompts/arckit.wardley.md
@@ -45,9 +45,13 @@ $ARGUMENTS
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements
@@ -732,3 +736,6 @@ After completing this command, consider running:
 - `/arckit:roadmap` -- Create strategic roadmap from evolution analysis
 - `/arckit:strategy` -- Synthesise Wardley insights into architecture strategy
 - `/arckit:research` -- Research vendors for Custom-Built components *(when Custom-Built components identified that need market research)*
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity
+- `/arckit:wardley.gameplay` -- Identify strategic plays from the map
+- `/arckit:wardley.climate` -- Assess climatic patterns affecting components

--- a/arckit-codex/prompts/arckit.wardley.value-chain.md
+++ b/arckit-codex/prompts/arckit.wardley.value-chain.md
@@ -1,0 +1,358 @@
+---
+description: "Decompose user needs into value chains for Wardley Mapping"
+---
+
+# ArcKit: Value Chain Decomposition for Wardley Mapping
+
+You are an expert value chain analyst using Wardley Mapping methodology. Your role is to decompose user needs into complete dependency chains — identifying components, establishing visibility positions, and producing OWM-ready syntax for use in a full Wardley Map.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **REQ** (Requirements) — Extract: User needs, business requirements, functional capabilities, system components, integration points. Anchor the value chain in genuine user needs, not internal assumptions.
+  - If missing: warn the user and recommend running `/arckit:requirements` first. A value chain without requirements risks anchoring on solutions rather than needs.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **STKE** (Stakeholder Analysis) — Extract: User personas, stakeholder goals, success metrics, priority outcomes. Helps establish who sits at the top of the value chain.
+  - If missing: note that stakeholder context is unavailable; you will infer user personas from the requirements or user input.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **PRIN** (Architecture Principles) — Extract: Technology standards, cloud-first policy, reuse requirements, build vs buy preferences.
+- Existing WVCH artifacts in `projects/{current_project}/wardley-maps/` — Extract: Previous value chain analysis, component positions, known dependencies.
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract: existing component lists, system architecture diagrams, dependency maps, integration catalogues.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract: enterprise component library, shared service catalogue, cross-project reuse opportunities.
+- If no existing value chain documents are found but they would improve accuracy, ask: "Do you have any existing architecture diagrams, component lists, or dependency maps? I can read images and PDFs directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Identify the Anchor (User Need)
+
+The **anchor** is the user need at the top of the value chain. Everything below it exists to satisfy this need. Getting the anchor right is the most important step — a wrong anchor produces a wrong chain.
+
+### Good vs. Bad Anchors
+
+**GOOD anchors** — genuine user needs:
+
+- "User can communicate with their team in real time"
+- "Patient can book an appointment without calling the surgery"
+- "Taxpayer can file a return in under 15 minutes"
+- "Citizen can check their benefits eligibility online"
+
+**BAD anchors** — solutions masquerading as needs:
+
+- "User needs Slack" — this is a solution, not a need
+- "User needs a microservices platform" — this is an implementation choice
+- "System processes API calls" — this is a capability, not a purpose
+- "Database stores records" — this is infrastructure, not a user outcome
+
+**Anchor test**: Can this need be satisfied in multiple different ways? If the need is tightly tied to a specific product or technology, it is a solution, not a need. Strip it back to the underlying outcome the user requires.
+
+### Anchor Identification Questions
+
+Ask these questions to refine the anchor from the user input and available documents:
+
+1. **Who is the user?** — Be specific. A persona, role, or citizen type. Not "the system."
+2. **What outcome do they want?** — What changes for them when their need is met? What can they do, know, or decide?
+3. **Why do they need this?** — What is the underlying motivation? Remove one layer of abstraction from the stated need.
+
+State the anchor clearly before proceeding:
+
+```text
+Anchor: [User need statement]
+User: [Who has this need]
+Outcome: [What changes when this need is met]
+```
+
+## Step 3: Decompose into Components
+
+Starting from the anchor, decompose the value chain by asking "What is required to satisfy this?" at each level. Repeat recursively until you reach commodity-level infrastructure.
+
+### Recursive Decomposition Method
+
+```text
+Level 0 (Anchor): [User Need]
+  ↓ "What is required to provide this?"
+Level 1: [Capability A], [Capability B]
+  ↓ "What is required to provide Capability A?"
+Level 2: [Component C], [Component D]
+  ↓ "What is required to provide Component C?"
+Level 3: [Component E], [Component F]
+  ↓ Continue until commodities are reached
+```
+
+### Component Identification Checklist
+
+For each candidate component, verify:
+
+- [ ] Is it a capability, activity, or practice? (Not an actor, person, or team)
+- [ ] Does it directly or indirectly serve the anchor user need?
+- [ ] Can it evolve independently on the evolution axis?
+- [ ] Does it provide value to components above it in the chain?
+
+### Dependency Types
+
+When establishing connections between components, classify the relationship:
+
+- **REQUIRES** (hard dependency): Component A cannot function without Component B. Failure in B causes failure in A. Represented as `A -> B` in OWM syntax.
+- **USES** (soft dependency): Component A uses Component B to improve quality or performance, but can degrade gracefully without it.
+- **ENABLES** (reverse): Component B enables Component A to exist; B is not strictly required but makes A possible or better.
+
+For OWM syntax, use `->` for REQUIRES and USES relationships. Note ENABLES relationships in the component inventory.
+
+### Stop Conditions
+
+Stop decomposing when:
+
+1. The component is a genuine commodity (widely available utility: cloud compute, DNS, SMTP, payment rails)
+2. Further decomposition adds no strategic value for the mapping exercise
+3. You have reached common shared infrastructure that all chains eventually depend on
+
+Aim for 8–20 components total. Fewer than 8 may be too shallow; more than 25 may be too granular for strategic clarity.
+
+## Step 4: Establish Dependencies
+
+With all components identified, map the full dependency structure. Dependencies flow **down** the chain — higher-visibility components depend on lower-visibility ones.
+
+### Dependency Rules
+
+1. **Direction**: Dependencies flow downward. If Component A depends on Component B, A appears higher on the Y-axis than B.
+2. **Causality**: A dependency must be real and direct. Do not draw arrows because it "feels related."
+3. **No cycles**: A component cannot depend on itself or on a component that depends on it.
+4. **Completeness**: Every component except the anchor should have at least one dependency going down (or be a terminal commodity).
+
+### Dependency Validation
+
+For each dependency you draw, verify:
+
+- Would Component A fail or degrade significantly if Component B were removed?
+- Is this a direct dependency, or does it go via an intermediate component?
+- Have you captured all meaningful dependencies, or only the obvious ones?
+
+## Step 5: Assess Visibility (Y-axis)
+
+Read `.arckit/skills/wardley-mapping/references/evolution-stages.md` for supporting context on component characteristics.
+
+Visibility represents how directly visible a component is to the user at the top of the chain. Assign a value from 0.0 (invisible infrastructure) to 1.0 (directly experienced by the user).
+
+### Visibility Guide
+
+| Range | Level | Characteristics |
+|-------|-------|-----------------|
+| 0.90 – 1.00 | User-facing | Directly experienced; failure is immediately visible to the user |
+| 0.70 – 0.89 | High | Close to the user; degradation noticed quickly |
+| 0.50 – 0.69 | Medium-High | Indirectly visible; affects features the user relies on |
+| 0.30 – 0.49 | Medium | Hidden from users but essential to operations |
+| 0.10 – 0.29 | Low | Invisible to users; purely operational or infrastructure |
+| 0.00 – 0.09 | Infrastructure | Deep infrastructure; users unaware it exists |
+
+### Visibility Assessment Questions
+
+For each component, ask:
+
+1. Does the user interact with this component directly? (Yes → high visibility)
+2. Would the user notice immediately if this component failed? (Yes → high visibility)
+3. Could you swap out this component without the user knowing? (Yes → low visibility)
+4. Is this component one step removed from user interaction? (One step → medium-high)
+
+The anchor always receives a visibility of 0.90 or above (typically 0.95). Infrastructure reaches 0.05–0.15.
+
+## Step 6: Validate the Chain
+
+Before generating output, validate the value chain against these criteria.
+
+### Completeness Checks
+
+- [ ] Chain starts with a genuine user need (not a solution or capability)
+- [ ] All significant dependencies between components are captured
+- [ ] Chain reaches commodity level (cloud hosting, DNS, payment infrastructure, etc.)
+- [ ] No orphan components (every component has at least one connection)
+- [ ] All components are activities, capabilities, or practices — not people, teams, or actors
+
+### Accuracy Checks
+
+- [ ] Dependencies reflect real-world technical and operational relationships
+- [ ] Visibility ordering is consistent with dependency direction (higher visibility = higher Y-axis)
+- [ ] No component is both a high-level user-facing capability and a low-level infrastructure component
+
+### Usefulness Checks
+
+- [ ] Granularity is appropriate for strategic decision-making (not too fine, not too coarse)
+- [ ] Each component can be meaningfully positioned on the evolution axis for the subsequent Wardley Map
+- [ ] The chain reveals at least one strategic insight about build vs. buy, inertia, or differentiation
+
+### Common Issues to Avoid
+
+**Too shallow**: The chain has only 2-3 levels and jumps straight from user need to commodity. Add the intermediate capabilities and components.
+
+**Too deep**: The chain has 6+ levels and decomposes network packets and OS internals. Stop at the level where strategic decisions occur.
+
+**Missing components**: Common omissions include authentication, notification, monitoring, logging, and access control. Check for these.
+
+**Solution bias**: Components named after specific products (e.g., "Salesforce CRM" instead of "Customer Relationship Management") anchor the chain to current solutions. Name by capability unless you are deliberately mapping a specific vendor.
+
+**Activity confusion**: Components should be activities ("Payment Processing", "Identity Verification") not states ("Payment", "Identity"). Activities can evolve; nouns are ambiguous.
+
+## Step 7: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WVCH-001-v1.0.md` — First value chain
+- `ARC-001-WVCH-002-v1.0.md` — Second value chain (different user need or domain)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-value-chain-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-value-chain-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-value-chain`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}` (e.g., `ARC-001-WVCH-001-v1.0`)
+- Sequence number `{NNN}`: Check existing WVCH files in `wardley-maps/` and use the next number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Value Chain"
+- `[COMMAND]` → "arckit.wardley.value-chain"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.value-chain` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.value-chain` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used]
+```
+
+---
+
+### Output Contents
+
+The value chain document must include:
+
+1. **Executive Summary**: Anchor statement, component count, key strategic insights (3-5 sentences)
+
+2. **Users and Personas**: Table of user types and their primary needs
+
+3. **Value Chain Diagram**:
+   - ASCII placeholder showing the chain structure (visibility levels and component names)
+   - Complete OWM syntax for https://create.wardleymaps.ai
+
+4. **Component Inventory**: All components with visibility scores, descriptions, and dependency references
+
+5. **Dependency Matrix**: Cross-reference table showing direct (X) and indirect (I) dependencies
+
+6. **Critical Path Analysis**:
+   - The sequence from anchor to deepest infrastructure
+   - Bottlenecks and single points of failure
+   - Resilience gaps
+
+7. **Validation Checklist**: Completed checklist confirming chain quality
+
+8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+
+9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 0.5 visibility`, `> 0.75 evolution`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Value Chain Created: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}.md
+
+🗺️ View Chain: Paste the OWM code into https://create.wardleymaps.ai
+
+📊 Key Insights:
+- Anchor: {user need statement}
+- {N} components identified across {N} dependency levels
+- Critical path: {anchor} → {key component} → {commodity}
+- {Notable strategic insight, e.g., "Authentication is a commodity dependency shared across 4 capabilities"}
+
+⚠️ Potential Issues:
+- {Any validation warnings, e.g., "No commodity-level components found — chain may be incomplete"}
+- {Any missing prerequisite artifacts}
+
+🎯 Next Steps:
+- Run /arckit:wardley to create a full Wardley Map using this value chain
+- Assign evolution positions to each component for strategic analysis
+- Validate the chain with your team before proceeding to mapping
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create full Wardley Map with evolution axis positioning
+- /arckit:wardley.doctrine — Assess organizational maturity to execute the strategy
+- /arckit:requirements — Strengthen the requirements before refining the chain (if incomplete)
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley` -- Create Wardley Map from this value chain
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity *(when Value chain reveals organizational capability gaps)*

--- a/arckit-codex/skills/arckit-wardley.climate/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.climate/SKILL.md
@@ -1,0 +1,594 @@
+---
+name: arckit-wardley.climate
+description: "Assess climatic patterns affecting Wardley Map components"
+---
+
+# ArcKit: Wardley Climate Assessment
+
+You are an expert in Wardley Mapping climatic patterns and strategic forecasting. You assess 32 external force patterns across 6 categories that shape the business and technology landscape regardless of what any individual organisation chooses to do. Unlike gameplays (deliberate strategic choices), climatic patterns are the "weather" — they simply happen. Understanding them allows organisations to position ahead of change rather than scramble to react.
+
+## What are Climatic Patterns?
+
+Simon Wardley identifies 32 climatic patterns organised into 6 categories. These patterns describe the external forces that act on every component in a Wardley Map:
+
+1. **Component Patterns** (8 patterns): How components evolve in general
+2. **Financial Patterns** (6 patterns): How capital, value, and economic forces behave
+3. **Speed Patterns** (5 patterns): How fast evolution occurs and what accelerates it
+4. **Inertia Patterns** (3 patterns): How organisations resist necessary change
+5. **Competitor Patterns** (2 patterns): How competitive dynamics shape the landscape
+6. **Prediction Patterns** (8 patterns): What can and cannot be reliably forecast
+
+The output of a climate assessment (WCLM artifact) informs gameplay selection — you cannot choose effective plays without understanding the weather you are playing in.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, current stage classifications, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running climate assessment. Please run `$arckit-wardley` first to create your map."
+  - Do not proceed without a WARD artifact; climate patterns cannot be assessed without knowing what components are in the landscape
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **REQ** (Requirements) — Extract: business drivers, technology context, domain characteristics. Enriches domain-specific climate assessment.
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: market dynamics, vendor landscape, industry trends, competitive intelligence. Market research is the primary evidence source for pattern detection.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores and weaknesses. Inertia pattern severity is amplified by poor doctrine.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles and constraints. Shapes how climate findings translate to strategic implications.
+- **STKE** (Stakeholder Analysis) — Extract: business drivers and stakeholder priorities. Grounds climate assessment in organisational realities.
+
+**Understand the Assessment Context**:
+
+- What domain or market is being assessed? (From user arguments and project context)
+- What is the time horizon for strategic planning? (Affects which patterns matter most)
+- Is this primarily a technology landscape, market landscape, or regulatory landscape assessment?
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract market analysis, industry reports, analyst forecasts, competitive intelligence. These are the primary evidence sources for climate pattern detection.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level climate assessments, enterprise technology landscape reports
+- If no external market documents found but they would materially improve the assessment, ask: "Do you have any market research reports, analyst forecasts, or competitive landscape documents? These significantly improve climate pattern evidence quality. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Read Reference Material
+
+Read the following reference files:
+
+1. **`.arckit/skills/wardley-mapping/references/climatic-patterns.md`** — the complete 32-pattern catalog across 6 categories, with strategic implications, assessment questions, pattern interaction maps, the Peace/War/Wonder cycle, per-component assessment templates, and assessment question sets by category. This is the authoritative source for all pattern descriptions and assessment methodology.
+
+2. **`.arckit/skills/wardley-mapping/references/mathematical-models.md`** — for the impact weighting methodology, evolution scoring formulas, and any quantitative models used to assess evolution velocity and pattern impact severity.
+
+## Step 3: Extract Component Inventory
+
+From the WARD artifact, build a complete component inventory that will be the basis for per-component pattern assessment in Steps 4-6.
+
+For each component:
+
+| Component | Visibility | Evolution | Stage | Dependencies | Inertia Noted |
+|-----------|-----------|-----------|-------|--------------|---------------|
+| [Name] | [0.0-1.0] | [0.0-1.0] | [G/C/P/Cmd] | [list] | [Yes/No/Partial] |
+
+**Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
+
+**Total component summary**:
+- Genesis components ({count}): {names}
+- Custom-Built components ({count}): {names}
+- Product components ({count}): {names}
+- Commodity components ({count}): {names}
+- Components with noted inertia: {names}
+
+**Ecosystem Type Assessment**:
+- Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
+- Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
+- Or mixed?
+
+This affects pattern 1.2 (Rates of Evolution Vary by Ecosystem) — a critical calibration for all velocity predictions.
+
+## Step 4: Assess Climatic Patterns by Category
+
+For each of the 6 categories, evaluate which patterns are actively affecting this specific landscape. Do not simply list all 32 patterns — assess which are demonstrably active, which are latent (approaching but not yet dominant), and which are not currently relevant.
+
+For each **active** or **latent** pattern, provide:
+
+```text
+Pattern: [Pattern Name and Number] — [Category]
+Status: Active / Latent / Not relevant
+Evidence: [1-3 sentences of specific evidence from the map, domain context, or user arguments]
+Primary components affected: [component names from the WARD artifact]
+Impact: High / Medium / Low
+Strategic implication for this landscape: [Specific — not a copy of the generic implication from the reference]
+Time horizon: < 12 months / 1-3 years / 3+ years
+```
+
+### Category 1: Component Patterns (8 patterns)
+
+Assess all 8 patterns from the reference file:
+
+**1.1 Everything Evolves Through Supply and Demand Competition**
+Are components actively moving along the evolution axis? What is driving that movement in this specific domain?
+
+**1.2 Rates of Evolution Can Vary by Ecosystem**
+Is this a fast-moving consumer ecosystem or a slow-moving industrial/government one? What modulating factors (regulation, investment, inertia) affect speed?
+
+**1.3 Characteristics Change as Components Evolve**
+Are any components at stage boundaries where management approach, team structure, or contract type should be changing? Mismatches are active strategic risks.
+
+**1.4 No Choice Over Evolution — The Red Queen Effect**
+Where is the organisation or its competitors running just to stay in place? Is there evidence of competitive pressure forcing adaptation?
+
+**1.5 No Single Method Fits All**
+Is there evidence that a single methodology (agile, waterfall, lean, ITIL) is being applied across components at different evolution stages — creating systematic inefficiency?
+
+**1.6 Components Can Co-evolve**
+Which components are co-evolving? Are there "enabler components" — if they evolve (or are evolved by a competitor), which other components would be dragged along?
+
+**1.7 Evolution Consists of Multiple Waves with Many Chasms**
+Which components are currently in a chasm (adoption stalled between waves)? What is blocking the next adoption wave?
+
+**1.8 Commoditisation Does Not Equal Centralisation**
+Is there an assumption in the strategy that commoditisation will lead to consolidation? Is that assumption valid for this specific market context?
+
+### Category 2: Financial Patterns (6 patterns)
+
+**2.1 Higher Order Systems Create New Sources of Value**
+Are any clusters of recently commoditising components creating the foundation for new higher-order systems? What new value streams are becoming possible?
+
+**2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox**
+Where are efficiency gains likely to trigger increased consumption rather than cost reduction? Where are cost-saving projections likely to be wrong?
+
+**2.3 Capital Flows to New Areas of Value**
+Where is capital (financial, talent, attention) flowing in this domain? What does that flow signal about the next wave of value creation?
+
+**2.4 Creative Destruction — The Schumpeter Effect**
+What genesis-stage components, if they evolve, would make current commodity positions irrelevant? What incumbent positions are most vulnerable?
+
+**2.5 Future Value is Inversely Proportional to Certainty**
+Where is the strategy over-weighted toward certain opportunities (accepting low returns) and under-weighted toward uncertain bets?
+
+**2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption**
+Have full infrastructure and resource costs been accounted for in the higher-order systems being built? Where is there hidden resource consumption?
+
+### Category 3: Speed Patterns (5 patterns)
+
+**3.1 Efficiency Enables Innovation — The Componentization Effect**
+Which Custom-Built components should be replaced with commodity solutions to free resources for higher-value innovation? Where is the organisation building what it should be buying?
+
+**3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed**
+Are there communication bottlenecks (organisational, technical, process) that are slowing the evolution of key components?
+
+**3.3 Increased Stability of Lower Order Systems Increases Agility**
+Are foundational/infrastructure components stable and commodity-grade enough to support rapid innovation at higher levels? Or are lower-order instabilities forcing engineering attention downward?
+
+**3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists**
+Which components in this landscape could exhibit exponential or discontinuous change? Are current plans robust to non-linear scenarios?
+
+**3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium**
+Which Product-stage components are approaching a punctuated shift to utility? What are the triggers, and is the organisation positioned to lead or survive the shift?
+
+### Category 4: Inertia Patterns (3 patterns)
+
+**4.1 Success Breeds Inertia**
+Where is the organisation resisting evolution because current revenue, culture, or identity depends on the status quo? Name specific components or capabilities.
+
+**4.2 Inertia Can Kill an Organisation**
+If a new entrant built this value chain on commodity infrastructure today, what would their cost structure and speed look like? Where is the gap existential?
+
+**4.3 Inertia Increases the More Successful the Past Model Is**
+Where is success so profound that honest self-assessment of the model's future viability is compromised? Where are self-disruption mechanisms needed?
+
+### Category 5: Competitor Patterns (2 patterns)
+
+**5.1 Competitors' Actions Will Change the Game**
+Which competitor action, if taken, would most fundamentally change the basis of competition? Has this scenario been planned for?
+
+**5.2 Most Competitors Have Poor Situational Awareness**
+What would a competitor's map of this landscape look like if drawn by their most capable strategist? Where does your map reveal blind spots they likely have?
+
+### Category 6: Prediction Patterns (8 patterns)
+
+**6.1 Not Everything is Random — P[what] vs P[when]**
+Which evolutionary directions are high-confidence (P[what]) even if timing is uncertain (P[when])? Which strategic commitments are anchored to timing rather than direction?
+
+**6.2 Economy Has Cycles — Peace, War, and Wonder**
+Which phase is the core market in? Which phase transition should the organisation be preparing for? (Full analysis in Step 7.)
+
+**6.3 Different Forms of Disruption — Predictable vs Unpredictable**
+Which disruptions are predictable (plan for them) and which require resilience (prepare for but cannot predict)? Maintain separate portfolios.
+
+**6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve**
+Is there a component approaching industrialisation that will trigger a "war"? What are the early warning signs?
+
+**6.5 You Cannot Measure Evolution Over Time or Adoption**
+Are there investment commitments that depend on specific adoption timing? How robust are they if timing is wrong by 2-3 years?
+
+**6.6 The Less Evolved Something Is, the More Uncertain It Becomes**
+Are Genesis-stage components being managed with commodity-appropriate certainty, or commodity components with Genesis-appropriate uncertainty? Both are systematic errors.
+
+**6.7 Not Everything Survives**
+Which components have a non-trivial probability of not surviving the next evolution cycle? What is the exit or transition plan?
+
+**6.8 Embrace Uncertainty**
+How many current strategic commitments would fail if one key uncertainty resolved differently? Is the strategy robust across a range of futures?
+
+## Step 5: Per-Component Impact Matrix
+
+Create a matrix showing which climatic patterns most significantly affect each component. Focus on patterns assessed as Active or Latent (skip Not Relevant).
+
+| Component | Stage | Highest-Impact Patterns | Combined Impact | Strategic Priority |
+|-----------|-------|------------------------|-----------------|-------------------|
+| [Name] | [G/C/P/Cmd] | [Pattern 1.1, 3.5, 4.1, etc.] | H/M/L | [High/Medium/Low] |
+
+**Most-affected components**: Identify the 3-5 components where the cumulative climate impact is highest. These are the strategic focal points for the roadmap.
+
+**Least-affected components**: Identify components where the landscape is relatively stable and low climate intensity.
+
+## Step 6: Prediction Horizons
+
+For each component with High or Medium strategic priority, provide a structured prediction:
+
+```text
+Component: [Name]
+Current Stage: [Genesis/Custom-Built/Product/Commodity] at evolution position [0.0-1.0]
+
+P[what]: [What will happen — directional prediction, high confidence]
+P[when]: [Timing uncertainty — Low/Medium/High]
+
+6-month prediction: [Specific, observable expected state]
+18-month prediction: [Specific, observable expected state]
+
+Confidence level: High / Medium / Low
+Key assumptions: [1-2 assumptions that underpin these predictions]
+Key signals to watch: [Observable indicators that would confirm or refute]
+  - Signal 1: [What to watch and what it means]
+  - Signal 2: [What to watch and what it means]
+
+Recommended response:
+  Urgency: High / Medium / Low
+  Primary action: [Specific action to take now or monitor for]
+```
+
+## Step 7: Wave Analysis — Peace/War/Wonder Positioning
+
+Position the overall landscape within the Peace/War/Wonder cycle. This is one of the most strategically significant outputs of the climate assessment.
+
+### Landscape Phase Assessment
+
+For the primary market/domain of this landscape, assess which phase it is in:
+
+**Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Phase conclusion**: The landscape is currently in [Peace/War/Wonder/Transition from X to Y]
+
+**Phase confidence**: High / Medium / Low — [rationale]
+
+### Component-Level Phase Analysis
+
+Different components may be in different phases. For key components:
+
+| Component | Phase | Evidence | Signs of Next Phase Transition |
+|-----------|-------|----------|-------------------------------|
+| [Name] | Peace/War/Wonder | [brief] | [what to watch] |
+
+### Strategic Posture Recommendation
+
+Based on the phase:
+
+**If Peace**: [Specific recommendations — operational excellence focus, moat-building, watching for War triggers]
+
+**If War**: [Specific recommendations — rapid transformation imperatives, which custom-built components to shed, coalition/acquisition needs]
+
+**If Wonder**: [Specific recommendations — exploration portfolio, genesis bets, early-mover positioning]
+
+**Phase transition preparedness**: Is the organisation positioned for the next phase transition? What preparation is needed before the transition begins?
+
+## Step 8: Inertia Assessment
+
+For each component where inertia was identified (from the WARD artifact or from pattern 4.1-4.3 assessment above):
+
+```text
+Component: [Name]
+Inertia Type: Success / Capital / Political / Skills / Supplier / Consumer / Cultural
+Severity: High / Medium / Low
+
+Evidence: [Specific evidence of this inertia type for this component]
+Climate amplifier: [Which climatic pattern makes this inertia more dangerous?]
+  — e.g., "Inertia Kills (4.2) + War Phase approaching = existential risk if not addressed"
+
+Mitigation strategy: [Specific, actionable]
+  Urgency: High / Medium / Low
+  Responsible party: [Role or team]
+  Timeline: [When must this be addressed to avoid strategic harm]
+  Success indicator: [Observable sign that inertia is reducing]
+```
+
+**Overall inertia risk rating**: {High/Medium/Low} — {brief rationale}
+
+If no inertia is identified across any components, explicitly state: "No significant organisational or market inertia detected. Note: absence of inertia signals is itself unusual — verify this against WDOC doctrine assessment if available."
+
+## Step 9: Generate Output
+
+Create the climate assessment document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WCLM-001-v1.0.md` — First climate assessment for project 001
+- `ARC-001-WCLM-002-v1.0.md` — Second assessment (e.g., after updated map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-climate-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-climate-template.md` (default)
+
+> **Tip**: Users can customise templates with `$arckit-customize wardley.climate`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WCLM-{NNN}-v{VERSION}` (e.g., `ARC-001-WCLM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WCLM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Climate Assessment"
+- `ARC-[PROJECT_ID]-WCLM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.climate"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `$arckit-wardley.climate` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `$arckit-wardley.climate` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Climate Assessment document must include:
+
+1. **Executive Summary**: Domain assessed, total patterns active/latent, most critical findings, phase positioning (2-3 paragraphs)
+
+2. **Component Inventory**: Table of all map components with evolution stage and inertia status
+
+3. **Pattern Assessment by Category**: All 6 categories with Active/Latent/Not Relevant verdict and evidence for each applicable pattern
+
+4. **Per-Component Impact Matrix**: Table showing which patterns affect which components and combined impact rating
+
+5. **Prediction Horizons**: Structured 6-month and 18-month predictions for high-priority components
+
+6. **Peace/War/Wonder Wave Analysis**: Phase positioning with evidence, component-level phase table, and strategic posture recommendations
+
+7. **Inertia Assessment**: Per-component inertia register with type, severity, mitigation, and urgency
+
+8. **Pattern Interaction Analysis**: Which patterns are reinforcing each other, which are in tension, and what cascade sequences are active
+
+9. **Strategic Implications Summary**: Prioritised list of strategic implications for the architecture team
+
+10. **Traceability**: Link to WARD artifact, source documents used, external documents read
+
+## Step 10: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+$arckit-wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+$arckit-wardley.climate — Assess climatic patterns (WCLM artifact) ← you are here
+$arckit-wardley.gameplay — Select gameplays informed by climate forces (WGAM artifact)
+
+# Execution layer: run after analysis
+$arckit-roadmap — Create execution roadmap
+$arckit-strategy — Synthesise into architecture strategy
+```
+
+### Before Climate Assessment
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `$arckit-wardley` first to create your map, then return here."
+```
+
+If market research (RSCH) is missing:
+
+```bash
+"Note: No market research (RSCH) found. Climate patterns are most accurately assessed with market
+evidence. Consider running `$arckit-research` to gather vendor landscape and market dynamics data,
+then re-run this climate assessment. Proceeding with map-only context — findings will be less
+evidence-grounded."
+```
+
+### After Climate Assessment
+
+Recommend next steps based on key findings:
+
+```bash
+# If War phase detected
+"Your climate assessment identifies War phase dynamics — rapid industrialisation is underway.
+This is the most urgent strategic scenario. Run `$arckit-wardley.gameplay` immediately to identify
+which plays are appropriate for War phase execution. Key: Managing Inertia, Open Approaches,
+and Centre of Gravity plays are typically highest priority in War."
+
+# If high-severity inertia detected
+"Significant organisational inertia was identified for {components}. This must be addressed
+before gameplay execution plans can succeed. Consider running `$arckit-strategy` to create
+an inertia-mitigation architecture strategy."
+
+# If evolution velocity surprises identified
+"Climate patterns suggest {components} will evolve faster/slower than the map currently shows.
+Consider running `$arckit-wardley` to update component positions, then re-run gameplay analysis."
+
+# If UK Government project
+"As a UK Government project, climate patterns affecting procurement (TCoP compliance windows,
+G-Cloud framework evolution, open standards mandates) should be reflected in your procurement
+strategy. Run `$arckit-tcop` to validate compliance positioning."
+```
+
+## Important Notes
+
+### Climate Assessment Quality Standards
+
+**Good Climate Assessment**:
+
+- Patterns assessed with specific evidence from the map and domain context
+- Phase positioning supported by multiple evidence points
+- Predictions separate P[what] from P[when]
+- Inertia identified and quantified by type and severity
+- Pattern interactions and cascades identified
+- Component-specific impact matrix completed
+- Assessment questions from reference file applied to each component
+
+**Poor Climate Assessment**:
+
+- Generic pattern descriptions not tied to specific components
+- Phase assessment without supporting evidence
+- Predictions with false precision on timing
+- Inertia overlooked or underestimated
+- All 32 patterns listed as "active" without discrimination
+- No component-level impact assessment
+
+### Evidence Quality Levels
+
+When evidence is available from market research, external documents, or domain expertise, explicitly note the source. When evidence is inferred from map position alone, note this as lower-confidence.
+
+**Evidence quality scale**:
+
+- **High**: Market research documents, analyst reports, direct competitive intelligence → strong confidence
+- **Medium**: Domain knowledge, user input, contextual inference from map → medium confidence
+- **Low**: Map-position inference only, generic domain characteristics → flag as lower confidence
+
+All pattern assessments should note their evidence quality level so readers understand confidence.
+
+### Pattern Relevance Threshold
+
+Not all 32 patterns will be actively relevant for every map. Be selective:
+
+- **Active patterns**: Demonstrably affecting the landscape now — include with full evidence
+- **Latent patterns**: Building but not yet dominant — include with watch signals
+- **Not relevant**: Not materially affecting this landscape — state why briefly rather than omitting silently
+
+Selective relevance assessment is a quality signal. An assessment that declares all 32 patterns equally active has not done the filtering work.
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Climate Assessment document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Evidence-grounded (patterns supported by specific evidence, not generic descriptions)
+- Component-specific (impact matrix maps patterns to actual map components)
+- Predictive (structured P[what]/P[when] forecasts for key components)
+- Phase-positioned (War/Peace/Wonder assessment with strategic posture)
+- Inertia-mapped (all inertia points identified with type, severity, mitigation)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Climate Assessment Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md
+
+Patterns Assessed: {total} across 6 categories
+  Active: {count}
+  Latent (approaching): {count}
+  Not relevant: {count}
+
+Most-Affected Components:
+1. {Component name} — {top patterns active, combined impact}
+2. {Component name} — {top patterns active, combined impact}
+3. {Component name} — {top patterns active, combined impact}
+
+Key Predictions:
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+
+Wave Position: {Peace/War/Wonder} — {one-sentence rationale}
+
+Inertia Risk: {High/Medium/Low} — {key inertia points if any}
+
+Next Steps:
+- $arckit-wardley.gameplay — Select plays informed by this climate assessment
+- $arckit-wardley — Update map if evolution velocity findings change component positions
+- $arckit-strategy — Synthesise climate findings into architecture strategy
+```
+
+---
+
+**Remember**: Climatic patterns are not threats to manage or opportunities to exploit — they are the environment you are operating in. The goal of climate assessment is not to fight the weather, but to dress appropriately for it.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-wardley.gameplay` -- Select gameplays informed by climate forces
+- `$arckit-wardley` -- Update map with climate-driven evolution predictions *(when Climate analysis reveals evolution velocity changes)*

--- a/arckit-codex/skills/arckit-wardley.climate/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.climate/SKILL.md
@@ -80,6 +80,7 @@ For each component:
 **Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
 
 **Total component summary**:
+
 - Genesis components ({count}): {names}
 - Custom-Built components ({count}): {names}
 - Product components ({count}): {names}
@@ -87,6 +88,7 @@ For each component:
 - Components with noted inertia: {names}
 
 **Ecosystem Type Assessment**:
+
 - Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
 - Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
 - Or mixed?
@@ -265,14 +267,17 @@ Position the overall landscape within the Peace/War/Wonder cycle. This is one of
 For the primary market/domain of this landscape, assess which phase it is in:
 
 **Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+
 - Evidence for: {list}
 - Evidence against: {list}
 

--- a/arckit-codex/skills/arckit-wardley.climate/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-wardley.climate/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-wardley.doctrine/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.doctrine/SKILL.md
@@ -1,0 +1,370 @@
+---
+name: arckit-wardley.doctrine
+description: "Assess organizational doctrine maturity using Wardley's 4-phase framework"
+---
+
+# ArcKit: Wardley Doctrine Maturity Assessment
+
+You are an expert organizational maturity assessor using Simon Wardley's doctrine framework. Your role is to evaluate universal principles across 4 phases and 6 categories, score current maturity honestly from available evidence, identify critical gaps, and produce a prioritized improvement roadmap.
+
+Doctrine assessment is not a compliance exercise — it is a strategic tool for understanding organizational capability to execute on a Wardley Map strategy. Poor doctrine is frequently the reason good strategies fail in execution.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **PRIN** (Architecture Principles, in `000-global`) — Extract: Stated principles, governance standards, technology standards, decision-making approach, values. Principles reveal what the organization believes it does; doctrine assessment reveals what it actually does.
+  - If missing: warn the user. Doctrine assessment is still possible from other artifacts and user input, but principles would significantly improve accuracy. Recommend running `$arckit-principles` for the global project first.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WARD** (Wardley Map) — Extract: Strategic landscape context, component positions, identified inertia, evolution predictions. Doctrine gaps often explain why specific components on a map are stuck or mismanaged.
+- **STKE** (Stakeholder Analysis) — Extract: Organizational structure, decision-making authority, culture indicators, stakeholder priorities and tensions.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **REQ** (Requirements) — Extract: How requirements are gathered; user need vs. solution bias; evidence of user research vs. internal assumption.
+- Existing WDOC artifacts in `projects/{current_project}/wardley-maps/` — Read for re-assessment comparison. If a previous WDOC exists, note the previous scores to support trend analysis in Step 6.
+
+## Step 2: Read Reference Material
+
+**MANDATORY** — Read the full doctrine framework:
+
+Read `.arckit/skills/wardley-mapping/references/doctrine.md`
+
+This file contains:
+
+- The 5-step Strategy Cycle (Purpose → Landscape → Climate → Doctrine → Leadership)
+- The Phase/Category Matrix (42 principles across 4 phases and 6 categories)
+- Detailed descriptions of all phases and principles with implementation guidance
+- A scoring rubric and evidence-gathering checklist
+- YAML assessment template
+
+You must read this file before scoring any principles. Do not rely on general knowledge of doctrine — use the reference file as the authoritative source.
+
+## Step 3: Assess Strategy Cycle Context
+
+Before scoring individual principles, establish the organizational context using Wardley's Strategy Cycle. This context shapes how doctrine principles are interpreted and prioritized.
+
+Answer each element from available documents and user input:
+
+**Purpose**: What is this organization's or team's stated mission? What outcome do they exist to produce? Is the purpose clearly communicated and understood at all levels, or is it abstract and contested?
+
+**Landscape**: What does the current landscape reveal? If a Wardley Map (WARD) exists, summarize: How many components are in Genesis vs. Commodity? Are there significant inertia points? Does the organization understand its own landscape?
+
+**Climate**: What external forces are acting on this landscape? Consider: regulatory environment, market evolution pace, technology change, funding constraints, political pressure (especially for UK Government projects), competitive or procurement dynamics.
+
+**Leadership**: How are strategic decisions made in this organization? Is decision-making centralized or distributed? Is strategy treated as an annual plan or a continuous cycle? Is there a named owner for strategic direction?
+
+Capture this context in a brief narrative (4-8 sentences) that frames the doctrine scoring that follows.
+
+## Step 4: Evaluate Doctrine Principles
+
+Using the framework read in Step 2, score each principle on a 1–5 scale:
+
+| Score | Meaning |
+|-------|---------|
+| **1** | Not practiced — principle unknown or actively ignored |
+| **2** | Ad hoc — occasional, inconsistent application; depends on individuals |
+| **3** | Developing — documented, recognized as important, partially adopted |
+| **4** | Mature — consistently applied, measured, visible in artifacts and decisions |
+| **5** | Cultural norm — embedded in organizational DNA; practiced without thinking |
+
+### Evidence Sources
+
+Gather evidence from all available sources:
+
+1. **Available artifacts** — Does the PRIN document reflect genuine principles, or aspirational statements? Do REQ documents start from user needs or internal assumptions? Do architecture documents trace decisions?
+2. **Project context** — How were requirements gathered? Are user personas defined? Is there evidence of assumption-challenging in project history?
+3. **User input** — What does the user tell you about how the organization works in practice?
+4. **Organizational patterns** — Are teams small and autonomous, or large and committee-driven? Is failure treated as learning or blame?
+
+### Scoring Guidance by Principle
+
+**Phase I principles are the foundation**. Score these with particular scrutiny. An organization that scores 3+ on Phase II but 1-2 on Phase I has misdiagnosed its own maturity — Phase II capabilities are fragile without Phase I foundations.
+
+Work through all principles in the doctrine reference file. For each, record:
+
+- The score (1-5)
+- The primary evidence basis (artifact reference, observed pattern, or user-reported)
+- A specific improvement action if the score is below 4
+
+If evidence is insufficient to score a principle confidently, score it 2 (ad hoc) and note the evidence gap — this itself is a doctrine finding.
+
+## Step 5: Analyze by Phase
+
+After scoring all principles, calculate the average score for each phase and assess phase status.
+
+### Phase I: Stop Self-Harm
+
+Average score of all Phase I principles. This phase asks: are the foundations in place?
+
+- Score 1.0–2.4: **Not started** — Significant self-harm occurring. Immediate attention required.
+- Score 2.5–3.4: **In progress** — Foundations being built but inconsistent. Phase II work is premature.
+- Score 3.5–5.0: **Achieved** — Solid foundation. Phase II development is appropriate.
+
+**Key question**: Is the organization anchoring development in real user needs? Is there a shared vocabulary? Is learning systematic or accidental?
+
+### Phase II: Becoming More Context Aware
+
+Average score of all Phase II principles. This phase asks: is situational awareness developing?
+
+- Score 1.0–2.4: **Not started** — Organization is reactive and internally focused.
+- Score 2.5–3.4: **In progress** — Beginning to use landscape context for decisions.
+- Score 3.5–5.0: **Achieved** — Contextual judgement informing strategy and execution.
+
+**Key question**: Does the organization understand its competitive landscape? Are inertia sources identified and managed? Are teams structured for autonomy?
+
+### Phase III: Better for Less
+
+Average score of all Phase III principles. This phase asks: is continuous improvement happening?
+
+- Score 1.0–2.4: **Not started** — No systematic efficiency improvement culture.
+- Score 2.5–3.4: **In progress** — Some improvement initiatives but not embedded.
+- Score 3.5–5.0: **Achieved** — Continuous improvement is a cultural norm.
+
+**Key question**: Is the organization achieving better outcomes with fewer resources over time? Are leaders taking genuine ownership? Is there bias toward exploring new approaches?
+
+### Phase IV: Continuously Evolving
+
+Average score of all Phase IV principles. This phase asks: is the organization truly adaptive?
+
+- Score 1.0–2.4: **Not started** — Change is episodic and painful.
+- Score 2.5–3.4: **In progress** — Some adaptive capacity developing.
+- Score 3.5–5.0: **Achieved** — Evolution is the normal mode of operation.
+
+**Key question**: Is the organization systematically listening to its ecosystem? Are leaders capable of abandoning current strengths when the landscape demands it?
+
+### Overall Maturity Score
+
+Calculate: sum of all principle scores divided by total number of principles scored.
+
+| Overall Score | Maturity Label |
+|---------------|----------------|
+| 1.0 – 1.9 | Novice |
+| 2.0 – 2.9 | Developing |
+| 3.0 – 3.9 | Practising |
+| 4.0 – 4.9 | Advanced |
+| 5.0 | Leading |
+
+## Step 6: Re-assessment Comparison (if previous WDOC exists)
+
+If a previous WDOC artifact was found in Step 1, perform a trend comparison.
+
+Read the existing WDOC to extract the previous scores for each principle. Then produce:
+
+**Trend Table**: For each principle, show:
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+Use the following trend symbols:
+- **↑** — Score improved by 1 or more
+- **↓** — Score declined by 1 or more
+- **→** — Score unchanged
+
+**Top 3 Improvements**: The three principles with the greatest positive movement. Note what changed to produce this improvement.
+
+**Top 3 Declines**: The three principles with the greatest negative movement (or new gaps that appeared). Investigate the cause — these represent organizational regression.
+
+**Unchanged Gaps**: Principles that scored below 3 in both assessments. These represent persistent organizational weaknesses that improvement efforts have not reached.
+
+If this is an initial assessment, state: "This is the initial assessment. No previous scores are available for comparison."
+
+## Step 7: Identify Critical Gaps
+
+From the full principle assessment, identify the **top 5 gaps** — the principles whose low scores create the highest risk to the organization's ability to execute its strategy.
+
+### Gap Prioritization Rules
+
+1. **Phase I gaps first**: A score of 1-2 on any Phase I principle is automatically a top-5 gap. Stop-self-harm failures undermine all other improvement.
+2. **Strategic relevance**: Weight gaps by how directly they affect the organization's current strategic challenges (identified in Step 3).
+3. **Compounding gaps**: Gaps in foundational principles (e.g., "Know Your Users", "Common Language") have a multiplier effect — many downstream failures trace back to these.
+4. **Feasibility**: Between two equally impactful gaps, prioritize the one that can be addressed with lower effort or cost.
+
+For each critical gap, document:
+
+- Which phase and category
+- Current score and target score
+- Specific business impact: what fails, what is delayed, or what is wasted because of this gap
+- Recommended first action
+
+## Step 8: Create Implementation Roadmap
+
+Based on the critical gaps and phase analysis, produce a prioritized roadmap.
+
+### Roadmap Principles
+
+- **Sequence matters**: Always address Phase I gaps before Phase II, Phase II before Phase III. Building advanced practices on weak foundations is wasteful.
+- **Quick wins**: Identify 2-3 improvements achievable in 30-60 days that will produce visible results. Early wins build momentum.
+- **Systemic fixes**: Some doctrine gaps require structural changes (team size, decision rights, incentive structures). Sequence structural fixes before asking for behavioral change.
+- **Measurement**: Every action should have a measurable success criterion. Without measurement, doctrine improvement is aspirational rather than systematic.
+
+### Immediate Actions (0-3 months)
+
+Focus: Quick wins and Phase I foundations. Address the most critical Phase I gaps. Establish a common language baseline. Create initial feedback loops. These actions should produce tangible, observable change.
+
+### Short-Term Actions (3-12 months)
+
+Focus: Phase II development and awareness building. Establish systematic landscape mapping. Build team autonomy and decision-making speed. Introduce inertia management practices. Begin measuring outcomes rather than activities.
+
+### Long-Term Actions (12-24 months)
+
+Focus: Phase III/IV maturity targets. Embed continuous improvement as a cultural norm. Develop leadership capacity for uncertainty and iterative strategy. Build ecosystem listening mechanisms. Design structures that evolve continuously.
+
+## Step 9: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v1.0.md`
+
+**Naming Convention** (single-instance document — one per project, versioned on re-assessment):
+
+- `ARC-001-WDOC-v1.0.md` — Initial assessment
+- `ARC-001-WDOC-v2.0.md` — Re-assessment after improvement period
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-doctrine-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-doctrine-template.md` (default)
+
+> **Tip**: Users can customize templates with `$arckit-customize wardley-doctrine`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WDOC-v{VERSION}` (e.g., `ARC-001-WDOC-v1.0`)
+- WDOC is single-instance per project. If `ARC-{PROJECT_ID}-WDOC-v1.0.md` already exists, create `v2.0` as a re-assessment.
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (initial) or next version if re-assessing
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Doctrine Assessment"
+- `[COMMAND]` → "arckit.wardley.doctrine"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 90 days (doctrine matures over quarters, not months)
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team, Leadership" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial doctrine assessment from `$arckit-wardley.doctrine` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `$arckit-wardley.doctrine` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
+```
+
+---
+
+### Output Contents
+
+The doctrine assessment document must include:
+
+1. **Executive Summary**: Overall maturity score, phase positioning table, critical findings (3 bullets), narrative summary (2-3 sentences)
+
+2. **Strategy Cycle Context**: Purpose, Landscape, Climate, Leadership summary table
+
+3. **Doctrine Assessment Matrix**: All principles scored across all 4 phases with evidence and improvement actions
+
+4. **Detailed Phase Findings**: For each phase — phase score, strongest principles, weakest principles, narrative
+
+5. **Previous Assessment Comparison** (re-assessment only): Trend table, top 3 improvements, top 3 declines, unchanged gaps
+
+6. **Critical Gaps**: Top 5 gaps with phase, category, principle, scores, and business impact
+
+7. **Implementation Roadmap**: Immediate (0-3 months), Short-term (3-12 months), Long-term (12-24 months) actions
+
+8. **Recommendations**: Top 3 recommendations with rationale, expected benefit, and risk of inaction
+
+9. **Traceability**: Links to PRIN, WARD, and STKE artifacts
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3.0 score`, `> 4.0 maturity`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Doctrine Assessment Complete: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v{VERSION}.md
+
+📊 Maturity Summary:
+- Overall Score: {X.X / 5.0} ({Maturity Label})
+- Phase I (Stop Self-Harm): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase II (Context Aware): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase III (Better for Less): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase IV (Continuously Evolving): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+
+⚠️ Top Gaps:
+1. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+2. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+3. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+
+🗓️ Roadmap Highlights:
+- Immediate (0-3m): {Top immediate action}
+- Short-term (3-12m): {Top short-term action}
+- Long-term (12-24m): {Top long-term goal}
+
+🔗 Recommended Commands:
+- $arckit-wardley — Create or refine Wardley Map informed by doctrine gaps
+- $arckit-wardley.gameplay — Select gameplays that address doctrine weaknesses
+- $arckit-principles — Review and update architecture principles to reflect doctrine findings
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-wardley` -- Create or refine Wardley Map informed by doctrine gaps *(when Doctrine gaps affect component positioning or strategy)*
+- `$arckit-wardley.gameplay` -- Select gameplays that address doctrine weaknesses

--- a/arckit-codex/skills/arckit-wardley.doctrine/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.doctrine/SKILL.md
@@ -168,6 +168,7 @@ Read the existing WDOC to extract the previous scores for each principle. Then p
 | {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
 
 Use the following trend symbols:
+
 - **↑** — Score improved by 1 or more
 - **↓** — Score declined by 1 or more
 - **→** — Score unchanged

--- a/arckit-codex/skills/arckit-wardley.doctrine/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-wardley.doctrine/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-wardley.gameplay/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.gameplay/SKILL.md
@@ -1,0 +1,591 @@
+---
+name: arckit-wardley.gameplay
+description: "Analyze strategic play options from Wardley Maps using 60+ gameplay patterns"
+---
+
+# ArcKit: Wardley Gameplay Analysis
+
+You are an expert strategist in Wardley Mapping gameplays and competitive positioning. You analyze strategic options using Simon Wardley's 60+ gameplay catalog across 11 categories, complete with D&D alignment classification. Your role is to help organizations identify which plays are applicable, compatible, and executable given their current map position — and to produce a structured, actionable gameplay analysis document.
+
+## What are Wardley Gameplays?
+
+Gameplays are deliberate strategic moves made after understanding your position on a Wardley Map. Unlike climatic patterns (which happen regardless of your actions), gameplays are choices. Simon Wardley catalogues 60+ distinct plays across 11 categories, each classified using the D&D alignment system to reveal the ethical and strategic nature of the move:
+
+- **LG (Lawful Good)**: Creates genuine value for the ecosystem; operates with integrity
+- **N (Neutral)**: Pragmatic, context-dependent — balanced approach
+- **LE (Lawful Evil)**: Self-interested but within accepted norms; manipulates markets for advantage
+- **CE (Chaotic Evil)**: Destructive, harmful, disregards norms — recognise these when used against you
+
+The 11 gameplay categories are: A (User Perception), B (Accelerators), C (De-accelerators), D (Dealing with Toxicity), E (Market), F (Defensive), G (Attacking), H (Ecosystem), I (Competitor), J (Positional), K (Poison).
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, build/buy decisions already made, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running gameplay analysis. Please run `$arckit-wardley` first to create your map."
+  - Do not proceed without a WARD artifact; the gameplay analysis has no basis without component positions
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WCLM** (Climate Assessment) — Extract: active climatic patterns, evolution velocity predictions, war/peace/wonder phase assessment. Informs which plays are timely.
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores, identified weaknesses. Weak doctrine constrains which plays can be executed successfully.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: vendor landscape, market dynamics, competitive intelligence. Enriches competitor and market gameplay options.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles, technology standards, ethical constraints. Filters out plays incompatible with organisational values.
+
+**Understand the Strategic Context**:
+
+- What is the core strategic question the map was built to answer?
+- What decisions need to be made? (Build vs Buy, market entry, competitive response, ecosystem play)
+- What is the organisation's risk tolerance? (LG/N plays only, or all alignments considered?)
+- What time horizon? (Immediate: 0-3 months, Near: 3-12 months, Strategic: 12-24 months)
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract existing strategic analysis, competitive intelligence, market research
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level plays in progress
+- If no external strategic documents found but they would improve gameplay selection, note: "External competitive intelligence or market research documents would enrich this analysis. Place them in `projects/{project-dir}/external/` and re-run."
+
+## Step 2: Read Reference Material
+
+Read `.arckit/skills/wardley-mapping/references/gameplay-patterns.md` — this is the full 60+ gameplay catalog across 11 categories with D&D alignments, Play-Position Matrix, compatibility tables, anti-patterns, and case study summaries. This file is the authoritative source for all gameplay descriptions, applicability guidance, and compatibility rules used in Steps 4-9 below.
+
+## Step 3: Extract Map Context
+
+From the WARD artifact, extract the following structured information that will drive gameplay selection:
+
+**Component Inventory**:
+
+For each component on the map, record:
+- Component name
+- Visibility position (0.0-1.0)
+- Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)
+- Dependencies (what it depends on, what depends on it)
+- Inertia indicators (if any noted in the WARD artifact)
+- Build/buy/reuse decision already made (if recorded)
+
+**Strategic Position Summary**:
+
+- Total components: {count}
+- Genesis components: {count and names}
+- Custom-Built components: {count and names}
+- Product components: {count and names}
+- Commodity components: {count and names}
+- Components with inertia: {list}
+- Key dependencies and critical path: {summary}
+
+**Existing Build/Buy Decisions**:
+
+- Components being built in-house: {list}
+- Components being bought/licensed: {list}
+- Decisions still undecided: {list}
+
+## Step 4: Situational Assessment
+
+Before evaluating plays, establish the situational context that determines which plays are viable.
+
+### Position Analysis
+
+Where are your components on the map relative to the competitive landscape?
+
+- **Genesis concentration**: Are you leading with novel capabilities competitors haven't mapped yet?
+- **Custom-Built differentiation**: Where do you have bespoke competitive advantage?
+- **Product parity**: Where are you competing on features with established vendors?
+- **Commodity laggard**: Where are you running custom infrastructure that the market has commoditised?
+
+Identify the **dominant position type** (Genesis leader / Custom-Built strength / Product parity / Commodity laggard) as this drives the Play-Position Matrix selection in Step 5.
+
+### Capability Assessment
+
+What can the organisation actually execute?
+
+- **Resources**: Investment capacity for directed plays (Directed Investment, Land Grab, Threat Acquisition)
+- **Risk tolerance**: Can the organisation absorb failure from Experimentation, Fool's Mate, or Ambush plays?
+- **Ecosystem relationships**: Are partnerships, alliances, or community ties available to support Ecosystem plays?
+- **Time horizon**: Urgency drives towards faster plays (Fool's Mate, Land Grab); longer horizons allow Experimentation and Education
+- **Doctrine maturity** (from WDOC if available): Weak doctrine limits execution of complex multi-play strategies
+
+### Market Context
+
+What is the market doing?
+
+- **Growing or consolidating?**: Growing markets favour Land Grab and Directed Investment; consolidating markets favour Harvesting and Last Man Standing
+- **Regulatory pressures**: Presence of government/regulatory factors enables Industrial Policy; constraints on Lobbying plays
+- **Customer pain points**: Unmet needs favour Education, Market Enablement, and Creating Artificial Needs
+- **Substitutes emerging?**: Threat of substitution suggests Raising Barriers to Entry, Tower and Moat, or proactive Open Approaches
+
+### Peace/War/Wonder Phase
+
+If WCLM is available, extract the phase assessment. If not, infer from map:
+
+- **Peace**: Feature competition dominates → favour Differentiation, Standards Game, Sensing Engines
+- **War**: Industrialisation underway → favour Open Approaches, Ecosystem, Centre of Gravity, Managing Inertia
+- **Wonder**: New higher-order systems emerging → favour Experimentation, Weak Signal/Horizon, Co-creation
+
+## Step 5: Evaluate Play Options by Category
+
+Evaluate each of the 11 categories systematically. For each category, list plays that are applicable given your map position and situational assessment.
+
+Use the Play-Position Matrix from `gameplay-patterns.md` section 3 to match your dominant position to appropriate plays. Then assess each play within the applicable categories.
+
+For each applicable play, provide:
+
+```text
+Play: [Play Name] ([D&D Alignment])
+Category: [Category Letter and Name]
+Applicable because: [1-2 sentences referencing specific components/positions from the map]
+Evolution stage match: [Does this play match the component's evolution stage?]
+Recommendation: Apply / Monitor / Skip
+Rationale: [Why apply/monitor/skip — specific to this map and context]
+```
+
+### Category A: User Perception
+
+Evaluate: Education, Bundling, Creating Artificial Needs, Confusion of Choice, Brand and Marketing, FUD, Artificial Competition, Lobbying/Counterplay
+
+Which plays are relevant given your user-facing components and their evolution stage?
+
+### Category B: Accelerators
+
+Evaluate: Market Enablement, Open Approaches, Exploiting Network Effects, Co-operation, Industrial Policy
+
+Which plays would accelerate evolution of Custom-Built components you want to commoditise, or grow a market you want to lead?
+
+### Category C: De-accelerators
+
+Evaluate: Exploiting Constraint, Intellectual Property Rights/IPR, Creating Constraints
+
+Which plays could slow commoditisation of components you want to protect? Note CE plays with explicit warning.
+
+### Category D: Dealing with Toxicity
+
+Evaluate: Pig in a Poke, Disposal of Liability, Sweat and Dump, Refactoring
+
+Which components are toxic (technical debt, poor fit, declining value) and what is the appropriate disposal strategy?
+
+### Category E: Market
+
+Evaluate: Differentiation, Pricing Policy, Buyer/Supplier Power, Harvesting, Standards Game, Last Man Standing, Signal Distortion, Trading
+
+What market-positioning plays are available given your evolution stage and competitive position?
+
+### Category F: Defensive
+
+Evaluate: Threat Acquisition, Raising Barriers to Entry, Procrastination, Defensive Regulation, Limitation of Competition, Managing Inertia
+
+What threats need defending against, and which defensive plays are appropriate?
+
+### Category G: Attacking
+
+Evaluate: Directed Investment, Experimentation, Centre of Gravity, Undermining Barriers to Entry, Fool's Mate, Press Release Process, Playing Both Sides
+
+What offensive plays are executable given your resources, risk tolerance, and time horizon?
+
+### Category H: Ecosystem
+
+Evaluate: Alliances, Co-creation, Sensing Engines/ILC, Tower and Moat, N-sided Markets, Co-opting and Intercession, Embrace and Extend, Channel Conflicts and Disintermediation
+
+What ecosystem plays are available — do you have the components and relationships to build or join an ecosystem?
+
+### Category I: Competitor
+
+Evaluate: Ambush, Fragmentation Play, Reinforcing Competitor Inertia, Sapping, Misdirection, Restriction of Movement, Talent Raid, Circling and Probing
+
+What competitor-directed plays are available? Flag CE plays with explicit ethical caution.
+
+### Category J: Positional
+
+Evaluate: Land Grab, First Mover/Fast Follower, Aggregation, Weak Signal/Horizon
+
+What positional plays would secure or improve your strategic position on the map?
+
+### Category K: Poison
+
+Evaluate: Licensing Play, Insertion, Designed to Fail
+
+Recognise these when they are used against you. Flag whether any are currently affecting your value chain as defensive awareness.
+
+## Step 6: Check Play Compatibility
+
+From the plays recommended as "Apply" in Step 5, check compatibility using the tables in `gameplay-patterns.md` section 4.
+
+### Reinforcing Combinations
+
+List recommended plays that work well together, referencing the compatibility table:
+
+```text
+Primary Play + Compatible Play → Why they reinforce each other
+Example: Open Approaches + Co-creation → Openness attracts community that co-creates the ecosystem
+```
+
+Identify 2-3 high-value combinations that form a coherent strategic thrust.
+
+### Conflicting Plays
+
+Flag any selected plays that conflict with each other:
+
+```text
+Play A conflicts with Play B → Why (referencing the conflicts table)
+Resolution: Which to prioritise, or how to resolve the conflict
+```
+
+Do not recommend play combinations that undermine each other — force an explicit resolution.
+
+### Overall Play Coherence
+
+Assess the selected play portfolio:
+
+- Are the plays strategically coherent? Do they tell a consistent story?
+- Is there an appropriate mix of offensive and defensive plays?
+- Is the alignment profile acceptable? (All LG/N? Mix includes LE? Any CE flagged for recognition only?)
+
+## Step 7: Detail Selected Plays
+
+For each play recommended as "Apply" in Step 5, provide a detailed execution plan. Limit to the top 5-8 plays to keep the document actionable.
+
+For each detailed play:
+
+### [Play Name] ([D&D Alignment]) — Category [Letter]
+
+**Description**: [One sentence from the gameplay catalog, tailored to this specific context]
+
+**Why it applies here**: [Specific reference to components, evolution positions, and situational factors that make this play appropriate]
+
+**Prerequisites**: What must be true before executing this play?
+
+- [Prerequisite 1: specific to this map context]
+- [Prerequisite 2]
+- [Prerequisite 3 if needed]
+
+**Execution Steps**:
+
+1. [Specific, actionable first step — who does what]
+2. [Second step]
+3. [Third step]
+4. [Continuing steps as needed]
+
+**Expected Outcomes**:
+
+- **Short-term (0-3 months)**: [Tangible, observable result]
+- **Long-term (6-18 months)**: [Strategic position achieved]
+
+**Risks and Mitigations**:
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| [Risk 1] | H/M/L | [Specific mitigation] |
+| [Risk 2] | H/M/L | [Specific mitigation] |
+
+**Success Criteria** (measurable):
+
+- [ ] [Criterion 1 — observable, specific]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+**Review Points**: When should progress on this play be reassessed?
+
+- [Trigger or date] — check [what specifically]
+
+## Step 8: Anti-Pattern Check
+
+Before finalising the strategy, verify it avoids the six strategic anti-patterns from `gameplay-patterns.md` section 5.
+
+For each anti-pattern, explicitly confirm or flag:
+
+**Playing in the wrong evolution stage**: Are any recommended plays applied to components at the wrong evolution stage? (e.g., Experimentation on a commodity component, Harvesting on a Genesis component)
+→ Status: [No violations identified / Flagged: {details}]
+
+**Ignoring inertia**: Have inertia points from the WARD artifact been addressed in the execution plans? Is there a play (e.g., Managing Inertia) to handle organisational resistance?
+→ Status: [Addressed via [play name] / Warning: inertia points {list} have no mitigation]
+
+**Single-play dependence**: Is the strategy dangerously dependent on one play succeeding? Is there a layered play portfolio?
+→ Status: [Portfolio of {count} plays provides redundancy / Warning: single play {name} is the only defence/offence]
+
+**Misreading evolution pace**: Has the evolution velocity of key components been validated (against WCLM if available)?
+→ Status: [Evolution positions verified / Warning: {components} may be mis-positioned]
+
+**Ecosystem hubris**: If ecosystem plays (Tower and Moat, N-sided Markets, Sensing Engines) are selected, is there a plan to continue generating genuine ecosystem value?
+→ Status: [ILC/Weak Signal plays included to maintain ecosystem health / Warning: ecosystem play selected without monitoring mechanism]
+
+**Open washing**: If Open Approaches is selected alongside Licensing Play, Standards Game, or Embrace and Extend — is this coherent?
+→ Status: [Coherent — no contradiction identified / Warning: Open Approaches and {play} may signal open washing to the community]
+
+## Step 9: Case Study Cross-References
+
+Which real-world examples from `gameplay-patterns.md` section 6 most closely parallel the recommended strategy? For each relevant case study, provide a 1-2 sentence connection to the selected plays.
+
+| Case Study | Plays Used | Relevance to This Strategy |
+|------------|-----------|---------------------------|
+| [Company] | [Play names] | [How this parallels the recommended approach] |
+
+Limit to the 3-5 most relevant case studies. Avoid forcing connections where the parallel is weak.
+
+## Step 10: Generate Output
+
+Create the gameplay analysis document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WGAM-001-v1.0.md` — First gameplay analysis for project 001
+- `ARC-001-WGAM-002-v1.0.md` — Second gameplay analysis (e.g., for a revised map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-gameplay-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-gameplay-template.md` (default)
+
+> **Tip**: Users can customise templates with `$arckit-customize wardley.gameplay`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WGAM-{NNN}-v{VERSION}` (e.g., `ARC-001-WGAM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WGAM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Gameplay Analysis"
+- `ARC-[PROJECT_ID]-WGAM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.gameplay"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `$arckit-wardley.gameplay` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `$arckit-wardley.gameplay` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Gameplay Analysis document must include:
+
+1. **Executive Summary**: Strategic context, map summary, recommended play portfolio overview (2-3 paragraphs)
+
+2. **Map Context**: Component inventory table, dominant position type, situational assessment summary
+
+3. **Play Evaluation by Category**: All 11 categories assessed with Apply/Monitor/Skip for each applicable play
+
+4. **Play Compatibility Matrix**: Reinforcing combinations and flagged conflicts
+
+5. **Detailed Play Execution Plans**: Top 5-8 plays with prerequisites, execution steps, outcomes, risks, success criteria
+
+6. **Anti-Pattern Check**: Explicit pass/fail for all 6 anti-patterns
+
+7. **Case Study Cross-References**: 3-5 relevant real-world parallels
+
+8. **Recommended Play Portfolio**: Summary table of all recommended plays with alignment, category, priority, and time horizon
+
+9. **Traceability**: Link to WARD artifact, WCLM (if used), WDOC (if used), RSCH (if used)
+
+## Step 11: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+$arckit-wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+$arckit-wardley.climate — Assess climatic patterns (WCLM artifact)
+$arckit-wardley.gameplay — Identify strategic plays (WGAM artifact) ← you are here
+
+# Execution layer: run after analysis
+$arckit-roadmap — Create roadmap to execute selected plays
+$arckit-strategy — Synthesise into architecture strategy document
+```
+
+### Before Gameplay Analysis
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `$arckit-wardley` first to create your map, then return here."
+```
+
+If WCLM is missing but gameplay is proceeding:
+
+```bash
+"Note: No climate assessment (WCLM) found. Consider running `$arckit-wardley.climate` after this analysis —
+climate patterns may affect which plays are timely and which are premature."
+```
+
+### After Gameplay Analysis
+
+Recommend next steps based on selected plays:
+
+```bash
+# If Directed Investment or Land Grab selected
+"Your selected plays include resource-intensive options. Consider running `$arckit-roadmap` to create a
+phased execution plan with investment milestones."
+
+# If ecosystem plays selected (Tower and Moat, N-sided Markets, etc.)
+"Your strategy includes ecosystem plays. Consider running `$arckit-strategy` to synthesise these into
+a coherent architecture strategy document."
+
+# If Open Approaches selected
+"The Open Approaches play may involve open-sourcing or publishing components. Consider running
+`$arckit-sow` if procurement is needed for the ecosystem, or `$arckit-research` to identify
+existing open communities to join."
+
+# If UK Government project
+"As a UK Government project, ecosystem and market plays should be validated against TCoP Point 3
+(Open Source), Point 8 (Share/Reuse), and G-Cloud procurement constraints. Run `$arckit-tcop`."
+```
+
+## Important Notes
+
+### Gameplay Selection Quality Standards
+
+**Good Gameplay Analysis**:
+
+- Plays matched to actual component evolution stages (not generic advice)
+- Play-Position Matrix used explicitly
+- Compatibility conflicts identified and resolved
+- Anti-patterns explicitly checked and cleared
+- Execution plans are specific and actionable (not generic)
+- Alignment profile considered against organisational values
+- Case study references are genuinely analogous
+
+**Poor Gameplay Analysis**:
+
+- Recommending all plays without prioritisation
+- Ignoring evolution stage when selecting plays
+- Mixing conflicting plays without resolution
+- Recommending CE plays without ethical flagging
+- Generic execution steps not tied to specific components
+- No anti-pattern check
+
+### Alignment Ethics
+
+When recommending plays with LE or CE alignment:
+
+- **LE plays**: Flag explicitly with "(Lawful Evil — self-interested but within accepted norms)" and note reputational or regulatory risks
+- **CE plays**: Include explicit warning — "This play is classified CE (Chaotic Evil). It is presented for recognition purposes only. Deploying this play deliberately would damage stakeholder trust and may create legal exposure."
+- **CE plays should never appear in "Apply" recommendations** — only in "Recognise and Defend Against" lists
+
+### Play Sequencing
+
+Some plays must be sequenced carefully:
+
+- **Education before Open Approaches**: Market must understand the value before openness can grow it
+- **Weak Signal/Horizon before Land Grab**: Identify the opportunity before committing resources to capture it
+- **Managing Inertia before Ecosystem plays**: Internal resistance must be addressed before ecosystem commitments can be honoured
+- **Experimentation before Directed Investment**: Validate the opportunity before scaling it
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Gameplay Analysis document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Complete with all sections from template
+- Specific (plays matched to actual map components, not generic advice)
+- Executable (each recommended play has actionable steps)
+- Ethically annotated (alignment flags for LE/CE plays)
+- Compatible (conflicting plays resolved, reinforcing combinations identified)
+- Anti-pattern checked (all 6 anti-patterns explicitly cleared)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Gameplay Analysis Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md
+
+Plays Evaluated: {total_plays_considered} across 11 categories
+Recommended (Apply): {count} plays
+Monitor: {count} plays
+Skip: {count} plays
+
+Top 3 Recommended Plays:
+1. {Play Name} ({Alignment}) — {one-line rationale}
+2. {Play Name} ({Alignment}) — {one-line rationale}
+3. {Play Name} ({Alignment}) — {one-line rationale}
+
+Key Reinforcing Combination: {Play A} + {Play B} → {why}
+
+Key Risks:
+- {Risk 1}
+- {Risk 2}
+
+Anti-Pattern Check: {count}/6 passed — {any warnings}
+
+Next Steps:
+- $arckit-wardley.climate — Validate plays against climatic forces (if not done)
+- $arckit-roadmap — Create execution roadmap for selected plays
+- $arckit-strategy — Synthesise gameplay into architecture strategy
+```
+
+---
+
+**Remember**: Gameplay analysis is only as good as the map it is based on. If the map components are mispositioned, the play selection will be wrong. Always validate component evolution positions before committing to a play strategy.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-roadmap` -- Create roadmap to execute selected plays
+- `$arckit-strategy` -- Synthesise gameplay into architecture strategy
+- `$arckit-wardley.climate` -- Validate plays against climatic patterns *(when Climate assessment not yet performed)*

--- a/arckit-codex/skills/arckit-wardley.gameplay/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.gameplay/SKILL.md
@@ -68,6 +68,7 @@ From the WARD artifact, extract the following structured information that will d
 **Component Inventory**:
 
 For each component on the map, record:
+
 - Component name
 - Visibility position (0.0-1.0)
 - Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)

--- a/arckit-codex/skills/arckit-wardley.gameplay/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-wardley.gameplay/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-wardley.value-chain/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley.value-chain/SKILL.md
@@ -1,0 +1,359 @@
+---
+name: arckit-wardley.value-chain
+description: "Decompose user needs into value chains for Wardley Mapping"
+---
+
+# ArcKit: Value Chain Decomposition for Wardley Mapping
+
+You are an expert value chain analyst using Wardley Mapping methodology. Your role is to decompose user needs into complete dependency chains — identifying components, establishing visibility positions, and producing OWM-ready syntax for use in a full Wardley Map.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **REQ** (Requirements) — Extract: User needs, business requirements, functional capabilities, system components, integration points. Anchor the value chain in genuine user needs, not internal assumptions.
+  - If missing: warn the user and recommend running `$arckit-requirements` first. A value chain without requirements risks anchoring on solutions rather than needs.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **STKE** (Stakeholder Analysis) — Extract: User personas, stakeholder goals, success metrics, priority outcomes. Helps establish who sits at the top of the value chain.
+  - If missing: note that stakeholder context is unavailable; you will infer user personas from the requirements or user input.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **PRIN** (Architecture Principles) — Extract: Technology standards, cloud-first policy, reuse requirements, build vs buy preferences.
+- Existing WVCH artifacts in `projects/{current_project}/wardley-maps/` — Extract: Previous value chain analysis, component positions, known dependencies.
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract: existing component lists, system architecture diagrams, dependency maps, integration catalogues.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract: enterprise component library, shared service catalogue, cross-project reuse opportunities.
+- If no existing value chain documents are found but they would improve accuracy, ask: "Do you have any existing architecture diagrams, component lists, or dependency maps? I can read images and PDFs directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Identify the Anchor (User Need)
+
+The **anchor** is the user need at the top of the value chain. Everything below it exists to satisfy this need. Getting the anchor right is the most important step — a wrong anchor produces a wrong chain.
+
+### Good vs. Bad Anchors
+
+**GOOD anchors** — genuine user needs:
+
+- "User can communicate with their team in real time"
+- "Patient can book an appointment without calling the surgery"
+- "Taxpayer can file a return in under 15 minutes"
+- "Citizen can check their benefits eligibility online"
+
+**BAD anchors** — solutions masquerading as needs:
+
+- "User needs Slack" — this is a solution, not a need
+- "User needs a microservices platform" — this is an implementation choice
+- "System processes API calls" — this is a capability, not a purpose
+- "Database stores records" — this is infrastructure, not a user outcome
+
+**Anchor test**: Can this need be satisfied in multiple different ways? If the need is tightly tied to a specific product or technology, it is a solution, not a need. Strip it back to the underlying outcome the user requires.
+
+### Anchor Identification Questions
+
+Ask these questions to refine the anchor from the user input and available documents:
+
+1. **Who is the user?** — Be specific. A persona, role, or citizen type. Not "the system."
+2. **What outcome do they want?** — What changes for them when their need is met? What can they do, know, or decide?
+3. **Why do they need this?** — What is the underlying motivation? Remove one layer of abstraction from the stated need.
+
+State the anchor clearly before proceeding:
+
+```text
+Anchor: [User need statement]
+User: [Who has this need]
+Outcome: [What changes when this need is met]
+```
+
+## Step 3: Decompose into Components
+
+Starting from the anchor, decompose the value chain by asking "What is required to satisfy this?" at each level. Repeat recursively until you reach commodity-level infrastructure.
+
+### Recursive Decomposition Method
+
+```text
+Level 0 (Anchor): [User Need]
+  ↓ "What is required to provide this?"
+Level 1: [Capability A], [Capability B]
+  ↓ "What is required to provide Capability A?"
+Level 2: [Component C], [Component D]
+  ↓ "What is required to provide Component C?"
+Level 3: [Component E], [Component F]
+  ↓ Continue until commodities are reached
+```
+
+### Component Identification Checklist
+
+For each candidate component, verify:
+
+- [ ] Is it a capability, activity, or practice? (Not an actor, person, or team)
+- [ ] Does it directly or indirectly serve the anchor user need?
+- [ ] Can it evolve independently on the evolution axis?
+- [ ] Does it provide value to components above it in the chain?
+
+### Dependency Types
+
+When establishing connections between components, classify the relationship:
+
+- **REQUIRES** (hard dependency): Component A cannot function without Component B. Failure in B causes failure in A. Represented as `A -> B` in OWM syntax.
+- **USES** (soft dependency): Component A uses Component B to improve quality or performance, but can degrade gracefully without it.
+- **ENABLES** (reverse): Component B enables Component A to exist; B is not strictly required but makes A possible or better.
+
+For OWM syntax, use `->` for REQUIRES and USES relationships. Note ENABLES relationships in the component inventory.
+
+### Stop Conditions
+
+Stop decomposing when:
+
+1. The component is a genuine commodity (widely available utility: cloud compute, DNS, SMTP, payment rails)
+2. Further decomposition adds no strategic value for the mapping exercise
+3. You have reached common shared infrastructure that all chains eventually depend on
+
+Aim for 8–20 components total. Fewer than 8 may be too shallow; more than 25 may be too granular for strategic clarity.
+
+## Step 4: Establish Dependencies
+
+With all components identified, map the full dependency structure. Dependencies flow **down** the chain — higher-visibility components depend on lower-visibility ones.
+
+### Dependency Rules
+
+1. **Direction**: Dependencies flow downward. If Component A depends on Component B, A appears higher on the Y-axis than B.
+2. **Causality**: A dependency must be real and direct. Do not draw arrows because it "feels related."
+3. **No cycles**: A component cannot depend on itself or on a component that depends on it.
+4. **Completeness**: Every component except the anchor should have at least one dependency going down (or be a terminal commodity).
+
+### Dependency Validation
+
+For each dependency you draw, verify:
+
+- Would Component A fail or degrade significantly if Component B were removed?
+- Is this a direct dependency, or does it go via an intermediate component?
+- Have you captured all meaningful dependencies, or only the obvious ones?
+
+## Step 5: Assess Visibility (Y-axis)
+
+Read `.arckit/skills/wardley-mapping/references/evolution-stages.md` for supporting context on component characteristics.
+
+Visibility represents how directly visible a component is to the user at the top of the chain. Assign a value from 0.0 (invisible infrastructure) to 1.0 (directly experienced by the user).
+
+### Visibility Guide
+
+| Range | Level | Characteristics |
+|-------|-------|-----------------|
+| 0.90 – 1.00 | User-facing | Directly experienced; failure is immediately visible to the user |
+| 0.70 – 0.89 | High | Close to the user; degradation noticed quickly |
+| 0.50 – 0.69 | Medium-High | Indirectly visible; affects features the user relies on |
+| 0.30 – 0.49 | Medium | Hidden from users but essential to operations |
+| 0.10 – 0.29 | Low | Invisible to users; purely operational or infrastructure |
+| 0.00 – 0.09 | Infrastructure | Deep infrastructure; users unaware it exists |
+
+### Visibility Assessment Questions
+
+For each component, ask:
+
+1. Does the user interact with this component directly? (Yes → high visibility)
+2. Would the user notice immediately if this component failed? (Yes → high visibility)
+3. Could you swap out this component without the user knowing? (Yes → low visibility)
+4. Is this component one step removed from user interaction? (One step → medium-high)
+
+The anchor always receives a visibility of 0.90 or above (typically 0.95). Infrastructure reaches 0.05–0.15.
+
+## Step 6: Validate the Chain
+
+Before generating output, validate the value chain against these criteria.
+
+### Completeness Checks
+
+- [ ] Chain starts with a genuine user need (not a solution or capability)
+- [ ] All significant dependencies between components are captured
+- [ ] Chain reaches commodity level (cloud hosting, DNS, payment infrastructure, etc.)
+- [ ] No orphan components (every component has at least one connection)
+- [ ] All components are activities, capabilities, or practices — not people, teams, or actors
+
+### Accuracy Checks
+
+- [ ] Dependencies reflect real-world technical and operational relationships
+- [ ] Visibility ordering is consistent with dependency direction (higher visibility = higher Y-axis)
+- [ ] No component is both a high-level user-facing capability and a low-level infrastructure component
+
+### Usefulness Checks
+
+- [ ] Granularity is appropriate for strategic decision-making (not too fine, not too coarse)
+- [ ] Each component can be meaningfully positioned on the evolution axis for the subsequent Wardley Map
+- [ ] The chain reveals at least one strategic insight about build vs. buy, inertia, or differentiation
+
+### Common Issues to Avoid
+
+**Too shallow**: The chain has only 2-3 levels and jumps straight from user need to commodity. Add the intermediate capabilities and components.
+
+**Too deep**: The chain has 6+ levels and decomposes network packets and OS internals. Stop at the level where strategic decisions occur.
+
+**Missing components**: Common omissions include authentication, notification, monitoring, logging, and access control. Check for these.
+
+**Solution bias**: Components named after specific products (e.g., "Salesforce CRM" instead of "Customer Relationship Management") anchor the chain to current solutions. Name by capability unless you are deliberately mapping a specific vendor.
+
+**Activity confusion**: Components should be activities ("Payment Processing", "Identity Verification") not states ("Payment", "Identity"). Activities can evolve; nouns are ambiguous.
+
+## Step 7: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WVCH-001-v1.0.md` — First value chain
+- `ARC-001-WVCH-002-v1.0.md` — Second value chain (different user need or domain)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-value-chain-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-value-chain-template.md` (default)
+
+> **Tip**: Users can customize templates with `$arckit-customize wardley-value-chain`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}` (e.g., `ARC-001-WVCH-001-v1.0`)
+- Sequence number `{NNN}`: Check existing WVCH files in `wardley-maps/` and use the next number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Value Chain"
+- `[COMMAND]` → "arckit.wardley.value-chain"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `$arckit-wardley.value-chain` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `$arckit-wardley.value-chain` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used]
+```
+
+---
+
+### Output Contents
+
+The value chain document must include:
+
+1. **Executive Summary**: Anchor statement, component count, key strategic insights (3-5 sentences)
+
+2. **Users and Personas**: Table of user types and their primary needs
+
+3. **Value Chain Diagram**:
+   - ASCII placeholder showing the chain structure (visibility levels and component names)
+   - Complete OWM syntax for https://create.wardleymaps.ai
+
+4. **Component Inventory**: All components with visibility scores, descriptions, and dependency references
+
+5. **Dependency Matrix**: Cross-reference table showing direct (X) and indirect (I) dependencies
+
+6. **Critical Path Analysis**:
+   - The sequence from anchor to deepest infrastructure
+   - Bottlenecks and single points of failure
+   - Resilience gaps
+
+7. **Validation Checklist**: Completed checklist confirming chain quality
+
+8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+
+9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 0.5 visibility`, `> 0.75 evolution`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Value Chain Created: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}.md
+
+🗺️ View Chain: Paste the OWM code into https://create.wardleymaps.ai
+
+📊 Key Insights:
+- Anchor: {user need statement}
+- {N} components identified across {N} dependency levels
+- Critical path: {anchor} → {key component} → {commodity}
+- {Notable strategic insight, e.g., "Authentication is a commodity dependency shared across 4 capabilities"}
+
+⚠️ Potential Issues:
+- {Any validation warnings, e.g., "No commodity-level components found — chain may be incomplete"}
+- {Any missing prerequisite artifacts}
+
+🎯 Next Steps:
+- Run $arckit-wardley to create a full Wardley Map using this value chain
+- Assign evolution positions to each component for strategic analysis
+- Validate the chain with your team before proceeding to mapping
+
+🔗 Recommended Commands:
+- $arckit-wardley — Create full Wardley Map with evolution axis positioning
+- $arckit-wardley.doctrine — Assess organizational maturity to execute the strategy
+- $arckit-requirements — Strengthen the requirements before refining the chain (if incomplete)
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `$arckit-wardley` -- Create Wardley Map from this value chain
+- `$arckit-wardley.doctrine` -- Assess organizational doctrine maturity *(when Value chain reveals organizational capability gaps)*

--- a/arckit-codex/skills/arckit-wardley.value-chain/agents/openai.yaml
+++ b/arckit-codex/skills/arckit-wardley.value-chain/agents/openai.yaml
@@ -1,0 +1,2 @@
+policy:
+  allow_implicit_invocation: false

--- a/arckit-codex/skills/arckit-wardley/SKILL.md
+++ b/arckit-codex/skills/arckit-wardley/SKILL.md
@@ -46,9 +46,13 @@ $ARGUMENTS
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements
@@ -733,3 +737,6 @@ After completing this command, consider running:
 - `$arckit-roadmap` -- Create strategic roadmap from evolution analysis
 - `$arckit-strategy` -- Synthesise Wardley insights into architecture strategy
 - `$arckit-research` -- Research vendors for Custom-Built components *(when Custom-Built components identified that need market research)*
+- `$arckit-wardley.doctrine` -- Assess organizational doctrine maturity
+- `$arckit-wardley.gameplay` -- Identify strategic plays from the map
+- `$arckit-wardley.climate` -- Assess climatic patterns affecting components

--- a/arckit-codex/skills/wardley-mapping/SKILL.md
+++ b/arckit-codex/skills/wardley-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wardley-mapping
-description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, gameplay patterns, doctrine, build vs. buy decisions, inertia analysis, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
+description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, value chain decomposition, gameplay patterns, doctrine assessment, doctrine maturity, climatic patterns, climate assessment, build vs. buy decisions, inertia analysis, D&D alignment of strategies, peace/war/wonder cycles, play-position matrix, pioneers/settlers/planners, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
 ---
 
 # Wardley Mapping
@@ -251,15 +251,23 @@ wardley_map:
 
 Consult these reference files for deeper analysis:
 
-- [Evolution Stages](references/evolution-stages.md) — Detailed stage characteristics, indicators, and positioning criteria
-- [Climatic Patterns](references/climatic-patterns.md) — External forces affecting the landscape (economic, competitive, technology, market patterns)
-- [Gameplay Patterns](references/gameplay-patterns.md) — Offensive/defensive strategic moves, build vs. buy vs. outsource, anti-patterns
-- [Doctrine](references/doctrine.md) — Universal strategy patterns and organizational maturity assessment
-- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product
-- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection
+- [Evolution Stages](references/evolution-stages.md) — Stage characteristics, indicators, positioning criteria, transition heuristics, pioneers/settlers/planners talent model
+- [Climatic Patterns](references/climatic-patterns.md) — 32 patterns across 6 categories (component, financial, speed, inertia, competitor, prediction), peace/war/wonder cycle, pattern interactions
+- [Gameplay Patterns](references/gameplay-patterns.md) — 60+ plays across 11 categories with D&D alignment classification, play-position matrix, play compatibility, case studies (AWS, Netflix, Tesla, Spotify)
+- [Doctrine](references/doctrine.md) — 40+ principles across 4 phases and 6 categories, Strategy Cycle framework, implementation journeys, maturity assessment template
+- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product, TechnoGadget Smart Home, value chain decomposition walkthrough, case study cross-references
+- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection, play-position scoring, climate pattern impact weighting
 
 ## ArcKit Integration
 
 This skill handles **conversational** Wardley Mapping — quick questions, evolution stage lookups, doctrine assessments, and interactive map creation.
 
-For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the `$arckit-wardley` command instead. It generates versioned Wardley Map artifacts saved to your project directory with full traceability to requirements and architecture principles.
+For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the ArcKit Wardley suite:
+
+- `/arckit.wardley.value-chain` — Decompose user needs into value chains (WVCH artifact)
+- `/arckit.wardley` — Create strategic Wardley Maps (WARD artifact)
+- `/arckit.wardley.doctrine` — Assess organizational doctrine maturity across 4 phases, 40+ principles (WDOC artifact)
+- `/arckit.wardley.gameplay` — Analyze strategic plays from 60+ gameplay patterns with D&D alignment (WGAM artifact)
+- `/arckit.wardley.climate` — Assess 32 climatic patterns across 6 categories with prediction horizons (WCLM artifact)
+
+These generate versioned artifacts saved to your project directory with full traceability to requirements and architecture principles. Each command works standalone but gets richer when sibling artifacts exist.

--- a/arckit-codex/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-codex/skills/wardley-mapping/references/climatic-patterns.md
@@ -1,260 +1,456 @@
-# Climatic Patterns
+# Climatic Patterns Reference
 
-External forces that affect the landscape, outside organizational control.
+Climatic patterns are external forces that shape the business landscape regardless of your actions. They are the "weather" of strategy — you cannot control them, but you can anticipate and prepare. Unlike gameplays (deliberate choices), climatic patterns simply happen. Understanding them lets you position ahead of change rather than react to it.
 
-## Economic Patterns
+---
 
-### Everything Evolves
+## 1. Component Patterns — Chapter IV
 
-```yaml
-pattern:
-  name: "Everything Evolves"
-  description: "All components evolve through genesis → custom → product → commodity"
+### 1.1 Everything Evolves Through Supply and Demand Competition
 
-  implications:
-    - "No competitive advantage is permanent"
-    - "Today's differentiator is tomorrow's commodity"
-    - "Plan for evolution, don't fight it"
+All components — activities, practices, data, knowledge — move from genesis through custom-built, product, and commodity stages driven by supply and demand forces. Supply-side competition drives standardisation and efficiency; demand-side pressure shifts expectations from "novel capability" to "expected utility." Value perception shifts from scarcity and uniqueness at genesis, to features at product stage, to cost and reliability at commodity stage.
 
-  example: "Cloud computing: mainframe → server → VM → container → serverless"
+**Strategic implication:** No competitive advantage is permanent — plan for evolution, not against it.
+
+**Assessment question:** Which components are actively evolving and what does their next stage look like?
+
+---
+
+### 1.2 Rates of Evolution Can Vary by Ecosystem
+
+Evolution does not occur at a uniform pace. Consumer ecosystems (individual users, rapid adoption, trend-driven, network effects) evolve far faster than industrial ecosystems (B2B, long decision cycles, regulatory constraints, high switching costs). Factors that modulate speed include regulatory environment, investment levels, industry inertia, and how dependent a component is on underlying technologies that are themselves evolving.
+
+**Strategic implication:** Map the evolutionary speed of your specific ecosystem, not a generic average, to time investments and innovation correctly.
+
+**Assessment question:** Is this component in a fast or slow ecosystem, and does your strategy match that cadence?
+
+---
+
+### 1.3 Characteristics Change as Components Evolve
+
+As a component moves along the evolution axis, its fundamental characteristics transform. Genesis: uncertain, rare, high-risk, radical innovation, pioneer teams. Custom-built: emerging understanding, divergent approaches, hypothesis-driven. Product: standardising, feature competition, settler teams. Commodity: well-understood, price-based competition, high reliability required, town planner teams. Management approach, failure tolerance, contract type, and talent profile must all change with the stage.
+
+**Strategic implication:** Applying product-stage management to a genesis component (or vice versa) is a systematic source of failure.
+
+**Assessment question:** Does the management approach, team structure, and contract type match the current evolution stage of this component?
+
+---
+
+### 1.4 No Choice Over Evolution — The Red Queen Effect
+
+Named after Lewis Carroll's Red Queen: "It takes all the running you can do, to keep in the same place." Evolution in business ecosystems is not optional. Competitive pressures, technological advancement, and shifting customer expectations force continuous adaptation. Absolute progress (improving your own capabilities) does not guarantee relative progress if competitors evolve at the same or faster rate. BlackBerry and Nokia improved their products; the market moved past them anyway.
+
+**Strategic implication:** Continuous adaptation is a survival requirement, not a strategic option.
+
+**Assessment question:** Where are we running just to stay still, and are we running fast enough?
+
+---
+
+### 1.5 No Single Method Fits All
+
+Different evolution stages require fundamentally different approaches. Software development: agile for genesis/custom, DevOps for maturing product, Six Sigma/lean for commodity. Contracts: time-and-materials for genesis, fixed-price for commodity. Architecture: disposable PoCs at genesis, standardised patterns at commodity. Amazon exemplifies this — AWS runs on continuous deployment, fulfillment centres on lean manufacturing, Amazon Go on experimental tech. Applying a single methodology across all stages creates systematic inefficiency.
+
+**Strategic implication:** Build a toolkit of methods and the organisational capability to switch between them as components evolve.
+
+**Assessment question:** Are we applying the right management method for each component's current evolution stage?
+
+---
+
+### 1.6 Components Can Co-evolve
+
+Components do not evolve in isolation. The evolution of one component can trigger, accelerate, or constrain the evolution of related components. Types: symbiotic (mobile hardware and mobile apps), practice-based (DevOps emerged with cloud infrastructure), competitive (fintech forcing bank digital evolution). Co-evolution creates new opportunities at intersection points and new risks when dependent components evolve at mismatched speeds.
+
+**Strategic implication:** Watch for "enabler components" — when they evolve, they can unlock rapid evolution in components that depend on them.
+
+**Assessment question:** Which components, if evolved by a competitor, would trigger co-evolutionary pressure on our differentiators?
+
+---
+
+### 1.7 Evolution Consists of Multiple Waves of Diffusion with Many Chasms
+
+Drawing on Rogers' Diffusion of Innovations and Moore's chasm concept: adoption does not flow smoothly. Each wave (innovators/early adopters → early majority → late majority → laggards) has distinct characteristics, and between waves lie chasms where adoption stalls. Cloud computing crossed at least two major chasms — the security concern chasm before enterprise adoption, and the legacy integration chasm before cloud-native architectures. Products can die in a chasm even if the technology is sound.
+
+**Strategic implication:** Crossing a chasm requires a different strategy than riding a wave — segment, adapt the offer, build reference cases, develop ecosystem support.
+
+**Assessment question:** Which chasm is this component currently in, and what is blocking the next adoption wave?
+
+---
+
+### 1.8 Commoditization Does Not Equal Centralisation
+
+A common misconception: if something commoditises, it must consolidate to a single provider. Reality is more nuanced. Many commoditised components remain decentralised due to local regulation, physical constraints, security requirements, resilience needs, or customer preferences for local relationships. Banking services are largely commoditised but thousands of institutions persist. Electricity is standardised but generation is distributed. Cloud computing is commoditised but multiple providers compete.
+
+**Strategic implication:** Commoditised markets may still offer opportunities for differentiation through localisation, specialisation, or distributed models.
+
+**Assessment question:** Are we assuming centralisation will follow commoditisation, and is that assumption valid for our specific market context?
+
+---
+
+## 2. Financial Patterns — Chapter V
+
+### 2.1 Higher Order Systems Create New Sources of Value
+
+When lower-order components commoditise, they become building blocks for new, higher-order systems that exhibit emergent properties not present in constituent parts. Cloud computing (commodity compute + storage + networking) enabled the SaaS economy. Smartphones (commodity hardware) enabled the app economy. IoT = sensors + connectivity + cloud + analytics. Each higher-order system opens new value streams, new business models, and new genesis opportunities above it.
+
+**Strategic implication:** Look for clusters of recently commoditised components — they are the foundation for the next wave of higher-order innovation.
+
+**Assessment question:** What higher-order system could be built on top of components that are now commoditising in our value chain?
+
+---
+
+### 2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox
+
+Named after 19th-century economist William Stanley Jevons: improvements in the efficiency of resource use tend to increase total consumption, not reduce it, because lower cost enables new use cases and broader adoption. Cloud computing became more efficient and cheaper — total cloud spend skyrocketed. Fuel-efficient cars led to more driving. More efficient LEDs led to more lighting. In Wardley terms: as components commoditise and efficiency improves, new applications emerge that consume more of that resource overall.
+
+**Strategic implication:** Efficiency gains in a component should be treated as a demand amplifier, not a cost reducer — plan for increased consumption and new use cases, not reduced spend.
+
+**Assessment question:** Where are we planning cost savings from efficiency improvements that will actually be consumed by new demand?
+
+---
+
+### 2.3 Capital Flows to New Areas of Value
+
+Capital (financial, human, intellectual, organisational attention) consistently flows away from commoditised, low-margin areas toward genesis and early custom-built components with high differentiation potential. As an area commoditises, capital exits to fund the next cycle of innovation. This is visible in VC trends (AI/ML, quantum, clean energy), talent migration patterns, and M&A activity. The direction of capital flow is a leading indicator of where value is being created.
+
+**Strategic implication:** Track where capital is flowing — it signals where the next wave of value creation is forming.
+
+**Assessment question:** Is capital flowing toward or away from our core differentiators, and what does that signal about their evolution stage?
+
+---
+
+### 2.4 Creative Destruction — The Schumpeter Effect
+
+Joseph Schumpeter described creative destruction as "a process of industrial mutation that incessantly revolutionises the economic structure from within, incessantly destroying the old one, incessantly creating a new one." New innovations render existing components, business models, and sometimes entire industries obsolete. Digital photography destroyed film. Streaming destroyed video rental. EV is restructuring automotive. In Wardley terms, new genesis components emerge and evolve rapidly to displace commodity incumbents.
+
+**Strategic implication:** No incumbent position is safe from creative destruction — organisations must simultaneously exploit current advantages and invest in the innovations that may replace them.
+
+**Assessment question:** What genesis-stage component, if it evolves, would make our current commodity position irrelevant?
+
+---
+
+### 2.5 Future Value is Inversely Proportional to Certainty
+
+The higher the certainty about an outcome, the lower its potential value — because certainty is priced in by competitors. Genesis components (high uncertainty, low certainty) carry the highest potential value but also the highest risk. Commodity components (high certainty, low uncertainty) offer stable returns but no differentiation. Venture capital portfolios embody this: most investments fail, but the few that succeed return multiples that dwarf the losses. The relationship also applies to timing: the P[what] of a change may be high (EV will dominate) while P[when] remains uncertain.
+
+**Strategic implication:** Pursuing only certain opportunities means accepting low returns — a portfolio of high-uncertainty bets is needed to capture asymmetric upside.
+
+**Assessment question:** Are we systematically avoiding uncertain opportunities in ways that cap our future value potential?
+
+---
+
+### 2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption
+
+As systems become more complex and organised locally (higher order), they require more energy and resources overall — not less. More complex systems are more ordered locally but increase entropy in their environment. This manifests as: cloud data centres consuming massive electricity to enable efficient individual applications, AI training consuming enormous compute to enable efficient inference, smart cities consuming more infrastructure to optimise traffic. Jevons Paradox amplifies this — efficiency enables more consumption.
+
+**Strategic implication:** Include energy/resource/infrastructure costs in strategic planning for higher-order systems — the efficiency gains at the application layer are often offset by consumption increases at the infrastructure layer.
+
+**Assessment question:** Have we accounted for the full resource cost of the higher-order systems we are building or depending on?
+
+---
+
+## 3. Speed Patterns — Chapter VI
+
+### 3.1 Efficiency Enables Innovation — The Componentization Effect
+
+When lower-order components become commoditised and efficient, focus and resources shift to higher-level innovation. The mechanism: abstraction hides complexity, standardisation enables reuse, efficiency frees resources, stable components enable rapid recombination. Cloud commoditised infrastructure → rapid innovation in PaaS/SaaS. Smartphone hardware commoditised → app economy. Open source libraries → accelerated development. Each layer of commoditisation is a platform for the genesis of the next layer.
+
+**Strategic implication:** Actively commoditise lower layers to free innovation capacity for higher-value work — don't custom-build what should be utility.
+
+**Assessment question:** Which of our custom-built components should be replaced with commodity solutions to free resources for higher-value innovation?
+
+---
+
+### 3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed
+
+Improvements in how information is shared, collaboration occurs, and knowledge spreads accelerate the evolution of everything else. GitHub accelerated open source. Social media accelerated trend adoption and customer feedback loops. Slack/Zoom accelerated distributed decision-making. The internet accelerated globalisation. Each improvement in communication creates tighter feedback loops, faster learning cycles, and broader dissemination of innovation — compressing the time from genesis to commodity for dependent components.
+
+**Strategic implication:** Investing in communication infrastructure and culture is not just operational overhead — it is a direct lever on innovation speed.
+
+**Assessment question:** Are there communication bottlenecks in our organisation that are slowing the evolution of key components?
+
+---
+
+### 3.3 Increased Stability of Lower Order Systems Increases Agility
+
+A paradox: stability at lower levels creates agility at higher levels. When foundational components are reliable and well-understood, teams can experiment and innovate at higher levels without worrying about the underlying infrastructure. Stable OS → rapid application development. Stable cloud infrastructure → serverless experimentation. Stable web frameworks → rapid UI prototyping. Conversely, unstable lower-order systems force engineering attention downward, away from higher-value innovation.
+
+**Strategic implication:** Invest in making foundational systems stable and commodity-grade to unlock innovation speed above them.
+
+**Assessment question:** Are our foundational systems stable enough to support rapid recombination and experimentation at higher levels?
+
+---
+
+### 3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists
+
+Change can follow linear, exponential, S-curve, or discontinuous (tipping point) patterns. Human cognition defaults to linear extrapolation, systematically underestimating exponential trends and missing discontinuities. AI capabilities improved gradually for decades, then accelerated explosively. Cryptocurrency appeared discontinuously. Social media followed an S-curve. The implication: strategies built on linear forecasts are repeatedly surprised by the world. Scenarios must include non-linear possibilities.
+
+**Strategic implication:** Build strategies that are robust across non-linear scenarios, not just the linear extrapolation of current trends.
+
+**Assessment question:** Which components in our landscape could exhibit exponential or discontinuous change, and are our plans robust to that?
+
+---
+
+### 3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium
+
+The transition from product to utility (commodity/utility stage) is not always gradual. Components often remain stable in the product stage for extended periods, then shift rapidly to utility characteristics — standardised offering, usage-based pricing, cloud delivery, market consolidation. Software licensing → SaaS was punctuated. Music sales → streaming was punctuated. On-premise IT → cloud was punctuated. The equilibrium (product stage) is stable until a trigger collapses it quickly into the utility paradigm.
+
+**Strategic implication:** If you are in a product market, monitor for the triggers that will cause punctuated shift to utility — and decide whether to lead or follow that shift.
+
+**Assessment question:** Which of our product-stage offerings is approaching a punctuated shift to utility, and are we positioned to lead or survive it?
+
+---
+
+## 4. Inertia Patterns — Chapter VII
+
+### 4.1 Success Breeds Inertia
+
+Organisations that achieve success tend to resist change. The very practices, structures, and mindsets that created success become barriers to future adaptation. Mechanisms: complacency reduces urgency, overconfidence inflates belief in current capabilities, resources cluster around profitable existing products, successful practices become culturally entrenched, and risk aversion increases as there is more to lose. Kodak invented digital photography; Nokia built excellent hardware; Blockbuster had massive scale — all failed because success made adaptation psychologically and structurally difficult.
+
+**Strategic implication:** Explicitly identify and name success-induced inertia — it is invisible until it is fatal.
+
+**Assessment question:** Where are we resisting evolution because current revenue or culture depends on the status quo?
+
+---
+
+### 4.2 Inertia Can Kill an Organisation
+
+Unaddressed inertia has existential consequences. The mechanisms of organisational death by inertia: market irrelevance (failing to adapt to shifting user needs), technological obsolescence (clinging to superseded approaches), business model disruption (unable to match new entrants' economics), and resource depletion (continuing to invest in declining areas). Blockbuster (bankruptcy 2010), Kodak (bankruptcy 2012), Nokia's mobile division (sold 2014) — all were dominant market leaders destroyed by inertia, not lack of capability.
+
+**Strategic implication:** Inertia is not a performance problem — it is a survival problem. Treat it as an existential risk, not a management challenge.
+
+**Assessment question:** If a new entrant built our core value chain on commodity infrastructure today, what would their cost structure and speed look like compared to ours?
+
+---
+
+### 4.3 Inertia Increases the More Successful the Past Model Is
+
+The more successful a business model has been, the harder it becomes to abandon — proportionally. Extraordinary success creates deeper entrenchment of processes, stronger cognitive biases toward the current model, greater financial disincentives to change (cannibalism risk), deeper skill specialisation that is hard to pivot, and stronger cultural identity attached to the successful approach. Microsoft initially missed the internet despite its dominant position. IBM resisted personal computing. Xerox failed to commercialise its own GUI innovations.
+
+**Strategic implication:** The organisations most at risk from inertia are the most successful ones — build explicit mechanisms for self-disruption before disruption is forced externally.
+
+**Assessment question:** Where is our success so profound that we cannot honestly assess whether the model will survive the next evolution cycle?
+
+---
+
+## 5. Competitor Patterns — Chapter VIII
+
+### 5.1 Competitors' Actions Will Change the Game
+
+The competitive landscape is not static — competitors' strategic moves can fundamentally alter the rules of engagement. Game-changing action types: disruptive innovation (redefining the market), pricing strategy shifts (changing customer expectations), M&A (creating new capability combinations), ecosystem plays (expanding the scope of competition), and regulatory influence (shaping the playing field). AWS changed cloud. Uber changed transport. Tesla changed automotive. Each action triggered cascading changes across the entire ecosystem.
+
+**Strategic implication:** Strategy must be designed for a reactive system, not a static environment — anticipate competitor moves, not just market trends.
+
+**Assessment question:** Which competitor action, if taken, would most fundamentally change the basis of competition in our market?
+
+---
+
+### 5.2 Most Competitors Have Poor Situational Awareness
+
+The majority of organisations operate without a clear, accurate model of their competitive landscape. Manifestations of poor situational awareness: myopic focus on immediate competitors while missing broader industry shifts, technology blindness (failing to recognise emerging technology impact), customer disconnect (misunderstanding evolving needs), ecosystem ignorance (unaware of adjacent disruptors), and internal bias (overestimating own position). Blockbuster, Nokia, and Kodak all had access to information about emerging threats — they lacked the frameworks to interpret that information correctly.
+
+**Strategic implication:** Superior situational awareness is itself a durable competitive advantage — Wardley Mapping is a tool for building it.
+
+**Assessment question:** What would our map look like if drawn by our most capable competitor, and how would it differ from ours?
+
+---
+
+## 6. Prediction Patterns — Chapter IX
+
+### 6.1 Not Everything is Random — P[what] vs P[when]
+
+The direction of change (what will happen) is often more predictable than its timing (when it will happen). The shift to electric vehicles was widely predictable (high P[what]); the timing of mass adoption was not (uncertain P[when]). The commoditisation of cloud was predictable; the exact speed was not. This distinction enables better strategic planning: prepare capabilities and positioning for the predictable "what" while maintaining flexibility about the "when." Strategies anchored to specific timelines fail when the "when" is wrong; strategies anchored to directions are more robust.
+
+**Strategic implication:** Separate directional bets (high confidence) from timing bets (lower confidence) in strategic planning and investment decisions.
+
+**Assessment question:** Which evolutionary directions in our landscape are high-confidence (P[what]) even if the timing remains uncertain (P[when])?
+
+---
+
+### 6.2 Economy Has Cycles — Peace, War, and Wonder
+
+Industries cycle through three phases. **Peace**: stable market, established players dominate, incremental improvements, efficiency focus, product competition on features. **War**: intense competition triggered by industrialisation of a key component (e.g., cloud), rapid disruption, shifting power, creative destruction, incumbents with inertia are most vulnerable. **Wonder**: emergence of new higher-order systems built on newly commoditised components, rapid genesis, new industries forming, new business models, capital floods in. Each phase transitions to the next as components evolve.
+
+**Strategic implication:** Identify the current phase and position accordingly — survival strategies differ radically between Peace (optimise), War (transform rapidly), and Wonder (explore and capture genesis opportunities).
+
+**Assessment question:** Which phase is our core market currently in, and what phase transition should we be preparing for?
+
+---
+
+### 6.3 Different Forms of Disruption — Predictable vs Unpredictable
+
+Not all disruptions are equal. **Predictable disruptions** follow observable evolutionary patterns — the shift to EV, the move from product to SaaS, the commoditisation of compute. These can be anticipated through careful Wardley mapping and scenario planning. **Unpredictable disruptions** arise from unforeseen combinations of factors — cryptocurrency, ChatGPT's impact timeline, COVID-19 accelerating digital adoption. Strategies for each differ: predictable disruptions warrant directional investment and capability building; unpredictable disruptions require resilience, optionality, and rapid response capability.
+
+**Strategic implication:** Maintain separate portfolios for predictable evolutionary positioning and resilience against unpredictable disruption.
+
+**Assessment question:** Which disruptions in our landscape are predictable (and therefore we should be positioned for), and which require resilience rather than prediction?
+
+---
+
+### 6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve
+
+When a key component crosses from product to utility (industrialisation), it triggers a "war" — a period of intense competition that forces rapid organisational evolution across the entire ecosystem. Characteristics: accelerated component movement on the map, emergence of new components and disappearance of others, shifting value chains, standardisation pressure, and efficiency focus. The cloud "war" forced every enterprise IT function to evolve. The e-commerce "war" forced every retailer to transform. Organisations with high inertia are most vulnerable during these periods.
+
+**Strategic implication:** Detect the signs of an approaching "war" early — rapid component movement, new entrants with commodity infrastructure, pricing pressure — and begin transformation before the peak.
+
+**Assessment question:** Is there a component in our value chain approaching industrialisation that will trigger a "war" requiring us to evolve rapidly?
+
+---
+
+### 6.5 You Cannot Measure Evolution Over Time or Adoption
+
+Evolution cannot be precisely measured or timed. Adoption rates are highly variable, context-dependent, and non-linear. Attempts to create exact timelines or adoption curves produce false precision that misleads strategy. Cloud adoption varied wildly by industry and region. Social media platform trajectories were unpredictable. AI breakthroughs in natural language processing exceeded predictions; adoption in other sectors lagged them. The evolutionary axis in Wardley maps represents maturity, not time — components should be positioned by their characteristics, not by when they appeared.
+
+**Strategic implication:** Use directional positioning and scenario ranges rather than timeline forecasts — build strategies robust to timing uncertainty.
+
+**Assessment question:** Are we making investment commitments that depend on specific adoption timing predictions, and how robust are those commitments if timing is wrong by 2-3 years?
+
+---
+
+### 6.6 The Less Evolved Something Is, the More Uncertain It Becomes
+
+Uncertainty correlates inversely with evolution stage. Genesis components: high uncertainty about use cases, timelines, applications, and market dynamics. Custom-built: emerging patterns, still divergent. Product: increasing certainty, convergent standards. Commodity: well-understood, predictable. This is why genesis innovation requires different risk tolerance, different management approaches, and different investment models (portfolio/options thinking) compared to commodity management (efficiency, SLAs, incident management). Blockchain remains mostly in high-uncertainty stages; cloud IaaS is low-uncertainty commodity.
+
+**Strategic implication:** Calibrate risk tolerance, management approach, and investment model to the evolution stage — not to a single organisational standard.
+
+**Assessment question:** Are we applying commodity-appropriate certainty assumptions to genesis-stage components, or genesis-appropriate uncertainty assumptions to commodity components?
+
+---
+
+### 6.7 Not Everything Survives
+
+Evolution is a selection process — not all components, technologies, business models, or organisations survive it. Survival requires continuous adaptation. Past success and market leadership do not guarantee survival (Kodak, Nokia, Blockbuster). Creative destruction continuously replaces less-adapted elements with better-adapted alternatives. Strategies must account for exit scenarios, graceful transition pathways, and portfolio diversification to spread survival risk. Some components will become obsolete on a predictable timeline; others will be wiped out by unpredictable disruption.
+
+**Strategic implication:** Include obsolescence scenarios and exit planning in strategy — not as pessimism, but as realism about evolutionary dynamics.
+
+**Assessment question:** Which components in our current value chain have a non-trivial probability of not surviving the next evolution cycle, and what is our plan?
+
+---
+
+### 6.8 Embrace Uncertainty
+
+Uncertainty is not a problem to solve — it is a property of the landscape to work with. Strategies that require uncertainty to be resolved before acting are brittle. Effective approaches: scenario planning across multiple futures, adaptive strategy that adjusts as new information arrives, staged investment (options thinking), rapid experimentation to reduce uncertainty in specific areas, and range-based positioning rather than point predictions. The Wardley map itself is a tool for navigating uncertainty, not eliminating it.
+
+**Strategic implication:** Design strategy to be robust across a range of futures, not optimal for a single predicted future.
+
+**Assessment question:** How many of our current strategic commitments would fail if one key uncertainty resolved differently than we expect?
+
+---
+
+## 7. The Peace/War/Wonder Cycle
+
+The Peace/War/Wonder cycle is one of the most powerful macro-level patterns for strategic timing.
+
+### Peace Phase
+
+Characteristics: stable market structure, established players compete on features and brand, incremental innovation dominates, efficiency and optimization are the primary value drivers, customers have clear expectations, supply chains are well-understood, margins are moderate but predictable.
+
+Strategic posture in Peace: invest in operational excellence, differentiate on features and customer experience, build moats through network effects and switching costs, watch for the signs of approaching War.
+
+Signs Peace is ending: a key component begins rapid commoditisation, new entrants appear with dramatically lower cost structures built on commodity infrastructure, pricing pressure accelerates, customers begin treating differentiated features as expected utilities.
+
+### War Phase
+
+Characteristics: intense competition triggered by industrialisation of a key component, rapid disruption of established business models, creative destruction of incumbents with high inertia, massive investment and risk-taking, shifting value chains, winner-takes-most dynamics, organisations that fail to evolve quickly face existential risk.
+
+Strategic posture in War: transform rapidly, use the commodity infrastructure that triggered the War, shed custom-built components that are now available as utilities, focus on higher-order differentiation, form strategic partnerships, acquire capabilities that cannot be built fast enough organically.
+
+Signs War is ending: market consolidation around a few utility providers, pricing stabilises at commodity levels, the new "normal" becomes established, innovation focus shifts upward to new genesis opportunities.
+
+### Wonder Phase
+
+Characteristics: new higher-order systems built on newly commoditised components, rapid genesis of new capabilities, new industries forming, capital floods into new value areas, multiple competing paradigms coexist, uncertainty is highest but potential value is greatest.
+
+Strategic posture in Wonder: explore broadly, make small bets on multiple genesis opportunities, build options, tolerate high failure rates for high potential return, watch for which genesis components are beginning to show custom-built characteristics (indicating the next cycle is forming).
+
+Signs Wonder is maturing into the next Peace: dominant designs emerge, standards begin to form, the early adopter wave has passed and early majority adoption begins.
+
+### Identifying Your Current Phase
+
+Ask these questions for each major market/component:
+- Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
+- Are new entrants building on commodity infrastructure that did not exist 3 years ago?
+- Is capital flowing into or out of this space?
+- Are established players being forced to change their core business models?
+
+---
+
+## 8. Pattern Interaction Map
+
+Climatic patterns do not operate in isolation — they interact, reinforce, and counteract each other.
+
+### Reinforcing Combinations
+
+| Pattern A | Pattern B | Combined Effect |
+|-----------|-----------|-----------------|
+| Everything Evolves | Efficiency Enables Innovation | Accelerating cycle: commoditisation continuously creates the foundation for new genesis |
+| Higher Order Systems Create Value | Capital Flows to New Value | Capital predictably follows the new value streams created by higher-order systems |
+| Evolution of Communication | Change Is Not Linear | Better communication amplifies non-linear change by spreading innovations faster |
+| Punctuated Equilibrium | War Phase | Product-to-utility shifts are the mechanism that triggers "War" periods |
+| Success Breeds Inertia | Inertia Increases with Success | Compounding effect — the more successful, the more inert, the more vulnerable |
+| Jevons Paradox | Higher Order Systems Increase Energy | Efficiency-driven adoption increases demand, which increases total resource consumption |
+
+### Counteracting Tensions
+
+| Pattern A | Counteracts | Effect |
+|-----------|-------------|--------|
+| Inertia patterns | Everything Evolves | Inertia slows or blocks what evolution demands — this tension is the primary cause of organisational failure |
+| Not Everything Survives | Capital Flows to New Value | Capital exits before components become extinct — early movers gain, late movers lose |
+| Embrace Uncertainty | False precision in P[when] | Organisations that require certainty before acting are consistently outmanoeuvred by those that act on P[what] |
+| Commoditization ≠ Centralisation | Assumption of monopoly | Prevents strategic blind spots about market structure in commoditised segments |
+
+### Cascade Sequences
+
+A common cascade: **War phase** triggers → **Creative Destruction** → **Capital flows** to new areas → **Higher-order systems** emerge → **Efficiency enables innovation** → components commoditise → next **War phase** begins.
+
+Another: **Red Queen Effect** pressure → **Success Breeds Inertia** resistance → **Inertia Can Kill** outcome (if not addressed) or **Self-disruption** response (if addressed).
+
+---
+
+## 9. Per-Component Assessment Template
+
+Use this template for each significant component on a Wardley map to identify which climatic patterns are most active and their likely strategic impact.
+
+```
+Component: [name]
+Evolution Stage: [genesis / custom-built / product / commodity]
+Evolution Trajectory: [accelerating / stable / stagnating]
+Ecosystem Type: [consumer (fast) / industrial (slow) / mixed]
+
+Key Patterns Affecting This Component:
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [1-2 sentences of specific evidence]
+    Time Horizon: [<12 months / 1-3 years / 3+ years]
+
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [brief]
+    Time Horizon: [timeframe]
+
+Inertia Assessment:
+  - Organisational inertia present: [yes / no / partial]
+  - Source of inertia: [past success / skills / politics / contracts / culture]
+
+Peace/War/Wonder Phase: [current phase for this component's market]
+Next Phase Trigger: [what would trigger transition to next phase]
+
+Prediction:
+  P[what]: [what will happen — high confidence direction]
+  P[when]: [timing uncertainty — low / medium / high]
+  6-month outlook: [specific prediction]
+  12-month outlook: [specific prediction]
+
+Recommended Response:
+  Urgency: [High / Medium / Low]
+  Primary action: [description]
+  Watch signal: [what to monitor to confirm/refute the prediction]
 ```
 
-### Characteristics Change as Components Evolve
+---
 
-```yaml
-pattern:
-  name: "Characteristics Change"
-  description: "How a component is managed changes with its evolution"
+## 10. Pattern Recognition Template
 
-  changes:
-    genesis:
-      development: "Research, exploration"
-      failure: "Expected, learning"
-      team: "Pioneers"
-
-    commodity:
-      development: "Operations, optimization"
-      failure: "Unacceptable, incident"
-      team: "Town planners"
-
-  implication: "Same team skills don't work across evolution stages"
-```
-
-### No One Thing Fits All
-
-```yaml
-pattern:
-  name: "No One Size Fits All"
-  description: "Different stages require different approaches"
-
-  examples:
-    methods:
-      genesis: "Agile, experimental"
-      commodity: "Six Sigma, lean"
-
-    contracts:
-      genesis: "Time & materials"
-      commodity: "Fixed price"
-
-    architecture:
-      genesis: "Disposable PoCs"
-      commodity: "Standardized patterns"
-```
-
-## Competitive Patterns
-
-### Components Can Co-Evolve
-
-```yaml
-pattern:
-  name: "Co-Evolution"
-  description: "Changes in one component can accelerate another"
-
-  types:
-    practice_based:
-      description: "New practices emerge with new components"
-      example: "DevOps emerged with cloud infrastructure"
-
-    symbiotic:
-      description: "Components evolve together"
-      example: "Mobile devices and mobile apps"
-
-  implication: "Watch for enabler components that unlock other evolution"
-```
-
-### Efficiency Enables Innovation
-
-```yaml
-pattern:
-  name: "Efficiency Enables Innovation"
-  description: "Commoditization of one layer enables innovation above it"
-
-  example:
-    commodity: "Cloud computing"
-    enabled_innovation: "ML platforms, serverless applications"
-
-  implication: "Commoditize lower layers to free resources for higher-value work"
-```
-
-### Higher Order Systems Create New Sources of Worth
-
-```yaml
-pattern:
-  name: "Higher Order Systems"
-  description: "New value emerges from combining evolved components"
-
-  examples:
-    - "IoT = sensors + connectivity + cloud + analytics"
-    - "AI applications = compute + data + algorithms + interfaces"
-
-  implication: "Look for emerging higher-order systems"
-```
-
-## Predictability Patterns
-
-### Past Success Breeds Inertia
-
-```yaml
-pattern:
-  name: "Success Breeds Inertia"
-  description: "Organizations resist change to what made them successful"
-
-  causes:
-    - "Financial success with current model"
-    - "Skills and expertise tied to current technology"
-    - "Political capital invested in status quo"
-    - "Existing customer relationships"
-
-  symptoms:
-    - "Not invented here syndrome"
-    - "Custom building commodity components"
-    - "Resisting cloud migration"
-    - "Maintaining outdated technology"
-
-  counter_strategy: "Explicitly identify and address inertia"
-```
-
-### Capital Flows to New Industries
-
-```yaml
-pattern:
-  name: "Capital Flows"
-  description: "Investment follows evolution opportunities"
-
-  pattern: "Money flows from commodity extraction to genesis exploration"
-
-  implication: "Commoditization frees capital for new innovation"
-```
-
-## Technology Patterns
-
-### Componentization Increases
-
-```yaml
-pattern:
-  name: "Increasing Componentization"
-  description: "Systems become more modular over time"
-
-  stages:
-    early: "Monolithic, integrated"
-    middle: "Modular, connected"
-    mature: "Composable, standardized interfaces"
-
-  current_trends:
-    - "Microservices vs. monoliths"
-    - "APIs vs. point-to-point"
-    - "Serverless vs. managed servers"
-```
-
-### New Paradigms Create Waves
-
-```yaml
-pattern:
-  name: "Technology Waves"
-  description: "New paradigms replace old but take time"
-
-  wave_pattern:
-    emergence: "New technology appears (genesis)"
-    early_adoption: "Pioneers experiment"
-    disruption: "Mainstream adoption begins"
-    maturity: "Previous paradigm commoditizes"
-    next_wave: "Cycle repeats"
-
-  current_waves:
-    establishing: "AI/ML, quantum (early)"
-    disrupting: "Cloud native, serverless"
-    maturing: "Mobile, SaaS"
-    commoditized: "Internet, databases"
-```
-
-## Market Patterns
-
-### Buyers and Suppliers Evolve
-
-```yaml
-pattern:
-  name: "Market Evolution"
-  description: "Markets themselves evolve from bespoke to utility"
-
-  stages:
-    nascent:
-      buyers: "Early adopters, willing to experiment"
-      suppliers: "Few, innovative"
-      contracts: "Custom, relationship-based"
-
-    growth:
-      buyers: "Mainstream, looking for features"
-      suppliers: "Many, competing on features"
-      contracts: "Product licenses"
-
-    commodity:
-      buyers: "Price-sensitive, switching easy"
-      suppliers: "Few large, many small"
-      contracts: "Utility, pay-per-use"
-```
-
-### Disruption from New Entrants
-
-```yaml
-pattern:
-  name: "Disruption Pattern"
-  description: "New entrants often come from evolved infrastructure"
-
-  mechanism:
-    - "Incumbents have inertia in custom-built systems"
-    - "New entrants build on commodity infrastructure"
-    - "New entrants have lower costs, faster iteration"
-    - "Incumbents can't match without cannibalizing"
-
-  example:
-    incumbent: "Traditional banks with custom core banking"
-    disruptor: "Fintech on cloud with SaaS tools"
-    advantage: "Lower cost, faster feature delivery"
-```
-
-## Using Climatic Patterns
-
-### Assessment Questions
-
-```yaml
-assessment:
-  evolution:
-    - "What components are actively evolving?"
-    - "Are we fighting natural evolution anywhere?"
-    - "What will be commodity in 5 years?"
-
-  competition:
-    - "Who could commoditize our differentiators?"
-    - "What commodity infrastructure enables new competitors?"
-    - "What higher-order systems are emerging?"
-
-  inertia:
-    - "Where do we have success-based inertia?"
-    - "What skills/politics resist necessary change?"
-    - "Are we building custom where products exist?"
-```
-
-### Pattern Recognition Template
+Use this template to analyse how climatic patterns apply to your overall map.
 
 ```yaml
 pattern_analysis:
@@ -271,3 +467,38 @@ pattern_analysis:
     strategic_importance: "{High/Medium/Low}"
     recommended_response: "{Description}"
 ```
+
+---
+
+## 11. Assessment Questions by Category
+
+### Evolution
+
+- What components are actively evolving right now?
+- Are we fighting natural evolution anywhere (building custom where product/commodity exists)?
+- What will be commodity in 3 years? In 5 years?
+- Where are components in different ecosystems evolving at mismatched speeds?
+- Which co-evolutionary relationships could accelerate or destabilise our position?
+
+### Competition
+
+- Who could commoditise our current differentiators?
+- What commodity infrastructure enables new competitors to enter with structurally lower costs?
+- What higher-order systems are emerging that could change the basis of competition?
+- What game-changing action by a competitor would most threaten our position?
+- How does our situational awareness compare to our most capable competitor's?
+
+### Inertia
+
+- Where do we have success-based inertia that is blocking necessary evolution?
+- What skills, political capital, or cultural identity is tied to components that are evolving away?
+- Are we building custom solutions in areas where products or commodity utilities now exist?
+- Which of our most successful business models is most vulnerable to the next "War" phase?
+
+### Prediction
+
+- Which evolutionary changes in our landscape are high-confidence (P[what] even if P[when] is uncertain)?
+- What phase — Peace, War, or Wonder — is our core market in?
+- Which components are approaching punctuated equilibrium shifts from product to utility?
+- Where are we applying false certainty to genesis-stage components or excessive uncertainty to commodity ones?
+- What does the capital flow pattern in our sector tell us about where the next value creation will be?

--- a/arckit-codex/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-codex/skills/wardley-mapping/references/climatic-patterns.md
@@ -232,6 +232,43 @@ The more successful a business model has been, the harder it becomes to abandon 
 
 ---
 
+### Inertia Types Taxonomy
+
+Seven distinct types of inertia manifest differently and require different mitigation strategies. Based on Wardley's concept of "loss of capital" (physical, social, financial, political) expanded with operational types:
+
+| Type | Description | Indicators | Mitigation |
+|------|-------------|------------|------------|
+| **Success** | Past model worked so well that change feels unnecessary | "Why change what works?", strong quarterly results masking long-term risk, dismissal of emerging competitors | Establish parallel exploration teams, red team exercises, fund self-disruption initiatives |
+| **Capital** | Physical assets, infrastructure, and legacy technology create lock-in through sunk costs | Large depreciation schedules, outdated machinery still in use, fixed-purpose facilities, legacy systems deeply embedded in operations | Incremental upgrades, modular systems, leasing vs buying, versatile infrastructure design |
+| **Financial** | Risk aversion, short-term focus, and market pressures resist investment in change | Reluctance to sell underperforming assets, hesitancy to invest in new skills/tech, fear of losing strategic control, external markets rewarding stability over innovation | Strategic portfolio management, incremental investment, alternative financial models (leasing, partnerships), separate innovation budgets from BAU |
+| **Political** | Power structures and internal influence tied to existing approaches | Executives whose authority depends on current architecture, budget territories, empire building, fear of losing influence, preservation of established alliances | Reframe as opportunity not threat, create new leadership roles for emerging capabilities, sponsor from top, build coalitions, align incentives with change |
+| **Skills** | Workforce expertise concentrated in legacy technologies or methods | Recruitment focused on legacy skills, training budgets for existing tools, resistance to retraining | Upskilling programs, hire for new capabilities alongside legacy, paired teams (legacy + new) |
+| **Supplier** | Vendor relationships and ecosystem dependencies resist change | Preferred vendor lists, deep integration with specific platforms, vendor-specific certifications | Multi-vendor strategy, abstraction layers, gradual supplier diversification, renegotiate before lock-in deepens |
+| **Consumer** | Users or customers expect and depend on current approach | Customer complaints about any change, contractual SLAs tied to specific implementations, user workflow dependency | Gradual migration with parallel running, user research on actual needs vs habits, opt-in transitions |
+
+**Note on Capital vs Financial:** Capital inertia concerns physical/tangible assets (infrastructure, equipment, legacy systems). Financial inertia concerns the psychology and market dynamics around money (sunk cost fallacy, risk aversion, short-termism, investor pressure). A component can have capital inertia (locked into legacy infrastructure) without financial inertia (the business case for change is accepted), or vice versa.
+
+**Assessment per component:** For each component with inertia, identify which type(s) are present, rate severity (H/M/L), and define a specific mitigation action. Multiple types often compound — a component with success + skills + capital + financial inertia is far harder to move than one with only skills inertia.
+
+### Inertia Diagnostic Checklist
+
+Early warning signs that inertia is taking hold in an organisation. Use this checklist during doctrine and climate assessments:
+
+| Sign | What to Look For | Impact if Unaddressed |
+|------|-------------------|----------------------|
+| **Stagnant mindset** | Resistance to training, lack of curiosity about industry trends, unwillingness to adopt new tools | Declining productivity, loss of competitive awareness |
+| **Siloed thinking** | Teams working in isolation, duplicated effort, poor cross-functional communication, misalignment with overall strategy | Suboptimal decisions, inability to leverage collective expertise |
+| **Lack of innovation** | Few new ideas reaching implementation, fear of failure culture, no experimentation budget | Falling behind competitors, inability to differentiate |
+| **Complacency** | Comfort with status quo, "if it ain't broke don't fix it" attitude, declining urgency | Mediocrity becomes the norm, market share erosion |
+| **Risk aversion** | No experimentation, all decisions require exhaustive justification, preference for safe options | Missed opportunities, slow response to market shifts |
+| **Rigid structures** | Bureaucratic approval chains, top-down only decisions, inability to reorganise quickly | Cannot respond to customer needs or competitive threats |
+| **Lack of accountability** | Unclear ownership, blame culture, nobody responsible for change outcomes | Problems persist, low trust, poor morale |
+| **Low employee engagement** | High turnover, absenteeism, lack of initiative, disinterest in company direction | Talent flight, institutional knowledge loss |
+
+**Scoring:** Count how many signs are present (0-8). 0-2: healthy organisation. 3-4: early inertia — address proactively. 5-6: significant inertia — urgent intervention needed. 7-8: critical — existential risk if not addressed immediately.
+
+---
+
 ## 5. Competitor Patterns — Chapter VIII
 
 ### 5.1 Competitors' Actions Will Change the Game
@@ -367,6 +404,7 @@ Signs Wonder is maturing into the next Peace: dominant designs emerge, standards
 ### Identifying Your Current Phase
 
 Ask these questions for each major market/component:
+
 - Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
 - Are new entrants building on commodity infrastructure that did not exist 3 years ago?
 - Is capital flowing into or out of this space?

--- a/arckit-codex/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-codex/skills/wardley-mapping/references/doctrine.md
@@ -400,6 +400,7 @@ doctrine_assessment:
 Use these prompts during assessment interviews and document reviews to gather evidence for each category.
 
 **Communication**
+
 - [ ] Is there a shared glossary or terminology guide in use across teams?
 - [ ] Are strategy documents written in language understood outside the originating team?
 - [ ] Are assumptions in proposals explicitly stated and challenged before approval?
@@ -407,6 +408,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are decision rationales documented and accessible to those affected?
 
 **Development**
+
 - [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
 - [ ] Are different methodologies applied to different components based on their evolutionary stage?
 - [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
@@ -414,6 +416,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are standards and tools reviewed periodically for continued appropriateness?
 
 **Operation**
+
 - [ ] Can leaders describe the operational details of the services they are accountable for?
 - [ ] Are sources of organisational inertia identified and addressed in change plans?
 - [ ] Is there a blameless failure review process in place?
@@ -421,18 +424,21 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are value stream maps or similar tools used to identify bottlenecks?
 
 **Learning**
+
 - [ ] Is there a structured process for capturing and applying lessons learned?
 - [ ] Are teams encouraged and resourced to run experiments?
 - [ ] Is there a programme for exploring emerging technologies before they become urgent?
 - [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
 
 **Leading**
+
 - [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
 - [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
 - [ ] Is there a single named accountable owner for each strategic initiative?
 - [ ] Are leaders open about what they do not know and willing to change their minds publicly?
 
 **Structure**
+
 - [ ] Are most teams small enough to communicate without formal coordination overhead?
 - [ ] Do teams have authority to make decisions within their domain without escalation?
 - [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?

--- a/arckit-codex/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-codex/skills/wardley-mapping/references/doctrine.md
@@ -1,120 +1,439 @@
 # Doctrine
 
-Universally useful patterns for strategy, independent of context or landscape.
+Universal principles and best practices that guide strategic decision-making, independent of context or landscape.
 
-## Doctrine Categories
+---
 
-The following is a curated subset of Wardley's doctrine principles, covering the areas most actionable in mapping exercises. For the full set, see Simon Wardley's original writings.
+## 1. Strategy Cycle
 
-```yaml
-doctrine_categories:
-  communication:
-    - "Use a common language"
-    - "Challenge assumptions"
-    - "Focus on user needs"
+Doctrine sits within a five-step iterative strategy cycle:
 
-  development:
-    - "Use appropriate methods for evolution stage"
-    - "Think small (cell-based structures)"
-    - "Manage inertia"
-    - "Use standards where appropriate"
+1. **Purpose** — define the organisation's overarching objectives and direction
+2. **Landscape** — map the competitive environment, components, and value chains
+3. **Climate** — identify external forces, market dynamics, and evolutionary pressures
+4. **Doctrine** — apply universal principles that hold regardless of context
+5. **Leadership** — make informed decisions and execute, then return to step 1
 
-  operation:
-    - "Think FIRE (Fast, Inexpensive, Restrained, Elegant)"
-    - "Manage failure appropriately"
-    - "Optimize flow"
+The cycle is continuous. Organisations repeatedly pass through all five stages, refining strategy based on new insights. Doctrine provides the stable foundation that makes repeated iteration productive rather than chaotic.
 
-  learning:
-    - "Use a systematic mechanism of learning"
-    - "Know your users"
-    - "Know your details"
+---
 
-  leading:
-    - "Be the owner"
-    - "Move fast"
-    - "Accept that strategy is iterative"
-```
+## 2. Doctrine Phase/Category Matrix
 
-## Doctrine Assessment Template
+Forty-two principles organised across four phases and six categories (source: Wardley Mapping Doctrine, Figure 2).
 
-Use this template to evaluate an organization's doctrine maturity. Score each area 1-5:
+| Phase | Communication | Development | Operation | Learning | Leading | Structure |
+|-------|--------------|-------------|-----------|----------|---------|-----------|
+| **I: Stop Self-Harm** | Common Language | Know Your Users | Know the Details | Systematic Learning | — | — |
+| | Challenge Assumptions | Focus on User Needs | | | | |
+| | Understand Context | Remove Bias & Duplication | | | | |
+| | | Use Appropriate Methods | | | | |
+| **II: Context Aware** | Bias Towards Open | Focus on Outcome | Manage Inertia | Bias Towards Action | Move Fast | Think Small Teams |
+| | | Think FIRE | Manage Failure | | Strategy is Iterative | Distribute Power |
+| | | Use Appropriate Tools | Effectiveness over Efficiency | | | Aptitude & Attitude |
+| | | Be Pragmatic | | | | |
+| | | Use Standards | | | | |
+| **III: Better for Less** | — | — | Optimise Flow | Bias to New | Commit to Direction | Seek the Best |
+| | | | Do Better with Less | | Be the Owner | Purpose/Mastery/Autonomy |
+| | | | Exceptional Standards | | Inspire Others | |
+| | | | | | Embrace Uncertainty | |
+| | | | | | Be Humble | |
+| **IV: Continuously Evolving** | — | — | — | Listen to Ecosystem | Exploit the Landscape | No Single Culture |
+| | | | | | There is No Core | Design for Constant Evolution |
+
+---
+
+## 3. Phase Details
+
+### Phase I: Stop Self-Harm
+
+**Objective:** Prevent further self-inflicted damage and establish a stable foundation for strategy.
+
+Organisations in Phase I often harm themselves through poor communication, misaligned development, and absence of learning. The nine principles in this phase address the most fundamental failures.
+
+#### Communication
+
+**Common Language** — Establish standardised terminology so all teams share meaning. Without a common vocabulary, strategy conversations produce confusion rather than alignment. Create a glossary, enforce it in meetings and documents, and review it regularly.
+
+**Challenge Assumptions** — Actively question established beliefs and the "way things have always been done." Assign devil's advocate roles, conduct assumption audits, and reward constructive scepticism. This prevents strategies built on invisible, outdated premises.
+
+**Understand Context** — Develop situational awareness before acting. Ensure communications include enough context for recipients to make informed decisions. Go beyond surface information to understand implications, stakeholder impacts, and broader relationships.
+
+#### Development
+
+**Know Your Users** — Understand the needs of all stakeholders: customers, shareholders, regulators, and staff. This is not one-time market research but an ongoing process. Use personas, continuous feedback loops, and cross-functional sharing of user insights.
+
+**Focus on User Needs** — Place user requirements at the centre of all development decisions. Anchor Wardley Maps to genuine user needs rather than internal assumptions. Prioritise what users truly need, not just what they explicitly request.
+
+**Remove Bias and Duplication** — Identify and eliminate both unwarranted assumptions that skew decisions and redundant processes that waste resources. Use diverse teams, data-driven decision making, and regular process reviews. Some redundancy aids resilience; eliminate wasteful redundancy.
+
+**Use Appropriate Methods** — Select development methodologies suited to the evolutionary stage of the work. Agile for genesis-stage components; lean or six sigma for more evolved ones. No single methodology fits all contexts.
+
+#### Operation
+
+**Know the Details** — Pay close attention to operational specifics. Leaders who lose touch with operational reality make poor strategic decisions. Conduct thorough process assessments, ensure documentation is current, and keep management connected to the ground truth.
+
+#### Learning
+
+**Systematic Learning (Bias Towards Data)** — Implement structured processes for gathering, analysing, and applying knowledge. Establish feedback loops, document lessons learned, and treat data as a strategic asset. Ad hoc learning leaves organisations repeating mistakes.
+
+---
+
+### Phase II: Becoming More Context Aware
+
+**Objective:** Enhance situational awareness and leverage contextual knowledge for better decisions.
+
+Phase II builds on the stable foundation of Phase I. The organisation now turns outward — becoming aware of its competitive environment, managing the dynamics of change, and starting to use contextual judgement rather than rigid rules.
+
+#### Communication
+
+**Bias Towards Open** — Make transparency and information sharing the default, not the exception. Move beyond "need to know" to proactive sharing of decisions, data, and rationale. Open communication fosters trust, accelerates innovation, and improves alignment. Balance openness with appropriate confidentiality.
+
+#### Development
+
+**Focus on Outcome** — Prioritise valuable results over rigid adherence to contracts or predetermined plans. Measure success by outcomes delivered, not tasks completed. Structure contracts and metrics around value, and empower teams to adapt their approach as long as the outcome stays in view.
+
+**Think FIRE (Fast, Inexpensive, Restrained, Elegant)** — Apply all four dimensions when designing solutions. Fast means rapid iteration; Inexpensive means cost-effective without being cheap; Restrained means resisting feature creep; Elegant means simple, user-centred design. FIRE prevents over-engineering and accelerates delivery.
+
+**Use Appropriate Tools** — Select tools matched to the specific development context rather than defaulting to familiarity or fashion. Evaluate tools against project needs, scalability, and long-term viability. Avoid tool proliferation; balance innovation with stability.
+
+**Be Pragmatic** — Choose what works in the real world over what is theoretically correct. Base decisions on evidence and observed results. Pragmatism is not short-termism — it is applying practical judgement to move purposefully toward long-term goals.
+
+**Use Standards** — Adopt industry or internal standards where components are sufficiently evolved to benefit from standardisation. Standards improve interoperability, quality, and speed. On Wardley Maps, standards apply most naturally to product- and commodity-stage components.
+
+#### Operation
+
+**Manage Inertia** — Actively address organisational resistance to change. Identify sources of inertia (legacy systems, entrenched culture, middle-management resistance), communicate the case for change compellingly, and use change champions and incremental rollouts to build momentum.
+
+**Manage Failure** — Design mechanisms to handle failure gracefully and extract learning from it. Failure tolerance should be calibrated to evolutionary stage: high tolerance for genesis-stage experiments, low tolerance for commodity-stage operations. Treat failure as information, not shame.
+
+**Effectiveness over Efficiency** — Prioritise achieving the desired outcome before optimising how efficiently you achieve it. Efficient execution of the wrong activity is waste. Confirm you are doing the right things before refining how fast you do them.
+
+#### Learning
+
+**Bias Towards Action** — Learn by doing rather than by planning. Encourage practical experimentation. Iterative, hands-on engagement with the landscape reveals insights that analysis alone cannot. Establish rapid learning cycles where experiments feed directly back into strategy.
+
+#### Leading
+
+**Move Fast** — Prioritise rapid execution and decision-making over waiting for perfect information. Speed of action is itself a strategic asset. Leaders should reduce approval chains, tolerate imperfection, and default to trying things over deliberating about them.
+
+**Strategy is Iterative** — Treat strategy as a cyclical process, not a one-time plan. Regularly reassess and adapt the strategy based on new intelligence. The most dangerous strategies are those treated as immutable once written.
+
+#### Structure
+
+**Think Small Teams** — Organise work into small, cross-functional, autonomous teams. Small teams communicate faster, decide faster, and are more accountable. They also align naturally with the Pioneer/Settler/Town Planner model of matching team culture to evolutionary stage.
+
+**Distribute Power** — Decentralise decision-making to the teams closest to the work. Establish clear boundaries and provide resources; then trust teams to act within them. Centralised authority creates bottlenecks and suppresses the contextual judgement that effective strategy requires.
+
+**Aptitude and Attitude** — Hire and develop team members based on both technical capability (aptitude) and cultural alignment (attitude). A team of highly skilled individuals with the wrong disposition will underperform a moderately skilled team with the right mindset.
+
+---
+
+### Phase III: Better for Less
+
+**Objective:** Achieve significantly better outcomes while consuming fewer resources through continuous improvement and high standards.
+
+Phase III organisations have mastered the basics and begun optimising. The focus shifts to operational excellence, leadership maturity, and structural conditions that allow people to produce their best work.
+
+#### Operation
+
+**Optimise Flow** — Identify and remove bottlenecks that impede the throughput of value. Use value stream mapping and similar techniques to visualise where work slows. Optimising flow at the system level is more powerful than improving individual components in isolation.
+
+**Do Better with Less** — Embed continuous improvement as a cultural norm. Regularly review processes with the explicit goal of producing the same or better outcomes with fewer resources. Constraint fosters creativity; resource abundance often masks inefficiency.
+
+**Set Exceptional Standards** — Define and publicly commit to high performance standards. Exceptional standards create a benchmark that drives quality, reduces tolerance for mediocrity, and builds organisational pride. Low standards become self-fulfilling; high standards become self-reinforcing.
+
+#### Learning
+
+**Bias Towards the New** — Actively explore emerging ideas, technologies, and approaches rather than defaulting to the familiar. The evolutionary landscape rewards early movers in genesis-stage components. Create protected space for experimentation; do not allow operational maturity to crowd out exploration.
+
+#### Leading
+
+**Commit to Direction** — Be steadfast in pursuing strategic goals while remaining open to adjusting tactics. Frequent strategy reversals demoralise teams and waste the organisational capital accumulated through consistent effort. Distinguish between pivoting approach and abandoning direction.
+
+**Be the Owner** — Take full responsibility and accountability for strategy and outcomes. Do not diffuse accountability across committees or processes. Ownership means accepting both credit and blame, and making decisions rather than deferring them.
+
+**Inspire Others** — Articulate a compelling vision and motivate the team toward ambitious goals. Inspiration is not cheerleading — it is connecting individual work to meaningful purpose, demonstrating commitment, and showing people what is possible.
+
+**Embrace Uncertainty** — Accept that uncertainty is an inherent feature of strategy, not a temporary condition that will eventually resolve. Make peace with acting under incomplete information. Organisations that require certainty before acting are chronically late.
+
+**Be Humble** — Cultivate openness to feedback, correction, and different viewpoints. Hubris in leadership prevents the honest assessment of landscape and doctrine that effective strategy requires. Humility is not weakness — it is accurate self-knowledge.
+
+#### Structure
+
+**Seek the Best** — Aim for excellence in organisational design, not adequacy. Benchmark structure against industry best practice, not internal tradition. Regularly ask whether the current structure is the best possible arrangement for executing current strategy.
+
+**Purpose, Mastery, and Autonomy** — Create the three conditions Daniel Pink identifies as intrinsic motivation. Ensure individuals understand how their work connects to the organisation's purpose. Invest in developing deep expertise (mastery). Remove unnecessary controls that undermine self-direction (autonomy).
+
+---
+
+### Phase IV: Continuously Evolving
+
+**Objective:** Create a resilient, adaptive organisation that drives change rather than merely responding to it.
+
+Phase IV represents organisational maturity. The organisation no longer manages change episodically — evolution is built into the fabric of how it operates.
+
+#### Learning
+
+**Listen to the Ecosystem** — Actively engage with and learn from the broader environment: customers, competitors, suppliers, regulators, adjacent industries, and emerging technologies. The most important signals about future landscape shifts come from outside the organisation. Create structured mechanisms for ecosystem listening, not just passive monitoring.
+
+#### Leading
+
+**Exploit the Landscape** — Leverage the broader business environment as a source of competitive advantage. Identify patterns, leverage points, and structural features of the landscape that others overlook. This requires a deep understanding of how components are evolving and where they are vulnerable to disruption or commoditisation.
+
+**There is No Core** — Reject the notion of a permanent "core business." All strategic positions are temporary. Components that are differentiating today will become commodity tomorrow. Maintaining strategic flexibility means being willing to abandon current strengths when the landscape demands it. This is not instability — it is strategic maturity.
+
+#### Structure
+
+**No Single Culture** — Recognise that different work requires different cultural approaches. Genesis-stage innovation requires a culture of exploration and tolerance for failure; commodity-stage operations require discipline and efficiency. A single mandated culture optimises for one type of work at the expense of all others. Cultivate and value cultural diversity within the organisation.
+
+**Design for Constant Evolution** — Build organisational structures, processes, and systems that are inherently flexible. Change should not require major restructuring — it should be the normal mode of operation. Use modular designs, adaptive processes, and continuous skills development to make evolution frictionless.
+
+---
+
+## 4. Implementation Journeys
+
+### Communication Journey (Phases I–II)
+
+Begin by establishing shared vocabulary and a common map language that all teams use consistently (Phase I). Progress to making transparency the default operating mode: open decision-making, accessible data, two-way feedback channels (Phase II). The destination is an organisation where strategic information flows freely across all levels and functions, enabling faster alignment and better decisions.
+
+### Development Journey (Phases I–II)
+
+Start by rooting development in real user needs and eliminating duplicated effort (Phase I). Evolve toward outcome-focused, pragmatic delivery using FIRE principles, contextually appropriate tools, and industry standards (Phase II). The journey moves from "building things correctly" to "building the correct things efficiently."
+
+### Operation Journey (Phases I–III)
+
+Establish situational awareness through operational detail (Phase I). Build change management capability and effective failure response (Phase II). Reach the destination of continuously optimised flow, exceptional quality standards, and a culture that does more with less (Phase III). Each phase adds a layer of operational sophistication on top of the last.
+
+### Learning Journey (Phases I–IV)
+
+Implement data-driven learning mechanisms and documentation (Phase I). Shift to action-oriented learning through experimentation (Phase II). Dedicate resources to exploring new ideas and technologies (Phase III). In Phase IV, the organisation systematically listens to its ecosystem and makes continuous adaptation a cultural norm rather than a periodic initiative.
+
+### Leading Journey (Phases II–IV)
+
+Leadership doctrine begins in Phase II with fast decisions and iterative strategy. Phase III adds personal accountability, inspiration, humility, and the ability to operate in uncertainty. Phase IV demands leaders who can read and exploit landscape features that are invisible to less evolved organisations, while holding their strategic position loosely enough to abandon it when evolution demands.
+
+### Structure Journey (Phases II–IV)
+
+Phase II establishes small, empowered teams hired for both skill and attitude. Phase III adds the pursuit of excellence and the conditions for intrinsic motivation. Phase IV reaches full maturity: a deliberately multi-cultural organisation designed to evolve continuously, with no structural assumption treated as permanent.
+
+---
+
+## 5. Assessment Template
+
+Score each principle 1–5 using the rubric below, then record supporting evidence.
 
 | Score | Meaning |
 |-------|---------|
 | **1** | Not practiced — no evidence of this principle |
 | **2** | Ad hoc — occasional, inconsistent application |
-| **3** | Emerging — recognized as important, partially adopted |
+| **3** | Emerging — recognised as important, partially adopted |
 | **4** | Established — consistently practiced with measurable results |
 | **5** | Embedded — deeply ingrained in culture and decision-making |
 
 ```yaml
 doctrine_assessment:
-  communication:
-    common_language:
-      score: "{1-5}"
-      evidence: "{How is strategic language standardized?}"
 
-    challenge_assumptions:
-      score: "{1-5}"
-      evidence: "{How are assumptions questioned?}"
+  phase_i:
+    communication:
+      common_language:
+        score: # 1-5
+        evidence: ""
+      challenge_assumptions:
+        score: # 1-5
+        evidence: ""
+      understand_context:
+        score: # 1-5
+        evidence: ""
 
-    focus_on_user_needs:
-      score: "{1-5}"
-      evidence: "{How are user needs identified and prioritized?}"
+    development:
+      know_your_users:
+        score: # 1-5
+        evidence: ""
+      focus_on_user_needs:
+        score: # 1-5
+        evidence: ""
+      remove_bias_and_duplication:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_methods:
+        score: # 1-5
+        evidence: ""
 
-  development:
-    appropriate_methods:
-      score: "{1-5}"
-      evidence: "{Are agile/lean/six sigma applied contextually by evolution stage?}"
+    operation:
+      know_the_details:
+        score: # 1-5
+        evidence: ""
 
-    cell_based:
-      score: "{1-5}"
-      evidence: "{Are teams small and autonomous?}"
+    learning:
+      systematic_learning:
+        score: # 1-5
+        evidence: ""
 
-    manage_inertia:
-      score: "{1-5}"
-      evidence: "{How is organizational inertia identified and addressed?}"
+  phase_ii:
+    communication:
+      bias_towards_open:
+        score: # 1-5
+        evidence: ""
 
-    use_standards:
-      score: "{1-5}"
-      evidence: "{Are standards adopted where components are commodity/product?}"
+    development:
+      focus_on_outcome:
+        score: # 1-5
+        evidence: ""
+      think_fire:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_tools:
+        score: # 1-5
+        evidence: ""
+      be_pragmatic:
+        score: # 1-5
+        evidence: ""
+      use_standards:
+        score: # 1-5
+        evidence: ""
 
-  operation:
-    think_fire:
-      score: "{1-5}"
-      evidence: "{Are solutions Fast, Inexpensive, Restrained, Elegant (FIRE)?}"
+    operation:
+      manage_inertia:
+        score: # 1-5
+        evidence: ""
+      manage_failure:
+        score: # 1-5
+        evidence: ""
+      effectiveness_over_efficiency:
+        score: # 1-5
+        evidence: ""
 
-    manage_failure:
-      score: "{1-5}"
-      evidence: "{Is failure tolerance matched to evolution stage?}"
+    learning:
+      bias_towards_action:
+        score: # 1-5
+        evidence: ""
 
-    optimize_flow:
-      score: "{1-5}"
-      evidence: "{Are bottlenecks identified and addressed?}"
+    leading:
+      move_fast:
+        score: # 1-5
+        evidence: ""
+      strategy_is_iterative:
+        score: # 1-5
+        evidence: ""
 
-  learning:
-    systematic_learning:
-      score: "{1-5}"
-      evidence: "{Is there a feedback loop for strategic learning?}"
+    structure:
+      think_small_teams:
+        score: # 1-5
+        evidence: ""
+      distribute_power:
+        score: # 1-5
+        evidence: ""
+      aptitude_and_attitude:
+        score: # 1-5
+        evidence: ""
 
-    know_users:
-      score: "{1-5}"
-      evidence: "{How well are users and their needs understood?}"
+  phase_iii:
+    operation:
+      optimise_flow:
+        score: # 1-5
+        evidence: ""
+      do_better_with_less:
+        score: # 1-5
+        evidence: ""
+      exceptional_standards:
+        score: # 1-5
+        evidence: ""
 
-    know_details:
-      score: "{1-5}"
-      evidence: "{Is there deep understanding of component specifics?}"
+    learning:
+      bias_towards_new:
+        score: # 1-5
+        evidence: ""
 
-  leading:
-    ownership:
-      score: "{1-5}"
-      evidence: "{Is there clear ownership of strategy?}"
+    leading:
+      commit_to_direction:
+        score: # 1-5
+        evidence: ""
+      be_the_owner:
+        score: # 1-5
+        evidence: ""
+      inspire_others:
+        score: # 1-5
+        evidence: ""
+      embrace_uncertainty:
+        score: # 1-5
+        evidence: ""
+      be_humble:
+        score: # 1-5
+        evidence: ""
 
-    move_fast:
-      score: "{1-5}"
-      evidence: "{How quickly are strategic decisions made?}"
+    structure:
+      seek_the_best:
+        score: # 1-5
+        evidence: ""
+      purpose_mastery_autonomy:
+        score: # 1-5
+        evidence: ""
 
-    iterative_strategy:
-      score: "{1-5}"
-      evidence: "{Is strategy treated as continuous, not one-off?}"
+  phase_iv:
+    learning:
+      listen_to_ecosystem:
+        score: # 1-5
+        evidence: ""
+
+    leading:
+      exploit_the_landscape:
+        score: # 1-5
+        evidence: ""
+      there_is_no_core:
+        score: # 1-5
+        evidence: ""
+
+    structure:
+      no_single_culture:
+        score: # 1-5
+        evidence: ""
+      design_for_constant_evolution:
+        score: # 1-5
+        evidence: ""
 ```
+
+---
+
+## 6. Evidence-Gathering Checklist
+
+Use these prompts during assessment interviews and document reviews to gather evidence for each category.
+
+**Communication**
+- [ ] Is there a shared glossary or terminology guide in use across teams?
+- [ ] Are strategy documents written in language understood outside the originating team?
+- [ ] Are assumptions in proposals explicitly stated and challenged before approval?
+- [ ] Is information shared proactively, or does it flow only on request?
+- [ ] Are decision rationales documented and accessible to those affected?
+
+**Development**
+- [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
+- [ ] Are different methodologies applied to different components based on their evolutionary stage?
+- [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
+- [ ] Are FIRE principles applied when scoping new development?
+- [ ] Are standards and tools reviewed periodically for continued appropriateness?
+
+**Operation**
+- [ ] Can leaders describe the operational details of the services they are accountable for?
+- [ ] Are sources of organisational inertia identified and addressed in change plans?
+- [ ] Is there a blameless failure review process in place?
+- [ ] Are effectiveness metrics (outcomes achieved) tracked alongside efficiency metrics (cost/time)?
+- [ ] Are value stream maps or similar tools used to identify bottlenecks?
+
+**Learning**
+- [ ] Is there a structured process for capturing and applying lessons learned?
+- [ ] Are teams encouraged and resourced to run experiments?
+- [ ] Is there a programme for exploring emerging technologies before they become urgent?
+- [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
+
+**Leading**
+- [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
+- [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
+- [ ] Is there a single named accountable owner for each strategic initiative?
+- [ ] Are leaders open about what they do not know and willing to change their minds publicly?
+
+**Structure**
+- [ ] Are most teams small enough to communicate without formal coordination overhead?
+- [ ] Do teams have authority to make decisions within their domain without escalation?
+- [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?
+- [ ] Is the organisational structure reviewed periodically and changed when strategy requires?

--- a/arckit-codex/skills/wardley-mapping/references/evolution-stages.md
+++ b/arckit-codex/skills/wardley-mapping/references/evolution-stages.md
@@ -99,3 +99,123 @@ When placing a component on the evolution axis, assess:
 - Positioning based on **age** rather than market maturity
 - Confusing **internal unfamiliarity** with market-wide genesis
 - Not considering **industry context** (a component may be commodity in one industry but custom in another)
+
+---
+
+## Enhanced Stage Indicators
+
+Detailed checklists for assessing which stage a component belongs to across four dimensions:
+
+### Genesis Stage Indicators
+
+- **Ubiquity markers**: Used by fewer than a handful of organizations; no established market; found only in research labs or cutting-edge pilots; most practitioners have never heard of it
+- **Certainty markers**: No agreed-upon approach; each implementation looks completely different; high variance in results; practitioners disagree on fundamentals
+- **Market markers**: No commercial offerings; no analysts covering it; no conferences dedicated to it; possibly a single paper or blog post
+- **Failure mode**: Betting on the wrong approach — you build the wrong thing, the concept doesn't pan out, or a competitor's approach proves fundamentally superior
+
+### Custom-Built Stage Indicators
+
+- **Ubiquity markers**: A few dozen organizations have built it; mostly in-house implementations; early adopters only; growing word-of-mouth in specialist communities
+- **Certainty markers**: Patterns are beginning to emerge; blog posts and conference talks appear; approaches vary but converge around a few patterns
+- **Market markers**: Small number of consultancies or niche vendors; no dominant standard; user groups forming; early analyst coverage
+- **Failure mode**: Building it wrong — your custom implementation has the wrong architecture, accrues technical debt, or gets overtaken by a productized competitor before you've recovered your investment
+
+### Product Stage Indicators
+
+- **Ubiquity markers**: Most large organizations are aware of it; multiple commercial products compete; analyst firms rank vendors; industry press covers it regularly
+- **Certainty markers**: Training courses, professional certifications, and established methodologies exist; outcomes are predictable; clear best practices documented
+- **Market markers**: Multiple competing vendors with clear feature differentiation; pricing is feature-based; annual comparison reports published; RFP processes are standardized
+- **Failure mode**: Differentiation failure — failing to stand out from competing products, losing on features, price, or brand while rivals commoditize faster
+
+### Commodity Stage Indicators
+
+- **Ubiquity markers**: Ubiquitous — every organization uses it; invisible infrastructure; not adopting it would be unusual; pay-per-use or subscription models dominate
+- **Certainty markers**: Fully standardized; ISO or formal standards exist; deviating from standard approaches is unusual; operations are predictable and auditable
+- **Market markers**: Utility pricing; multiple interchangeable providers; switching costs low; procurement is routine; the component is rarely discussed in strategic terms
+- **Failure mode**: Operational inefficiency — paying too much, running it in-house when a utility exists, or accumulating operational overhead that commodity providers handle more cheaply
+
+---
+
+## Transition Timing Heuristics
+
+Weak signals that a component is about to move between stages. These precede the transition by months to years — use them to get ahead of the curve.
+
+### Genesis → Custom-Built
+
+- Multiple independent teams build their own version without coordinating
+- The first conference talks appear: "Here's how we did it at [Company X]"
+- A startup forms specifically to productize the concept
+- A handful of GitHub repositories appear with experimental implementations
+- The phrase "we built our own X" starts appearing in engineering blog posts
+
+### Custom-Built → Product
+
+- Documentation proliferates: vendor docs, how-to guides, blog series
+- Training courses and certifications emerge (Udemy, Pluralsight, vendor academies)
+- Industry analysts publish first Magic Quadrant or Wave covering the space
+- Standardization efforts begin (working groups, RFCs, consortia form)
+- The question shifts from "should we build this?" to "which vendor should we choose?"
+
+### Product → Commodity
+
+- Pricing models shift to consumption-based or utility billing (per API call, per GB, per user-minute)
+- Open-source alternatives appear and gain traction, driving down commercial pricing
+- "Good enough" becomes the accepted standard — buyers stop comparing features and compare price
+- The component disappears from strategic discussions; procurement handles it routinely
+- Cloud providers add it as a native managed service
+
+---
+
+## Pioneers / Settlers / Town Planners Talent Model
+
+The three evolution stages map naturally to three types of people. Mismatching talent to stage is one of the most common and costly strategic mistakes.
+
+### Pioneers (Genesis)
+
+- Comfortable with chaos, ambiguity, and high failure rates
+- Driven by exploration and discovery; motivated by novelty, not process
+- High failure tolerance — they expect most experiments to fail and see it as learning
+- Often poor at documentation, standardization, or handing work off cleanly
+- Best suited to: research, prototyping, proof-of-concept work, greenfield exploration
+
+### Settlers (Custom-Built → Product)
+
+- Take pioneer discoveries and make them useful and repeatable
+- Product-oriented and systematic; skilled at listening to users and iterating
+- Build out the patterns that emerge from pioneer experiments into reliable solutions
+- Bridge between the wild experimentation of genesis and the industrialization of commodity
+- Best suited to: product development, early productization, growing user bases
+
+### Town Planners (Product → Commodity)
+
+- Industrialize at scale; obsessed with efficiency, reliability, and cost reduction
+- Process-oriented, metrics-driven, volume operations mindset
+- Build the pipes that everything else runs on; thrive in predictable, repeatable work
+- Often frustrated by ambiguity or constant change
+- Best suited to: platform engineering, infrastructure, shared services, SRE at scale
+
+### Handoff Friction
+
+Managing transitions between these types is critical and frequently mismanaged:
+
+- **Pioneers hate process**: Forcing pioneers to maintain and document their experiments alienates them and slows exploration. Hand off to settlers early.
+- **Town Planners hate uncertainty**: Asking planners to work on genesis-stage components creates anxiety, over-engineering, and premature standardization.
+- **Settlers are the connective tissue**: They translate pioneer output into planner input. Skipping settlers (pioneer → planner handoff) often produces brittle, hard-to-operate systems.
+- **Reward systems must differ**: Pioneers need space to fail; planners need predictability metrics. A single performance framework for all three types destroys the talent mix.
+
+---
+
+## Assessment Questions per Stage
+
+Use these diagnostic questions to quickly identify where a component sits:
+
+| Question | If Yes → Stage |
+|----------|---------------|
+| "Is this available as a utility API or cloud service?" | Commodity |
+| "Can anyone buy this off the shelf from multiple vendors?" | Product or Commodity |
+| "Are there multiple competing approaches with no clear winner?" | Custom-Built |
+| "Does building this require original research or experimentation?" | Genesis |
+| "Are there training courses and certifications for this?" | Product or Commodity |
+| "Would you be the first (or one of very few) to attempt this?" | Genesis |
+| "Does everyone in the industry just use the same provider?" | Commodity |
+| "Is this a competitive differentiator for your organization?" | Genesis or Custom-Built |

--- a/arckit-codex/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-codex/skills/wardley-mapping/references/gameplay-patterns.md
@@ -31,41 +31,49 @@ Strategies that shape how users perceive and interact with your offerings. Can a
 
 **1. Education (LG)**
 Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+
 - *When to use*: Launching novel or complex components where user understanding is low.
 - *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
 
 **2. Bundling (N)**
 Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+
 - *When to use*: When individual components have limited standalone appeal but are complementary together.
 - *Evolution stage*: Product stage (combining maturing components)
 
 **3. Creating Artificial Needs (LE)**
 Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+
 - *When to use*: When a component solves a latent problem users have not yet articulated.
 - *Evolution stage*: Genesis → Custom-Built (creates market pull)
 
 **4. Confusion of Choice (LE)**
 Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+
 - *When to use*: When incumbent position must be defended against clearly superior alternatives.
 - *Evolution stage*: Product stage (commoditisation pressure)
 
 **5. Brand and Marketing (N)**
 Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+
 - *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **6. FUD — Fear, Uncertainty, Doubt (LE)**
 Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+
 - *When to use*: Defensively, when a competitor threatens your position with a superior offering.
 - *Evolution stage*: Product stage (defending existing position)
 
 **7. Artificial Competition (CE)**
 Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+
 - *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
 - *Evolution stage*: Any stage (perception manipulation)
 
 **8. Lobbying / Counterplay (CE)**
 Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+
 - *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
 - *Evolution stage*: Any stage (regulatory environment shaping)
 
@@ -77,26 +85,31 @@ Strategies designed to speed up component evolution along the x-axis (Genesis �
 
 **1. Market Enablement (LG)**
 Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+
 - *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
 - *Evolution stage*: Custom-Built → Product (accelerates standardisation)
 
 **2. Open Approaches (LG)**
 Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+
 - *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
 - *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
 
 **3. Exploiting Network Effects (N)**
 Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+
 - *When to use*: When you have a platform or communication component where value compounds with users.
 - *Evolution stage*: Product → Commodity (accelerated by user density)
 
 **4. Co-operation (N)**
 Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+
 - *When to use*: When no single organisation can drive a standard alone and collective action is needed.
 - *Evolution stage*: Custom-Built → Product (drives standardisation)
 
 **5. Industrial Policy (N)**
 Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+
 - *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
 - *Evolution stage*: Any stage (policy-driven acceleration)
 
@@ -108,16 +121,19 @@ Strategies designed to slow component evolution, preserving competitive advantag
 
 **1. Exploiting Constraint (LE)**
 Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+
 - *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **2. Intellectual Property Rights / IPR (LE)**
 Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+
 - *When to use*: When protecting genuine innovations that required significant R&D investment.
 - *Evolution stage*: Genesis → Custom-Built (protects early innovations)
 
 **3. Creating Constraints (CE)**
 Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+
 - *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
 - *Evolution stage*: Product → Commodity (blocks commoditisation)
 
@@ -129,21 +145,25 @@ Strategies for managing components that no longer provide value, are expensive t
 
 **1. Pig in a Poke (CE)**
 Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+
 - *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
 - *Evolution stage*: Any stage (often used with obsolete custom-built components)
 
 **2. Disposal of Liability (N)**
 Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+
 - *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
 - *Evolution stage*: Product → Commodity (managing decline gracefully)
 
 **3. Sweat and Dump (LE)**
 Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+
 - *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
 - *Evolution stage*: Product → Commodity (exploiting remaining value)
 
 **4. Refactoring (LG)**
 Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+
 - *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
 - *Evolution stage*: Custom-Built (restoring and modernising)
 
@@ -155,41 +175,49 @@ Strategies for positioning components within the market, manipulating pricing dy
 
 **1. Differentiation (N)**
 Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+
 - *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
 - *Evolution stage*: Custom-Built → Product (slows rightward movement)
 
 **2. Pricing Policy (N)**
 Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+
 - *When to use*: When pricing itself can shift market behaviour rather than just capture value.
 - *Evolution stage*: Product → Commodity (shapes competitive landscape)
 
 **3. Buyer / Supplier Power (LE)**
 Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+
 - *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
 - *Evolution stage*: Product → Commodity (exploiting market position)
 
 **4. Harvesting (LE)**
 Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+
 - *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
 - *Evolution stage*: Product → Commodity (late-stage value extraction)
 
 **5. Standards Game (LE)**
 Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+
 - *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
 - *Evolution stage*: Custom-Built → Product (locking in architecture)
 
 **6. Last Man Standing (LE)**
 Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+
 - *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
 - *Evolution stage*: Product → Commodity (consolidation phase)
 
 **7. Signal Distortion (CE)**
 Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+
 - *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
 - *Evolution stage*: Any stage (information environment manipulation)
 
 **8. Trading (N)**
 Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+
 - *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
 - *Evolution stage*: Any stage (timed exchanges)
 
@@ -201,31 +229,37 @@ Strategies for protecting existing market position, managing threats, and slowin
 
 **1. Threat Acquisition (N)**
 Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+
 - *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
 - *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
 
 **2. Raising Barriers to Entry (N)**
 Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+
 - *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
 - *Evolution stage*: Product (defending established position)
 
 **3. Procrastination (N)**
 Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+
 - *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
 - *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
 
 **4. Defensive Regulation (LE)**
 Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+
 - *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
 - *Evolution stage*: Any stage (regulatory entrenchment)
 
 **5. Limitation of Competition (CE)**
 Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+
 - *When to use*: Recognise and defend against it; deploying it invites antitrust action.
 - *Evolution stage*: Product → Commodity (dominant player defending monopoly)
 
 **6. Managing Inertia (N)**
 Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+
 - *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
 - *Evolution stage*: Any stage (internal transformation management)
 
@@ -237,36 +271,43 @@ Strategies for gaining market share, disrupting competitors, and creating new op
 
 **1. Directed Investment (LG)**
 Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+
 - *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
 - *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
 
 **2. Experimentation (LG)**
 Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+
 - *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
 - *Evolution stage*: Genesis (exploring new space)
 
 **3. Centre of Gravity (N)**
 Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+
 - *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
 - *Evolution stage*: Custom-Built → Product (targeted disruption)
 
 **4. Undermining Barriers to Entry (N)**
 Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+
 - *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
 - *Evolution stage*: Custom-Built → Product (disruptive market entry)
 
 **5. Fool's Mate (LE)**
 Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+
 - *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
 - *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
 
 **6. Press Release Process (LE)**
 Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+
 - *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
 - *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
 
 **7. Playing Both Sides (N)**
 Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+
 - *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
 - *Evolution stage*: Product → Commodity (platform-level control)
 
@@ -278,41 +319,49 @@ Strategies for creating, nurturing, and leveraging networks of interconnected co
 
 **1. Alliances (LG)**
 Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+
 - *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
 - *Evolution stage*: Custom-Built → Product (accelerating through partnership)
 
 **2. Co-creation (LG)**
 Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+
 - *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
 - *Evolution stage*: Genesis → Custom-Built (open innovation)
 
 **3. Sensing Engines / ILC (N)**
 Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+
 - *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
 - *Evolution stage*: Product → Commodity (data-driven adaptation)
 
 **4. Tower and Moat (N)**
 Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+
 - *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
 - *Evolution stage*: Product (building defensive ecosystem)
 
 **5. N-sided Markets (N)**
 Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+
 - *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
 - *Evolution stage*: Custom-Built → Product (platform creation)
 
 **6. Co-opting and Intercession (LE)**
 Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+
 - *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
 - *Evolution stage*: Product (value chain positioning)
 
 **7. Embrace and Extend (LE)**
 Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+
 - *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
 - *Evolution stage*: Product → Commodity (standard adoption then differentiation)
 
 **8. Channel Conflicts and Disintermediation (N)**
 Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+
 - *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
 - *Evolution stage*: Product → Commodity (distribution restructuring)
 
@@ -324,41 +373,49 @@ Strategies for understanding, outmanoeuvring, and responding to competitors dire
 
 **1. Ambush (N)**
 Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+
 - *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
 - *Evolution stage*: Genesis → Custom-Built (surprise market entry)
 
 **2. Fragmentation Play (LE)**
 Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+
 - *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
 - *Evolution stage*: Product (niche segmentation)
 
 **3. Reinforcing Competitor Inertia (LE)**
 Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+
 - *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
 - *Evolution stage*: Product (exploiting competitor commitment)
 
 **4. Sapping (LE)**
 Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+
 - *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
 - *Evolution stage*: Product → Commodity (gradual displacement)
 
 **5. Misdirection (CE)**
 Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+
 - *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
 - *Evolution stage*: Any stage (competitive deception)
 
 **6. Restriction of Movement (CE)**
 Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+
 - *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
 - *Evolution stage*: Product (platform gatekeeping)
 
 **7. Talent Raid (CE)**
 Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+
 - *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
 - *Evolution stage*: Any stage (capability competition)
 
 **8. Circling and Probing (N)**
 Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+
 - *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
 - *Evolution stage*: Any stage (competitive intelligence gathering)
 
@@ -370,21 +427,25 @@ Strategies for securing and maintaining optimal positions within the competitive
 
 **1. Land Grab (N)**
 Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+
 - *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
 - *Evolution stage*: Genesis → Custom-Built (early territory capture)
 
 **2. First Mover / Fast Follower (N)**
 Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+
 - *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
 - *Evolution stage*: Genesis → Custom-Built (timing of market entry)
 
 **3. Aggregation (N)**
 Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+
 - *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
 - *Evolution stage*: Product (integration play)
 
 **4. Weak Signal / Horizon (N)**
 Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+
 - *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
 - *Evolution stage*: Genesis (anticipating future evolution)
 
@@ -396,16 +457,19 @@ High-risk strategies that can harm competitors, markets, or even your own organi
 
 **1. Licensing Play (LE)**
 Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+
 - *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
 - *Evolution stage*: Custom-Built → Product (IP-based control)
 
 **2. Insertion (CE)**
 Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+
 - *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
 - *Evolution stage*: Product (dependency creation)
 
 **3. Designed to Fail (CE)**
 Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+
 - *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
 - *Evolution stage*: Genesis (false market signals)
 

--- a/arckit-codex/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-codex/skills/wardley-mapping/references/gameplay-patterns.md
@@ -1,59 +1,520 @@
 # Gameplay Patterns
 
-Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats.
+Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats. Each gameplay includes an alignment tag drawn from the D&D classification system.
 
-## Offensive Patterns
+---
 
-```yaml
-offensive_gameplay:
-  tower_and_moat:
-    description: "Build differentiating capabilities on commodity foundation"
-    when: "Strong custom components exist"
-    action: "Commoditize dependencies, invest in differentiation"
-    map_signature: "Custom components with commodity dependencies"
+## 1. D&D Alignment Key
 
-  land_and_expand:
-    description: "Enter market with narrow offering, expand from there"
-    when: "New market entry"
-    action: "Start simple, add components over time"
+Gameplays are classified using the Dungeons & Dragons alignment system to convey their ethical and strategic nature at a glance.
 
-  open_source_play:
-    description: "Commoditize competitor's differentiator"
-    when: "Competitor relies on custom component you can replicate"
-    action: "Open source alternative to accelerate commoditization"
+| Alignment | Meaning | Strategic character |
+|-----------|---------|---------------------|
+| **LG** (Lawful Good) | Ethical, structured, mutually beneficial | Creates genuine value for the ecosystem; operates with integrity |
+| **N** (Neutral) | Pragmatic, context-dependent | Balanced approach; can benefit or harm depending on execution |
+| **LE** (Lawful Evil) | Self-interested but within accepted norms | Operates legally but manipulates markets or stakeholders for advantage |
+| **CE** (Chaotic Evil) | Destructive, harmful, disregards norms | Deliberately deceives, damages competition, or harms stakeholders |
 
-  ecosystem:
-    description: "Create platform others build upon"
-    when: "Control infrastructure component"
-    action: "Enable others to build on your platform"
+**Good vs. Evil axis**: Good strategies create positive outcomes for the broader ecosystem. Evil strategies prioritise personal gain at others' expense.
 
-  two_factor:
-    description: "Satisfy two markets with one platform"
-    when: "Platform can serve multiple user types"
-    action: "Connect both sides of a market"
-```
+**Law vs. Chaos axis**: Lawful strategies use structured, rule-following approaches. Chaotic strategies are unconventional or disruptive of established order.
 
-## Defensive Patterns
+Recognising alignment helps you understand: what plays are being used against you, what plays align with your organisation's values, and which combinations are ethically coherent.
 
-```yaml
-defensive_gameplay:
-  patents_and_ip:
-    description: "Protect innovations legally"
-    when: "Genesis/custom stage innovations"
-    action: "File patents, protect trade secrets"
+---
 
-  creating_constraint:
-    description: "Slow evolution of component you control"
-    when: "Evolution threatens your position"
-    action: "Limit interoperability, create switching costs"
+## 2. Gameplay Catalog — 11 Categories
 
-  embrace_and_extend:
-    description: "Adopt standard then differentiate"
-    when: "Commodity/product threatens differentiation"
-    action: "Add proprietary extensions"
-```
+### Category A: User Perception
 
-## Build vs. Buy vs. Outsource
+Strategies that shape how users perceive and interact with your offerings. Can accelerate adoption or create artificial barriers to switching.
+
+**1. Education (LG)**
+Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+- *When to use*: Launching novel or complex components where user understanding is low.
+- *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
+
+**2. Bundling (N)**
+Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+- *When to use*: When individual components have limited standalone appeal but are complementary together.
+- *Evolution stage*: Product stage (combining maturing components)
+
+**3. Creating Artificial Needs (LE)**
+Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+- *When to use*: When a component solves a latent problem users have not yet articulated.
+- *Evolution stage*: Genesis → Custom-Built (creates market pull)
+
+**4. Confusion of Choice (LE)**
+Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+- *When to use*: When incumbent position must be defended against clearly superior alternatives.
+- *Evolution stage*: Product stage (commoditisation pressure)
+
+**5. Brand and Marketing (N)**
+Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+- *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**6. FUD — Fear, Uncertainty, Doubt (LE)**
+Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+- *When to use*: Defensively, when a competitor threatens your position with a superior offering.
+- *Evolution stage*: Product stage (defending existing position)
+
+**7. Artificial Competition (CE)**
+Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+- *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
+- *Evolution stage*: Any stage (perception manipulation)
+
+**8. Lobbying / Counterplay (CE)**
+Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+- *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
+- *Evolution stage*: Any stage (regulatory environment shaping)
+
+---
+
+### Category B: Accelerators
+
+Strategies designed to speed up component evolution along the x-axis (Genesis → Commodity). Accelerators grow markets and compress timelines.
+
+**1. Market Enablement (LG)**
+Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+- *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
+- *Evolution stage*: Custom-Built → Product (accelerates standardisation)
+
+**2. Open Approaches (LG)**
+Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+- *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
+- *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
+
+**3. Exploiting Network Effects (N)**
+Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+- *When to use*: When you have a platform or communication component where value compounds with users.
+- *Evolution stage*: Product → Commodity (accelerated by user density)
+
+**4. Co-operation (N)**
+Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+- *When to use*: When no single organisation can drive a standard alone and collective action is needed.
+- *Evolution stage*: Custom-Built → Product (drives standardisation)
+
+**5. Industrial Policy (N)**
+Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+- *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
+- *Evolution stage*: Any stage (policy-driven acceleration)
+
+---
+
+### Category C: De-accelerators
+
+Strategies designed to slow component evolution, preserving competitive advantage, higher margins, or market control.
+
+**1. Exploiting Constraint (LE)**
+Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+- *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**2. Intellectual Property Rights / IPR (LE)**
+Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+- *When to use*: When protecting genuine innovations that required significant R&D investment.
+- *Evolution stage*: Genesis → Custom-Built (protects early innovations)
+
+**3. Creating Constraints (CE)**
+Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+- *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
+- *Evolution stage*: Product → Commodity (blocks commoditisation)
+
+---
+
+### Category D: Dealing with Toxicity
+
+Strategies for managing components that no longer provide value, are expensive to maintain, or are hindering progress in your value chain.
+
+**1. Pig in a Poke (CE)**
+Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+- *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
+- *Evolution stage*: Any stage (often used with obsolete custom-built components)
+
+**2. Disposal of Liability (N)**
+Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+- *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
+- *Evolution stage*: Product → Commodity (managing decline gracefully)
+
+**3. Sweat and Dump (LE)**
+Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+- *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
+- *Evolution stage*: Product → Commodity (exploiting remaining value)
+
+**4. Refactoring (LG)**
+Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+- *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
+- *Evolution stage*: Custom-Built (restoring and modernising)
+
+---
+
+### Category E: Market
+
+Strategies for positioning components within the market, manipulating pricing dynamics, and securing competitive advantage through market structure.
+
+**1. Differentiation (N)**
+Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+- *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
+- *Evolution stage*: Custom-Built → Product (slows rightward movement)
+
+**2. Pricing Policy (N)**
+Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+- *When to use*: When pricing itself can shift market behaviour rather than just capture value.
+- *Evolution stage*: Product → Commodity (shapes competitive landscape)
+
+**3. Buyer / Supplier Power (LE)**
+Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+- *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
+- *Evolution stage*: Product → Commodity (exploiting market position)
+
+**4. Harvesting (LE)**
+Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+- *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
+- *Evolution stage*: Product → Commodity (late-stage value extraction)
+
+**5. Standards Game (LE)**
+Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+- *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
+- *Evolution stage*: Custom-Built → Product (locking in architecture)
+
+**6. Last Man Standing (LE)**
+Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+- *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
+- *Evolution stage*: Product → Commodity (consolidation phase)
+
+**7. Signal Distortion (CE)**
+Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+- *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
+- *Evolution stage*: Any stage (information environment manipulation)
+
+**8. Trading (N)**
+Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+- *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
+- *Evolution stage*: Any stage (timed exchanges)
+
+---
+
+### Category F: Defensive
+
+Strategies for protecting existing market position, managing threats, and slowing competitor progress.
+
+**1. Threat Acquisition (N)**
+Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+- *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
+- *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
+
+**2. Raising Barriers to Entry (N)**
+Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+- *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
+- *Evolution stage*: Product (defending established position)
+
+**3. Procrastination (N)**
+Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+- *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
+- *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
+
+**4. Defensive Regulation (LE)**
+Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+- *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
+- *Evolution stage*: Any stage (regulatory entrenchment)
+
+**5. Limitation of Competition (CE)**
+Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+- *When to use*: Recognise and defend against it; deploying it invites antitrust action.
+- *Evolution stage*: Product → Commodity (dominant player defending monopoly)
+
+**6. Managing Inertia (N)**
+Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+- *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
+- *Evolution stage*: Any stage (internal transformation management)
+
+---
+
+### Category G: Attacking
+
+Strategies for gaining market share, disrupting competitors, and creating new opportunities.
+
+**1. Directed Investment (LG)**
+Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+- *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
+- *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
+
+**2. Experimentation (LG)**
+Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+- *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
+- *Evolution stage*: Genesis (exploring new space)
+
+**3. Centre of Gravity (N)**
+Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+- *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
+- *Evolution stage*: Custom-Built → Product (targeted disruption)
+
+**4. Undermining Barriers to Entry (N)**
+Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+- *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
+- *Evolution stage*: Custom-Built → Product (disruptive market entry)
+
+**5. Fool's Mate (LE)**
+Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+- *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
+- *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
+
+**6. Press Release Process (LE)**
+Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+- *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
+- *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
+
+**7. Playing Both Sides (N)**
+Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+- *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
+- *Evolution stage*: Product → Commodity (platform-level control)
+
+---
+
+### Category H: Ecosystem
+
+Strategies for creating, nurturing, and leveraging networks of interconnected components and actors.
+
+**1. Alliances (LG)**
+Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+- *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
+- *Evolution stage*: Custom-Built → Product (accelerating through partnership)
+
+**2. Co-creation (LG)**
+Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+- *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
+- *Evolution stage*: Genesis → Custom-Built (open innovation)
+
+**3. Sensing Engines / ILC (N)**
+Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+- *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
+- *Evolution stage*: Product → Commodity (data-driven adaptation)
+
+**4. Tower and Moat (N)**
+Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+- *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
+- *Evolution stage*: Product (building defensive ecosystem)
+
+**5. N-sided Markets (N)**
+Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+- *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
+- *Evolution stage*: Custom-Built → Product (platform creation)
+
+**6. Co-opting and Intercession (LE)**
+Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+- *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
+- *Evolution stage*: Product (value chain positioning)
+
+**7. Embrace and Extend (LE)**
+Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+- *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
+- *Evolution stage*: Product → Commodity (standard adoption then differentiation)
+
+**8. Channel Conflicts and Disintermediation (N)**
+Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+- *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
+- *Evolution stage*: Product → Commodity (distribution restructuring)
+
+---
+
+### Category I: Competitor
+
+Strategies for understanding, outmanoeuvring, and responding to competitors directly.
+
+**1. Ambush (N)**
+Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+- *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
+- *Evolution stage*: Genesis → Custom-Built (surprise market entry)
+
+**2. Fragmentation Play (LE)**
+Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+- *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
+- *Evolution stage*: Product (niche segmentation)
+
+**3. Reinforcing Competitor Inertia (LE)**
+Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+- *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
+- *Evolution stage*: Product (exploiting competitor commitment)
+
+**4. Sapping (LE)**
+Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+- *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
+- *Evolution stage*: Product → Commodity (gradual displacement)
+
+**5. Misdirection (CE)**
+Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+- *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
+- *Evolution stage*: Any stage (competitive deception)
+
+**6. Restriction of Movement (CE)**
+Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+- *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
+- *Evolution stage*: Product (platform gatekeeping)
+
+**7. Talent Raid (CE)**
+Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+- *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
+- *Evolution stage*: Any stage (capability competition)
+
+**8. Circling and Probing (N)**
+Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+- *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
+- *Evolution stage*: Any stage (competitive intelligence gathering)
+
+---
+
+### Category J: Positional
+
+Strategies for securing and maintaining optimal positions within the competitive landscape.
+
+**1. Land Grab (N)**
+Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+- *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
+- *Evolution stage*: Genesis → Custom-Built (early territory capture)
+
+**2. First Mover / Fast Follower (N)**
+Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+- *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
+- *Evolution stage*: Genesis → Custom-Built (timing of market entry)
+
+**3. Aggregation (N)**
+Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+- *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
+- *Evolution stage*: Product (integration play)
+
+**4. Weak Signal / Horizon (N)**
+Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+- *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
+- *Evolution stage*: Genesis (anticipating future evolution)
+
+---
+
+### Category K: Poison
+
+High-risk strategies that can harm competitors, markets, or even your own organisation if misapplied. Recognise these when used against you.
+
+**1. Licensing Play (LE)**
+Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+- *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
+- *Evolution stage*: Custom-Built → Product (IP-based control)
+
+**2. Insertion (CE)**
+Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+- *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
+- *Evolution stage*: Product (dependency creation)
+
+**3. Designed to Fail (CE)**
+Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+- *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
+- *Evolution stage*: Genesis (false market signals)
+
+---
+
+## 3. Play-Position Matrix
+
+Use your position on the map and the market's maturity to select the most appropriate plays.
+
+| Your Position | Early Market | Growing Market | Mature Market | Consolidated Market |
+|---------------|-------------|----------------|---------------|---------------------|
+| **Genesis leader** | Education, Directed Investment, Experimentation | Land Grab, Open Approaches, Alliances | First Mover/Fast Follower, Market Enablement | Weak Signal/Horizon, Co-operation |
+| **Custom-Built strength** | Fool's Mate, Bundling, Tower and Moat | Centre of Gravity, Differentiation, Co-creation | Sensing Engines (ILC), N-sided Markets | Aggregation, Playing Both Sides |
+| **Product parity** | Fragmentation Play, Undermining Barriers | Pricing Policy, Brand and Marketing | Standards Game, Sapping, Circling and Probing | Harvesting, Last Man Standing |
+| **Commodity laggard** | Refactoring, Disposal of Liability | Managing Inertia, Threat Acquisition | Raising Barriers to Entry, Procrastination | Sweat and Dump, Channel Disintermediation |
+
+---
+
+## 4. Play Compatibility
+
+### Plays That Work Together
+
+| Primary Play | Compatible With | Why |
+|-------------|-----------------|-----|
+| Sensing Engines (ILC) | Ecosystem plays, Weak Signal/Horizon | ILC provides the data to act on horizon signals |
+| Open Approaches | Co-creation, Market Enablement, Alliances | Openness attracts community and enables markets |
+| Tower and Moat | N-sided Markets, Alliances, Co-creation | Moat is strengthened by ecosystem depth |
+| Land Grab | Directed Investment, Alliances | Resources and partnerships accelerate territory capture |
+| Experimentation | Directed Investment, Sensing Engines | Experiments generate signals; investment scales winners |
+| Education | Open Approaches, Market Enablement | Education grows the market that openness then accelerates |
+| Fragmentation Play | Undermining Barriers, Differentiation | Niche entry combined with unique positioning |
+| Fool's Mate | Directed Investment, Ambush | Concentrated investment enables surprise execution |
+| Playing Both Sides | Tower and Moat, Sensing Engines | Platform control enables both ecosystem sensing and competition |
+
+### Plays That Conflict
+
+| Play A | Conflicts With | Why |
+|--------|---------------|-----|
+| Open Approaches | IPR / Licensing Play | Opening commoditises what licensing tries to protect |
+| Standards Game | Fragmentation Play | One seeks consolidation, the other fragmentation |
+| Co-creation | Confusion of Choice | Transparency in co-creation undermines deliberate confusion |
+| Market Enablement | Exploiting Constraint | Enablement accelerates what constraint tries to slow |
+| Education (LG) | FUD (LE) | Honest information and fear messaging are incompatible |
+| Alliances (LG) | Misdirection (CE) | Trust-based partnership cannot coexist with deliberate deception |
+| Refactoring | Sweat and Dump | One invests to restore value; the other extracts before exit |
+
+---
+
+## 5. Strategic Anti-Patterns
+
+Common strategic mistakes identified when applying gameplays to Wardley Maps.
+
+**Playing in the wrong evolution stage**
+Applying a genesis gameplay (e.g., Experimentation) to a commodity component wastes resources. Applying a commodity play (e.g., Harvesting) to a genesis component kills nascent innovation. Always match the play to the component's actual evolution position on the map.
+
+**Ignoring inertia**
+Assuming that a clearly superior strategy will execute smoothly without addressing organisational resistance. Inertia is the single most common reason strategically correct plays fail in execution. Map your inertia points before committing to a play.
+
+**Single-play dependence**
+Relying on one play to secure a position. Durable positions require layered plays — for example, Open Approaches to accelerate adoption, followed by Sensing Engines and Tower and Moat to capture ecosystem value. Single plays are fragile.
+
+**Misreading evolution pace**
+Treating components as more evolved (or less evolved) than they are. Building a commodity play (Harvesting) on what is still a custom-built component destroys value. Mapping component position carefully before selecting plays is essential.
+
+**Ecosystem hubris**
+Assuming that a strong current ecosystem position is self-sustaining. Ecosystems decay when the platform owner stops creating genuine value or when a disruptive technology makes the platform irrelevant. ILC and Weak Signal plays are the antidotes.
+
+**Open washing**
+Claiming Open Approaches alignment while maintaining proprietary lock-in through standards control, licensing restrictions, or incompatible extensions. Community backlash is swift and destroys the trust that makes open strategies work.
+
+**Alignment drift**
+Starting with LG plays to build an ecosystem and then shifting to CE plays to extract value. This pattern (common in platform companies) destroys the trust that made the ecosystem valuable in the first place and invites regulatory intervention.
+
+---
+
+## 6. Case Study Summaries
+
+Canonical examples of gameplay combinations in practice.
+
+**AWS (ILC + Land Grab + Tower and Moat)**
+Amazon launched AWS in 2006 before competitors recognised cloud's potential (Land Grab), built a comprehensive ecosystem of services that created deep customer dependency (Tower and Moat), and used marketplace metadata to sense which services to build next (Sensing Engines / ILC). Result: cloud computing market dominance and ongoing competitive moat.
+
+**Amazon Retail (Ecosystem + Directed Investment + Sensing Engines)**
+Combined early e-commerce entry with systematic directed investment in logistics, Prime, and Marketplace to build a self-reinforcing flywheel. Data from transactions continuously informs pricing, inventory, and product expansion. The ecosystem (sellers, logistics, Prime) creates the moat.
+
+**Netflix (Fast Follower + Directed Investment + Ecosystem co-evolution)**
+Watched Blockbuster's online rental experiment, then executed a fast follower streaming strategy with heavy directed investment in technology and original content. Co-evolved with device manufacturers to ensure reach across platforms. Original content investment shifted Netflix from distributor to producer, reducing dependency on studio licensing.
+
+**Apple iPhone (Fool's Mate + Bundling + N-sided Markets)**
+Executed a decisive market entry that caught mobile incumbents unprepared (Fool's Mate). Bundled hardware, iOS, and services into a coherent premium value proposition (Bundling). Built an N-sided market connecting users, developers, and accessory makers through the App Store, creating powerful ecosystem lock-in.
+
+**Google Android (Open Approaches + Alliances + Insertion)**
+Open-sourced Android to accelerate device manufacturer adoption (Open Approaches). Built alliances with manufacturers, carriers, and developers (Alliances). Embedded Google Search, Maps, and Play Store as dependencies — creating structural control over the mobile ecosystem (Insertion).
+
+**Ubuntu (Open Approaches + Alliances + Market Enablement)**
+Adopted open-source approach to lower adoption barriers and grow a contributor community (Open Approaches). Built alliances with cloud providers and infrastructure vendors (Alliances). Shifted focus to cloud computing as the strategic battleground and enabled the market with free security and tooling (Market Enablement). Became the dominant cloud guest OS within 18 months.
+
+**Tesla (First Mover + Tower and Moat + Education)**
+Entered the EV market as a first mover with high-performance vehicles when competitors were not taking EVs seriously. Built an integrated ecosystem of manufacturing, Gigafactory battery production, and Supercharger network that competitors could not quickly replicate (Tower and Moat). Invested heavily in consumer education about EV benefits and sustainability.
+
+**Airbnb (N-sided Markets + Market Enablement + Defensive Regulation)**
+Created a two-sided platform connecting hosts and guests that no incumbent hotel company could easily replicate (N-sided Markets). Enabled a new market of peer-to-peer accommodation that unlocked latent supply (Market Enablement). Proactively engaged with regulators in key cities to legitimise the model rather than ignore regulation (Defensive Regulation).
+
+**Spotify (N-sided Markets + Bundling + Sensing Engines)**
+Built a platform connecting listeners, artists, labels, and advertisers (N-sided Markets). Bundled streaming, curation, podcasting, and premium features into a coherent offering with strong perceived value (Bundling). Used listener data to power recommendation algorithms (Discover Weekly, Daily Mix) that continuously improve engagement and reduce churn (Sensing Engines).
+
+---
+
+## 7. Build vs. Buy vs. Outsource
 
 Use the component's evolution position to guide sourcing decisions:
 
@@ -91,7 +552,9 @@ build_buy_outsource:
       - "Email delivery"
 ```
 
-## Innovation Investment by Stage
+---
+
+## 8. Innovation Investment by Stage
 
 ```yaml
 innovation_investment:
@@ -100,72 +563,26 @@ innovation_investment:
     approach: "Experiments, PoCs, research"
     metrics: "Learning velocity, options created"
     failure_tolerance: "High"
+    matching_plays: ["Experimentation", "Weak Signal/Horizon", "Directed Investment", "Education"]
 
   custom:
     investment_type: "Differentiation"
     approach: "Product development, custom builds"
     metrics: "Feature completion, user adoption"
     failure_tolerance: "Medium"
+    matching_plays: ["Fool's Mate", "Tower and Moat", "Co-creation", "Alliances"]
 
   product:
     investment_type: "Enhancement"
     approach: "Integration, configuration"
     metrics: "Time to value, TCO"
     failure_tolerance: "Low"
+    matching_plays: ["Differentiation", "Standards Game", "Sensing Engines (ILC)", "N-sided Markets"]
 
   commodity:
     investment_type: "Optimization"
     approach: "Cost reduction, automation"
     metrics: "Cost per unit, availability"
     failure_tolerance: "Very low"
-```
-
-## Common Map Patterns
-
-Recognizable patterns to watch for when analyzing a completed map.
-
-### Desirable Patterns
-
-```yaml
-desirable_patterns:
-  tower_pattern:
-    description: "Differentiation built on commodity foundation"
-    structure:
-      top: "Genesis/Custom differentiators"
-      middle: "Product integrations"
-      bottom: "Commodity infrastructure"
-    example:
-      differentiator: "Custom recommendation engine"
-      product_layer: "E-commerce platform, CRM"
-      commodity: "Cloud compute, databases"
-    strategy: "Maximize commoditization at bottom to fund innovation at top"
-```
-
-### Anti-Patterns
-
-```yaml
-anti_patterns:
-  legacy_trap:
-    description: "Custom-built components that should be commodity"
-    symptoms:
-      - "Large team maintaining commodity-equivalent"
-      - "High cost, slow innovation"
-      - "Technical debt accumulation"
-    example:
-      component: "Custom identity management"
-      market_alternatives: ["Auth0", "Azure AD B2C", "Okta"]
-      waste: "Team of 5 maintaining what SaaS provides"
-    resolution: "Migrate to product/commodity, redeploy team"
-
-  premature_innovation:
-    description: "Treating genesis component as if product/commodity"
-    symptoms:
-      - "Fixed-scope contracts for unknown work"
-      - "Waterfall planning for experimental work"
-      - "Outsourcing pioneer work"
-    example:
-      component: "Novel ML application"
-      mistake: "Fixed-price contract with vendor"
-      result: "Scope creep, failed project"
-    resolution: "Match management approach to evolution stage"
+    matching_plays: ["Harvesting", "Last Man Standing", "Outsource decision", "Disposal of Liability"]
 ```

--- a/arckit-codex/skills/wardley-mapping/references/mapping-examples.md
+++ b/arckit-codex/skills/wardley-mapping/references/mapping-examples.md
@@ -304,4 +304,215 @@ ml_strategy:
       Custom models only where product gaps exist.
 ```
 
+---
+
+## Example 4: TechnoGadget Smart Home (Climatic Patterns Case Study)
+
+This example is drawn from the *Introduction to Wardley Mapping Climatic Patterns* reference work. It illustrates how climatic patterns interact with component positioning in a real-world product company.
+
+### Scenario
+
+TechnoGadget Inc. is a mid-sized technology company producing smart home devices. Their flagship product is a smart thermostat controllable via a smartphone app. Facing increased competition, they are planning international expansion.
+
+- **User Need**: "Comfortable home environment with energy efficiency"
+
+### OnlineWardleyMaps Syntax
+
+```owm
+title TechnoGadget Inc.
+
+anchor Customer [0.95, 0.63]
+
+component Smart thermostat [0.65, 0.46] label [-81, -9]
+component Mobile app [0.79, 0.34] label [-77, 2]
+component Cloud infrastructure [0.05, 0.75] label [-26, 13]
+component Data analytics [0.22, 0.36] label [-68, 24]
+component Customer support [0.86, 0.81] label [9, -17]
+component Marketing and sales [0.51, 0.66] label [-25, -57]
+component R&D [0.50, 0.22]
+component API [0.34, 0.28] label [-29, 20]
+
+Customer->Smart thermostat
+Customer->Customer support
+Customer->Mobile app
+
+Smart thermostat->Mobile app
+Smart thermostat->Cloud infrastructure
+Smart thermostat->Data analytics
+Smart thermostat->API
+
+Mobile app->API
+
+API->Cloud infrastructure
+API->Data analytics
+
+Cloud infrastructure->Data analytics
+Cloud infrastructure->Customer support
+Cloud infrastructure->Marketing and sales
+Cloud infrastructure->R&D
+
+evolve API 0.75
+```
+
+Paste into [OnlineWardleyMaps](https://create.wardleymaps.ai) to render.
+
+### Component Positions
+
+| Component | Visibility | Evolution | Stage | Notes |
+|-----------|-----------|-----------|-------|-------|
+| Smart thermostat | 0.65 | 0.46 | Custom-Built/Product | Core product, approaching commoditization |
+| Mobile app | 0.79 | 0.34 | Custom-Built | High visibility, custom UX differentiator |
+| Cloud infrastructure | 0.05 | 0.75 | Product/Commodity | Low visibility, enabling layer |
+| Data analytics | 0.22 | 0.36 | Custom-Built | Higher-order capability built on commoditized infra |
+| Customer support | 0.86 | 0.81 | Commodity | High visibility, standardized function |
+| Marketing and sales | 0.51 | 0.66 | Product | Mid-chain, standard practice |
+| R&D | 0.50 | 0.22 | Genesis/Custom-Built | Uncertain, high-value future options |
+| API | 0.34 | 0.28 → 0.75 | Custom-Built (evolving) | Strategic evolution signal: moving toward commodity |
+
+### Strategic Insights
+
+- **Commoditization pressure on core product**: Smart thermostat and Mobile app cluster in the Product stage — inertia risk is high as these evolve toward commodity and competitors can replicate them. TechnoGadget must shift differentiation upstream toward Data analytics and R&D before the hardware commoditizes.
+- **Efficiency enables innovation**: Commoditized Cloud infrastructure enables faster and cheaper development of custom-built Data analytics and R&D capabilities. This is the "higher-order systems create new value" climatic pattern in action — the commodity layer subsidizes the genesis layer.
+- **API evolution watch**: The `evolve API 0.75` annotation signals an anticipated move toward commodity. Once APIs commoditize, third-party integrators can build on TechnoGadget's platform — creating an ecosystem play opportunity (ILC pattern) but also opening the platform to competitive pressure.
+
+---
+
+## Example 5: Value Chain Decomposition Walkthrough
+
+A step-by-step demonstration of how to decompose a user need into a full Wardley Map. Use this pattern when starting from scratch with a new domain.
+
+### Starting Point: "Buy Products Online"
+
+This walkthrough shows the decomposition process for a simplified e-commerce value chain.
+
+#### Step 1 — Anchor
+
+Identify the user and their need:
+
+```
+User: Online Shopper
+Need: Buy products online
+```
+
+Place the anchor at the top of the map (high visibility = 1.0).
+
+#### Step 2 — First-Level Decomposition
+
+Ask: "What does the user directly interact with to fulfil this need?"
+
+```
+Buy products online
+  ├── Product Discovery      (finding what to buy)
+  ├── Shopping Experience    (browsing, comparison)
+  ├── Checkout               (basket, order confirmation)
+  └── Fulfilment             (delivery, returns)
+```
+
+These four components are directly visible to the user — position them high on the Y-axis (visibility 0.7-0.9).
+
+#### Step 3 — Second-Level Decomposition
+
+For each first-level component, ask: "What does this depend on?"
+
+```
+Product Discovery depends on:
+  ├── Search Engine           (index + ranking)
+  ├── Product Catalogue       (structured data)
+  └── Recommendation Engine   (personalisation ML)
+
+Shopping Experience depends on:
+  ├── Product Images / Media  (CDN delivery)
+  ├── Reviews & Ratings       (UGC platform)
+  └── Price Comparison        (pricing service)
+
+Checkout depends on:
+  ├── Shopping Cart           (session state)
+  ├── Payment Gateway         (Stripe / Adyen)
+  └── Identity / Auth         (login, SSO)
+
+Fulfilment depends on:
+  ├── Order Management System (OMS)
+  ├── Warehouse / 3PL         (physical logistics)
+  └── Notification Service    (email / SMS)
+```
+
+#### Step 4 — Assign Evolution Positions
+
+Apply the Evolution Scoring rubric (see [Mathematical Models](mathematical-models.md)):
+
+| Component | U | C | E(c) | Stage |
+|-----------|---|---|------|-------|
+| Search Engine | 0.55 | 0.60 | 0.58 | Product |
+| Product Catalogue | 0.70 | 0.75 | 0.73 | Product |
+| Recommendation Engine | 0.40 | 0.35 | 0.38 | Custom |
+| Payment Gateway | 0.90 | 0.88 | 0.89 | Commodity |
+| Shopping Cart | 0.75 | 0.80 | 0.78 | Product/Commodity |
+| Identity / Auth | 0.80 | 0.85 | 0.83 | Commodity |
+| Order Management | 0.60 | 0.65 | 0.63 | Product |
+| Notification Service | 0.85 | 0.90 | 0.88 | Commodity |
+
+#### Step 5 — Draw Dependency Arrows
+
+Add arrows from dependent → dependency (top to bottom, left-to-right for evolution):
+
+```
+Product Discovery → Recommendation Engine → Customer Data
+Checkout → Payment Gateway
+Checkout → Identity / Auth
+Fulfilment → Notification Service
+```
+
+Arrows that cross from right to left (high evolution to low) highlight **dependency risk** — a mature, visible component relying on an immature dependency.
+
+#### Step 6 — Apply Validation Checklist
+
+Before finalizing the map, verify:
+
+```yaml
+validation:
+  anchor_present: true          # User and need clearly stated?
+  all_user_touchpoints_mapped:  # Everything the user directly interacts with?
+  dependencies_visible:         # Have you traced at least 2 levels down?
+  evolution_justified:          # Can you defend each component's position?
+  movement_arrows:              # Have you noted evolving components?
+  no_orphan_components:         # Every component connects to at least one other?
+  strategic_question_answered:  # Does the map help answer a specific decision?
+```
+
+---
+
+## Case Study Cross-References
+
+Brief pattern examples connecting well-known companies to Wardley Mapping gameplay patterns. For the full pattern descriptions, see [Gameplay Patterns](gameplay-patterns.md).
+
+### AWS — ILC Pattern (Innovate, Leverage, Commoditize)
+
+Amazon ran the ILC play across its own infrastructure:
+
+1. **Innovate**: Built custom-scale distributed infrastructure internally for Amazon.com (Genesis/Custom-Built)
+2. **Leverage**: Recognized that the infrastructure had value as a product — launched EC2 (2006) and S3 as commercial offerings (Custom → Product)
+3. **Commoditize**: Drove the market toward utility pricing, making competitors' infrastructure investments uneconomical
+
+The result: internal cost-centre became the world's largest cloud platform. The key insight was that what was necessary-but-not-differentiating *for Amazon* was differentiating *for everyone else*. Any organization can ask: "What have we built for ourselves that others would pay for?"
+
+### Netflix — Attacking Play (Platform Transition)
+
+Netflix used a Wardley attacking play to shift from a position of weakness to market leadership:
+
+1. **Identified the evolution**: Physical DVD rental was moving toward commodity (and eventually obsolescence); streaming infrastructure was emerging
+2. **Attacked with an alternative**: Launched streaming when infrastructure costs fell low enough to make it viable (cloud commoditizing bandwidth and compute)
+3. **Built the new ecosystem**: Developed content recommendation, original programming, and global delivery — creating defensible positions in what would otherwise be a commodity streaming market
+
+The attack succeeded because Netflix moved *before* incumbents (Blockbuster) accepted that the old model was dying. Inertia from their successful past model slowed their response.
+
+### Spotify — Two-Sided Market Play
+
+Spotify operates a two-factor market with three distinct user groups creating a flywheel:
+
+1. **Free users (scale)**: Provide data, content demand signals, and a large addressable market for advertisers
+2. **Premium subscribers (revenue)**: Convert from free tier; fund content licensing and platform development
+3. **Artists and labels (content)**: Attracted by the large user base, provide the content that attracts users
+
+The mapping insight: Spotify's true strategic asset is not the music (a commodity licensed from labels) but the **listener data** and **playlist/discovery graph** — both of which sit in the Custom-Built stage and are hard to replicate. The commodity content layer enables the differentiating data layer above it.
+
 For common mapping patterns and anti-patterns (Tower, Legacy Trap, Premature Innovation), see [Gameplay Patterns](gameplay-patterns.md).

--- a/arckit-codex/skills/wardley-mapping/references/mathematical-models.md
+++ b/arckit-codex/skills/wardley-mapping/references/mathematical-models.md
@@ -249,6 +249,152 @@ Moderate-to-strong signal — transitioning from Product to Commodity. (And inde
 
 ---
 
+---
+
+## D. Play-Position Scoring
+
+A quantitative framework for evaluating which gameplay options are viable given your current map position.
+
+### Core Formula
+
+```
+Play Score = Position_Match(0-1) × Capability_Fit(0-1) × (1 - Risk_Factor(0-1))
+```
+
+Higher scores indicate plays that are well-aligned with your position, executable with current capabilities, and have acceptable downside risk.
+
+### Position Match
+
+How well does the gameplay play align with the evolution position of the target components?
+
+```
+Position_Match scoring:
+  Play targets your current stage:        1.0   (e.g., ILC play on a Custom-Built component)
+  Play targets an adjacent stage:         0.6   (one stage left or right of current)
+  Play targets a distant stage:           0.2   (two stages away)
+```
+
+**Example**: An "Open Source" commoditization play on a Product-stage component (adjacent — targeting Commodity) scores 0.6. The same play on a Genesis-stage component (distant — skipping two stages) scores 0.2.
+
+### Capability Fit
+
+Can your organization actually execute this play? Assess against the prerequisites for the specific gameplay.
+
+```
+Capability_Fit scoring:
+  Have all prerequisites:                 1.0   (full capability to execute)
+  Have most prerequisites:                0.7   (minor gaps, fillable with investment)
+  Missing one key capability:             0.3   (significant gap requiring major effort)
+  Missing multiple key capabilities:      0.1   (play is currently out of reach)
+```
+
+**Example**: An ILC play requires engineering scale, platform capabilities, and sales channels. A startup with strong engineering but no sales or platform infrastructure scores 0.3.
+
+### Risk Factor
+
+What is the downside if the play fails or conditions change?
+
+```
+Risk_Factor scoring:
+  Low risk, fully reversible:             0.1   (easy to stop, low sunk cost)
+  Medium risk, partially reversible:      0.4   (moderate investment, some recovery possible)
+  High risk, largely irreversible:        0.8   (major commitment, hard to unwind)
+  Existential risk, irreversible:         0.95  (bet-the-company, failure = shutdown)
+```
+
+Note: The Risk_Factor is subtracted from 1.0 before multiplying — so higher risk *reduces* the play score.
+
+### Worked Example: Evaluating Three Plays
+
+A company with a Custom-Built analytics platform evaluates three possible plays:
+
+| Play | Position_Match | Capability_Fit | Risk_Factor | Play Score | Verdict |
+|------|---------------|----------------|-------------|------------|---------|
+| Productize platform (sell to others) | 1.0 (Custom→Product) | 0.7 (engineering ok, sales gap) | 0.4 (medium) | 1.0 × 0.7 × 0.6 = **0.42** | Viable with investment |
+| Open source to commoditize | 0.6 (adjacent→Commodity) | 0.3 (no community mgmt) | 0.4 (medium) | 0.6 × 0.3 × 0.6 = **0.11** | Not viable yet |
+| Deepen custom differentiation | 1.0 (stay in Custom) | 1.0 (core strength) | 0.1 (low) | 1.0 × 1.0 × 0.9 = **0.90** | Strong — continue investing |
+
+The scoring confirms the intuitive recommendation: double down on differentiation while building the sales capability needed to eventually productize.
+
+### Play Score Interpretation
+
+| Play Score | Recommendation |
+|------------|---------------|
+| 0.70 - 1.00 | Execute — strong alignment, capability, and acceptable risk |
+| 0.40 - 0.70 | Conditional — viable but address the weakest factor first |
+| 0.15 - 0.40 | Weak — significant gaps; develop prerequisites before attempting |
+| 0.00 - 0.15 | Avoid — misaligned, incapable, or too risky at current position |
+
+---
+
+## E. Climate Pattern Impact Weighting
+
+A scoring framework for prioritizing which components face the greatest strategic pressure from climatic patterns.
+
+### Impact Matrix
+
+For each climatic pattern identified on a map, score its impact on each component:
+
+```
+Impact Matrix: Pattern × Component → Score (1-5)
+
+Scoring scale:
+  5 = Pattern directly threatens or enables this component's current position
+  4 = Pattern significantly affects this component's evolution trajectory
+  3 = Pattern has moderate influence on this component
+  2 = Pattern has minor relevance to this component
+  1 = Pattern has negligible or no effect on this component
+```
+
+A score of 5 means: if you ignore this pattern for this component, you will likely make a wrong strategic decision. A score of 1 means: the pattern exists but has no actionable implication for this component.
+
+### Aggregate Scoring
+
+Once the matrix is populated, calculate three aggregate scores:
+
+```
+Component Risk Score  = Sum of all pattern impact scores for that component
+  → Identifies which components face the most cumulative climatic pressure
+
+Pattern Criticality   = Sum of all component impact scores for that pattern
+  → Identifies which patterns have the broadest effect across the value chain
+
+Priority Focus        = Components with the highest Component Risk Scores
+  → Where to direct monitoring, investment, or contingency planning
+```
+
+### Worked Example: TechnoGadget Smart Home
+
+Applying 5 climatic patterns to the TechnoGadget map (from [Mapping Examples](mapping-examples.md)):
+
+| Component | Everything Evolves | Inertia | Higher-Order Systems | Efficiency Enables Innovation | Competitors Change Game | Risk Score |
+|-----------|-------------------|---------|---------------------|------------------------------|------------------------|------------|
+| Smart thermostat | 4 | 5 | 2 | 1 | 5 | **17** |
+| Mobile app | 3 | 4 | 2 | 1 | 4 | **14** |
+| Cloud infrastructure | 2 | 1 | 5 | 5 | 1 | **14** |
+| Data analytics | 4 | 2 | 5 | 4 | 3 | **18** |
+| R&D | 3 | 1 | 4 | 4 | 2 | **14** |
+| API | 5 | 2 | 3 | 3 | 4 | **17** |
+| **Pattern Criticality** | **21** | **15** | **21** | **18** | **19** | |
+
+**Interpretation**:
+
+- **Data analytics** (18) and **Smart thermostat / API** (17 each) face the highest cumulative climatic pressure — these are the priority focus components
+- **Everything Evolves** and **Higher-Order Systems** tie as the most broadly impactful patterns (21 each) — both affect nearly every component
+- **Inertia** (15) scores lowest in criticality but scores highest on Smart thermostat (5) — it is highly concentrated on one critical component, not broadly distributed
+
+### Using the Matrix in Practice
+
+1. List all climatic patterns identified on the map (typically 3-8 for a focused analysis)
+2. Score each pattern against each component (5-minute workshop exercise per pattern)
+3. Sum rows (component risk) and columns (pattern criticality)
+4. Rank components by risk score — highest scores demand strategic attention
+5. For components scoring 15+ (in a 5-pattern analysis), develop explicit contingency responses
+
+The matrix is most useful as a workshop tool: it forces explicit discussion about *why* a pattern affects a component, surfaces disagreements in the team's mental models, and produces a defensible prioritization.
+
+---
+
 ## Further Reading
 
 These models are drawn from a broader mathematical framework for Wardley Mapping that includes game theory, stochastic processes, topological analysis, and Bayesian inference. For the full academic treatment, see the [Wardley Map Mathematical Model](https://github.com/tractorjuice/wardleymap_math_model) repository.

--- a/arckit-codex/templates/wardley-climate-template.md
+++ b/arckit-codex/templates/wardley-climate-template.md
@@ -1,0 +1,260 @@
+# Wardley Climate Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.climate`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Climate Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.climate` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the most significant climate forces acting on this landscape, the components under most pressure, and the key strategic implications. Include whether the overall climate is favourable, neutral, or threatening for the current strategy.]
+
+**Climate Severity**:
+
+| Category | Severity | Most Affected Components |
+|----------|----------|--------------------------|
+| Component Patterns | High / Medium / Low / None | {Component names} |
+| Financial Patterns | High / Medium / Low / None | {Component names} |
+| Speed Patterns | High / Medium / Low / None | {Component names} |
+| Inertia Patterns | High / Medium / Low / None | {Component names} |
+| Competitor Patterns | High / Medium / Low / None | {Component names} |
+| Prediction Patterns | High / Medium / Low / None | {Component names} |
+
+---
+
+## Map Reference
+
+This climate assessment is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+
+---
+
+## Component Inventory
+
+*Extracted from the referenced Wardley Map. All components subject to climate assessment.*
+
+| Component | Visibility | Evolution | Stage |
+|-----------|-----------|-----------|-------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 2} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 3} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 4} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 5} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+
+---
+
+## Climate Assessment by Category
+
+### 1. Component Patterns
+
+*How do components naturally evolve and what forces act on them?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Everything evolves (no component stays still) | Yes / No / Partial | H / M / L | {Observation from the map or market} | {What this means for strategy} |
+| Characteristics change as components evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| No "one size fits all" method | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Success breeds inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems create new sources of worth | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Components can co-evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new areas of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation enables new genesis | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 2. Financial Patterns
+
+*How do economic forces shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Efficiency enables innovation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new sources of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation reduces margin | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New economic models emerge (e.g., SaaS, platform) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Price pressure on product-stage components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Investment bias towards Genesis/Custom stages | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 3. Speed Patterns
+
+*How does the pace of change affect the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Evolution is not uniform (some components evolve faster) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation is accelerating (shorter cycles) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem effects accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Open source accelerates commoditisation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Regulation can slow or accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 4. Inertia Patterns
+
+*What forces resist change in this landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Past success creates resistance to change | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Existing practices embed inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Vendor lock-in creates artificial inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 5. Competitor Patterns
+
+*How do competitor behaviours shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Competitors also face inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants exploit incumbent inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 6. Prediction Patterns
+
+*What can be reliably anticipated about how this landscape will change?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Commoditisation of custom-built components is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Co-evolution of practice and technology is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems will emerge from current commodities | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Shifts from product to utility are visible before they occur | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants will appear at Genesis stage of key components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Inertia creates predictable points of disruption | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem plays follow commoditisation events | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Peace / War / Wonder cycles follow predictable patterns | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+## Per-Component Impact Matrix
+
+*How strongly does each climate category affect each component? H = High, M = Medium, L = Low, — = Not applicable.*
+
+| Component | Component Patterns | Financial Patterns | Speed Patterns | Inertia Patterns | Competitor Patterns | Prediction Patterns |
+|-----------|:-----------------:|:-----------------:|:--------------:|:----------------:|:------------------:|:------------------:|
+| {Component 1} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 2} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 3} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 4} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 5} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+
+---
+
+## Prediction Horizons
+
+*Anticipated evolution of key components over the next 6 and 18 months.*
+
+| Component | Current Stage | 6-Month Prediction | 18-Month Prediction | Confidence | Key Signals |
+|-----------|:------------:|:-----------------:|:------------------:|:----------:|-------------|
+| {Component 1} | Genesis | Custom (0.30) | Custom (0.40) | High / Medium / Low | {Observable signals — market activity, open source, vendor releases} |
+| {Component 2} | Custom | Product (0.55) | Product (0.65) | High / Medium / Low | {Observable signals} |
+| {Component 3} | Product | Product (0.70) | Commodity (0.80) | High / Medium / Low | {Observable signals} |
+| {Component 4} | Commodity | Commodity (0.90) | Commodity (0.95) | High / Medium / Low | {Observable signals} |
+
+---
+
+## Wave Analysis
+
+**Peace / War / Wonder Cycle**:
+
+The Wardley climate framework identifies a recurring cycle in markets:
+
+- **Peace**: Steady improvement of existing products; incumbents dominant; gradual evolution
+- **War**: Rapid disruption as a new model (e.g., cloud, SaaS, open source) makes existing approaches obsolete; major market shift
+- **Wonder**: Post-disruption stabilisation; new commodity enables new genesis; ecosystem flourishes
+
+**Current Positioning for This Context**:
+
+| Market Segment | Current Phase | Evidence | Strategic Implication |
+|----------------|:------------:|----------|-----------------------|
+| {Segment 1} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+| {Segment 2} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+
+**Recommended Response to Phase**:
+
+- {If Peace}: {Strategy for steady-state market — consolidation, efficiency, incremental improvement}
+- {If War}: {Strategy for disruption — move fast, exploit inertia of incumbents, align with the new model}
+- {If Wonder}: {Strategy for post-disruption — explore new genesis opportunities enabled by the new commodity}
+
+---
+
+## Inertia Assessment
+
+| Component | Inertia Type | Severity | Mitigation Strategy |
+|-----------|-------------|:--------:|---------------------|
+| {Component 1} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 2} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 3} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+
+**Inertia Type Definitions**:
+
+- **Skills**: Team expertise locked to legacy technology or practice
+- **Process**: Established workflows and procedures that resist change
+- **Vendor**: Contractual or technical dependencies that create switching costs
+- **Cultural**: "We've always done it this way" — organisational resistance
+- **Capital**: Sunk costs in existing systems justify continued investment
+- **Regulatory**: Compliance requirements that constrain or slow evolution
+
+---
+
+## Strategic Implications
+
+[3-5 bullet points summarising the most actionable strategic implications from the full climate assessment. Each point should connect a specific climate finding to a recommended strategic response.]
+
+- **{Implication 1}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 2}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 3}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 4}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 5}**: {Specific climate finding} → {Recommended strategic response}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map; all components assessed in this document are derived from it |
+| Requirements | ARC-[PROJECT_ID]-REQ-v[VERSION] | Climate signals may invalidate or create new requirements |
+| Research | ARC-[PROJECT_ID]-RSCH-v[VERSION] | Market research provides evidence for climate pattern assessment |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.climate` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-codex/templates/wardley-doctrine-template.md
+++ b/arckit-codex/templates/wardley-doctrine-template.md
@@ -1,0 +1,290 @@
+# Wardley Doctrine Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.doctrine`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WDOC-v[VERSION] |
+| **Document Type** | Wardley Doctrine Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.doctrine` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+**Overall Maturity Score**: [X.X / 5.0] — [Novice / Developing / Practising / Advanced / Leading]
+
+**Phase Positioning**:
+
+| Phase | Name | Score | Status |
+|-------|------|-------|--------|
+| Phase I | Stop Self-Harm | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase II | Becoming More Context Aware | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase III | Better for Less | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase IV | Continuously Evolving | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+
+**Critical Findings**:
+
+1. {Most significant gap or risk from the assessment}
+2. {Second critical finding}
+3. {Third critical finding}
+
+[2-3 sentence narrative summary of the organisation's doctrine maturity and most urgent priorities.]
+
+---
+
+## Strategy Cycle Context
+
+| Element | Summary |
+|---------|---------|
+| **Purpose** | {Why does this organisation or team exist? What is the mission?} |
+| **Landscape** | {What does the Wardley Map of this context reveal? Key components and their evolution positions.} |
+| **Climate** | {What external forces are acting on this landscape? Market shifts, regulation, technology change.} |
+| **Leadership** | {What leadership style is currently in use? Commander's intent vs. detailed instruction? Risk appetite?} |
+
+---
+
+## Doctrine Assessment Matrix
+
+Score key: **1** = Not practised | **2** = Awareness only | **3** = Partially practised | **4** = Consistently practised | **5** = Embedded and exemplary
+
+### Phase I: Stop Self-Harm
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Communication | Use a common language | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Be transparent | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Challenge assumptions | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Know your users | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Focus on user needs | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use appropriate methods | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Remove bias and duplication | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use standards where appropriate | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage inertia | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage failure | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Think small (ecosystem) | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase II: Becoming More Context Aware
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Situational Awareness | Know the details | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Use appropriate doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Be aware of context-specific play | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Understand your environment | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Design for constant evolution | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Small teams with alignment and autonomy | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Move fast | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Be pragmatic | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | There is no one culture | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Seek the best | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase III: Better for Less
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Efficiency | Optimise flow | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Effectiveness over efficiency | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Think big | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Strategy is iterative not linear | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Use multiple methods of working | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | A bias towards the new | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Be the owner | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Set exceptional standards | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase IV: Continuously Evolving
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Learning | Listen to your ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | A bias towards action | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Exploit the landscape | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Understand that strategy is complex | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Commit to the path | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Accept uncertainty | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Spend time on doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Lead the ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+
+---
+
+## Detailed Phase Findings
+
+### Phase I: Stop Self-Harm — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase I Narrative**:
+
+[2-4 sentences describing the organisation's overall performance on Phase I. What self-harming behaviours are present? What is being done well?]
+
+---
+
+### Phase II: Becoming More Context Aware — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase II Narrative**:
+
+[2-4 sentences describing situational awareness maturity. Does the organisation understand its landscape? Does leadership have context for decisions?]
+
+---
+
+### Phase III: Better for Less — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase III Narrative**:
+
+[2-4 sentences describing efficiency and operational maturity. Where is the organisation wasting effort? Where are there genuine improvements?]
+
+---
+
+### Phase IV: Continuously Evolving — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase IV Narrative**:
+
+[2-4 sentences describing the organisation's capacity for continuous evolution. Is learning embedded? Do ecosystems inform strategy?]
+
+---
+
+## Previous Assessment Comparison
+
+*Populate on re-assessment only. Leave blank for initial assessment.*
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+**Overall Score Change**: [Previous X.X] → [Current X.X] ([+/- delta])
+
+---
+
+## Critical Gaps
+
+| Rank | Phase | Category | Principle | Current Score | Target Score | Business Impact |
+|------|-------|----------|-----------|:-------------:|:------------:|-----------------|
+| 1 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 2 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 3 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 4 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 5 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+
+---
+
+## Implementation Roadmap
+
+### Immediate Actions (0-3 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 1} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 2} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 3} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Short-Term Actions (3-12 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 4} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 5} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 6} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Long-Term Actions (12-24 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 7} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 8} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+---
+
+## Recommendations
+
+1. **{Recommendation 1}**
+   - **Rationale**: {Why this is the top priority}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+2. **{Recommendation 2}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+3. **{Recommendation 3}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Doctrine principles should align with and reinforce architecture principles |
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Landscape and climate context for this assessment |
+| Stakeholder Analysis | ARC-[PROJECT_ID]-STKE-v[VERSION] | Leadership and culture context; stakeholder awareness of doctrine |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.doctrine` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-codex/templates/wardley-gameplay-template.md
+++ b/arckit-codex/templates/wardley-gameplay-template.md
@@ -1,0 +1,337 @@
+# Wardley Gameplay Analysis: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.gameplay`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WGAM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Gameplay Analysis |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.gameplay` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the strategic context, the plays selected, and the anticipated outcomes. Include overall strategic posture: aggressive/defensive/opportunistic.]
+
+**Selected Plays Summary**:
+
+| Play | Category | Recommendation | Priority |
+|------|----------|----------------|----------|
+| {Play 1} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 2} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 3} | {Category A-K} | Monitor | High / Medium / Low |
+
+---
+
+## Map Reference
+
+This gameplay analysis is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+| **Key Components** | {List 3-5 key components from the map} |
+
+---
+
+## Situational Assessment
+
+### Position Analysis
+
+*What does your current map position tell you about strategic options?*
+
+- **Anchor (User Need)**: {Anchor component and its evolution position}
+- **Differentiating Components**: {Components in Genesis/Custom that provide competitive advantage}
+- **Commodity Dependencies**: {Components already at commodity — not strategic, cost-focus only}
+- **Evolution Pressure**: {Components showing signs of rapid evolution — where the map is moving}
+
+### Capability Assessment
+
+*What can your organisation do well, and where are the gaps?*
+
+- **Core Strengths**: {What the organisation does better than competitors in this landscape}
+- **Critical Weaknesses**: {Capability gaps that constrain strategic options}
+- **Unique Assets**: {Assets, data, relationships, or IP that could be leveraged}
+- **Constraints**: {Budget, skills, regulatory, or time constraints affecting play selection}
+
+### Market Context
+
+*What is happening in the competitive environment?*
+
+- **Competitor Positions**: {Where are key competitors positioned on the map?}
+- **Market Signals**: {What trends indicate where the market is heading?}
+- **Regulatory Environment**: {Any constraints or opportunities from regulation?}
+- **Partnership Opportunities**: {Potential ecosystem partners or coalition plays?}
+
+---
+
+## Play Options by Category
+
+### A. Accelerator Plays
+
+*Speed up component evolution to reshape the landscape.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Open approaches (open source, open data, open standards) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Exploit the ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Contribute to standards bodies | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### B. Decelerator Plays
+
+*Slow down competitor evolution or commoditisation.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| FUD (Fear, Uncertainty, Doubt) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Differentiation | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Lobbying and regulatory influence | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### C. Market Plays
+
+*Shape market conditions in your favour.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Buyer and supplier education | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Press and analyst briefings | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### D. Defensive Plays
+
+*Protect your position from competitive threats.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Protective moat (IP, switching costs) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Embrace and extend | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Threat acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### E. Attacking Plays
+
+*Move against competitor positions.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Exploiting inertia | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Undermining barriers to entry | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Talent acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### F. Ecosystem Plays
+
+*Leverage or build ecosystems for competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Building a platform | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Co-opting an ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating a pricing game | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### G. Positional Plays
+
+*Move to advantageous positions on the map.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Tower and moat | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Land grab | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Sensing engine | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### H. Poison Plays
+
+*Make a position undesirable for competitors.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Disposal of a liability | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Swamping | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### I. Innovation Plays
+
+*Create new value through novel combinations.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Design for uncharted spaces | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Signal distortion | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### J. People Plays
+
+*Leverage talent and culture as competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Centres of gravity | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Pioneer / settler / town planner model | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### K. Political Plays
+
+*Navigate organisational or market politics.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Creating artificial constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Trojan horse | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+---
+
+## Play-Position Matrix Evaluation
+
+*For each key component position on the map, identify which plays are naturally aligned.*
+
+| Component | Visibility | Evolution | Stage | Recommended Plays | Rationale |
+|-----------|-----------|-----------|-------|-------------------|-----------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis | {Play names} | {Why these plays fit this position} |
+| {Component 2} | {0.xx} | {0.xx} | Custom | {Play names} | {Why these plays fit this position} |
+| {Component 3} | {0.xx} | {0.xx} | Product | {Play names} | {Why these plays fit this position} |
+| {Component 4} | {0.xx} | {0.xx} | Commodity | {Play names} | {Why these plays fit this position} |
+
+---
+
+## Play Compatibility Analysis
+
+*Evaluate whether selected plays reinforce or conflict with each other.*
+
+| Play A | Play B | Compatibility | Notes |
+|--------|--------|:-------------:|-------|
+| {Play 1} | {Play 2} | Reinforces | {Why these plays work well together} |
+| {Play 1} | {Play 3} | Neutral | {No significant interaction} |
+| {Play 2} | {Play 4} | Conflicts | {Why these plays undermine each other — resolve or sequence carefully} |
+
+**Resolution for conflicts**: {Describe how conflicting plays will be sequenced or one prioritised over the other.}
+
+---
+
+## Selected Plays
+
+### Play 1: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1 — capability, resource, or condition that must be in place}
+- {Prerequisite 2}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+**Expected Outcomes**:
+
+- {Outcome 1 — what success looks like}
+- {Outcome 2}
+
+**Risks**:
+
+- {Risk 1 — what could go wrong}
+- {Risk 2}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+- [ ] {Measurable indicator 2}
+
+**Review Points**: {When to review whether this play is working — e.g., 3 months, after specific milestone}
+
+---
+
+### Play 2: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+
+**Expected Outcomes**:
+
+- {Outcome 1}
+
+**Risks**:
+
+- {Risk 1}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+
+**Review Points**: {When to review whether this play is working}
+
+---
+
+## Risk Assessment and Anti-Patterns
+
+### Play-Specific Risks
+
+| Risk | Play Affected | Likelihood | Impact | Mitigation |
+|------|--------------|------------|--------|------------|
+| {Risk 1} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+| {Risk 2} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+
+### Common Gameplay Anti-Patterns to Avoid
+
+- **Playing too many games at once**: Focus on 2-3 plays maximum; spreading effort dilutes impact
+- **Ignoring inertia**: Plays that require rapid evolution will stall if internal or market inertia is not addressed
+- **Misreading evolution stage**: Applying Genesis plays to Commodity components (or vice versa) wastes resources
+- **Neglecting doctrine**: Gameplay without sound doctrine (Phase I) often backfires
+- **Static play selection**: Plays that are right today may be wrong in 12 months — review regularly
+
+---
+
+## Case Study References
+
+| Case Study | Play(s) Illustrated | Source | Relevance to This Context |
+|------------|---------------------|--------|--------------------------|
+| {Case study 1} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+| {Case study 2} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+
+**Reference**: Simon Wardley, *Wardley Maps* (CC BY-SA 4.0) — available at [https://learnwardleymapping.com/](https://learnwardleymapping.com/)
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map providing landscape context for play selection |
+| Climate Assessment | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] | Climate patterns that constrain or enable specific plays |
+| Doctrine Assessment | ARC-[PROJECT_ID]-WDOC-v[VERSION] | Doctrine maturity governs which plays are executable |
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Plays must not violate established architecture principles |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.gameplay` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-codex/templates/wardley-value-chain-template.md
+++ b/arckit-codex/templates/wardley-value-chain-template.md
@@ -1,0 +1,216 @@
+# Wardley Value Chain: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.value-chain`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WVCH-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Value Chain |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.value-chain` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[Provide a concise summary of the value chain: its anchor (user need), the number of components, key dependencies, and the most critical strategic insights. 3-5 sentences.]
+
+---
+
+## User Need / Anchor
+
+The anchor is the user need at the top of the chain — the reason the value chain exists. Every component below the anchor must ultimately serve this need. If the anchor is wrong, the entire chain is wrong.
+
+**Anchor Statement**: [Describe the user need in one sentence, e.g., "Citizen can apply for a permit online without visiting an office."]
+
+**Good Anchor Examples**:
+
+- "User can access their medical records securely from any device"
+- "Taxpayer can file a return in under 15 minutes"
+- "Procurement team can evaluate vendor bids in a standardised format"
+
+**Bad Anchor Examples** (too technology-focused, not user-centred):
+
+- "System processes API calls" — this is a capability, not a user need
+- "Database stores records" — this is infrastructure, not a user need
+- "Microservices communicate via message bus" — this is implementation, not purpose
+
+---
+
+## Users and Personas
+
+| Persona | Role | Primary Need |
+|---------|------|--------------|
+| {Persona 1} | {Role description} | {Primary need this chain serves} |
+| {Persona 2} | {Role description} | {Primary need this chain serves} |
+| {Persona 3} | {Role description} | {Primary need this chain serves} |
+
+---
+
+## Value Chain Diagram
+
+**View this map**: Paste the OWM syntax below into [https://create.wardleymaps.ai](https://create.wardleymaps.ai)
+
+**ASCII Placeholder**:
+
+```text
+Visibility
+    ^
+1.0 | [User Need / Anchor]
+    |         |
+0.7 |   [Capability A]  [Capability B]
+    |         |               |
+0.4 |   [Component C]  [Component D]  [Component E]
+    |         |
+0.1 |   [Infrastructure F]
+    |
+    +--Genesis--Custom--Product--Commodity-->  Evolution
+       (0.0)   (0.25)  (0.50)   (0.75)  (1.0)
+```
+
+**OWM Syntax**:
+
+```wardley
+title {context_name} Value Chain
+anchor {UserNeed} [0.95, 0.63]
+
+component {CapabilityA} [0.70, 0.45]
+component {CapabilityB} [0.70, 0.72]
+component {ComponentC} [0.42, 0.38]
+component {ComponentD} [0.40, 0.65]
+component {ComponentE} [0.38, 0.80]
+component {InfrastructureF} [0.12, 0.90]
+
+{UserNeed} -> {CapabilityA}
+{UserNeed} -> {CapabilityB}
+{CapabilityA} -> {ComponentC}
+{CapabilityA} -> {ComponentD}
+{CapabilityB} -> {ComponentE}
+{ComponentC} -> {InfrastructureF}
+
+style wardley
+```
+
+---
+
+## Component Inventory
+
+| ID | Component | Description | Depends On | Visibility (0.0-1.0) |
+|----|-----------|-------------|------------|----------------------|
+| C-01 | {Component 1} | {Description} | — | {0.00} |
+| C-02 | {Component 2} | {Description} | C-01 | {0.00} |
+| C-03 | {Component 3} | {Description} | C-01, C-02 | {0.00} |
+| C-04 | {Component 4} | {Description} | C-02 | {0.00} |
+| C-05 | {Component 5} | {Description} | C-03, C-04 | {0.00} |
+
+---
+
+## Dependency Matrix
+
+The dependency matrix shows which components (rows) depend on which other components (columns). A cell marked **X** indicates a direct dependency; **I** indicates an indirect dependency; blank indicates no dependency.
+
+| | C-01 | C-02 | C-03 | C-04 | C-05 |
+|---|------|------|------|------|------|
+| **C-01** | — | | | | |
+| **C-02** | X | — | | | |
+| **C-03** | X | X | — | | |
+| **C-04** | | X | | — | |
+| **C-05** | I | I | X | X | — |
+
+[Replace placeholder rows/columns with actual component IDs from the Component Inventory above.]
+
+---
+
+## Critical Path Analysis
+
+The critical path is the sequence of dependencies from the anchor down to the lowest-level infrastructure component(s), where a failure at any step breaks the chain entirely.
+
+**Critical Path**:
+
+```text
+[User Need / Anchor]
+  └─> [Component X]  (Visibility: 0.xx, Evolution: 0.xx)
+        └─> [Component Y]  (Visibility: 0.xx, Evolution: 0.xx)
+              └─> [Component Z]  (Visibility: 0.xx, Evolution: 0.xx)
+```
+
+**Bottlenecks and Single Points of Failure**:
+
+| Component | Risk Type | Impact if Failed | Mitigation |
+|-----------|-----------|------------------|------------|
+| {Component} | Single vendor / Genesis fragility / Low maturity | {Impact description} | {Mitigation plan} |
+
+**Resilience Gaps**:
+
+- [ ] {Identify components with no fallback or redundancy}
+- [ ] {Identify dependencies on Genesis-stage components}
+- [ ] {Identify vendor lock-in on critical path}
+
+---
+
+## Validation Checklist
+
+- [ ] Chain starts with user need (anchor)
+- [ ] All critical dependencies captured
+- [ ] Chain reaches commodity level
+- [ ] No orphan components
+- [ ] Dependencies reflect reality
+- [ ] Visibility ordering correct
+- [ ] Granularity appropriate for purpose
+
+---
+
+## Visibility Assessment
+
+| Level | Range | Characteristics | Examples |
+|-------|-------|-----------------|---------|
+| **User-facing** | 0.90 - 1.00 | Directly experienced by the user; failure is immediately visible | Login page, search results, payment confirmation |
+| **High** | 0.70 - 0.89 | Close to user; users notice degradation quickly | API gateway, authentication service, user profile |
+| **Medium-High** | 0.50 - 0.69 | Indirectly visible; affects features users rely on | Business logic layer, data validation, reporting engine |
+| **Medium** | 0.30 - 0.49 | Hidden from users but essential to operations; failure noticed over time | Caching layer, queue management, audit logging |
+| **Low** | 0.10 - 0.29 | Invisible to users; operational/infrastructure concern | Database engine, message broker, network routing |
+| **Infrastructure** | 0.00 - 0.09 | Deep infrastructure; users unaware it exists | Power supply, physical server, OS kernel |
+
+---
+
+## Assumptions and Open Questions
+
+**Assumptions Made**:
+
+| # | Assumption | Basis | Confidence |
+|---|------------|-------|------------|
+| A-01 | {Assumption 1} | {Evidence or rationale} | High / Medium / Low |
+| A-02 | {Assumption 2} | {Evidence or rationale} | High / Medium / Low |
+
+**Open Questions**:
+
+| # | Question | Owner | Due Date |
+|---|----------|-------|----------|
+| Q-01 | {Open question 1} | {Owner} | [YYYY-MM-DD] |
+| Q-02 | {Open question 2} | {Owner} | [YYYY-MM-DD] |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.value-chain` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-copilot/docs/guides/mcp-servers.md
+++ b/arckit-copilot/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 60 slash commands
+- **Commands**: 64 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-copilot/docs/guides/remote-control.md
+++ b/arckit-copilot/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 60 ArcKit commands and 6 research agents remain fully available
+- All 64 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-copilot/docs/guides/roles/README.md
+++ b/arckit-copilot/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-copilot/docs/guides/roles/enterprise-architect.md
+++ b/arckit-copilot/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-copilot/docs/guides/start.md
+++ b/arckit-copilot/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 60 commands | Plugin mode
+Version 2.10.0 | 64 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-copilot/docs/guides/wardley-climate.md
+++ b/arckit-copilot/docs/guides/wardley-climate.md
@@ -1,0 +1,122 @@
+# Climate Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.climate` assesses 32 climatic patterns affecting mapped components.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to understand the external forces acting on your components. Climate patterns are the rules of the game -- they apply regardless of your strategy. Understanding them lets you anticipate change, identify inertia, and choose gameplay that works with (not against) external forces.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map whose components are assessed for climatic forces |
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Recommended -- Business context for impact assessment |
+| Research findings (`ARC-<id>-RSCH-*.md`) | Recommended -- Market data to validate pattern detection |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.climate Assess climate for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WCLM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Climate Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being assessed |
+| Pattern Assessment | 32 climatic patterns evaluated against components |
+| Category Summary | Aggregated assessment across 6 pattern categories |
+| Peace/War/Wonder Cycle | Current cycle phase and implications |
+| Inertia Assessment | Components and organizations resisting change |
+| Prediction Horizons | What can be predicted and with what confidence |
+| Strategic Implications | How climate forces shape available strategies |
+
+---
+
+## Key Concepts
+
+### 32 Climatic Patterns Across 6 Categories
+
+| Category | Example Patterns |
+|----------|-----------------|
+| Competition | Competitors will copy successful plays, most competitors have poor situational awareness |
+| Components | Everything evolves through supply and demand competition, characteristics change as components evolve |
+| Financial | Higher-order systems create new sources of value, capital flows to new areas of value |
+| Speed | Evolution does not respect corporate boundaries, no single method fits all |
+| Prediction | Not everything is predictable, you can predict the direction of evolution |
+| Ecosystem | Efficiency enables innovation, evolution of one component affects others |
+
+### Peace / War / Wonder Cycle
+
+The evolution of components follows a repeating cycle:
+
+| Phase | Characteristics |
+|-------|-----------------|
+| Peace | Stable product competition, incremental improvement, predictable |
+| War | Commodity transition, disruption, rapid change, casualties |
+| Wonder | New genesis components emerge from commodity, novel value created |
+
+Identifying which phase each component is in reveals whether stability or disruption is imminent.
+
+### Inertia Assessment
+
+Inertia is resistance to change. Climate assessment identifies:
+
+- **Component inertia** -- Technology or practices that resist evolution
+- **Organizational inertia** -- Cultural resistance, sunk cost, existing contracts
+- **Market inertia** -- Vendor lock-in, switching costs, standards
+
+### Prediction Horizons
+
+Not all climate effects are equally predictable:
+
+| Horizon | Confidence |
+|---------|------------|
+| Direction of evolution | High -- components always evolve toward commodity |
+| Timing of evolution | Medium -- depends on competition and market forces |
+| Specific disruptions | Low -- individual events are unpredictable |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- All 32 climatic patterns assessed against map components.
+- Peace/War/Wonder phase identified for each key component.
+- Inertia sources documented with severity.
+- Prediction horizons are realistic (not overconfident).
+- Strategic implications link back to specific components.
+- Assessment is evidence-based, not speculative.
+
+---
+
+## Tips
+
+1. **Climate before gameplay** -- Climate constrains which plays are viable. Always assess climate first.
+2. **Look for war signals** -- Components approaching commodity transition are the highest-risk, highest-opportunity areas.
+3. **Challenge inertia** -- Organizational inertia is often the hardest to overcome. Name it explicitly.
+4. **Update with the map** -- Climate assessment is tied to a specific map version. When the map changes, re-assess.
+5. **Use research data** -- Market research (`/arckit.research`) provides evidence for pattern detection. Do not assess climate in a vacuum.

--- a/arckit-copilot/docs/guides/wardley-doctrine.md
+++ b/arckit-copilot/docs/guides/wardley-doctrine.md
@@ -1,0 +1,120 @@
+# Doctrine Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.doctrine` assesses organizational doctrine maturity across 4 phases and 40+ principles.
+
+---
+
+## When to Use
+
+Run this command to assess organizational maturity, identify capability gaps, and plan improvements. Doctrine assessment reveals how well an organization applies universal strategic principles -- independent of any specific map or context. Use it to:
+
+- Baseline current organizational maturity
+- Identify systemic weaknesses before they manifest in projects
+- Plan targeted improvement programmes
+- Re-assess periodically to measure progress
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Architecture principles (`ARC-000-PRIN-v1.0.md`) | **Mandatory** -- Governance principles to assess against |
+| Wardley Map (`ARC-<id>-WARD-*.md`) | Recommended -- Provides strategic context for scoring |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- Organizational context and drivers |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.doctrine Assess doctrine maturity for <organisation>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WDOC-v1.0.md` (single instance per project)
+
+---
+
+## Doctrine Structure
+
+| Section | Contents |
+|---------|----------|
+| Phase Assessment | Which of the 4 phases the organization has reached |
+| Category Scores | Maturity scores across 6 doctrine categories |
+| Principle-Level Detail | Individual 1-5 scoring for 40+ principles |
+| Gap Analysis | Weaknesses and improvement priorities |
+| Improvement Roadmap | Phased plan to advance doctrine maturity |
+
+---
+
+## Key Concepts
+
+### The 4 Phases of Doctrine
+
+| Phase | Name | Focus |
+|-------|------|-------|
+| I | Stop Self-Harm | Eliminate basic organizational dysfunctions |
+| II | Becoming Context Aware | Develop situational awareness and mapping capability |
+| III | Better for Less | Optimize through strategic play and efficiency |
+| IV | Continuously Evolving | Anticipate and adapt to change systemically |
+
+Organizations must master each phase before progressing to the next.
+
+### The 6 Categories
+
+| Category | Examples |
+|----------|---------|
+| Communication | Common language, challenge assumptions, listen to ecosystems |
+| Development | Use appropriate methods, think small, know your details |
+| Learning | Use a systematic mechanism of learning, bias towards data |
+| Leading | Move fast, be the owner, think big |
+| Operations | Manage inertia, optimise flow, think aptitude and attitude |
+| Structure | Provide purpose, use small teams, think standards |
+
+### Scoring (1-5)
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Not practiced -- principle is unknown or ignored |
+| 2 | Ad hoc -- applied inconsistently |
+| 3 | Developing -- recognized and partly systematized |
+| 4 | Practiced -- systematically applied across the organization |
+| 5 | Mastered -- deeply embedded, continuously improved |
+
+### Re-Assessment
+
+Doctrine assessments support periodic re-assessment. When re-running the command, the previous assessment is read and scores are compared to show progress, regression, or stagnation.
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Foundation | Establish architecture principles | `/arckit.principles` |
+| Assessment | Score doctrine maturity | `/arckit.wardley.doctrine` |
+| Mapping | Create Wardley Maps with doctrine context | `/arckit.wardley` |
+| Strategy | Synthesise into strategy | `/arckit.strategy` |
+
+---
+
+## Review Checklist
+
+- All 40+ principles scored with evidence.
+- Phase classification is justified.
+- Gap analysis identifies top priority improvements.
+- Improvement roadmap has realistic timelines.
+- Comparison with previous assessment included (if re-assessment).
+- Scores reflect reality, not aspiration.
+
+---
+
+## Tips
+
+1. **Be honest** -- Doctrine assessment only has value if scores reflect reality. Aspirational scoring hides problems.
+2. **Involve multiple stakeholders** -- A single assessor introduces bias; cross-functional input produces better scores.
+3. **Start with Phase I** -- If Phase I principles are not mastered, skip ahead at your peril.
+4. **Re-assess quarterly** -- Doctrine maturity changes slowly; quarterly cadence balances effort and insight.
+5. **Link to principles** -- Map each doctrine principle to your architecture principles for traceability.

--- a/arckit-copilot/docs/guides/wardley-gameplay.md
+++ b/arckit-copilot/docs/guides/wardley-gameplay.md
@@ -1,0 +1,123 @@
+# Gameplay Analysis Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.gameplay` analyzes strategic plays from 60+ gameplay patterns.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to identify strategic plays available to your organization. Gameplay analysis examines your map and recommends actions based on component positions, movements, and the competitive landscape. Best combined with climate assessment (`/arckit.wardley.climate`) for a complete strategic picture.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map to analyze for strategic plays |
+| Climate assessment (`ARC-<id>-WCLM-*.md`) | Recommended -- External forces affecting gameplay choices |
+| Doctrine assessment (`ARC-<id>-WDOC-*.md`) | Recommended -- Organizational readiness for each play |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.gameplay Analyze gameplay for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WGAM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Gameplay Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being analyzed |
+| Applicable Plays | Strategic plays identified from component positions |
+| Play-Position Matrix | Which plays apply to which components |
+| Alignment Classification | D&D alignment for each play (Lawful/Neutral/Chaotic) |
+| Recommended Actions | Prioritized list of strategic actions |
+| Risk Assessment | Risks and counter-plays for each recommendation |
+
+---
+
+## Key Concepts
+
+### 11 Gameplay Categories
+
+| Category | Focus |
+|----------|-------|
+| User Perception | Shaping how users see value |
+| Accelerators | Speeding evolution of components |
+| De-accelerators | Slowing evolution to protect advantage |
+| Market | Creating or reshaping markets |
+| Defensive | Protecting current position |
+| Attacking | Disrupting competitors |
+| Ecosystem | Building or leveraging ecosystems |
+| Positional | Exploiting map position |
+| Poison | Undermining competitor strategies |
+| Military | Direct competitive confrontation |
+| Political | Influencing rules and standards |
+
+### 60+ Plays
+
+Examples include open source (accelerator), create a constraint (de-accelerator), tower and moat (defensive), two-factor markets (ecosystem), and standards game (political). Each play has specific applicability based on component evolution stage and visibility.
+
+### D&D Alignment Classification
+
+Plays are classified on two axes:
+
+| Axis | Options |
+|------|---------|
+| Lawful / Neutral / Chaotic | How the play relates to established norms |
+| Good / Neutral / Evil | The ethical dimension of the play |
+
+This classification helps organizations choose plays that align with their values and governance requirements.
+
+### Play-Position Matrix
+
+The matrix maps each play to the evolution stages where it is most effective:
+
+| Evolution Stage | Example Plays |
+|-----------------|---------------|
+| Genesis | Experimentation, talent raid, first mover |
+| Custom | Sensing engines, co-creation |
+| Product | Industrialisation plays, ecosystem building |
+| Commodity | Standards game, utility plays, commoditisation |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- Wardley Map is current and validated.
+- All applicable plays identified for each component.
+- D&D alignment classification is consistent.
+- Risks and counter-plays documented for each recommendation.
+- Play-position matrix is populated.
+- Recommendations are prioritized by impact and feasibility.
+- Organizational readiness considered (doctrine assessment).
+
+---
+
+## Tips
+
+1. **Map first, play second** -- Never select gameplay without a current Wardley Map.
+2. **Combine with climate** -- Climate patterns constrain which plays are viable. Assess climate first.
+3. **Check doctrine readiness** -- Some plays require organizational maturity. A Phase I organization cannot execute Phase III plays.
+4. **Consider ethics** -- The D&D alignment classification is not decorative. Choose plays consistent with your governance.
+5. **Revisit after map changes** -- When components move or the landscape shifts, gameplay analysis must be refreshed.

--- a/arckit-copilot/docs/guides/wardley-value-chain.md
+++ b/arckit-copilot/docs/guides/wardley-value-chain.md
@@ -1,0 +1,122 @@
+# Value Chain Decomposition Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.value-chain` decomposes user needs into value chains for Wardley Mapping.
+
+---
+
+## When to Use
+
+Run this command **before** creating a Wardley Map when you need to decompose a domain into its constituent components. Value chain decomposition identifies all the capabilities, services, and activities required to meet user needs -- producing the raw material that `/arckit.wardley` then positions on an evolution axis.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | **Mandatory** -- Capabilities, user needs, and business context |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- User roles and business drivers |
+| Architecture diagrams | Optional -- Existing component landscape |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.value-chain Decompose value chain for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WVCH-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Value Chain Structure
+
+| Section | Contents |
+|---------|----------|
+| Anchor Identification | User needs vs internal solution anchors |
+| Recursive Decomposition | Break each need into sub-components until atomic |
+| Visibility Mapping | How visible each component is to the end user |
+| Dependency Analysis | Which components depend on which |
+| Component Catalogue | Full list with descriptions, types, and owners |
+
+---
+
+## Key Concepts
+
+### Anchors: User Needs vs Solutions
+
+Wardley Maps start from **user needs**, not technology. Value chain decomposition distinguishes:
+
+- **User-need anchors** -- What the user actually wants (e.g., "book an appointment")
+- **Solution anchors** -- Internal capabilities that serve the need (e.g., "appointment scheduling service")
+
+Always anchor at user needs; solutions are components in the chain below.
+
+### Recursive Decomposition
+
+Each user need is broken down recursively:
+
+1. Identify the top-level need
+2. Ask "what is needed to provide this?"
+3. For each answer, repeat until you reach atomic components
+4. Atomic = a component that can be sourced as a single unit (build, buy, or utility)
+
+### Visibility Axis
+
+Components sit on a visibility spectrum:
+
+| Position | Description |
+|----------|-------------|
+| Top (visible) | User-facing capabilities, directly experienced |
+| Middle | Supporting services, seen by operators |
+| Bottom (invisible) | Infrastructure and utilities, invisible to users |
+
+### Dependency Types
+
+| Type | Description |
+|------|-------------|
+| Direct | Component A cannot function without Component B |
+| Indirect | Component A benefits from Component B but can operate without it |
+| Shared | Multiple components depend on a common service |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Requirements | Define user needs and capabilities | `/arckit.requirements` |
+| Decomposition | Break needs into value chains | `/arckit.wardley.value-chain` |
+| Mapping | Position components on evolution axis | `/arckit.wardley` |
+| Analysis | Assess doctrine, climate, gameplay | `/arckit.wardley.doctrine`, `/arckit.wardley.climate`, `/arckit.wardley.gameplay` |
+
+---
+
+## Review Checklist
+
+- All user needs identified and used as anchors.
+- Decomposition is recursive to atomic components.
+- Visibility axis reflects real user perspective.
+- Dependencies between components are explicit.
+- No technology assumptions baked into anchors.
+- Component catalogue is complete with descriptions.
+
+---
+
+## Tips
+
+1. **Start with users, not technology** -- If your first anchor is a database, you have started too low.
+2. **Challenge "obvious" components** -- Decompose even well-understood areas; hidden dependencies live there.
+3. **Use stakeholder analysis** -- Stakeholder drivers reveal needs that requirements alone may miss.
+4. **One chain per user need** -- Separate chains keep the analysis focused.
+5. **Feed into Wardley Map** -- The value chain output is the direct input to `/arckit.wardley`.
+
+---
+
+## Feeds Into
+
+- `/arckit.wardley` -- Use the decomposed value chain to create a positioned Wardley Map
+- `/arckit.data-model` -- Components often map to data entities

--- a/arckit-copilot/docs/guides/wardley.md
+++ b/arckit-copilot/docs/guides/wardley.md
@@ -6,6 +6,29 @@
 
 ---
 
+## Wardley Mapping Suite
+
+ArcKit provides a full suite of Wardley Mapping commands that work together as a strategic analysis pipeline:
+
+| Command | Purpose | Output |
+|---------|---------|--------|
+| `/arckit.wardley.value-chain` | Decompose user needs into value chains | WVCH |
+| `/arckit.wardley` | Create positioned Wardley Maps | WARD |
+| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity | WDOC |
+| `/arckit.wardley.climate` | Assess 32 climatic patterns | WCLM |
+| `/arckit.wardley.gameplay` | Analyze 60+ strategic gameplay patterns | WGAM |
+
+**Recommended workflow order:**
+
+1. **Value Chain** -- Decompose domain into components ([guide](wardley-value-chain.md))
+2. **Wardley Map** -- Position components on evolution axis (this guide)
+3. **Doctrine** -- Assess organizational maturity ([guide](wardley-doctrine.md))
+4. **Climate** -- Understand external forces ([guide](wardley-climate.md))
+5. **Gameplay** -- Identify strategic plays ([guide](wardley-gameplay.md))
+6. **Strategy / Roadmap** -- Synthesise findings into actionable plans
+
+---
+
 ## Inputs
 
 | Artefact | Purpose |

--- a/arckit-copilot/prompts/arckit-wardley.climate.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.climate.prompt.md
@@ -81,6 +81,7 @@ For each component:
 **Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
 
 **Total component summary**:
+
 - Genesis components ({count}): {names}
 - Custom-Built components ({count}): {names}
 - Product components ({count}): {names}
@@ -88,6 +89,7 @@ For each component:
 - Components with noted inertia: {names}
 
 **Ecosystem Type Assessment**:
+
 - Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
 - Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
 - Or mixed?
@@ -266,14 +268,17 @@ Position the overall landscape within the Peace/War/Wonder cycle. This is one of
 For the primary market/domain of this landscape, assess which phase it is in:
 
 **Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+
 - Evidence for: {list}
 - Evidence against: {list}
 

--- a/arckit-copilot/prompts/arckit-wardley.climate.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.climate.prompt.md
@@ -1,0 +1,595 @@
+---
+description: 'Assess climatic patterns affecting Wardley Map components'
+agent: 'agent'
+tools: ['readFile', 'editFiles', 'runCommand', 'codebase', 'search']
+---
+
+# ArcKit: Wardley Climate Assessment
+
+You are an expert in Wardley Mapping climatic patterns and strategic forecasting. You assess 32 external force patterns across 6 categories that shape the business and technology landscape regardless of what any individual organisation chooses to do. Unlike gameplays (deliberate strategic choices), climatic patterns are the "weather" — they simply happen. Understanding them allows organisations to position ahead of change rather than scramble to react.
+
+## What are Climatic Patterns?
+
+Simon Wardley identifies 32 climatic patterns organised into 6 categories. These patterns describe the external forces that act on every component in a Wardley Map:
+
+1. **Component Patterns** (8 patterns): How components evolve in general
+2. **Financial Patterns** (6 patterns): How capital, value, and economic forces behave
+3. **Speed Patterns** (5 patterns): How fast evolution occurs and what accelerates it
+4. **Inertia Patterns** (3 patterns): How organisations resist necessary change
+5. **Competitor Patterns** (2 patterns): How competitive dynamics shape the landscape
+6. **Prediction Patterns** (8 patterns): What can and cannot be reliably forecast
+
+The output of a climate assessment (WCLM artifact) informs gameplay selection — you cannot choose effective plays without understanding the weather you are playing in.
+
+## User Input
+
+```text
+${input:topic:Enter project name or topic}
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, current stage classifications, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running climate assessment. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; climate patterns cannot be assessed without knowing what components are in the landscape
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **REQ** (Requirements) — Extract: business drivers, technology context, domain characteristics. Enriches domain-specific climate assessment.
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: market dynamics, vendor landscape, industry trends, competitive intelligence. Market research is the primary evidence source for pattern detection.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores and weaknesses. Inertia pattern severity is amplified by poor doctrine.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles and constraints. Shapes how climate findings translate to strategic implications.
+- **STKE** (Stakeholder Analysis) — Extract: business drivers and stakeholder priorities. Grounds climate assessment in organisational realities.
+
+**Understand the Assessment Context**:
+
+- What domain or market is being assessed? (From user arguments and project context)
+- What is the time horizon for strategic planning? (Affects which patterns matter most)
+- Is this primarily a technology landscape, market landscape, or regulatory landscape assessment?
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract market analysis, industry reports, analyst forecasts, competitive intelligence. These are the primary evidence sources for climate pattern detection.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level climate assessments, enterprise technology landscape reports
+- If no external market documents found but they would materially improve the assessment, ask: "Do you have any market research reports, analyst forecasts, or competitive landscape documents? These significantly improve climate pattern evidence quality. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Read Reference Material
+
+Read the following reference files:
+
+1. **`.arckit/skills/wardley-mapping/references/climatic-patterns.md`** — the complete 32-pattern catalog across 6 categories, with strategic implications, assessment questions, pattern interaction maps, the Peace/War/Wonder cycle, per-component assessment templates, and assessment question sets by category. This is the authoritative source for all pattern descriptions and assessment methodology.
+
+2. **`.arckit/skills/wardley-mapping/references/mathematical-models.md`** — for the impact weighting methodology, evolution scoring formulas, and any quantitative models used to assess evolution velocity and pattern impact severity.
+
+## Step 3: Extract Component Inventory
+
+From the WARD artifact, build a complete component inventory that will be the basis for per-component pattern assessment in Steps 4-6.
+
+For each component:
+
+| Component | Visibility | Evolution | Stage | Dependencies | Inertia Noted |
+|-----------|-----------|-----------|-------|--------------|---------------|
+| [Name] | [0.0-1.0] | [0.0-1.0] | [G/C/P/Cmd] | [list] | [Yes/No/Partial] |
+
+**Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
+
+**Total component summary**:
+- Genesis components ({count}): {names}
+- Custom-Built components ({count}): {names}
+- Product components ({count}): {names}
+- Commodity components ({count}): {names}
+- Components with noted inertia: {names}
+
+**Ecosystem Type Assessment**:
+- Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
+- Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
+- Or mixed?
+
+This affects pattern 1.2 (Rates of Evolution Vary by Ecosystem) — a critical calibration for all velocity predictions.
+
+## Step 4: Assess Climatic Patterns by Category
+
+For each of the 6 categories, evaluate which patterns are actively affecting this specific landscape. Do not simply list all 32 patterns — assess which are demonstrably active, which are latent (approaching but not yet dominant), and which are not currently relevant.
+
+For each **active** or **latent** pattern, provide:
+
+```text
+Pattern: [Pattern Name and Number] — [Category]
+Status: Active / Latent / Not relevant
+Evidence: [1-3 sentences of specific evidence from the map, domain context, or user arguments]
+Primary components affected: [component names from the WARD artifact]
+Impact: High / Medium / Low
+Strategic implication for this landscape: [Specific — not a copy of the generic implication from the reference]
+Time horizon: < 12 months / 1-3 years / 3+ years
+```
+
+### Category 1: Component Patterns (8 patterns)
+
+Assess all 8 patterns from the reference file:
+
+**1.1 Everything Evolves Through Supply and Demand Competition**
+Are components actively moving along the evolution axis? What is driving that movement in this specific domain?
+
+**1.2 Rates of Evolution Can Vary by Ecosystem**
+Is this a fast-moving consumer ecosystem or a slow-moving industrial/government one? What modulating factors (regulation, investment, inertia) affect speed?
+
+**1.3 Characteristics Change as Components Evolve**
+Are any components at stage boundaries where management approach, team structure, or contract type should be changing? Mismatches are active strategic risks.
+
+**1.4 No Choice Over Evolution — The Red Queen Effect**
+Where is the organisation or its competitors running just to stay in place? Is there evidence of competitive pressure forcing adaptation?
+
+**1.5 No Single Method Fits All**
+Is there evidence that a single methodology (agile, waterfall, lean, ITIL) is being applied across components at different evolution stages — creating systematic inefficiency?
+
+**1.6 Components Can Co-evolve**
+Which components are co-evolving? Are there "enabler components" — if they evolve (or are evolved by a competitor), which other components would be dragged along?
+
+**1.7 Evolution Consists of Multiple Waves with Many Chasms**
+Which components are currently in a chasm (adoption stalled between waves)? What is blocking the next adoption wave?
+
+**1.8 Commoditisation Does Not Equal Centralisation**
+Is there an assumption in the strategy that commoditisation will lead to consolidation? Is that assumption valid for this specific market context?
+
+### Category 2: Financial Patterns (6 patterns)
+
+**2.1 Higher Order Systems Create New Sources of Value**
+Are any clusters of recently commoditising components creating the foundation for new higher-order systems? What new value streams are becoming possible?
+
+**2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox**
+Where are efficiency gains likely to trigger increased consumption rather than cost reduction? Where are cost-saving projections likely to be wrong?
+
+**2.3 Capital Flows to New Areas of Value**
+Where is capital (financial, talent, attention) flowing in this domain? What does that flow signal about the next wave of value creation?
+
+**2.4 Creative Destruction — The Schumpeter Effect**
+What genesis-stage components, if they evolve, would make current commodity positions irrelevant? What incumbent positions are most vulnerable?
+
+**2.5 Future Value is Inversely Proportional to Certainty**
+Where is the strategy over-weighted toward certain opportunities (accepting low returns) and under-weighted toward uncertain bets?
+
+**2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption**
+Have full infrastructure and resource costs been accounted for in the higher-order systems being built? Where is there hidden resource consumption?
+
+### Category 3: Speed Patterns (5 patterns)
+
+**3.1 Efficiency Enables Innovation — The Componentization Effect**
+Which Custom-Built components should be replaced with commodity solutions to free resources for higher-value innovation? Where is the organisation building what it should be buying?
+
+**3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed**
+Are there communication bottlenecks (organisational, technical, process) that are slowing the evolution of key components?
+
+**3.3 Increased Stability of Lower Order Systems Increases Agility**
+Are foundational/infrastructure components stable and commodity-grade enough to support rapid innovation at higher levels? Or are lower-order instabilities forcing engineering attention downward?
+
+**3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists**
+Which components in this landscape could exhibit exponential or discontinuous change? Are current plans robust to non-linear scenarios?
+
+**3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium**
+Which Product-stage components are approaching a punctuated shift to utility? What are the triggers, and is the organisation positioned to lead or survive the shift?
+
+### Category 4: Inertia Patterns (3 patterns)
+
+**4.1 Success Breeds Inertia**
+Where is the organisation resisting evolution because current revenue, culture, or identity depends on the status quo? Name specific components or capabilities.
+
+**4.2 Inertia Can Kill an Organisation**
+If a new entrant built this value chain on commodity infrastructure today, what would their cost structure and speed look like? Where is the gap existential?
+
+**4.3 Inertia Increases the More Successful the Past Model Is**
+Where is success so profound that honest self-assessment of the model's future viability is compromised? Where are self-disruption mechanisms needed?
+
+### Category 5: Competitor Patterns (2 patterns)
+
+**5.1 Competitors' Actions Will Change the Game**
+Which competitor action, if taken, would most fundamentally change the basis of competition? Has this scenario been planned for?
+
+**5.2 Most Competitors Have Poor Situational Awareness**
+What would a competitor's map of this landscape look like if drawn by their most capable strategist? Where does your map reveal blind spots they likely have?
+
+### Category 6: Prediction Patterns (8 patterns)
+
+**6.1 Not Everything is Random — P[what] vs P[when]**
+Which evolutionary directions are high-confidence (P[what]) even if timing is uncertain (P[when])? Which strategic commitments are anchored to timing rather than direction?
+
+**6.2 Economy Has Cycles — Peace, War, and Wonder**
+Which phase is the core market in? Which phase transition should the organisation be preparing for? (Full analysis in Step 7.)
+
+**6.3 Different Forms of Disruption — Predictable vs Unpredictable**
+Which disruptions are predictable (plan for them) and which require resilience (prepare for but cannot predict)? Maintain separate portfolios.
+
+**6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve**
+Is there a component approaching industrialisation that will trigger a "war"? What are the early warning signs?
+
+**6.5 You Cannot Measure Evolution Over Time or Adoption**
+Are there investment commitments that depend on specific adoption timing? How robust are they if timing is wrong by 2-3 years?
+
+**6.6 The Less Evolved Something Is, the More Uncertain It Becomes**
+Are Genesis-stage components being managed with commodity-appropriate certainty, or commodity components with Genesis-appropriate uncertainty? Both are systematic errors.
+
+**6.7 Not Everything Survives**
+Which components have a non-trivial probability of not surviving the next evolution cycle? What is the exit or transition plan?
+
+**6.8 Embrace Uncertainty**
+How many current strategic commitments would fail if one key uncertainty resolved differently? Is the strategy robust across a range of futures?
+
+## Step 5: Per-Component Impact Matrix
+
+Create a matrix showing which climatic patterns most significantly affect each component. Focus on patterns assessed as Active or Latent (skip Not Relevant).
+
+| Component | Stage | Highest-Impact Patterns | Combined Impact | Strategic Priority |
+|-----------|-------|------------------------|-----------------|-------------------|
+| [Name] | [G/C/P/Cmd] | [Pattern 1.1, 3.5, 4.1, etc.] | H/M/L | [High/Medium/Low] |
+
+**Most-affected components**: Identify the 3-5 components where the cumulative climate impact is highest. These are the strategic focal points for the roadmap.
+
+**Least-affected components**: Identify components where the landscape is relatively stable and low climate intensity.
+
+## Step 6: Prediction Horizons
+
+For each component with High or Medium strategic priority, provide a structured prediction:
+
+```text
+Component: [Name]
+Current Stage: [Genesis/Custom-Built/Product/Commodity] at evolution position [0.0-1.0]
+
+P[what]: [What will happen — directional prediction, high confidence]
+P[when]: [Timing uncertainty — Low/Medium/High]
+
+6-month prediction: [Specific, observable expected state]
+18-month prediction: [Specific, observable expected state]
+
+Confidence level: High / Medium / Low
+Key assumptions: [1-2 assumptions that underpin these predictions]
+Key signals to watch: [Observable indicators that would confirm or refute]
+  - Signal 1: [What to watch and what it means]
+  - Signal 2: [What to watch and what it means]
+
+Recommended response:
+  Urgency: High / Medium / Low
+  Primary action: [Specific action to take now or monitor for]
+```
+
+## Step 7: Wave Analysis — Peace/War/Wonder Positioning
+
+Position the overall landscape within the Peace/War/Wonder cycle. This is one of the most strategically significant outputs of the climate assessment.
+
+### Landscape Phase Assessment
+
+For the primary market/domain of this landscape, assess which phase it is in:
+
+**Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Phase conclusion**: The landscape is currently in [Peace/War/Wonder/Transition from X to Y]
+
+**Phase confidence**: High / Medium / Low — [rationale]
+
+### Component-Level Phase Analysis
+
+Different components may be in different phases. For key components:
+
+| Component | Phase | Evidence | Signs of Next Phase Transition |
+|-----------|-------|----------|-------------------------------|
+| [Name] | Peace/War/Wonder | [brief] | [what to watch] |
+
+### Strategic Posture Recommendation
+
+Based on the phase:
+
+**If Peace**: [Specific recommendations — operational excellence focus, moat-building, watching for War triggers]
+
+**If War**: [Specific recommendations — rapid transformation imperatives, which custom-built components to shed, coalition/acquisition needs]
+
+**If Wonder**: [Specific recommendations — exploration portfolio, genesis bets, early-mover positioning]
+
+**Phase transition preparedness**: Is the organisation positioned for the next phase transition? What preparation is needed before the transition begins?
+
+## Step 8: Inertia Assessment
+
+For each component where inertia was identified (from the WARD artifact or from pattern 4.1-4.3 assessment above):
+
+```text
+Component: [Name]
+Inertia Type: Success / Capital / Political / Skills / Supplier / Consumer / Cultural
+Severity: High / Medium / Low
+
+Evidence: [Specific evidence of this inertia type for this component]
+Climate amplifier: [Which climatic pattern makes this inertia more dangerous?]
+  — e.g., "Inertia Kills (4.2) + War Phase approaching = existential risk if not addressed"
+
+Mitigation strategy: [Specific, actionable]
+  Urgency: High / Medium / Low
+  Responsible party: [Role or team]
+  Timeline: [When must this be addressed to avoid strategic harm]
+  Success indicator: [Observable sign that inertia is reducing]
+```
+
+**Overall inertia risk rating**: {High/Medium/Low} — {brief rationale}
+
+If no inertia is identified across any components, explicitly state: "No significant organisational or market inertia detected. Note: absence of inertia signals is itself unusual — verify this against WDOC doctrine assessment if available."
+
+## Step 9: Generate Output
+
+Create the climate assessment document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WCLM-001-v1.0.md` — First climate assessment for project 001
+- `ARC-001-WCLM-002-v1.0.md` — Second assessment (e.g., after updated map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-climate-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-climate-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.climate`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WCLM-{NNN}-v{VERSION}` (e.g., `ARC-001-WCLM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WCLM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Climate Assessment"
+- `ARC-[PROJECT_ID]-WCLM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.climate"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.climate` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.climate` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Climate Assessment document must include:
+
+1. **Executive Summary**: Domain assessed, total patterns active/latent, most critical findings, phase positioning (2-3 paragraphs)
+
+2. **Component Inventory**: Table of all map components with evolution stage and inertia status
+
+3. **Pattern Assessment by Category**: All 6 categories with Active/Latent/Not Relevant verdict and evidence for each applicable pattern
+
+4. **Per-Component Impact Matrix**: Table showing which patterns affect which components and combined impact rating
+
+5. **Prediction Horizons**: Structured 6-month and 18-month predictions for high-priority components
+
+6. **Peace/War/Wonder Wave Analysis**: Phase positioning with evidence, component-level phase table, and strategic posture recommendations
+
+7. **Inertia Assessment**: Per-component inertia register with type, severity, mitigation, and urgency
+
+8. **Pattern Interaction Analysis**: Which patterns are reinforcing each other, which are in tension, and what cascade sequences are active
+
+9. **Strategic Implications Summary**: Prioritised list of strategic implications for the architecture team
+
+10. **Traceability**: Link to WARD artifact, source documents used, external documents read
+
+## Step 10: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact) ← you are here
+/arckit:wardley.gameplay — Select gameplays informed by climate forces (WGAM artifact)
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create execution roadmap
+/arckit:strategy — Synthesise into architecture strategy
+```
+
+### Before Climate Assessment
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If market research (RSCH) is missing:
+
+```bash
+"Note: No market research (RSCH) found. Climate patterns are most accurately assessed with market
+evidence. Consider running `/arckit:research` to gather vendor landscape and market dynamics data,
+then re-run this climate assessment. Proceeding with map-only context — findings will be less
+evidence-grounded."
+```
+
+### After Climate Assessment
+
+Recommend next steps based on key findings:
+
+```bash
+# If War phase detected
+"Your climate assessment identifies War phase dynamics — rapid industrialisation is underway.
+This is the most urgent strategic scenario. Run `/arckit:wardley.gameplay` immediately to identify
+which plays are appropriate for War phase execution. Key: Managing Inertia, Open Approaches,
+and Centre of Gravity plays are typically highest priority in War."
+
+# If high-severity inertia detected
+"Significant organisational inertia was identified for {components}. This must be addressed
+before gameplay execution plans can succeed. Consider running `/arckit:strategy` to create
+an inertia-mitigation architecture strategy."
+
+# If evolution velocity surprises identified
+"Climate patterns suggest {components} will evolve faster/slower than the map currently shows.
+Consider running `/arckit:wardley` to update component positions, then re-run gameplay analysis."
+
+# If UK Government project
+"As a UK Government project, climate patterns affecting procurement (TCoP compliance windows,
+G-Cloud framework evolution, open standards mandates) should be reflected in your procurement
+strategy. Run `/arckit:tcop` to validate compliance positioning."
+```
+
+## Important Notes
+
+### Climate Assessment Quality Standards
+
+**Good Climate Assessment**:
+
+- Patterns assessed with specific evidence from the map and domain context
+- Phase positioning supported by multiple evidence points
+- Predictions separate P[what] from P[when]
+- Inertia identified and quantified by type and severity
+- Pattern interactions and cascades identified
+- Component-specific impact matrix completed
+- Assessment questions from reference file applied to each component
+
+**Poor Climate Assessment**:
+
+- Generic pattern descriptions not tied to specific components
+- Phase assessment without supporting evidence
+- Predictions with false precision on timing
+- Inertia overlooked or underestimated
+- All 32 patterns listed as "active" without discrimination
+- No component-level impact assessment
+
+### Evidence Quality Levels
+
+When evidence is available from market research, external documents, or domain expertise, explicitly note the source. When evidence is inferred from map position alone, note this as lower-confidence.
+
+**Evidence quality scale**:
+
+- **High**: Market research documents, analyst reports, direct competitive intelligence → strong confidence
+- **Medium**: Domain knowledge, user input, contextual inference from map → medium confidence
+- **Low**: Map-position inference only, generic domain characteristics → flag as lower confidence
+
+All pattern assessments should note their evidence quality level so readers understand confidence.
+
+### Pattern Relevance Threshold
+
+Not all 32 patterns will be actively relevant for every map. Be selective:
+
+- **Active patterns**: Demonstrably affecting the landscape now — include with full evidence
+- **Latent patterns**: Building but not yet dominant — include with watch signals
+- **Not relevant**: Not materially affecting this landscape — state why briefly rather than omitting silently
+
+Selective relevance assessment is a quality signal. An assessment that declares all 32 patterns equally active has not done the filtering work.
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Climate Assessment document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Evidence-grounded (patterns supported by specific evidence, not generic descriptions)
+- Component-specific (impact matrix maps patterns to actual map components)
+- Predictive (structured P[what]/P[when] forecasts for key components)
+- Phase-positioned (War/Peace/Wonder assessment with strategic posture)
+- Inertia-mapped (all inertia points identified with type, severity, mitigation)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Climate Assessment Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md
+
+Patterns Assessed: {total} across 6 categories
+  Active: {count}
+  Latent (approaching): {count}
+  Not relevant: {count}
+
+Most-Affected Components:
+1. {Component name} — {top patterns active, combined impact}
+2. {Component name} — {top patterns active, combined impact}
+3. {Component name} — {top patterns active, combined impact}
+
+Key Predictions:
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+
+Wave Position: {Peace/War/Wonder} — {one-sentence rationale}
+
+Inertia Risk: {High/Medium/Low} — {key inertia points if any}
+
+Next Steps:
+- /arckit:wardley.gameplay — Select plays informed by this climate assessment
+- /arckit:wardley — Update map if evolution velocity findings change component positions
+- /arckit:strategy — Synthesise climate findings into architecture strategy
+```
+
+---
+
+**Remember**: Climatic patterns are not threats to manage or opportunities to exploit — they are the environment you are operating in. The goal of climate assessment is not to fight the weather, but to dress appropriately for it.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit-wardley.gameplay` -- Select gameplays informed by climate forces
+- `/arckit-wardley` -- Update map with climate-driven evolution predictions *(when Climate analysis reveals evolution velocity changes)*

--- a/arckit-copilot/prompts/arckit-wardley.doctrine.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.doctrine.prompt.md
@@ -169,6 +169,7 @@ Read the existing WDOC to extract the previous scores for each principle. Then p
 | {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
 
 Use the following trend symbols:
+
 - **↑** — Score improved by 1 or more
 - **↓** — Score declined by 1 or more
 - **→** — Score unchanged

--- a/arckit-copilot/prompts/arckit-wardley.doctrine.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.doctrine.prompt.md
@@ -1,0 +1,371 @@
+---
+description: 'Assess organizational doctrine maturity using Wardley''s 4-phase framework'
+agent: 'agent'
+tools: ['readFile', 'editFiles', 'runCommand', 'codebase', 'search']
+---
+
+# ArcKit: Wardley Doctrine Maturity Assessment
+
+You are an expert organizational maturity assessor using Simon Wardley's doctrine framework. Your role is to evaluate universal principles across 4 phases and 6 categories, score current maturity honestly from available evidence, identify critical gaps, and produce a prioritized improvement roadmap.
+
+Doctrine assessment is not a compliance exercise — it is a strategic tool for understanding organizational capability to execute on a Wardley Map strategy. Poor doctrine is frequently the reason good strategies fail in execution.
+
+## User Input
+
+```text
+${input:topic:Enter project name or topic}
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **PRIN** (Architecture Principles, in `000-global`) — Extract: Stated principles, governance standards, technology standards, decision-making approach, values. Principles reveal what the organization believes it does; doctrine assessment reveals what it actually does.
+  - If missing: warn the user. Doctrine assessment is still possible from other artifacts and user input, but principles would significantly improve accuracy. Recommend running `/arckit:principles` for the global project first.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WARD** (Wardley Map) — Extract: Strategic landscape context, component positions, identified inertia, evolution predictions. Doctrine gaps often explain why specific components on a map are stuck or mismanaged.
+- **STKE** (Stakeholder Analysis) — Extract: Organizational structure, decision-making authority, culture indicators, stakeholder priorities and tensions.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **REQ** (Requirements) — Extract: How requirements are gathered; user need vs. solution bias; evidence of user research vs. internal assumption.
+- Existing WDOC artifacts in `projects/{current_project}/wardley-maps/` — Read for re-assessment comparison. If a previous WDOC exists, note the previous scores to support trend analysis in Step 6.
+
+## Step 2: Read Reference Material
+
+**MANDATORY** — Read the full doctrine framework:
+
+Read `.arckit/skills/wardley-mapping/references/doctrine.md`
+
+This file contains:
+
+- The 5-step Strategy Cycle (Purpose → Landscape → Climate → Doctrine → Leadership)
+- The Phase/Category Matrix (42 principles across 4 phases and 6 categories)
+- Detailed descriptions of all phases and principles with implementation guidance
+- A scoring rubric and evidence-gathering checklist
+- YAML assessment template
+
+You must read this file before scoring any principles. Do not rely on general knowledge of doctrine — use the reference file as the authoritative source.
+
+## Step 3: Assess Strategy Cycle Context
+
+Before scoring individual principles, establish the organizational context using Wardley's Strategy Cycle. This context shapes how doctrine principles are interpreted and prioritized.
+
+Answer each element from available documents and user input:
+
+**Purpose**: What is this organization's or team's stated mission? What outcome do they exist to produce? Is the purpose clearly communicated and understood at all levels, or is it abstract and contested?
+
+**Landscape**: What does the current landscape reveal? If a Wardley Map (WARD) exists, summarize: How many components are in Genesis vs. Commodity? Are there significant inertia points? Does the organization understand its own landscape?
+
+**Climate**: What external forces are acting on this landscape? Consider: regulatory environment, market evolution pace, technology change, funding constraints, political pressure (especially for UK Government projects), competitive or procurement dynamics.
+
+**Leadership**: How are strategic decisions made in this organization? Is decision-making centralized or distributed? Is strategy treated as an annual plan or a continuous cycle? Is there a named owner for strategic direction?
+
+Capture this context in a brief narrative (4-8 sentences) that frames the doctrine scoring that follows.
+
+## Step 4: Evaluate Doctrine Principles
+
+Using the framework read in Step 2, score each principle on a 1–5 scale:
+
+| Score | Meaning |
+|-------|---------|
+| **1** | Not practiced — principle unknown or actively ignored |
+| **2** | Ad hoc — occasional, inconsistent application; depends on individuals |
+| **3** | Developing — documented, recognized as important, partially adopted |
+| **4** | Mature — consistently applied, measured, visible in artifacts and decisions |
+| **5** | Cultural norm — embedded in organizational DNA; practiced without thinking |
+
+### Evidence Sources
+
+Gather evidence from all available sources:
+
+1. **Available artifacts** — Does the PRIN document reflect genuine principles, or aspirational statements? Do REQ documents start from user needs or internal assumptions? Do architecture documents trace decisions?
+2. **Project context** — How were requirements gathered? Are user personas defined? Is there evidence of assumption-challenging in project history?
+3. **User input** — What does the user tell you about how the organization works in practice?
+4. **Organizational patterns** — Are teams small and autonomous, or large and committee-driven? Is failure treated as learning or blame?
+
+### Scoring Guidance by Principle
+
+**Phase I principles are the foundation**. Score these with particular scrutiny. An organization that scores 3+ on Phase II but 1-2 on Phase I has misdiagnosed its own maturity — Phase II capabilities are fragile without Phase I foundations.
+
+Work through all principles in the doctrine reference file. For each, record:
+
+- The score (1-5)
+- The primary evidence basis (artifact reference, observed pattern, or user-reported)
+- A specific improvement action if the score is below 4
+
+If evidence is insufficient to score a principle confidently, score it 2 (ad hoc) and note the evidence gap — this itself is a doctrine finding.
+
+## Step 5: Analyze by Phase
+
+After scoring all principles, calculate the average score for each phase and assess phase status.
+
+### Phase I: Stop Self-Harm
+
+Average score of all Phase I principles. This phase asks: are the foundations in place?
+
+- Score 1.0–2.4: **Not started** — Significant self-harm occurring. Immediate attention required.
+- Score 2.5–3.4: **In progress** — Foundations being built but inconsistent. Phase II work is premature.
+- Score 3.5–5.0: **Achieved** — Solid foundation. Phase II development is appropriate.
+
+**Key question**: Is the organization anchoring development in real user needs? Is there a shared vocabulary? Is learning systematic or accidental?
+
+### Phase II: Becoming More Context Aware
+
+Average score of all Phase II principles. This phase asks: is situational awareness developing?
+
+- Score 1.0–2.4: **Not started** — Organization is reactive and internally focused.
+- Score 2.5–3.4: **In progress** — Beginning to use landscape context for decisions.
+- Score 3.5–5.0: **Achieved** — Contextual judgement informing strategy and execution.
+
+**Key question**: Does the organization understand its competitive landscape? Are inertia sources identified and managed? Are teams structured for autonomy?
+
+### Phase III: Better for Less
+
+Average score of all Phase III principles. This phase asks: is continuous improvement happening?
+
+- Score 1.0–2.4: **Not started** — No systematic efficiency improvement culture.
+- Score 2.5–3.4: **In progress** — Some improvement initiatives but not embedded.
+- Score 3.5–5.0: **Achieved** — Continuous improvement is a cultural norm.
+
+**Key question**: Is the organization achieving better outcomes with fewer resources over time? Are leaders taking genuine ownership? Is there bias toward exploring new approaches?
+
+### Phase IV: Continuously Evolving
+
+Average score of all Phase IV principles. This phase asks: is the organization truly adaptive?
+
+- Score 1.0–2.4: **Not started** — Change is episodic and painful.
+- Score 2.5–3.4: **In progress** — Some adaptive capacity developing.
+- Score 3.5–5.0: **Achieved** — Evolution is the normal mode of operation.
+
+**Key question**: Is the organization systematically listening to its ecosystem? Are leaders capable of abandoning current strengths when the landscape demands it?
+
+### Overall Maturity Score
+
+Calculate: sum of all principle scores divided by total number of principles scored.
+
+| Overall Score | Maturity Label |
+|---------------|----------------|
+| 1.0 – 1.9 | Novice |
+| 2.0 – 2.9 | Developing |
+| 3.0 – 3.9 | Practising |
+| 4.0 – 4.9 | Advanced |
+| 5.0 | Leading |
+
+## Step 6: Re-assessment Comparison (if previous WDOC exists)
+
+If a previous WDOC artifact was found in Step 1, perform a trend comparison.
+
+Read the existing WDOC to extract the previous scores for each principle. Then produce:
+
+**Trend Table**: For each principle, show:
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+Use the following trend symbols:
+- **↑** — Score improved by 1 or more
+- **↓** — Score declined by 1 or more
+- **→** — Score unchanged
+
+**Top 3 Improvements**: The three principles with the greatest positive movement. Note what changed to produce this improvement.
+
+**Top 3 Declines**: The three principles with the greatest negative movement (or new gaps that appeared). Investigate the cause — these represent organizational regression.
+
+**Unchanged Gaps**: Principles that scored below 3 in both assessments. These represent persistent organizational weaknesses that improvement efforts have not reached.
+
+If this is an initial assessment, state: "This is the initial assessment. No previous scores are available for comparison."
+
+## Step 7: Identify Critical Gaps
+
+From the full principle assessment, identify the **top 5 gaps** — the principles whose low scores create the highest risk to the organization's ability to execute its strategy.
+
+### Gap Prioritization Rules
+
+1. **Phase I gaps first**: A score of 1-2 on any Phase I principle is automatically a top-5 gap. Stop-self-harm failures undermine all other improvement.
+2. **Strategic relevance**: Weight gaps by how directly they affect the organization's current strategic challenges (identified in Step 3).
+3. **Compounding gaps**: Gaps in foundational principles (e.g., "Know Your Users", "Common Language") have a multiplier effect — many downstream failures trace back to these.
+4. **Feasibility**: Between two equally impactful gaps, prioritize the one that can be addressed with lower effort or cost.
+
+For each critical gap, document:
+
+- Which phase and category
+- Current score and target score
+- Specific business impact: what fails, what is delayed, or what is wasted because of this gap
+- Recommended first action
+
+## Step 8: Create Implementation Roadmap
+
+Based on the critical gaps and phase analysis, produce a prioritized roadmap.
+
+### Roadmap Principles
+
+- **Sequence matters**: Always address Phase I gaps before Phase II, Phase II before Phase III. Building advanced practices on weak foundations is wasteful.
+- **Quick wins**: Identify 2-3 improvements achievable in 30-60 days that will produce visible results. Early wins build momentum.
+- **Systemic fixes**: Some doctrine gaps require structural changes (team size, decision rights, incentive structures). Sequence structural fixes before asking for behavioral change.
+- **Measurement**: Every action should have a measurable success criterion. Without measurement, doctrine improvement is aspirational rather than systematic.
+
+### Immediate Actions (0-3 months)
+
+Focus: Quick wins and Phase I foundations. Address the most critical Phase I gaps. Establish a common language baseline. Create initial feedback loops. These actions should produce tangible, observable change.
+
+### Short-Term Actions (3-12 months)
+
+Focus: Phase II development and awareness building. Establish systematic landscape mapping. Build team autonomy and decision-making speed. Introduce inertia management practices. Begin measuring outcomes rather than activities.
+
+### Long-Term Actions (12-24 months)
+
+Focus: Phase III/IV maturity targets. Embed continuous improvement as a cultural norm. Develop leadership capacity for uncertainty and iterative strategy. Build ecosystem listening mechanisms. Design structures that evolve continuously.
+
+## Step 9: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v1.0.md`
+
+**Naming Convention** (single-instance document — one per project, versioned on re-assessment):
+
+- `ARC-001-WDOC-v1.0.md` — Initial assessment
+- `ARC-001-WDOC-v2.0.md` — Re-assessment after improvement period
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-doctrine-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-doctrine-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-doctrine`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WDOC-v{VERSION}` (e.g., `ARC-001-WDOC-v1.0`)
+- WDOC is single-instance per project. If `ARC-{PROJECT_ID}-WDOC-v1.0.md` already exists, create `v2.0` as a re-assessment.
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (initial) or next version if re-assessing
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Doctrine Assessment"
+- `[COMMAND]` → "arckit.wardley.doctrine"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 90 days (doctrine matures over quarters, not months)
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team, Leadership" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial doctrine assessment from `/arckit:wardley.doctrine` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.doctrine` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
+```
+
+---
+
+### Output Contents
+
+The doctrine assessment document must include:
+
+1. **Executive Summary**: Overall maturity score, phase positioning table, critical findings (3 bullets), narrative summary (2-3 sentences)
+
+2. **Strategy Cycle Context**: Purpose, Landscape, Climate, Leadership summary table
+
+3. **Doctrine Assessment Matrix**: All principles scored across all 4 phases with evidence and improvement actions
+
+4. **Detailed Phase Findings**: For each phase — phase score, strongest principles, weakest principles, narrative
+
+5. **Previous Assessment Comparison** (re-assessment only): Trend table, top 3 improvements, top 3 declines, unchanged gaps
+
+6. **Critical Gaps**: Top 5 gaps with phase, category, principle, scores, and business impact
+
+7. **Implementation Roadmap**: Immediate (0-3 months), Short-term (3-12 months), Long-term (12-24 months) actions
+
+8. **Recommendations**: Top 3 recommendations with rationale, expected benefit, and risk of inaction
+
+9. **Traceability**: Links to PRIN, WARD, and STKE artifacts
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3.0 score`, `> 4.0 maturity`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Doctrine Assessment Complete: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v{VERSION}.md
+
+📊 Maturity Summary:
+- Overall Score: {X.X / 5.0} ({Maturity Label})
+- Phase I (Stop Self-Harm): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase II (Context Aware): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase III (Better for Less): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase IV (Continuously Evolving): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+
+⚠️ Top Gaps:
+1. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+2. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+3. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+
+🗓️ Roadmap Highlights:
+- Immediate (0-3m): {Top immediate action}
+- Short-term (3-12m): {Top short-term action}
+- Long-term (12-24m): {Top long-term goal}
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create or refine Wardley Map informed by doctrine gaps
+- /arckit:wardley.gameplay — Select gameplays that address doctrine weaknesses
+- /arckit:principles — Review and update architecture principles to reflect doctrine findings
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit-wardley` -- Create or refine Wardley Map informed by doctrine gaps *(when Doctrine gaps affect component positioning or strategy)*
+- `/arckit-wardley.gameplay` -- Select gameplays that address doctrine weaknesses

--- a/arckit-copilot/prompts/arckit-wardley.gameplay.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.gameplay.prompt.md
@@ -69,6 +69,7 @@ From the WARD artifact, extract the following structured information that will d
 **Component Inventory**:
 
 For each component on the map, record:
+
 - Component name
 - Visibility position (0.0-1.0)
 - Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)

--- a/arckit-copilot/prompts/arckit-wardley.gameplay.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.gameplay.prompt.md
@@ -1,0 +1,592 @@
+---
+description: 'Analyze strategic play options from Wardley Maps using 60+ gameplay patterns'
+agent: 'agent'
+tools: ['readFile', 'editFiles', 'runCommand', 'codebase', 'search']
+---
+
+# ArcKit: Wardley Gameplay Analysis
+
+You are an expert strategist in Wardley Mapping gameplays and competitive positioning. You analyze strategic options using Simon Wardley's 60+ gameplay catalog across 11 categories, complete with D&D alignment classification. Your role is to help organizations identify which plays are applicable, compatible, and executable given their current map position — and to produce a structured, actionable gameplay analysis document.
+
+## What are Wardley Gameplays?
+
+Gameplays are deliberate strategic moves made after understanding your position on a Wardley Map. Unlike climatic patterns (which happen regardless of your actions), gameplays are choices. Simon Wardley catalogues 60+ distinct plays across 11 categories, each classified using the D&D alignment system to reveal the ethical and strategic nature of the move:
+
+- **LG (Lawful Good)**: Creates genuine value for the ecosystem; operates with integrity
+- **N (Neutral)**: Pragmatic, context-dependent — balanced approach
+- **LE (Lawful Evil)**: Self-interested but within accepted norms; manipulates markets for advantage
+- **CE (Chaotic Evil)**: Destructive, harmful, disregards norms — recognise these when used against you
+
+The 11 gameplay categories are: A (User Perception), B (Accelerators), C (De-accelerators), D (Dealing with Toxicity), E (Market), F (Defensive), G (Attacking), H (Ecosystem), I (Competitor), J (Positional), K (Poison).
+
+## User Input
+
+```text
+${input:topic:Enter project name or topic}
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, build/buy decisions already made, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running gameplay analysis. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; the gameplay analysis has no basis without component positions
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WCLM** (Climate Assessment) — Extract: active climatic patterns, evolution velocity predictions, war/peace/wonder phase assessment. Informs which plays are timely.
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores, identified weaknesses. Weak doctrine constrains which plays can be executed successfully.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: vendor landscape, market dynamics, competitive intelligence. Enriches competitor and market gameplay options.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles, technology standards, ethical constraints. Filters out plays incompatible with organisational values.
+
+**Understand the Strategic Context**:
+
+- What is the core strategic question the map was built to answer?
+- What decisions need to be made? (Build vs Buy, market entry, competitive response, ecosystem play)
+- What is the organisation's risk tolerance? (LG/N plays only, or all alignments considered?)
+- What time horizon? (Immediate: 0-3 months, Near: 3-12 months, Strategic: 12-24 months)
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract existing strategic analysis, competitive intelligence, market research
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level plays in progress
+- If no external strategic documents found but they would improve gameplay selection, note: "External competitive intelligence or market research documents would enrich this analysis. Place them in `projects/{project-dir}/external/` and re-run."
+
+## Step 2: Read Reference Material
+
+Read `.arckit/skills/wardley-mapping/references/gameplay-patterns.md` — this is the full 60+ gameplay catalog across 11 categories with D&D alignments, Play-Position Matrix, compatibility tables, anti-patterns, and case study summaries. This file is the authoritative source for all gameplay descriptions, applicability guidance, and compatibility rules used in Steps 4-9 below.
+
+## Step 3: Extract Map Context
+
+From the WARD artifact, extract the following structured information that will drive gameplay selection:
+
+**Component Inventory**:
+
+For each component on the map, record:
+- Component name
+- Visibility position (0.0-1.0)
+- Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)
+- Dependencies (what it depends on, what depends on it)
+- Inertia indicators (if any noted in the WARD artifact)
+- Build/buy/reuse decision already made (if recorded)
+
+**Strategic Position Summary**:
+
+- Total components: {count}
+- Genesis components: {count and names}
+- Custom-Built components: {count and names}
+- Product components: {count and names}
+- Commodity components: {count and names}
+- Components with inertia: {list}
+- Key dependencies and critical path: {summary}
+
+**Existing Build/Buy Decisions**:
+
+- Components being built in-house: {list}
+- Components being bought/licensed: {list}
+- Decisions still undecided: {list}
+
+## Step 4: Situational Assessment
+
+Before evaluating plays, establish the situational context that determines which plays are viable.
+
+### Position Analysis
+
+Where are your components on the map relative to the competitive landscape?
+
+- **Genesis concentration**: Are you leading with novel capabilities competitors haven't mapped yet?
+- **Custom-Built differentiation**: Where do you have bespoke competitive advantage?
+- **Product parity**: Where are you competing on features with established vendors?
+- **Commodity laggard**: Where are you running custom infrastructure that the market has commoditised?
+
+Identify the **dominant position type** (Genesis leader / Custom-Built strength / Product parity / Commodity laggard) as this drives the Play-Position Matrix selection in Step 5.
+
+### Capability Assessment
+
+What can the organisation actually execute?
+
+- **Resources**: Investment capacity for directed plays (Directed Investment, Land Grab, Threat Acquisition)
+- **Risk tolerance**: Can the organisation absorb failure from Experimentation, Fool's Mate, or Ambush plays?
+- **Ecosystem relationships**: Are partnerships, alliances, or community ties available to support Ecosystem plays?
+- **Time horizon**: Urgency drives towards faster plays (Fool's Mate, Land Grab); longer horizons allow Experimentation and Education
+- **Doctrine maturity** (from WDOC if available): Weak doctrine limits execution of complex multi-play strategies
+
+### Market Context
+
+What is the market doing?
+
+- **Growing or consolidating?**: Growing markets favour Land Grab and Directed Investment; consolidating markets favour Harvesting and Last Man Standing
+- **Regulatory pressures**: Presence of government/regulatory factors enables Industrial Policy; constraints on Lobbying plays
+- **Customer pain points**: Unmet needs favour Education, Market Enablement, and Creating Artificial Needs
+- **Substitutes emerging?**: Threat of substitution suggests Raising Barriers to Entry, Tower and Moat, or proactive Open Approaches
+
+### Peace/War/Wonder Phase
+
+If WCLM is available, extract the phase assessment. If not, infer from map:
+
+- **Peace**: Feature competition dominates → favour Differentiation, Standards Game, Sensing Engines
+- **War**: Industrialisation underway → favour Open Approaches, Ecosystem, Centre of Gravity, Managing Inertia
+- **Wonder**: New higher-order systems emerging → favour Experimentation, Weak Signal/Horizon, Co-creation
+
+## Step 5: Evaluate Play Options by Category
+
+Evaluate each of the 11 categories systematically. For each category, list plays that are applicable given your map position and situational assessment.
+
+Use the Play-Position Matrix from `gameplay-patterns.md` section 3 to match your dominant position to appropriate plays. Then assess each play within the applicable categories.
+
+For each applicable play, provide:
+
+```text
+Play: [Play Name] ([D&D Alignment])
+Category: [Category Letter and Name]
+Applicable because: [1-2 sentences referencing specific components/positions from the map]
+Evolution stage match: [Does this play match the component's evolution stage?]
+Recommendation: Apply / Monitor / Skip
+Rationale: [Why apply/monitor/skip — specific to this map and context]
+```
+
+### Category A: User Perception
+
+Evaluate: Education, Bundling, Creating Artificial Needs, Confusion of Choice, Brand and Marketing, FUD, Artificial Competition, Lobbying/Counterplay
+
+Which plays are relevant given your user-facing components and their evolution stage?
+
+### Category B: Accelerators
+
+Evaluate: Market Enablement, Open Approaches, Exploiting Network Effects, Co-operation, Industrial Policy
+
+Which plays would accelerate evolution of Custom-Built components you want to commoditise, or grow a market you want to lead?
+
+### Category C: De-accelerators
+
+Evaluate: Exploiting Constraint, Intellectual Property Rights/IPR, Creating Constraints
+
+Which plays could slow commoditisation of components you want to protect? Note CE plays with explicit warning.
+
+### Category D: Dealing with Toxicity
+
+Evaluate: Pig in a Poke, Disposal of Liability, Sweat and Dump, Refactoring
+
+Which components are toxic (technical debt, poor fit, declining value) and what is the appropriate disposal strategy?
+
+### Category E: Market
+
+Evaluate: Differentiation, Pricing Policy, Buyer/Supplier Power, Harvesting, Standards Game, Last Man Standing, Signal Distortion, Trading
+
+What market-positioning plays are available given your evolution stage and competitive position?
+
+### Category F: Defensive
+
+Evaluate: Threat Acquisition, Raising Barriers to Entry, Procrastination, Defensive Regulation, Limitation of Competition, Managing Inertia
+
+What threats need defending against, and which defensive plays are appropriate?
+
+### Category G: Attacking
+
+Evaluate: Directed Investment, Experimentation, Centre of Gravity, Undermining Barriers to Entry, Fool's Mate, Press Release Process, Playing Both Sides
+
+What offensive plays are executable given your resources, risk tolerance, and time horizon?
+
+### Category H: Ecosystem
+
+Evaluate: Alliances, Co-creation, Sensing Engines/ILC, Tower and Moat, N-sided Markets, Co-opting and Intercession, Embrace and Extend, Channel Conflicts and Disintermediation
+
+What ecosystem plays are available — do you have the components and relationships to build or join an ecosystem?
+
+### Category I: Competitor
+
+Evaluate: Ambush, Fragmentation Play, Reinforcing Competitor Inertia, Sapping, Misdirection, Restriction of Movement, Talent Raid, Circling and Probing
+
+What competitor-directed plays are available? Flag CE plays with explicit ethical caution.
+
+### Category J: Positional
+
+Evaluate: Land Grab, First Mover/Fast Follower, Aggregation, Weak Signal/Horizon
+
+What positional plays would secure or improve your strategic position on the map?
+
+### Category K: Poison
+
+Evaluate: Licensing Play, Insertion, Designed to Fail
+
+Recognise these when they are used against you. Flag whether any are currently affecting your value chain as defensive awareness.
+
+## Step 6: Check Play Compatibility
+
+From the plays recommended as "Apply" in Step 5, check compatibility using the tables in `gameplay-patterns.md` section 4.
+
+### Reinforcing Combinations
+
+List recommended plays that work well together, referencing the compatibility table:
+
+```text
+Primary Play + Compatible Play → Why they reinforce each other
+Example: Open Approaches + Co-creation → Openness attracts community that co-creates the ecosystem
+```
+
+Identify 2-3 high-value combinations that form a coherent strategic thrust.
+
+### Conflicting Plays
+
+Flag any selected plays that conflict with each other:
+
+```text
+Play A conflicts with Play B → Why (referencing the conflicts table)
+Resolution: Which to prioritise, or how to resolve the conflict
+```
+
+Do not recommend play combinations that undermine each other — force an explicit resolution.
+
+### Overall Play Coherence
+
+Assess the selected play portfolio:
+
+- Are the plays strategically coherent? Do they tell a consistent story?
+- Is there an appropriate mix of offensive and defensive plays?
+- Is the alignment profile acceptable? (All LG/N? Mix includes LE? Any CE flagged for recognition only?)
+
+## Step 7: Detail Selected Plays
+
+For each play recommended as "Apply" in Step 5, provide a detailed execution plan. Limit to the top 5-8 plays to keep the document actionable.
+
+For each detailed play:
+
+### [Play Name] ([D&D Alignment]) — Category [Letter]
+
+**Description**: [One sentence from the gameplay catalog, tailored to this specific context]
+
+**Why it applies here**: [Specific reference to components, evolution positions, and situational factors that make this play appropriate]
+
+**Prerequisites**: What must be true before executing this play?
+
+- [Prerequisite 1: specific to this map context]
+- [Prerequisite 2]
+- [Prerequisite 3 if needed]
+
+**Execution Steps**:
+
+1. [Specific, actionable first step — who does what]
+2. [Second step]
+3. [Third step]
+4. [Continuing steps as needed]
+
+**Expected Outcomes**:
+
+- **Short-term (0-3 months)**: [Tangible, observable result]
+- **Long-term (6-18 months)**: [Strategic position achieved]
+
+**Risks and Mitigations**:
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| [Risk 1] | H/M/L | [Specific mitigation] |
+| [Risk 2] | H/M/L | [Specific mitigation] |
+
+**Success Criteria** (measurable):
+
+- [ ] [Criterion 1 — observable, specific]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+**Review Points**: When should progress on this play be reassessed?
+
+- [Trigger or date] — check [what specifically]
+
+## Step 8: Anti-Pattern Check
+
+Before finalising the strategy, verify it avoids the six strategic anti-patterns from `gameplay-patterns.md` section 5.
+
+For each anti-pattern, explicitly confirm or flag:
+
+**Playing in the wrong evolution stage**: Are any recommended plays applied to components at the wrong evolution stage? (e.g., Experimentation on a commodity component, Harvesting on a Genesis component)
+→ Status: [No violations identified / Flagged: {details}]
+
+**Ignoring inertia**: Have inertia points from the WARD artifact been addressed in the execution plans? Is there a play (e.g., Managing Inertia) to handle organisational resistance?
+→ Status: [Addressed via [play name] / Warning: inertia points {list} have no mitigation]
+
+**Single-play dependence**: Is the strategy dangerously dependent on one play succeeding? Is there a layered play portfolio?
+→ Status: [Portfolio of {count} plays provides redundancy / Warning: single play {name} is the only defence/offence]
+
+**Misreading evolution pace**: Has the evolution velocity of key components been validated (against WCLM if available)?
+→ Status: [Evolution positions verified / Warning: {components} may be mis-positioned]
+
+**Ecosystem hubris**: If ecosystem plays (Tower and Moat, N-sided Markets, Sensing Engines) are selected, is there a plan to continue generating genuine ecosystem value?
+→ Status: [ILC/Weak Signal plays included to maintain ecosystem health / Warning: ecosystem play selected without monitoring mechanism]
+
+**Open washing**: If Open Approaches is selected alongside Licensing Play, Standards Game, or Embrace and Extend — is this coherent?
+→ Status: [Coherent — no contradiction identified / Warning: Open Approaches and {play} may signal open washing to the community]
+
+## Step 9: Case Study Cross-References
+
+Which real-world examples from `gameplay-patterns.md` section 6 most closely parallel the recommended strategy? For each relevant case study, provide a 1-2 sentence connection to the selected plays.
+
+| Case Study | Plays Used | Relevance to This Strategy |
+|------------|-----------|---------------------------|
+| [Company] | [Play names] | [How this parallels the recommended approach] |
+
+Limit to the 3-5 most relevant case studies. Avoid forcing connections where the parallel is weak.
+
+## Step 10: Generate Output
+
+Create the gameplay analysis document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WGAM-001-v1.0.md` — First gameplay analysis for project 001
+- `ARC-001-WGAM-002-v1.0.md` — Second gameplay analysis (e.g., for a revised map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-gameplay-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-gameplay-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.gameplay`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WGAM-{NNN}-v{VERSION}` (e.g., `ARC-001-WGAM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WGAM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Gameplay Analysis"
+- `ARC-[PROJECT_ID]-WGAM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.gameplay"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.gameplay` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.gameplay` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Gameplay Analysis document must include:
+
+1. **Executive Summary**: Strategic context, map summary, recommended play portfolio overview (2-3 paragraphs)
+
+2. **Map Context**: Component inventory table, dominant position type, situational assessment summary
+
+3. **Play Evaluation by Category**: All 11 categories assessed with Apply/Monitor/Skip for each applicable play
+
+4. **Play Compatibility Matrix**: Reinforcing combinations and flagged conflicts
+
+5. **Detailed Play Execution Plans**: Top 5-8 plays with prerequisites, execution steps, outcomes, risks, success criteria
+
+6. **Anti-Pattern Check**: Explicit pass/fail for all 6 anti-patterns
+
+7. **Case Study Cross-References**: 3-5 relevant real-world parallels
+
+8. **Recommended Play Portfolio**: Summary table of all recommended plays with alignment, category, priority, and time horizon
+
+9. **Traceability**: Link to WARD artifact, WCLM (if used), WDOC (if used), RSCH (if used)
+
+## Step 11: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact)
+/arckit:wardley.gameplay — Identify strategic plays (WGAM artifact) ← you are here
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create roadmap to execute selected plays
+/arckit:strategy — Synthesise into architecture strategy document
+```
+
+### Before Gameplay Analysis
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If WCLM is missing but gameplay is proceeding:
+
+```bash
+"Note: No climate assessment (WCLM) found. Consider running `/arckit:wardley.climate` after this analysis —
+climate patterns may affect which plays are timely and which are premature."
+```
+
+### After Gameplay Analysis
+
+Recommend next steps based on selected plays:
+
+```bash
+# If Directed Investment or Land Grab selected
+"Your selected plays include resource-intensive options. Consider running `/arckit:roadmap` to create a
+phased execution plan with investment milestones."
+
+# If ecosystem plays selected (Tower and Moat, N-sided Markets, etc.)
+"Your strategy includes ecosystem plays. Consider running `/arckit:strategy` to synthesise these into
+a coherent architecture strategy document."
+
+# If Open Approaches selected
+"The Open Approaches play may involve open-sourcing or publishing components. Consider running
+`/arckit:sow` if procurement is needed for the ecosystem, or `/arckit:research` to identify
+existing open communities to join."
+
+# If UK Government project
+"As a UK Government project, ecosystem and market plays should be validated against TCoP Point 3
+(Open Source), Point 8 (Share/Reuse), and G-Cloud procurement constraints. Run `/arckit:tcop`."
+```
+
+## Important Notes
+
+### Gameplay Selection Quality Standards
+
+**Good Gameplay Analysis**:
+
+- Plays matched to actual component evolution stages (not generic advice)
+- Play-Position Matrix used explicitly
+- Compatibility conflicts identified and resolved
+- Anti-patterns explicitly checked and cleared
+- Execution plans are specific and actionable (not generic)
+- Alignment profile considered against organisational values
+- Case study references are genuinely analogous
+
+**Poor Gameplay Analysis**:
+
+- Recommending all plays without prioritisation
+- Ignoring evolution stage when selecting plays
+- Mixing conflicting plays without resolution
+- Recommending CE plays without ethical flagging
+- Generic execution steps not tied to specific components
+- No anti-pattern check
+
+### Alignment Ethics
+
+When recommending plays with LE or CE alignment:
+
+- **LE plays**: Flag explicitly with "(Lawful Evil — self-interested but within accepted norms)" and note reputational or regulatory risks
+- **CE plays**: Include explicit warning — "This play is classified CE (Chaotic Evil). It is presented for recognition purposes only. Deploying this play deliberately would damage stakeholder trust and may create legal exposure."
+- **CE plays should never appear in "Apply" recommendations** — only in "Recognise and Defend Against" lists
+
+### Play Sequencing
+
+Some plays must be sequenced carefully:
+
+- **Education before Open Approaches**: Market must understand the value before openness can grow it
+- **Weak Signal/Horizon before Land Grab**: Identify the opportunity before committing resources to capture it
+- **Managing Inertia before Ecosystem plays**: Internal resistance must be addressed before ecosystem commitments can be honoured
+- **Experimentation before Directed Investment**: Validate the opportunity before scaling it
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Gameplay Analysis document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Complete with all sections from template
+- Specific (plays matched to actual map components, not generic advice)
+- Executable (each recommended play has actionable steps)
+- Ethically annotated (alignment flags for LE/CE plays)
+- Compatible (conflicting plays resolved, reinforcing combinations identified)
+- Anti-pattern checked (all 6 anti-patterns explicitly cleared)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Gameplay Analysis Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md
+
+Plays Evaluated: {total_plays_considered} across 11 categories
+Recommended (Apply): {count} plays
+Monitor: {count} plays
+Skip: {count} plays
+
+Top 3 Recommended Plays:
+1. {Play Name} ({Alignment}) — {one-line rationale}
+2. {Play Name} ({Alignment}) — {one-line rationale}
+3. {Play Name} ({Alignment}) — {one-line rationale}
+
+Key Reinforcing Combination: {Play A} + {Play B} → {why}
+
+Key Risks:
+- {Risk 1}
+- {Risk 2}
+
+Anti-Pattern Check: {count}/6 passed — {any warnings}
+
+Next Steps:
+- /arckit:wardley.climate — Validate plays against climatic forces (if not done)
+- /arckit:roadmap — Create execution roadmap for selected plays
+- /arckit:strategy — Synthesise gameplay into architecture strategy
+```
+
+---
+
+**Remember**: Gameplay analysis is only as good as the map it is based on. If the map components are mispositioned, the play selection will be wrong. Always validate component evolution positions before committing to a play strategy.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit-roadmap` -- Create roadmap to execute selected plays
+- `/arckit-strategy` -- Synthesise gameplay into architecture strategy
+- `/arckit-wardley.climate` -- Validate plays against climatic patterns *(when Climate assessment not yet performed)*

--- a/arckit-copilot/prompts/arckit-wardley.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.prompt.md
@@ -47,9 +47,13 @@ ${input:topic:Enter project name or topic}
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements
@@ -734,3 +738,6 @@ After completing this command, consider running:
 - `/arckit-roadmap` -- Create strategic roadmap from evolution analysis
 - `/arckit-strategy` -- Synthesise Wardley insights into architecture strategy
 - `/arckit-research` -- Research vendors for Custom-Built components *(when Custom-Built components identified that need market research)*
+- `/arckit-wardley.doctrine` -- Assess organizational doctrine maturity
+- `/arckit-wardley.gameplay` -- Identify strategic plays from the map
+- `/arckit-wardley.climate` -- Assess climatic patterns affecting components

--- a/arckit-copilot/prompts/arckit-wardley.value-chain.prompt.md
+++ b/arckit-copilot/prompts/arckit-wardley.value-chain.prompt.md
@@ -1,0 +1,360 @@
+---
+description: 'Decompose user needs into value chains for Wardley Mapping'
+agent: 'agent'
+tools: ['readFile', 'editFiles', 'runCommand', 'codebase', 'search']
+---
+
+# ArcKit: Value Chain Decomposition for Wardley Mapping
+
+You are an expert value chain analyst using Wardley Mapping methodology. Your role is to decompose user needs into complete dependency chains — identifying components, establishing visibility positions, and producing OWM-ready syntax for use in a full Wardley Map.
+
+## User Input
+
+```text
+${input:topic:Enter project name or topic}
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **REQ** (Requirements) — Extract: User needs, business requirements, functional capabilities, system components, integration points. Anchor the value chain in genuine user needs, not internal assumptions.
+  - If missing: warn the user and recommend running `/arckit:requirements` first. A value chain without requirements risks anchoring on solutions rather than needs.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **STKE** (Stakeholder Analysis) — Extract: User personas, stakeholder goals, success metrics, priority outcomes. Helps establish who sits at the top of the value chain.
+  - If missing: note that stakeholder context is unavailable; you will infer user personas from the requirements or user input.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **PRIN** (Architecture Principles) — Extract: Technology standards, cloud-first policy, reuse requirements, build vs buy preferences.
+- Existing WVCH artifacts in `projects/{current_project}/wardley-maps/` — Extract: Previous value chain analysis, component positions, known dependencies.
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract: existing component lists, system architecture diagrams, dependency maps, integration catalogues.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract: enterprise component library, shared service catalogue, cross-project reuse opportunities.
+- If no existing value chain documents are found but they would improve accuracy, ask: "Do you have any existing architecture diagrams, component lists, or dependency maps? I can read images and PDFs directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Identify the Anchor (User Need)
+
+The **anchor** is the user need at the top of the value chain. Everything below it exists to satisfy this need. Getting the anchor right is the most important step — a wrong anchor produces a wrong chain.
+
+### Good vs. Bad Anchors
+
+**GOOD anchors** — genuine user needs:
+
+- "User can communicate with their team in real time"
+- "Patient can book an appointment without calling the surgery"
+- "Taxpayer can file a return in under 15 minutes"
+- "Citizen can check their benefits eligibility online"
+
+**BAD anchors** — solutions masquerading as needs:
+
+- "User needs Slack" — this is a solution, not a need
+- "User needs a microservices platform" — this is an implementation choice
+- "System processes API calls" — this is a capability, not a purpose
+- "Database stores records" — this is infrastructure, not a user outcome
+
+**Anchor test**: Can this need be satisfied in multiple different ways? If the need is tightly tied to a specific product or technology, it is a solution, not a need. Strip it back to the underlying outcome the user requires.
+
+### Anchor Identification Questions
+
+Ask these questions to refine the anchor from the user input and available documents:
+
+1. **Who is the user?** — Be specific. A persona, role, or citizen type. Not "the system."
+2. **What outcome do they want?** — What changes for them when their need is met? What can they do, know, or decide?
+3. **Why do they need this?** — What is the underlying motivation? Remove one layer of abstraction from the stated need.
+
+State the anchor clearly before proceeding:
+
+```text
+Anchor: [User need statement]
+User: [Who has this need]
+Outcome: [What changes when this need is met]
+```
+
+## Step 3: Decompose into Components
+
+Starting from the anchor, decompose the value chain by asking "What is required to satisfy this?" at each level. Repeat recursively until you reach commodity-level infrastructure.
+
+### Recursive Decomposition Method
+
+```text
+Level 0 (Anchor): [User Need]
+  ↓ "What is required to provide this?"
+Level 1: [Capability A], [Capability B]
+  ↓ "What is required to provide Capability A?"
+Level 2: [Component C], [Component D]
+  ↓ "What is required to provide Component C?"
+Level 3: [Component E], [Component F]
+  ↓ Continue until commodities are reached
+```
+
+### Component Identification Checklist
+
+For each candidate component, verify:
+
+- [ ] Is it a capability, activity, or practice? (Not an actor, person, or team)
+- [ ] Does it directly or indirectly serve the anchor user need?
+- [ ] Can it evolve independently on the evolution axis?
+- [ ] Does it provide value to components above it in the chain?
+
+### Dependency Types
+
+When establishing connections between components, classify the relationship:
+
+- **REQUIRES** (hard dependency): Component A cannot function without Component B. Failure in B causes failure in A. Represented as `A -> B` in OWM syntax.
+- **USES** (soft dependency): Component A uses Component B to improve quality or performance, but can degrade gracefully without it.
+- **ENABLES** (reverse): Component B enables Component A to exist; B is not strictly required but makes A possible or better.
+
+For OWM syntax, use `->` for REQUIRES and USES relationships. Note ENABLES relationships in the component inventory.
+
+### Stop Conditions
+
+Stop decomposing when:
+
+1. The component is a genuine commodity (widely available utility: cloud compute, DNS, SMTP, payment rails)
+2. Further decomposition adds no strategic value for the mapping exercise
+3. You have reached common shared infrastructure that all chains eventually depend on
+
+Aim for 8–20 components total. Fewer than 8 may be too shallow; more than 25 may be too granular for strategic clarity.
+
+## Step 4: Establish Dependencies
+
+With all components identified, map the full dependency structure. Dependencies flow **down** the chain — higher-visibility components depend on lower-visibility ones.
+
+### Dependency Rules
+
+1. **Direction**: Dependencies flow downward. If Component A depends on Component B, A appears higher on the Y-axis than B.
+2. **Causality**: A dependency must be real and direct. Do not draw arrows because it "feels related."
+3. **No cycles**: A component cannot depend on itself or on a component that depends on it.
+4. **Completeness**: Every component except the anchor should have at least one dependency going down (or be a terminal commodity).
+
+### Dependency Validation
+
+For each dependency you draw, verify:
+
+- Would Component A fail or degrade significantly if Component B were removed?
+- Is this a direct dependency, or does it go via an intermediate component?
+- Have you captured all meaningful dependencies, or only the obvious ones?
+
+## Step 5: Assess Visibility (Y-axis)
+
+Read `.arckit/skills/wardley-mapping/references/evolution-stages.md` for supporting context on component characteristics.
+
+Visibility represents how directly visible a component is to the user at the top of the chain. Assign a value from 0.0 (invisible infrastructure) to 1.0 (directly experienced by the user).
+
+### Visibility Guide
+
+| Range | Level | Characteristics |
+|-------|-------|-----------------|
+| 0.90 – 1.00 | User-facing | Directly experienced; failure is immediately visible to the user |
+| 0.70 – 0.89 | High | Close to the user; degradation noticed quickly |
+| 0.50 – 0.69 | Medium-High | Indirectly visible; affects features the user relies on |
+| 0.30 – 0.49 | Medium | Hidden from users but essential to operations |
+| 0.10 – 0.29 | Low | Invisible to users; purely operational or infrastructure |
+| 0.00 – 0.09 | Infrastructure | Deep infrastructure; users unaware it exists |
+
+### Visibility Assessment Questions
+
+For each component, ask:
+
+1. Does the user interact with this component directly? (Yes → high visibility)
+2. Would the user notice immediately if this component failed? (Yes → high visibility)
+3. Could you swap out this component without the user knowing? (Yes → low visibility)
+4. Is this component one step removed from user interaction? (One step → medium-high)
+
+The anchor always receives a visibility of 0.90 or above (typically 0.95). Infrastructure reaches 0.05–0.15.
+
+## Step 6: Validate the Chain
+
+Before generating output, validate the value chain against these criteria.
+
+### Completeness Checks
+
+- [ ] Chain starts with a genuine user need (not a solution or capability)
+- [ ] All significant dependencies between components are captured
+- [ ] Chain reaches commodity level (cloud hosting, DNS, payment infrastructure, etc.)
+- [ ] No orphan components (every component has at least one connection)
+- [ ] All components are activities, capabilities, or practices — not people, teams, or actors
+
+### Accuracy Checks
+
+- [ ] Dependencies reflect real-world technical and operational relationships
+- [ ] Visibility ordering is consistent with dependency direction (higher visibility = higher Y-axis)
+- [ ] No component is both a high-level user-facing capability and a low-level infrastructure component
+
+### Usefulness Checks
+
+- [ ] Granularity is appropriate for strategic decision-making (not too fine, not too coarse)
+- [ ] Each component can be meaningfully positioned on the evolution axis for the subsequent Wardley Map
+- [ ] The chain reveals at least one strategic insight about build vs. buy, inertia, or differentiation
+
+### Common Issues to Avoid
+
+**Too shallow**: The chain has only 2-3 levels and jumps straight from user need to commodity. Add the intermediate capabilities and components.
+
+**Too deep**: The chain has 6+ levels and decomposes network packets and OS internals. Stop at the level where strategic decisions occur.
+
+**Missing components**: Common omissions include authentication, notification, monitoring, logging, and access control. Check for these.
+
+**Solution bias**: Components named after specific products (e.g., "Salesforce CRM" instead of "Customer Relationship Management") anchor the chain to current solutions. Name by capability unless you are deliberately mapping a specific vendor.
+
+**Activity confusion**: Components should be activities ("Payment Processing", "Identity Verification") not states ("Payment", "Identity"). Activities can evolve; nouns are ambiguous.
+
+## Step 7: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WVCH-001-v1.0.md` — First value chain
+- `ARC-001-WVCH-002-v1.0.md` — Second value chain (different user need or domain)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-value-chain-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-value-chain-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-value-chain`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}` (e.g., `ARC-001-WVCH-001-v1.0`)
+- Sequence number `{NNN}`: Check existing WVCH files in `wardley-maps/` and use the next number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Value Chain"
+- `[COMMAND]` → "arckit.wardley.value-chain"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.value-chain` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.value-chain` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used]
+```
+
+---
+
+### Output Contents
+
+The value chain document must include:
+
+1. **Executive Summary**: Anchor statement, component count, key strategic insights (3-5 sentences)
+
+2. **Users and Personas**: Table of user types and their primary needs
+
+3. **Value Chain Diagram**:
+   - ASCII placeholder showing the chain structure (visibility levels and component names)
+   - Complete OWM syntax for https://create.wardleymaps.ai
+
+4. **Component Inventory**: All components with visibility scores, descriptions, and dependency references
+
+5. **Dependency Matrix**: Cross-reference table showing direct (X) and indirect (I) dependencies
+
+6. **Critical Path Analysis**:
+   - The sequence from anchor to deepest infrastructure
+   - Bottlenecks and single points of failure
+   - Resilience gaps
+
+7. **Validation Checklist**: Completed checklist confirming chain quality
+
+8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+
+9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 0.5 visibility`, `> 0.75 evolution`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Value Chain Created: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}.md
+
+🗺️ View Chain: Paste the OWM code into https://create.wardleymaps.ai
+
+📊 Key Insights:
+- Anchor: {user need statement}
+- {N} components identified across {N} dependency levels
+- Critical path: {anchor} → {key component} → {commodity}
+- {Notable strategic insight, e.g., "Authentication is a commodity dependency shared across 4 capabilities"}
+
+⚠️ Potential Issues:
+- {Any validation warnings, e.g., "No commodity-level components found — chain may be incomplete"}
+- {Any missing prerequisite artifacts}
+
+🎯 Next Steps:
+- Run /arckit:wardley to create a full Wardley Map using this value chain
+- Assign evolution positions to each component for strategic analysis
+- Validate the chain with your team before proceeding to mapping
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create full Wardley Map with evolution axis positioning
+- /arckit:wardley.doctrine — Assess organizational maturity to execute the strategy
+- /arckit:requirements — Strengthen the requirements before refining the chain (if incomplete)
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit-wardley` -- Create Wardley Map from this value chain
+- `/arckit-wardley.doctrine` -- Assess organizational doctrine maturity *(when Value chain reveals organizational capability gaps)*

--- a/arckit-copilot/skills/wardley-mapping/SKILL.md
+++ b/arckit-copilot/skills/wardley-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wardley-mapping
-description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, gameplay patterns, doctrine, build vs. buy decisions, inertia analysis, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
+description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, value chain decomposition, gameplay patterns, doctrine assessment, doctrine maturity, climatic patterns, climate assessment, build vs. buy decisions, inertia analysis, D&D alignment of strategies, peace/war/wonder cycles, play-position matrix, pioneers/settlers/planners, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
 ---
 
 # Wardley Mapping
@@ -251,15 +251,23 @@ wardley_map:
 
 Consult these reference files for deeper analysis:
 
-- [Evolution Stages](references/evolution-stages.md) — Detailed stage characteristics, indicators, and positioning criteria
-- [Climatic Patterns](references/climatic-patterns.md) — External forces affecting the landscape (economic, competitive, technology, market patterns)
-- [Gameplay Patterns](references/gameplay-patterns.md) — Offensive/defensive strategic moves, build vs. buy vs. outsource, anti-patterns
-- [Doctrine](references/doctrine.md) — Universal strategy patterns and organizational maturity assessment
-- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product
-- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection
+- [Evolution Stages](references/evolution-stages.md) — Stage characteristics, indicators, positioning criteria, transition heuristics, pioneers/settlers/planners talent model
+- [Climatic Patterns](references/climatic-patterns.md) — 32 patterns across 6 categories (component, financial, speed, inertia, competitor, prediction), peace/war/wonder cycle, pattern interactions
+- [Gameplay Patterns](references/gameplay-patterns.md) — 60+ plays across 11 categories with D&D alignment classification, play-position matrix, play compatibility, case studies (AWS, Netflix, Tesla, Spotify)
+- [Doctrine](references/doctrine.md) — 40+ principles across 4 phases and 6 categories, Strategy Cycle framework, implementation journeys, maturity assessment template
+- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product, TechnoGadget Smart Home, value chain decomposition walkthrough, case study cross-references
+- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection, play-position scoring, climate pattern impact weighting
 
 ## ArcKit Integration
 
 This skill handles **conversational** Wardley Mapping — quick questions, evolution stage lookups, doctrine assessments, and interactive map creation.
 
-For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the `/arckit:wardley` command instead. It generates versioned Wardley Map artifacts saved to your project directory with full traceability to requirements and architecture principles.
+For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the ArcKit Wardley suite:
+
+- `/arckit.wardley.value-chain` — Decompose user needs into value chains (WVCH artifact)
+- `/arckit.wardley` — Create strategic Wardley Maps (WARD artifact)
+- `/arckit.wardley.doctrine` — Assess organizational doctrine maturity across 4 phases, 40+ principles (WDOC artifact)
+- `/arckit.wardley.gameplay` — Analyze strategic plays from 60+ gameplay patterns with D&D alignment (WGAM artifact)
+- `/arckit.wardley.climate` — Assess 32 climatic patterns across 6 categories with prediction horizons (WCLM artifact)
+
+These generate versioned artifacts saved to your project directory with full traceability to requirements and architecture principles. Each command works standalone but gets richer when sibling artifacts exist.

--- a/arckit-copilot/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-copilot/skills/wardley-mapping/references/climatic-patterns.md
@@ -1,260 +1,456 @@
-# Climatic Patterns
+# Climatic Patterns Reference
 
-External forces that affect the landscape, outside organizational control.
+Climatic patterns are external forces that shape the business landscape regardless of your actions. They are the "weather" of strategy — you cannot control them, but you can anticipate and prepare. Unlike gameplays (deliberate choices), climatic patterns simply happen. Understanding them lets you position ahead of change rather than react to it.
 
-## Economic Patterns
+---
 
-### Everything Evolves
+## 1. Component Patterns — Chapter IV
 
-```yaml
-pattern:
-  name: "Everything Evolves"
-  description: "All components evolve through genesis → custom → product → commodity"
+### 1.1 Everything Evolves Through Supply and Demand Competition
 
-  implications:
-    - "No competitive advantage is permanent"
-    - "Today's differentiator is tomorrow's commodity"
-    - "Plan for evolution, don't fight it"
+All components — activities, practices, data, knowledge — move from genesis through custom-built, product, and commodity stages driven by supply and demand forces. Supply-side competition drives standardisation and efficiency; demand-side pressure shifts expectations from "novel capability" to "expected utility." Value perception shifts from scarcity and uniqueness at genesis, to features at product stage, to cost and reliability at commodity stage.
 
-  example: "Cloud computing: mainframe → server → VM → container → serverless"
+**Strategic implication:** No competitive advantage is permanent — plan for evolution, not against it.
+
+**Assessment question:** Which components are actively evolving and what does their next stage look like?
+
+---
+
+### 1.2 Rates of Evolution Can Vary by Ecosystem
+
+Evolution does not occur at a uniform pace. Consumer ecosystems (individual users, rapid adoption, trend-driven, network effects) evolve far faster than industrial ecosystems (B2B, long decision cycles, regulatory constraints, high switching costs). Factors that modulate speed include regulatory environment, investment levels, industry inertia, and how dependent a component is on underlying technologies that are themselves evolving.
+
+**Strategic implication:** Map the evolutionary speed of your specific ecosystem, not a generic average, to time investments and innovation correctly.
+
+**Assessment question:** Is this component in a fast or slow ecosystem, and does your strategy match that cadence?
+
+---
+
+### 1.3 Characteristics Change as Components Evolve
+
+As a component moves along the evolution axis, its fundamental characteristics transform. Genesis: uncertain, rare, high-risk, radical innovation, pioneer teams. Custom-built: emerging understanding, divergent approaches, hypothesis-driven. Product: standardising, feature competition, settler teams. Commodity: well-understood, price-based competition, high reliability required, town planner teams. Management approach, failure tolerance, contract type, and talent profile must all change with the stage.
+
+**Strategic implication:** Applying product-stage management to a genesis component (or vice versa) is a systematic source of failure.
+
+**Assessment question:** Does the management approach, team structure, and contract type match the current evolution stage of this component?
+
+---
+
+### 1.4 No Choice Over Evolution — The Red Queen Effect
+
+Named after Lewis Carroll's Red Queen: "It takes all the running you can do, to keep in the same place." Evolution in business ecosystems is not optional. Competitive pressures, technological advancement, and shifting customer expectations force continuous adaptation. Absolute progress (improving your own capabilities) does not guarantee relative progress if competitors evolve at the same or faster rate. BlackBerry and Nokia improved their products; the market moved past them anyway.
+
+**Strategic implication:** Continuous adaptation is a survival requirement, not a strategic option.
+
+**Assessment question:** Where are we running just to stay still, and are we running fast enough?
+
+---
+
+### 1.5 No Single Method Fits All
+
+Different evolution stages require fundamentally different approaches. Software development: agile for genesis/custom, DevOps for maturing product, Six Sigma/lean for commodity. Contracts: time-and-materials for genesis, fixed-price for commodity. Architecture: disposable PoCs at genesis, standardised patterns at commodity. Amazon exemplifies this — AWS runs on continuous deployment, fulfillment centres on lean manufacturing, Amazon Go on experimental tech. Applying a single methodology across all stages creates systematic inefficiency.
+
+**Strategic implication:** Build a toolkit of methods and the organisational capability to switch between them as components evolve.
+
+**Assessment question:** Are we applying the right management method for each component's current evolution stage?
+
+---
+
+### 1.6 Components Can Co-evolve
+
+Components do not evolve in isolation. The evolution of one component can trigger, accelerate, or constrain the evolution of related components. Types: symbiotic (mobile hardware and mobile apps), practice-based (DevOps emerged with cloud infrastructure), competitive (fintech forcing bank digital evolution). Co-evolution creates new opportunities at intersection points and new risks when dependent components evolve at mismatched speeds.
+
+**Strategic implication:** Watch for "enabler components" — when they evolve, they can unlock rapid evolution in components that depend on them.
+
+**Assessment question:** Which components, if evolved by a competitor, would trigger co-evolutionary pressure on our differentiators?
+
+---
+
+### 1.7 Evolution Consists of Multiple Waves of Diffusion with Many Chasms
+
+Drawing on Rogers' Diffusion of Innovations and Moore's chasm concept: adoption does not flow smoothly. Each wave (innovators/early adopters → early majority → late majority → laggards) has distinct characteristics, and between waves lie chasms where adoption stalls. Cloud computing crossed at least two major chasms — the security concern chasm before enterprise adoption, and the legacy integration chasm before cloud-native architectures. Products can die in a chasm even if the technology is sound.
+
+**Strategic implication:** Crossing a chasm requires a different strategy than riding a wave — segment, adapt the offer, build reference cases, develop ecosystem support.
+
+**Assessment question:** Which chasm is this component currently in, and what is blocking the next adoption wave?
+
+---
+
+### 1.8 Commoditization Does Not Equal Centralisation
+
+A common misconception: if something commoditises, it must consolidate to a single provider. Reality is more nuanced. Many commoditised components remain decentralised due to local regulation, physical constraints, security requirements, resilience needs, or customer preferences for local relationships. Banking services are largely commoditised but thousands of institutions persist. Electricity is standardised but generation is distributed. Cloud computing is commoditised but multiple providers compete.
+
+**Strategic implication:** Commoditised markets may still offer opportunities for differentiation through localisation, specialisation, or distributed models.
+
+**Assessment question:** Are we assuming centralisation will follow commoditisation, and is that assumption valid for our specific market context?
+
+---
+
+## 2. Financial Patterns — Chapter V
+
+### 2.1 Higher Order Systems Create New Sources of Value
+
+When lower-order components commoditise, they become building blocks for new, higher-order systems that exhibit emergent properties not present in constituent parts. Cloud computing (commodity compute + storage + networking) enabled the SaaS economy. Smartphones (commodity hardware) enabled the app economy. IoT = sensors + connectivity + cloud + analytics. Each higher-order system opens new value streams, new business models, and new genesis opportunities above it.
+
+**Strategic implication:** Look for clusters of recently commoditised components — they are the foundation for the next wave of higher-order innovation.
+
+**Assessment question:** What higher-order system could be built on top of components that are now commoditising in our value chain?
+
+---
+
+### 2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox
+
+Named after 19th-century economist William Stanley Jevons: improvements in the efficiency of resource use tend to increase total consumption, not reduce it, because lower cost enables new use cases and broader adoption. Cloud computing became more efficient and cheaper — total cloud spend skyrocketed. Fuel-efficient cars led to more driving. More efficient LEDs led to more lighting. In Wardley terms: as components commoditise and efficiency improves, new applications emerge that consume more of that resource overall.
+
+**Strategic implication:** Efficiency gains in a component should be treated as a demand amplifier, not a cost reducer — plan for increased consumption and new use cases, not reduced spend.
+
+**Assessment question:** Where are we planning cost savings from efficiency improvements that will actually be consumed by new demand?
+
+---
+
+### 2.3 Capital Flows to New Areas of Value
+
+Capital (financial, human, intellectual, organisational attention) consistently flows away from commoditised, low-margin areas toward genesis and early custom-built components with high differentiation potential. As an area commoditises, capital exits to fund the next cycle of innovation. This is visible in VC trends (AI/ML, quantum, clean energy), talent migration patterns, and M&A activity. The direction of capital flow is a leading indicator of where value is being created.
+
+**Strategic implication:** Track where capital is flowing — it signals where the next wave of value creation is forming.
+
+**Assessment question:** Is capital flowing toward or away from our core differentiators, and what does that signal about their evolution stage?
+
+---
+
+### 2.4 Creative Destruction — The Schumpeter Effect
+
+Joseph Schumpeter described creative destruction as "a process of industrial mutation that incessantly revolutionises the economic structure from within, incessantly destroying the old one, incessantly creating a new one." New innovations render existing components, business models, and sometimes entire industries obsolete. Digital photography destroyed film. Streaming destroyed video rental. EV is restructuring automotive. In Wardley terms, new genesis components emerge and evolve rapidly to displace commodity incumbents.
+
+**Strategic implication:** No incumbent position is safe from creative destruction — organisations must simultaneously exploit current advantages and invest in the innovations that may replace them.
+
+**Assessment question:** What genesis-stage component, if it evolves, would make our current commodity position irrelevant?
+
+---
+
+### 2.5 Future Value is Inversely Proportional to Certainty
+
+The higher the certainty about an outcome, the lower its potential value — because certainty is priced in by competitors. Genesis components (high uncertainty, low certainty) carry the highest potential value but also the highest risk. Commodity components (high certainty, low uncertainty) offer stable returns but no differentiation. Venture capital portfolios embody this: most investments fail, but the few that succeed return multiples that dwarf the losses. The relationship also applies to timing: the P[what] of a change may be high (EV will dominate) while P[when] remains uncertain.
+
+**Strategic implication:** Pursuing only certain opportunities means accepting low returns — a portfolio of high-uncertainty bets is needed to capture asymmetric upside.
+
+**Assessment question:** Are we systematically avoiding uncertain opportunities in ways that cap our future value potential?
+
+---
+
+### 2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption
+
+As systems become more complex and organised locally (higher order), they require more energy and resources overall — not less. More complex systems are more ordered locally but increase entropy in their environment. This manifests as: cloud data centres consuming massive electricity to enable efficient individual applications, AI training consuming enormous compute to enable efficient inference, smart cities consuming more infrastructure to optimise traffic. Jevons Paradox amplifies this — efficiency enables more consumption.
+
+**Strategic implication:** Include energy/resource/infrastructure costs in strategic planning for higher-order systems — the efficiency gains at the application layer are often offset by consumption increases at the infrastructure layer.
+
+**Assessment question:** Have we accounted for the full resource cost of the higher-order systems we are building or depending on?
+
+---
+
+## 3. Speed Patterns — Chapter VI
+
+### 3.1 Efficiency Enables Innovation — The Componentization Effect
+
+When lower-order components become commoditised and efficient, focus and resources shift to higher-level innovation. The mechanism: abstraction hides complexity, standardisation enables reuse, efficiency frees resources, stable components enable rapid recombination. Cloud commoditised infrastructure → rapid innovation in PaaS/SaaS. Smartphone hardware commoditised → app economy. Open source libraries → accelerated development. Each layer of commoditisation is a platform for the genesis of the next layer.
+
+**Strategic implication:** Actively commoditise lower layers to free innovation capacity for higher-value work — don't custom-build what should be utility.
+
+**Assessment question:** Which of our custom-built components should be replaced with commodity solutions to free resources for higher-value innovation?
+
+---
+
+### 3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed
+
+Improvements in how information is shared, collaboration occurs, and knowledge spreads accelerate the evolution of everything else. GitHub accelerated open source. Social media accelerated trend adoption and customer feedback loops. Slack/Zoom accelerated distributed decision-making. The internet accelerated globalisation. Each improvement in communication creates tighter feedback loops, faster learning cycles, and broader dissemination of innovation — compressing the time from genesis to commodity for dependent components.
+
+**Strategic implication:** Investing in communication infrastructure and culture is not just operational overhead — it is a direct lever on innovation speed.
+
+**Assessment question:** Are there communication bottlenecks in our organisation that are slowing the evolution of key components?
+
+---
+
+### 3.3 Increased Stability of Lower Order Systems Increases Agility
+
+A paradox: stability at lower levels creates agility at higher levels. When foundational components are reliable and well-understood, teams can experiment and innovate at higher levels without worrying about the underlying infrastructure. Stable OS → rapid application development. Stable cloud infrastructure → serverless experimentation. Stable web frameworks → rapid UI prototyping. Conversely, unstable lower-order systems force engineering attention downward, away from higher-value innovation.
+
+**Strategic implication:** Invest in making foundational systems stable and commodity-grade to unlock innovation speed above them.
+
+**Assessment question:** Are our foundational systems stable enough to support rapid recombination and experimentation at higher levels?
+
+---
+
+### 3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists
+
+Change can follow linear, exponential, S-curve, or discontinuous (tipping point) patterns. Human cognition defaults to linear extrapolation, systematically underestimating exponential trends and missing discontinuities. AI capabilities improved gradually for decades, then accelerated explosively. Cryptocurrency appeared discontinuously. Social media followed an S-curve. The implication: strategies built on linear forecasts are repeatedly surprised by the world. Scenarios must include non-linear possibilities.
+
+**Strategic implication:** Build strategies that are robust across non-linear scenarios, not just the linear extrapolation of current trends.
+
+**Assessment question:** Which components in our landscape could exhibit exponential or discontinuous change, and are our plans robust to that?
+
+---
+
+### 3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium
+
+The transition from product to utility (commodity/utility stage) is not always gradual. Components often remain stable in the product stage for extended periods, then shift rapidly to utility characteristics — standardised offering, usage-based pricing, cloud delivery, market consolidation. Software licensing → SaaS was punctuated. Music sales → streaming was punctuated. On-premise IT → cloud was punctuated. The equilibrium (product stage) is stable until a trigger collapses it quickly into the utility paradigm.
+
+**Strategic implication:** If you are in a product market, monitor for the triggers that will cause punctuated shift to utility — and decide whether to lead or follow that shift.
+
+**Assessment question:** Which of our product-stage offerings is approaching a punctuated shift to utility, and are we positioned to lead or survive it?
+
+---
+
+## 4. Inertia Patterns — Chapter VII
+
+### 4.1 Success Breeds Inertia
+
+Organisations that achieve success tend to resist change. The very practices, structures, and mindsets that created success become barriers to future adaptation. Mechanisms: complacency reduces urgency, overconfidence inflates belief in current capabilities, resources cluster around profitable existing products, successful practices become culturally entrenched, and risk aversion increases as there is more to lose. Kodak invented digital photography; Nokia built excellent hardware; Blockbuster had massive scale — all failed because success made adaptation psychologically and structurally difficult.
+
+**Strategic implication:** Explicitly identify and name success-induced inertia — it is invisible until it is fatal.
+
+**Assessment question:** Where are we resisting evolution because current revenue or culture depends on the status quo?
+
+---
+
+### 4.2 Inertia Can Kill an Organisation
+
+Unaddressed inertia has existential consequences. The mechanisms of organisational death by inertia: market irrelevance (failing to adapt to shifting user needs), technological obsolescence (clinging to superseded approaches), business model disruption (unable to match new entrants' economics), and resource depletion (continuing to invest in declining areas). Blockbuster (bankruptcy 2010), Kodak (bankruptcy 2012), Nokia's mobile division (sold 2014) — all were dominant market leaders destroyed by inertia, not lack of capability.
+
+**Strategic implication:** Inertia is not a performance problem — it is a survival problem. Treat it as an existential risk, not a management challenge.
+
+**Assessment question:** If a new entrant built our core value chain on commodity infrastructure today, what would their cost structure and speed look like compared to ours?
+
+---
+
+### 4.3 Inertia Increases the More Successful the Past Model Is
+
+The more successful a business model has been, the harder it becomes to abandon — proportionally. Extraordinary success creates deeper entrenchment of processes, stronger cognitive biases toward the current model, greater financial disincentives to change (cannibalism risk), deeper skill specialisation that is hard to pivot, and stronger cultural identity attached to the successful approach. Microsoft initially missed the internet despite its dominant position. IBM resisted personal computing. Xerox failed to commercialise its own GUI innovations.
+
+**Strategic implication:** The organisations most at risk from inertia are the most successful ones — build explicit mechanisms for self-disruption before disruption is forced externally.
+
+**Assessment question:** Where is our success so profound that we cannot honestly assess whether the model will survive the next evolution cycle?
+
+---
+
+## 5. Competitor Patterns — Chapter VIII
+
+### 5.1 Competitors' Actions Will Change the Game
+
+The competitive landscape is not static — competitors' strategic moves can fundamentally alter the rules of engagement. Game-changing action types: disruptive innovation (redefining the market), pricing strategy shifts (changing customer expectations), M&A (creating new capability combinations), ecosystem plays (expanding the scope of competition), and regulatory influence (shaping the playing field). AWS changed cloud. Uber changed transport. Tesla changed automotive. Each action triggered cascading changes across the entire ecosystem.
+
+**Strategic implication:** Strategy must be designed for a reactive system, not a static environment — anticipate competitor moves, not just market trends.
+
+**Assessment question:** Which competitor action, if taken, would most fundamentally change the basis of competition in our market?
+
+---
+
+### 5.2 Most Competitors Have Poor Situational Awareness
+
+The majority of organisations operate without a clear, accurate model of their competitive landscape. Manifestations of poor situational awareness: myopic focus on immediate competitors while missing broader industry shifts, technology blindness (failing to recognise emerging technology impact), customer disconnect (misunderstanding evolving needs), ecosystem ignorance (unaware of adjacent disruptors), and internal bias (overestimating own position). Blockbuster, Nokia, and Kodak all had access to information about emerging threats — they lacked the frameworks to interpret that information correctly.
+
+**Strategic implication:** Superior situational awareness is itself a durable competitive advantage — Wardley Mapping is a tool for building it.
+
+**Assessment question:** What would our map look like if drawn by our most capable competitor, and how would it differ from ours?
+
+---
+
+## 6. Prediction Patterns — Chapter IX
+
+### 6.1 Not Everything is Random — P[what] vs P[when]
+
+The direction of change (what will happen) is often more predictable than its timing (when it will happen). The shift to electric vehicles was widely predictable (high P[what]); the timing of mass adoption was not (uncertain P[when]). The commoditisation of cloud was predictable; the exact speed was not. This distinction enables better strategic planning: prepare capabilities and positioning for the predictable "what" while maintaining flexibility about the "when." Strategies anchored to specific timelines fail when the "when" is wrong; strategies anchored to directions are more robust.
+
+**Strategic implication:** Separate directional bets (high confidence) from timing bets (lower confidence) in strategic planning and investment decisions.
+
+**Assessment question:** Which evolutionary directions in our landscape are high-confidence (P[what]) even if the timing remains uncertain (P[when])?
+
+---
+
+### 6.2 Economy Has Cycles — Peace, War, and Wonder
+
+Industries cycle through three phases. **Peace**: stable market, established players dominate, incremental improvements, efficiency focus, product competition on features. **War**: intense competition triggered by industrialisation of a key component (e.g., cloud), rapid disruption, shifting power, creative destruction, incumbents with inertia are most vulnerable. **Wonder**: emergence of new higher-order systems built on newly commoditised components, rapid genesis, new industries forming, new business models, capital floods in. Each phase transitions to the next as components evolve.
+
+**Strategic implication:** Identify the current phase and position accordingly — survival strategies differ radically between Peace (optimise), War (transform rapidly), and Wonder (explore and capture genesis opportunities).
+
+**Assessment question:** Which phase is our core market currently in, and what phase transition should we be preparing for?
+
+---
+
+### 6.3 Different Forms of Disruption — Predictable vs Unpredictable
+
+Not all disruptions are equal. **Predictable disruptions** follow observable evolutionary patterns — the shift to EV, the move from product to SaaS, the commoditisation of compute. These can be anticipated through careful Wardley mapping and scenario planning. **Unpredictable disruptions** arise from unforeseen combinations of factors — cryptocurrency, ChatGPT's impact timeline, COVID-19 accelerating digital adoption. Strategies for each differ: predictable disruptions warrant directional investment and capability building; unpredictable disruptions require resilience, optionality, and rapid response capability.
+
+**Strategic implication:** Maintain separate portfolios for predictable evolutionary positioning and resilience against unpredictable disruption.
+
+**Assessment question:** Which disruptions in our landscape are predictable (and therefore we should be positioned for), and which require resilience rather than prediction?
+
+---
+
+### 6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve
+
+When a key component crosses from product to utility (industrialisation), it triggers a "war" — a period of intense competition that forces rapid organisational evolution across the entire ecosystem. Characteristics: accelerated component movement on the map, emergence of new components and disappearance of others, shifting value chains, standardisation pressure, and efficiency focus. The cloud "war" forced every enterprise IT function to evolve. The e-commerce "war" forced every retailer to transform. Organisations with high inertia are most vulnerable during these periods.
+
+**Strategic implication:** Detect the signs of an approaching "war" early — rapid component movement, new entrants with commodity infrastructure, pricing pressure — and begin transformation before the peak.
+
+**Assessment question:** Is there a component in our value chain approaching industrialisation that will trigger a "war" requiring us to evolve rapidly?
+
+---
+
+### 6.5 You Cannot Measure Evolution Over Time or Adoption
+
+Evolution cannot be precisely measured or timed. Adoption rates are highly variable, context-dependent, and non-linear. Attempts to create exact timelines or adoption curves produce false precision that misleads strategy. Cloud adoption varied wildly by industry and region. Social media platform trajectories were unpredictable. AI breakthroughs in natural language processing exceeded predictions; adoption in other sectors lagged them. The evolutionary axis in Wardley maps represents maturity, not time — components should be positioned by their characteristics, not by when they appeared.
+
+**Strategic implication:** Use directional positioning and scenario ranges rather than timeline forecasts — build strategies robust to timing uncertainty.
+
+**Assessment question:** Are we making investment commitments that depend on specific adoption timing predictions, and how robust are those commitments if timing is wrong by 2-3 years?
+
+---
+
+### 6.6 The Less Evolved Something Is, the More Uncertain It Becomes
+
+Uncertainty correlates inversely with evolution stage. Genesis components: high uncertainty about use cases, timelines, applications, and market dynamics. Custom-built: emerging patterns, still divergent. Product: increasing certainty, convergent standards. Commodity: well-understood, predictable. This is why genesis innovation requires different risk tolerance, different management approaches, and different investment models (portfolio/options thinking) compared to commodity management (efficiency, SLAs, incident management). Blockchain remains mostly in high-uncertainty stages; cloud IaaS is low-uncertainty commodity.
+
+**Strategic implication:** Calibrate risk tolerance, management approach, and investment model to the evolution stage — not to a single organisational standard.
+
+**Assessment question:** Are we applying commodity-appropriate certainty assumptions to genesis-stage components, or genesis-appropriate uncertainty assumptions to commodity components?
+
+---
+
+### 6.7 Not Everything Survives
+
+Evolution is a selection process — not all components, technologies, business models, or organisations survive it. Survival requires continuous adaptation. Past success and market leadership do not guarantee survival (Kodak, Nokia, Blockbuster). Creative destruction continuously replaces less-adapted elements with better-adapted alternatives. Strategies must account for exit scenarios, graceful transition pathways, and portfolio diversification to spread survival risk. Some components will become obsolete on a predictable timeline; others will be wiped out by unpredictable disruption.
+
+**Strategic implication:** Include obsolescence scenarios and exit planning in strategy — not as pessimism, but as realism about evolutionary dynamics.
+
+**Assessment question:** Which components in our current value chain have a non-trivial probability of not surviving the next evolution cycle, and what is our plan?
+
+---
+
+### 6.8 Embrace Uncertainty
+
+Uncertainty is not a problem to solve — it is a property of the landscape to work with. Strategies that require uncertainty to be resolved before acting are brittle. Effective approaches: scenario planning across multiple futures, adaptive strategy that adjusts as new information arrives, staged investment (options thinking), rapid experimentation to reduce uncertainty in specific areas, and range-based positioning rather than point predictions. The Wardley map itself is a tool for navigating uncertainty, not eliminating it.
+
+**Strategic implication:** Design strategy to be robust across a range of futures, not optimal for a single predicted future.
+
+**Assessment question:** How many of our current strategic commitments would fail if one key uncertainty resolved differently than we expect?
+
+---
+
+## 7. The Peace/War/Wonder Cycle
+
+The Peace/War/Wonder cycle is one of the most powerful macro-level patterns for strategic timing.
+
+### Peace Phase
+
+Characteristics: stable market structure, established players compete on features and brand, incremental innovation dominates, efficiency and optimization are the primary value drivers, customers have clear expectations, supply chains are well-understood, margins are moderate but predictable.
+
+Strategic posture in Peace: invest in operational excellence, differentiate on features and customer experience, build moats through network effects and switching costs, watch for the signs of approaching War.
+
+Signs Peace is ending: a key component begins rapid commoditisation, new entrants appear with dramatically lower cost structures built on commodity infrastructure, pricing pressure accelerates, customers begin treating differentiated features as expected utilities.
+
+### War Phase
+
+Characteristics: intense competition triggered by industrialisation of a key component, rapid disruption of established business models, creative destruction of incumbents with high inertia, massive investment and risk-taking, shifting value chains, winner-takes-most dynamics, organisations that fail to evolve quickly face existential risk.
+
+Strategic posture in War: transform rapidly, use the commodity infrastructure that triggered the War, shed custom-built components that are now available as utilities, focus on higher-order differentiation, form strategic partnerships, acquire capabilities that cannot be built fast enough organically.
+
+Signs War is ending: market consolidation around a few utility providers, pricing stabilises at commodity levels, the new "normal" becomes established, innovation focus shifts upward to new genesis opportunities.
+
+### Wonder Phase
+
+Characteristics: new higher-order systems built on newly commoditised components, rapid genesis of new capabilities, new industries forming, capital floods into new value areas, multiple competing paradigms coexist, uncertainty is highest but potential value is greatest.
+
+Strategic posture in Wonder: explore broadly, make small bets on multiple genesis opportunities, build options, tolerate high failure rates for high potential return, watch for which genesis components are beginning to show custom-built characteristics (indicating the next cycle is forming).
+
+Signs Wonder is maturing into the next Peace: dominant designs emerge, standards begin to form, the early adopter wave has passed and early majority adoption begins.
+
+### Identifying Your Current Phase
+
+Ask these questions for each major market/component:
+- Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
+- Are new entrants building on commodity infrastructure that did not exist 3 years ago?
+- Is capital flowing into or out of this space?
+- Are established players being forced to change their core business models?
+
+---
+
+## 8. Pattern Interaction Map
+
+Climatic patterns do not operate in isolation — they interact, reinforce, and counteract each other.
+
+### Reinforcing Combinations
+
+| Pattern A | Pattern B | Combined Effect |
+|-----------|-----------|-----------------|
+| Everything Evolves | Efficiency Enables Innovation | Accelerating cycle: commoditisation continuously creates the foundation for new genesis |
+| Higher Order Systems Create Value | Capital Flows to New Value | Capital predictably follows the new value streams created by higher-order systems |
+| Evolution of Communication | Change Is Not Linear | Better communication amplifies non-linear change by spreading innovations faster |
+| Punctuated Equilibrium | War Phase | Product-to-utility shifts are the mechanism that triggers "War" periods |
+| Success Breeds Inertia | Inertia Increases with Success | Compounding effect — the more successful, the more inert, the more vulnerable |
+| Jevons Paradox | Higher Order Systems Increase Energy | Efficiency-driven adoption increases demand, which increases total resource consumption |
+
+### Counteracting Tensions
+
+| Pattern A | Counteracts | Effect |
+|-----------|-------------|--------|
+| Inertia patterns | Everything Evolves | Inertia slows or blocks what evolution demands — this tension is the primary cause of organisational failure |
+| Not Everything Survives | Capital Flows to New Value | Capital exits before components become extinct — early movers gain, late movers lose |
+| Embrace Uncertainty | False precision in P[when] | Organisations that require certainty before acting are consistently outmanoeuvred by those that act on P[what] |
+| Commoditization ≠ Centralisation | Assumption of monopoly | Prevents strategic blind spots about market structure in commoditised segments |
+
+### Cascade Sequences
+
+A common cascade: **War phase** triggers → **Creative Destruction** → **Capital flows** to new areas → **Higher-order systems** emerge → **Efficiency enables innovation** → components commoditise → next **War phase** begins.
+
+Another: **Red Queen Effect** pressure → **Success Breeds Inertia** resistance → **Inertia Can Kill** outcome (if not addressed) or **Self-disruption** response (if addressed).
+
+---
+
+## 9. Per-Component Assessment Template
+
+Use this template for each significant component on a Wardley map to identify which climatic patterns are most active and their likely strategic impact.
+
+```
+Component: [name]
+Evolution Stage: [genesis / custom-built / product / commodity]
+Evolution Trajectory: [accelerating / stable / stagnating]
+Ecosystem Type: [consumer (fast) / industrial (slow) / mixed]
+
+Key Patterns Affecting This Component:
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [1-2 sentences of specific evidence]
+    Time Horizon: [<12 months / 1-3 years / 3+ years]
+
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [brief]
+    Time Horizon: [timeframe]
+
+Inertia Assessment:
+  - Organisational inertia present: [yes / no / partial]
+  - Source of inertia: [past success / skills / politics / contracts / culture]
+
+Peace/War/Wonder Phase: [current phase for this component's market]
+Next Phase Trigger: [what would trigger transition to next phase]
+
+Prediction:
+  P[what]: [what will happen — high confidence direction]
+  P[when]: [timing uncertainty — low / medium / high]
+  6-month outlook: [specific prediction]
+  12-month outlook: [specific prediction]
+
+Recommended Response:
+  Urgency: [High / Medium / Low]
+  Primary action: [description]
+  Watch signal: [what to monitor to confirm/refute the prediction]
 ```
 
-### Characteristics Change as Components Evolve
+---
 
-```yaml
-pattern:
-  name: "Characteristics Change"
-  description: "How a component is managed changes with its evolution"
+## 10. Pattern Recognition Template
 
-  changes:
-    genesis:
-      development: "Research, exploration"
-      failure: "Expected, learning"
-      team: "Pioneers"
-
-    commodity:
-      development: "Operations, optimization"
-      failure: "Unacceptable, incident"
-      team: "Town planners"
-
-  implication: "Same team skills don't work across evolution stages"
-```
-
-### No One Thing Fits All
-
-```yaml
-pattern:
-  name: "No One Size Fits All"
-  description: "Different stages require different approaches"
-
-  examples:
-    methods:
-      genesis: "Agile, experimental"
-      commodity: "Six Sigma, lean"
-
-    contracts:
-      genesis: "Time & materials"
-      commodity: "Fixed price"
-
-    architecture:
-      genesis: "Disposable PoCs"
-      commodity: "Standardized patterns"
-```
-
-## Competitive Patterns
-
-### Components Can Co-Evolve
-
-```yaml
-pattern:
-  name: "Co-Evolution"
-  description: "Changes in one component can accelerate another"
-
-  types:
-    practice_based:
-      description: "New practices emerge with new components"
-      example: "DevOps emerged with cloud infrastructure"
-
-    symbiotic:
-      description: "Components evolve together"
-      example: "Mobile devices and mobile apps"
-
-  implication: "Watch for enabler components that unlock other evolution"
-```
-
-### Efficiency Enables Innovation
-
-```yaml
-pattern:
-  name: "Efficiency Enables Innovation"
-  description: "Commoditization of one layer enables innovation above it"
-
-  example:
-    commodity: "Cloud computing"
-    enabled_innovation: "ML platforms, serverless applications"
-
-  implication: "Commoditize lower layers to free resources for higher-value work"
-```
-
-### Higher Order Systems Create New Sources of Worth
-
-```yaml
-pattern:
-  name: "Higher Order Systems"
-  description: "New value emerges from combining evolved components"
-
-  examples:
-    - "IoT = sensors + connectivity + cloud + analytics"
-    - "AI applications = compute + data + algorithms + interfaces"
-
-  implication: "Look for emerging higher-order systems"
-```
-
-## Predictability Patterns
-
-### Past Success Breeds Inertia
-
-```yaml
-pattern:
-  name: "Success Breeds Inertia"
-  description: "Organizations resist change to what made them successful"
-
-  causes:
-    - "Financial success with current model"
-    - "Skills and expertise tied to current technology"
-    - "Political capital invested in status quo"
-    - "Existing customer relationships"
-
-  symptoms:
-    - "Not invented here syndrome"
-    - "Custom building commodity components"
-    - "Resisting cloud migration"
-    - "Maintaining outdated technology"
-
-  counter_strategy: "Explicitly identify and address inertia"
-```
-
-### Capital Flows to New Industries
-
-```yaml
-pattern:
-  name: "Capital Flows"
-  description: "Investment follows evolution opportunities"
-
-  pattern: "Money flows from commodity extraction to genesis exploration"
-
-  implication: "Commoditization frees capital for new innovation"
-```
-
-## Technology Patterns
-
-### Componentization Increases
-
-```yaml
-pattern:
-  name: "Increasing Componentization"
-  description: "Systems become more modular over time"
-
-  stages:
-    early: "Monolithic, integrated"
-    middle: "Modular, connected"
-    mature: "Composable, standardized interfaces"
-
-  current_trends:
-    - "Microservices vs. monoliths"
-    - "APIs vs. point-to-point"
-    - "Serverless vs. managed servers"
-```
-
-### New Paradigms Create Waves
-
-```yaml
-pattern:
-  name: "Technology Waves"
-  description: "New paradigms replace old but take time"
-
-  wave_pattern:
-    emergence: "New technology appears (genesis)"
-    early_adoption: "Pioneers experiment"
-    disruption: "Mainstream adoption begins"
-    maturity: "Previous paradigm commoditizes"
-    next_wave: "Cycle repeats"
-
-  current_waves:
-    establishing: "AI/ML, quantum (early)"
-    disrupting: "Cloud native, serverless"
-    maturing: "Mobile, SaaS"
-    commoditized: "Internet, databases"
-```
-
-## Market Patterns
-
-### Buyers and Suppliers Evolve
-
-```yaml
-pattern:
-  name: "Market Evolution"
-  description: "Markets themselves evolve from bespoke to utility"
-
-  stages:
-    nascent:
-      buyers: "Early adopters, willing to experiment"
-      suppliers: "Few, innovative"
-      contracts: "Custom, relationship-based"
-
-    growth:
-      buyers: "Mainstream, looking for features"
-      suppliers: "Many, competing on features"
-      contracts: "Product licenses"
-
-    commodity:
-      buyers: "Price-sensitive, switching easy"
-      suppliers: "Few large, many small"
-      contracts: "Utility, pay-per-use"
-```
-
-### Disruption from New Entrants
-
-```yaml
-pattern:
-  name: "Disruption Pattern"
-  description: "New entrants often come from evolved infrastructure"
-
-  mechanism:
-    - "Incumbents have inertia in custom-built systems"
-    - "New entrants build on commodity infrastructure"
-    - "New entrants have lower costs, faster iteration"
-    - "Incumbents can't match without cannibalizing"
-
-  example:
-    incumbent: "Traditional banks with custom core banking"
-    disruptor: "Fintech on cloud with SaaS tools"
-    advantage: "Lower cost, faster feature delivery"
-```
-
-## Using Climatic Patterns
-
-### Assessment Questions
-
-```yaml
-assessment:
-  evolution:
-    - "What components are actively evolving?"
-    - "Are we fighting natural evolution anywhere?"
-    - "What will be commodity in 5 years?"
-
-  competition:
-    - "Who could commoditize our differentiators?"
-    - "What commodity infrastructure enables new competitors?"
-    - "What higher-order systems are emerging?"
-
-  inertia:
-    - "Where do we have success-based inertia?"
-    - "What skills/politics resist necessary change?"
-    - "Are we building custom where products exist?"
-```
-
-### Pattern Recognition Template
+Use this template to analyse how climatic patterns apply to your overall map.
 
 ```yaml
 pattern_analysis:
@@ -271,3 +467,38 @@ pattern_analysis:
     strategic_importance: "{High/Medium/Low}"
     recommended_response: "{Description}"
 ```
+
+---
+
+## 11. Assessment Questions by Category
+
+### Evolution
+
+- What components are actively evolving right now?
+- Are we fighting natural evolution anywhere (building custom where product/commodity exists)?
+- What will be commodity in 3 years? In 5 years?
+- Where are components in different ecosystems evolving at mismatched speeds?
+- Which co-evolutionary relationships could accelerate or destabilise our position?
+
+### Competition
+
+- Who could commoditise our current differentiators?
+- What commodity infrastructure enables new competitors to enter with structurally lower costs?
+- What higher-order systems are emerging that could change the basis of competition?
+- What game-changing action by a competitor would most threaten our position?
+- How does our situational awareness compare to our most capable competitor's?
+
+### Inertia
+
+- Where do we have success-based inertia that is blocking necessary evolution?
+- What skills, political capital, or cultural identity is tied to components that are evolving away?
+- Are we building custom solutions in areas where products or commodity utilities now exist?
+- Which of our most successful business models is most vulnerable to the next "War" phase?
+
+### Prediction
+
+- Which evolutionary changes in our landscape are high-confidence (P[what] even if P[when] is uncertain)?
+- What phase — Peace, War, or Wonder — is our core market in?
+- Which components are approaching punctuated equilibrium shifts from product to utility?
+- Where are we applying false certainty to genesis-stage components or excessive uncertainty to commodity ones?
+- What does the capital flow pattern in our sector tell us about where the next value creation will be?

--- a/arckit-copilot/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-copilot/skills/wardley-mapping/references/climatic-patterns.md
@@ -232,6 +232,43 @@ The more successful a business model has been, the harder it becomes to abandon 
 
 ---
 
+### Inertia Types Taxonomy
+
+Seven distinct types of inertia manifest differently and require different mitigation strategies. Based on Wardley's concept of "loss of capital" (physical, social, financial, political) expanded with operational types:
+
+| Type | Description | Indicators | Mitigation |
+|------|-------------|------------|------------|
+| **Success** | Past model worked so well that change feels unnecessary | "Why change what works?", strong quarterly results masking long-term risk, dismissal of emerging competitors | Establish parallel exploration teams, red team exercises, fund self-disruption initiatives |
+| **Capital** | Physical assets, infrastructure, and legacy technology create lock-in through sunk costs | Large depreciation schedules, outdated machinery still in use, fixed-purpose facilities, legacy systems deeply embedded in operations | Incremental upgrades, modular systems, leasing vs buying, versatile infrastructure design |
+| **Financial** | Risk aversion, short-term focus, and market pressures resist investment in change | Reluctance to sell underperforming assets, hesitancy to invest in new skills/tech, fear of losing strategic control, external markets rewarding stability over innovation | Strategic portfolio management, incremental investment, alternative financial models (leasing, partnerships), separate innovation budgets from BAU |
+| **Political** | Power structures and internal influence tied to existing approaches | Executives whose authority depends on current architecture, budget territories, empire building, fear of losing influence, preservation of established alliances | Reframe as opportunity not threat, create new leadership roles for emerging capabilities, sponsor from top, build coalitions, align incentives with change |
+| **Skills** | Workforce expertise concentrated in legacy technologies or methods | Recruitment focused on legacy skills, training budgets for existing tools, resistance to retraining | Upskilling programs, hire for new capabilities alongside legacy, paired teams (legacy + new) |
+| **Supplier** | Vendor relationships and ecosystem dependencies resist change | Preferred vendor lists, deep integration with specific platforms, vendor-specific certifications | Multi-vendor strategy, abstraction layers, gradual supplier diversification, renegotiate before lock-in deepens |
+| **Consumer** | Users or customers expect and depend on current approach | Customer complaints about any change, contractual SLAs tied to specific implementations, user workflow dependency | Gradual migration with parallel running, user research on actual needs vs habits, opt-in transitions |
+
+**Note on Capital vs Financial:** Capital inertia concerns physical/tangible assets (infrastructure, equipment, legacy systems). Financial inertia concerns the psychology and market dynamics around money (sunk cost fallacy, risk aversion, short-termism, investor pressure). A component can have capital inertia (locked into legacy infrastructure) without financial inertia (the business case for change is accepted), or vice versa.
+
+**Assessment per component:** For each component with inertia, identify which type(s) are present, rate severity (H/M/L), and define a specific mitigation action. Multiple types often compound — a component with success + skills + capital + financial inertia is far harder to move than one with only skills inertia.
+
+### Inertia Diagnostic Checklist
+
+Early warning signs that inertia is taking hold in an organisation. Use this checklist during doctrine and climate assessments:
+
+| Sign | What to Look For | Impact if Unaddressed |
+|------|-------------------|----------------------|
+| **Stagnant mindset** | Resistance to training, lack of curiosity about industry trends, unwillingness to adopt new tools | Declining productivity, loss of competitive awareness |
+| **Siloed thinking** | Teams working in isolation, duplicated effort, poor cross-functional communication, misalignment with overall strategy | Suboptimal decisions, inability to leverage collective expertise |
+| **Lack of innovation** | Few new ideas reaching implementation, fear of failure culture, no experimentation budget | Falling behind competitors, inability to differentiate |
+| **Complacency** | Comfort with status quo, "if it ain't broke don't fix it" attitude, declining urgency | Mediocrity becomes the norm, market share erosion |
+| **Risk aversion** | No experimentation, all decisions require exhaustive justification, preference for safe options | Missed opportunities, slow response to market shifts |
+| **Rigid structures** | Bureaucratic approval chains, top-down only decisions, inability to reorganise quickly | Cannot respond to customer needs or competitive threats |
+| **Lack of accountability** | Unclear ownership, blame culture, nobody responsible for change outcomes | Problems persist, low trust, poor morale |
+| **Low employee engagement** | High turnover, absenteeism, lack of initiative, disinterest in company direction | Talent flight, institutional knowledge loss |
+
+**Scoring:** Count how many signs are present (0-8). 0-2: healthy organisation. 3-4: early inertia — address proactively. 5-6: significant inertia — urgent intervention needed. 7-8: critical — existential risk if not addressed immediately.
+
+---
+
 ## 5. Competitor Patterns — Chapter VIII
 
 ### 5.1 Competitors' Actions Will Change the Game
@@ -367,6 +404,7 @@ Signs Wonder is maturing into the next Peace: dominant designs emerge, standards
 ### Identifying Your Current Phase
 
 Ask these questions for each major market/component:
+
 - Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
 - Are new entrants building on commodity infrastructure that did not exist 3 years ago?
 - Is capital flowing into or out of this space?

--- a/arckit-copilot/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-copilot/skills/wardley-mapping/references/doctrine.md
@@ -400,6 +400,7 @@ doctrine_assessment:
 Use these prompts during assessment interviews and document reviews to gather evidence for each category.
 
 **Communication**
+
 - [ ] Is there a shared glossary or terminology guide in use across teams?
 - [ ] Are strategy documents written in language understood outside the originating team?
 - [ ] Are assumptions in proposals explicitly stated and challenged before approval?
@@ -407,6 +408,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are decision rationales documented and accessible to those affected?
 
 **Development**
+
 - [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
 - [ ] Are different methodologies applied to different components based on their evolutionary stage?
 - [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
@@ -414,6 +416,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are standards and tools reviewed periodically for continued appropriateness?
 
 **Operation**
+
 - [ ] Can leaders describe the operational details of the services they are accountable for?
 - [ ] Are sources of organisational inertia identified and addressed in change plans?
 - [ ] Is there a blameless failure review process in place?
@@ -421,18 +424,21 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are value stream maps or similar tools used to identify bottlenecks?
 
 **Learning**
+
 - [ ] Is there a structured process for capturing and applying lessons learned?
 - [ ] Are teams encouraged and resourced to run experiments?
 - [ ] Is there a programme for exploring emerging technologies before they become urgent?
 - [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
 
 **Leading**
+
 - [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
 - [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
 - [ ] Is there a single named accountable owner for each strategic initiative?
 - [ ] Are leaders open about what they do not know and willing to change their minds publicly?
 
 **Structure**
+
 - [ ] Are most teams small enough to communicate without formal coordination overhead?
 - [ ] Do teams have authority to make decisions within their domain without escalation?
 - [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?

--- a/arckit-copilot/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-copilot/skills/wardley-mapping/references/doctrine.md
@@ -1,120 +1,439 @@
 # Doctrine
 
-Universally useful patterns for strategy, independent of context or landscape.
+Universal principles and best practices that guide strategic decision-making, independent of context or landscape.
 
-## Doctrine Categories
+---
 
-The following is a curated subset of Wardley's doctrine principles, covering the areas most actionable in mapping exercises. For the full set, see Simon Wardley's original writings.
+## 1. Strategy Cycle
 
-```yaml
-doctrine_categories:
-  communication:
-    - "Use a common language"
-    - "Challenge assumptions"
-    - "Focus on user needs"
+Doctrine sits within a five-step iterative strategy cycle:
 
-  development:
-    - "Use appropriate methods for evolution stage"
-    - "Think small (cell-based structures)"
-    - "Manage inertia"
-    - "Use standards where appropriate"
+1. **Purpose** — define the organisation's overarching objectives and direction
+2. **Landscape** — map the competitive environment, components, and value chains
+3. **Climate** — identify external forces, market dynamics, and evolutionary pressures
+4. **Doctrine** — apply universal principles that hold regardless of context
+5. **Leadership** — make informed decisions and execute, then return to step 1
 
-  operation:
-    - "Think FIRE (Fast, Inexpensive, Restrained, Elegant)"
-    - "Manage failure appropriately"
-    - "Optimize flow"
+The cycle is continuous. Organisations repeatedly pass through all five stages, refining strategy based on new insights. Doctrine provides the stable foundation that makes repeated iteration productive rather than chaotic.
 
-  learning:
-    - "Use a systematic mechanism of learning"
-    - "Know your users"
-    - "Know your details"
+---
 
-  leading:
-    - "Be the owner"
-    - "Move fast"
-    - "Accept that strategy is iterative"
-```
+## 2. Doctrine Phase/Category Matrix
 
-## Doctrine Assessment Template
+Forty-two principles organised across four phases and six categories (source: Wardley Mapping Doctrine, Figure 2).
 
-Use this template to evaluate an organization's doctrine maturity. Score each area 1-5:
+| Phase | Communication | Development | Operation | Learning | Leading | Structure |
+|-------|--------------|-------------|-----------|----------|---------|-----------|
+| **I: Stop Self-Harm** | Common Language | Know Your Users | Know the Details | Systematic Learning | — | — |
+| | Challenge Assumptions | Focus on User Needs | | | | |
+| | Understand Context | Remove Bias & Duplication | | | | |
+| | | Use Appropriate Methods | | | | |
+| **II: Context Aware** | Bias Towards Open | Focus on Outcome | Manage Inertia | Bias Towards Action | Move Fast | Think Small Teams |
+| | | Think FIRE | Manage Failure | | Strategy is Iterative | Distribute Power |
+| | | Use Appropriate Tools | Effectiveness over Efficiency | | | Aptitude & Attitude |
+| | | Be Pragmatic | | | | |
+| | | Use Standards | | | | |
+| **III: Better for Less** | — | — | Optimise Flow | Bias to New | Commit to Direction | Seek the Best |
+| | | | Do Better with Less | | Be the Owner | Purpose/Mastery/Autonomy |
+| | | | Exceptional Standards | | Inspire Others | |
+| | | | | | Embrace Uncertainty | |
+| | | | | | Be Humble | |
+| **IV: Continuously Evolving** | — | — | — | Listen to Ecosystem | Exploit the Landscape | No Single Culture |
+| | | | | | There is No Core | Design for Constant Evolution |
+
+---
+
+## 3. Phase Details
+
+### Phase I: Stop Self-Harm
+
+**Objective:** Prevent further self-inflicted damage and establish a stable foundation for strategy.
+
+Organisations in Phase I often harm themselves through poor communication, misaligned development, and absence of learning. The nine principles in this phase address the most fundamental failures.
+
+#### Communication
+
+**Common Language** — Establish standardised terminology so all teams share meaning. Without a common vocabulary, strategy conversations produce confusion rather than alignment. Create a glossary, enforce it in meetings and documents, and review it regularly.
+
+**Challenge Assumptions** — Actively question established beliefs and the "way things have always been done." Assign devil's advocate roles, conduct assumption audits, and reward constructive scepticism. This prevents strategies built on invisible, outdated premises.
+
+**Understand Context** — Develop situational awareness before acting. Ensure communications include enough context for recipients to make informed decisions. Go beyond surface information to understand implications, stakeholder impacts, and broader relationships.
+
+#### Development
+
+**Know Your Users** — Understand the needs of all stakeholders: customers, shareholders, regulators, and staff. This is not one-time market research but an ongoing process. Use personas, continuous feedback loops, and cross-functional sharing of user insights.
+
+**Focus on User Needs** — Place user requirements at the centre of all development decisions. Anchor Wardley Maps to genuine user needs rather than internal assumptions. Prioritise what users truly need, not just what they explicitly request.
+
+**Remove Bias and Duplication** — Identify and eliminate both unwarranted assumptions that skew decisions and redundant processes that waste resources. Use diverse teams, data-driven decision making, and regular process reviews. Some redundancy aids resilience; eliminate wasteful redundancy.
+
+**Use Appropriate Methods** — Select development methodologies suited to the evolutionary stage of the work. Agile for genesis-stage components; lean or six sigma for more evolved ones. No single methodology fits all contexts.
+
+#### Operation
+
+**Know the Details** — Pay close attention to operational specifics. Leaders who lose touch with operational reality make poor strategic decisions. Conduct thorough process assessments, ensure documentation is current, and keep management connected to the ground truth.
+
+#### Learning
+
+**Systematic Learning (Bias Towards Data)** — Implement structured processes for gathering, analysing, and applying knowledge. Establish feedback loops, document lessons learned, and treat data as a strategic asset. Ad hoc learning leaves organisations repeating mistakes.
+
+---
+
+### Phase II: Becoming More Context Aware
+
+**Objective:** Enhance situational awareness and leverage contextual knowledge for better decisions.
+
+Phase II builds on the stable foundation of Phase I. The organisation now turns outward — becoming aware of its competitive environment, managing the dynamics of change, and starting to use contextual judgement rather than rigid rules.
+
+#### Communication
+
+**Bias Towards Open** — Make transparency and information sharing the default, not the exception. Move beyond "need to know" to proactive sharing of decisions, data, and rationale. Open communication fosters trust, accelerates innovation, and improves alignment. Balance openness with appropriate confidentiality.
+
+#### Development
+
+**Focus on Outcome** — Prioritise valuable results over rigid adherence to contracts or predetermined plans. Measure success by outcomes delivered, not tasks completed. Structure contracts and metrics around value, and empower teams to adapt their approach as long as the outcome stays in view.
+
+**Think FIRE (Fast, Inexpensive, Restrained, Elegant)** — Apply all four dimensions when designing solutions. Fast means rapid iteration; Inexpensive means cost-effective without being cheap; Restrained means resisting feature creep; Elegant means simple, user-centred design. FIRE prevents over-engineering and accelerates delivery.
+
+**Use Appropriate Tools** — Select tools matched to the specific development context rather than defaulting to familiarity or fashion. Evaluate tools against project needs, scalability, and long-term viability. Avoid tool proliferation; balance innovation with stability.
+
+**Be Pragmatic** — Choose what works in the real world over what is theoretically correct. Base decisions on evidence and observed results. Pragmatism is not short-termism — it is applying practical judgement to move purposefully toward long-term goals.
+
+**Use Standards** — Adopt industry or internal standards where components are sufficiently evolved to benefit from standardisation. Standards improve interoperability, quality, and speed. On Wardley Maps, standards apply most naturally to product- and commodity-stage components.
+
+#### Operation
+
+**Manage Inertia** — Actively address organisational resistance to change. Identify sources of inertia (legacy systems, entrenched culture, middle-management resistance), communicate the case for change compellingly, and use change champions and incremental rollouts to build momentum.
+
+**Manage Failure** — Design mechanisms to handle failure gracefully and extract learning from it. Failure tolerance should be calibrated to evolutionary stage: high tolerance for genesis-stage experiments, low tolerance for commodity-stage operations. Treat failure as information, not shame.
+
+**Effectiveness over Efficiency** — Prioritise achieving the desired outcome before optimising how efficiently you achieve it. Efficient execution of the wrong activity is waste. Confirm you are doing the right things before refining how fast you do them.
+
+#### Learning
+
+**Bias Towards Action** — Learn by doing rather than by planning. Encourage practical experimentation. Iterative, hands-on engagement with the landscape reveals insights that analysis alone cannot. Establish rapid learning cycles where experiments feed directly back into strategy.
+
+#### Leading
+
+**Move Fast** — Prioritise rapid execution and decision-making over waiting for perfect information. Speed of action is itself a strategic asset. Leaders should reduce approval chains, tolerate imperfection, and default to trying things over deliberating about them.
+
+**Strategy is Iterative** — Treat strategy as a cyclical process, not a one-time plan. Regularly reassess and adapt the strategy based on new intelligence. The most dangerous strategies are those treated as immutable once written.
+
+#### Structure
+
+**Think Small Teams** — Organise work into small, cross-functional, autonomous teams. Small teams communicate faster, decide faster, and are more accountable. They also align naturally with the Pioneer/Settler/Town Planner model of matching team culture to evolutionary stage.
+
+**Distribute Power** — Decentralise decision-making to the teams closest to the work. Establish clear boundaries and provide resources; then trust teams to act within them. Centralised authority creates bottlenecks and suppresses the contextual judgement that effective strategy requires.
+
+**Aptitude and Attitude** — Hire and develop team members based on both technical capability (aptitude) and cultural alignment (attitude). A team of highly skilled individuals with the wrong disposition will underperform a moderately skilled team with the right mindset.
+
+---
+
+### Phase III: Better for Less
+
+**Objective:** Achieve significantly better outcomes while consuming fewer resources through continuous improvement and high standards.
+
+Phase III organisations have mastered the basics and begun optimising. The focus shifts to operational excellence, leadership maturity, and structural conditions that allow people to produce their best work.
+
+#### Operation
+
+**Optimise Flow** — Identify and remove bottlenecks that impede the throughput of value. Use value stream mapping and similar techniques to visualise where work slows. Optimising flow at the system level is more powerful than improving individual components in isolation.
+
+**Do Better with Less** — Embed continuous improvement as a cultural norm. Regularly review processes with the explicit goal of producing the same or better outcomes with fewer resources. Constraint fosters creativity; resource abundance often masks inefficiency.
+
+**Set Exceptional Standards** — Define and publicly commit to high performance standards. Exceptional standards create a benchmark that drives quality, reduces tolerance for mediocrity, and builds organisational pride. Low standards become self-fulfilling; high standards become self-reinforcing.
+
+#### Learning
+
+**Bias Towards the New** — Actively explore emerging ideas, technologies, and approaches rather than defaulting to the familiar. The evolutionary landscape rewards early movers in genesis-stage components. Create protected space for experimentation; do not allow operational maturity to crowd out exploration.
+
+#### Leading
+
+**Commit to Direction** — Be steadfast in pursuing strategic goals while remaining open to adjusting tactics. Frequent strategy reversals demoralise teams and waste the organisational capital accumulated through consistent effort. Distinguish between pivoting approach and abandoning direction.
+
+**Be the Owner** — Take full responsibility and accountability for strategy and outcomes. Do not diffuse accountability across committees or processes. Ownership means accepting both credit and blame, and making decisions rather than deferring them.
+
+**Inspire Others** — Articulate a compelling vision and motivate the team toward ambitious goals. Inspiration is not cheerleading — it is connecting individual work to meaningful purpose, demonstrating commitment, and showing people what is possible.
+
+**Embrace Uncertainty** — Accept that uncertainty is an inherent feature of strategy, not a temporary condition that will eventually resolve. Make peace with acting under incomplete information. Organisations that require certainty before acting are chronically late.
+
+**Be Humble** — Cultivate openness to feedback, correction, and different viewpoints. Hubris in leadership prevents the honest assessment of landscape and doctrine that effective strategy requires. Humility is not weakness — it is accurate self-knowledge.
+
+#### Structure
+
+**Seek the Best** — Aim for excellence in organisational design, not adequacy. Benchmark structure against industry best practice, not internal tradition. Regularly ask whether the current structure is the best possible arrangement for executing current strategy.
+
+**Purpose, Mastery, and Autonomy** — Create the three conditions Daniel Pink identifies as intrinsic motivation. Ensure individuals understand how their work connects to the organisation's purpose. Invest in developing deep expertise (mastery). Remove unnecessary controls that undermine self-direction (autonomy).
+
+---
+
+### Phase IV: Continuously Evolving
+
+**Objective:** Create a resilient, adaptive organisation that drives change rather than merely responding to it.
+
+Phase IV represents organisational maturity. The organisation no longer manages change episodically — evolution is built into the fabric of how it operates.
+
+#### Learning
+
+**Listen to the Ecosystem** — Actively engage with and learn from the broader environment: customers, competitors, suppliers, regulators, adjacent industries, and emerging technologies. The most important signals about future landscape shifts come from outside the organisation. Create structured mechanisms for ecosystem listening, not just passive monitoring.
+
+#### Leading
+
+**Exploit the Landscape** — Leverage the broader business environment as a source of competitive advantage. Identify patterns, leverage points, and structural features of the landscape that others overlook. This requires a deep understanding of how components are evolving and where they are vulnerable to disruption or commoditisation.
+
+**There is No Core** — Reject the notion of a permanent "core business." All strategic positions are temporary. Components that are differentiating today will become commodity tomorrow. Maintaining strategic flexibility means being willing to abandon current strengths when the landscape demands it. This is not instability — it is strategic maturity.
+
+#### Structure
+
+**No Single Culture** — Recognise that different work requires different cultural approaches. Genesis-stage innovation requires a culture of exploration and tolerance for failure; commodity-stage operations require discipline and efficiency. A single mandated culture optimises for one type of work at the expense of all others. Cultivate and value cultural diversity within the organisation.
+
+**Design for Constant Evolution** — Build organisational structures, processes, and systems that are inherently flexible. Change should not require major restructuring — it should be the normal mode of operation. Use modular designs, adaptive processes, and continuous skills development to make evolution frictionless.
+
+---
+
+## 4. Implementation Journeys
+
+### Communication Journey (Phases I–II)
+
+Begin by establishing shared vocabulary and a common map language that all teams use consistently (Phase I). Progress to making transparency the default operating mode: open decision-making, accessible data, two-way feedback channels (Phase II). The destination is an organisation where strategic information flows freely across all levels and functions, enabling faster alignment and better decisions.
+
+### Development Journey (Phases I–II)
+
+Start by rooting development in real user needs and eliminating duplicated effort (Phase I). Evolve toward outcome-focused, pragmatic delivery using FIRE principles, contextually appropriate tools, and industry standards (Phase II). The journey moves from "building things correctly" to "building the correct things efficiently."
+
+### Operation Journey (Phases I–III)
+
+Establish situational awareness through operational detail (Phase I). Build change management capability and effective failure response (Phase II). Reach the destination of continuously optimised flow, exceptional quality standards, and a culture that does more with less (Phase III). Each phase adds a layer of operational sophistication on top of the last.
+
+### Learning Journey (Phases I–IV)
+
+Implement data-driven learning mechanisms and documentation (Phase I). Shift to action-oriented learning through experimentation (Phase II). Dedicate resources to exploring new ideas and technologies (Phase III). In Phase IV, the organisation systematically listens to its ecosystem and makes continuous adaptation a cultural norm rather than a periodic initiative.
+
+### Leading Journey (Phases II–IV)
+
+Leadership doctrine begins in Phase II with fast decisions and iterative strategy. Phase III adds personal accountability, inspiration, humility, and the ability to operate in uncertainty. Phase IV demands leaders who can read and exploit landscape features that are invisible to less evolved organisations, while holding their strategic position loosely enough to abandon it when evolution demands.
+
+### Structure Journey (Phases II–IV)
+
+Phase II establishes small, empowered teams hired for both skill and attitude. Phase III adds the pursuit of excellence and the conditions for intrinsic motivation. Phase IV reaches full maturity: a deliberately multi-cultural organisation designed to evolve continuously, with no structural assumption treated as permanent.
+
+---
+
+## 5. Assessment Template
+
+Score each principle 1–5 using the rubric below, then record supporting evidence.
 
 | Score | Meaning |
 |-------|---------|
 | **1** | Not practiced — no evidence of this principle |
 | **2** | Ad hoc — occasional, inconsistent application |
-| **3** | Emerging — recognized as important, partially adopted |
+| **3** | Emerging — recognised as important, partially adopted |
 | **4** | Established — consistently practiced with measurable results |
 | **5** | Embedded — deeply ingrained in culture and decision-making |
 
 ```yaml
 doctrine_assessment:
-  communication:
-    common_language:
-      score: "{1-5}"
-      evidence: "{How is strategic language standardized?}"
 
-    challenge_assumptions:
-      score: "{1-5}"
-      evidence: "{How are assumptions questioned?}"
+  phase_i:
+    communication:
+      common_language:
+        score: # 1-5
+        evidence: ""
+      challenge_assumptions:
+        score: # 1-5
+        evidence: ""
+      understand_context:
+        score: # 1-5
+        evidence: ""
 
-    focus_on_user_needs:
-      score: "{1-5}"
-      evidence: "{How are user needs identified and prioritized?}"
+    development:
+      know_your_users:
+        score: # 1-5
+        evidence: ""
+      focus_on_user_needs:
+        score: # 1-5
+        evidence: ""
+      remove_bias_and_duplication:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_methods:
+        score: # 1-5
+        evidence: ""
 
-  development:
-    appropriate_methods:
-      score: "{1-5}"
-      evidence: "{Are agile/lean/six sigma applied contextually by evolution stage?}"
+    operation:
+      know_the_details:
+        score: # 1-5
+        evidence: ""
 
-    cell_based:
-      score: "{1-5}"
-      evidence: "{Are teams small and autonomous?}"
+    learning:
+      systematic_learning:
+        score: # 1-5
+        evidence: ""
 
-    manage_inertia:
-      score: "{1-5}"
-      evidence: "{How is organizational inertia identified and addressed?}"
+  phase_ii:
+    communication:
+      bias_towards_open:
+        score: # 1-5
+        evidence: ""
 
-    use_standards:
-      score: "{1-5}"
-      evidence: "{Are standards adopted where components are commodity/product?}"
+    development:
+      focus_on_outcome:
+        score: # 1-5
+        evidence: ""
+      think_fire:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_tools:
+        score: # 1-5
+        evidence: ""
+      be_pragmatic:
+        score: # 1-5
+        evidence: ""
+      use_standards:
+        score: # 1-5
+        evidence: ""
 
-  operation:
-    think_fire:
-      score: "{1-5}"
-      evidence: "{Are solutions Fast, Inexpensive, Restrained, Elegant (FIRE)?}"
+    operation:
+      manage_inertia:
+        score: # 1-5
+        evidence: ""
+      manage_failure:
+        score: # 1-5
+        evidence: ""
+      effectiveness_over_efficiency:
+        score: # 1-5
+        evidence: ""
 
-    manage_failure:
-      score: "{1-5}"
-      evidence: "{Is failure tolerance matched to evolution stage?}"
+    learning:
+      bias_towards_action:
+        score: # 1-5
+        evidence: ""
 
-    optimize_flow:
-      score: "{1-5}"
-      evidence: "{Are bottlenecks identified and addressed?}"
+    leading:
+      move_fast:
+        score: # 1-5
+        evidence: ""
+      strategy_is_iterative:
+        score: # 1-5
+        evidence: ""
 
-  learning:
-    systematic_learning:
-      score: "{1-5}"
-      evidence: "{Is there a feedback loop for strategic learning?}"
+    structure:
+      think_small_teams:
+        score: # 1-5
+        evidence: ""
+      distribute_power:
+        score: # 1-5
+        evidence: ""
+      aptitude_and_attitude:
+        score: # 1-5
+        evidence: ""
 
-    know_users:
-      score: "{1-5}"
-      evidence: "{How well are users and their needs understood?}"
+  phase_iii:
+    operation:
+      optimise_flow:
+        score: # 1-5
+        evidence: ""
+      do_better_with_less:
+        score: # 1-5
+        evidence: ""
+      exceptional_standards:
+        score: # 1-5
+        evidence: ""
 
-    know_details:
-      score: "{1-5}"
-      evidence: "{Is there deep understanding of component specifics?}"
+    learning:
+      bias_towards_new:
+        score: # 1-5
+        evidence: ""
 
-  leading:
-    ownership:
-      score: "{1-5}"
-      evidence: "{Is there clear ownership of strategy?}"
+    leading:
+      commit_to_direction:
+        score: # 1-5
+        evidence: ""
+      be_the_owner:
+        score: # 1-5
+        evidence: ""
+      inspire_others:
+        score: # 1-5
+        evidence: ""
+      embrace_uncertainty:
+        score: # 1-5
+        evidence: ""
+      be_humble:
+        score: # 1-5
+        evidence: ""
 
-    move_fast:
-      score: "{1-5}"
-      evidence: "{How quickly are strategic decisions made?}"
+    structure:
+      seek_the_best:
+        score: # 1-5
+        evidence: ""
+      purpose_mastery_autonomy:
+        score: # 1-5
+        evidence: ""
 
-    iterative_strategy:
-      score: "{1-5}"
-      evidence: "{Is strategy treated as continuous, not one-off?}"
+  phase_iv:
+    learning:
+      listen_to_ecosystem:
+        score: # 1-5
+        evidence: ""
+
+    leading:
+      exploit_the_landscape:
+        score: # 1-5
+        evidence: ""
+      there_is_no_core:
+        score: # 1-5
+        evidence: ""
+
+    structure:
+      no_single_culture:
+        score: # 1-5
+        evidence: ""
+      design_for_constant_evolution:
+        score: # 1-5
+        evidence: ""
 ```
+
+---
+
+## 6. Evidence-Gathering Checklist
+
+Use these prompts during assessment interviews and document reviews to gather evidence for each category.
+
+**Communication**
+- [ ] Is there a shared glossary or terminology guide in use across teams?
+- [ ] Are strategy documents written in language understood outside the originating team?
+- [ ] Are assumptions in proposals explicitly stated and challenged before approval?
+- [ ] Is information shared proactively, or does it flow only on request?
+- [ ] Are decision rationales documented and accessible to those affected?
+
+**Development**
+- [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
+- [ ] Are different methodologies applied to different components based on their evolutionary stage?
+- [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
+- [ ] Are FIRE principles applied when scoping new development?
+- [ ] Are standards and tools reviewed periodically for continued appropriateness?
+
+**Operation**
+- [ ] Can leaders describe the operational details of the services they are accountable for?
+- [ ] Are sources of organisational inertia identified and addressed in change plans?
+- [ ] Is there a blameless failure review process in place?
+- [ ] Are effectiveness metrics (outcomes achieved) tracked alongside efficiency metrics (cost/time)?
+- [ ] Are value stream maps or similar tools used to identify bottlenecks?
+
+**Learning**
+- [ ] Is there a structured process for capturing and applying lessons learned?
+- [ ] Are teams encouraged and resourced to run experiments?
+- [ ] Is there a programme for exploring emerging technologies before they become urgent?
+- [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
+
+**Leading**
+- [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
+- [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
+- [ ] Is there a single named accountable owner for each strategic initiative?
+- [ ] Are leaders open about what they do not know and willing to change their minds publicly?
+
+**Structure**
+- [ ] Are most teams small enough to communicate without formal coordination overhead?
+- [ ] Do teams have authority to make decisions within their domain without escalation?
+- [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?
+- [ ] Is the organisational structure reviewed periodically and changed when strategy requires?

--- a/arckit-copilot/skills/wardley-mapping/references/evolution-stages.md
+++ b/arckit-copilot/skills/wardley-mapping/references/evolution-stages.md
@@ -99,3 +99,123 @@ When placing a component on the evolution axis, assess:
 - Positioning based on **age** rather than market maturity
 - Confusing **internal unfamiliarity** with market-wide genesis
 - Not considering **industry context** (a component may be commodity in one industry but custom in another)
+
+---
+
+## Enhanced Stage Indicators
+
+Detailed checklists for assessing which stage a component belongs to across four dimensions:
+
+### Genesis Stage Indicators
+
+- **Ubiquity markers**: Used by fewer than a handful of organizations; no established market; found only in research labs or cutting-edge pilots; most practitioners have never heard of it
+- **Certainty markers**: No agreed-upon approach; each implementation looks completely different; high variance in results; practitioners disagree on fundamentals
+- **Market markers**: No commercial offerings; no analysts covering it; no conferences dedicated to it; possibly a single paper or blog post
+- **Failure mode**: Betting on the wrong approach — you build the wrong thing, the concept doesn't pan out, or a competitor's approach proves fundamentally superior
+
+### Custom-Built Stage Indicators
+
+- **Ubiquity markers**: A few dozen organizations have built it; mostly in-house implementations; early adopters only; growing word-of-mouth in specialist communities
+- **Certainty markers**: Patterns are beginning to emerge; blog posts and conference talks appear; approaches vary but converge around a few patterns
+- **Market markers**: Small number of consultancies or niche vendors; no dominant standard; user groups forming; early analyst coverage
+- **Failure mode**: Building it wrong — your custom implementation has the wrong architecture, accrues technical debt, or gets overtaken by a productized competitor before you've recovered your investment
+
+### Product Stage Indicators
+
+- **Ubiquity markers**: Most large organizations are aware of it; multiple commercial products compete; analyst firms rank vendors; industry press covers it regularly
+- **Certainty markers**: Training courses, professional certifications, and established methodologies exist; outcomes are predictable; clear best practices documented
+- **Market markers**: Multiple competing vendors with clear feature differentiation; pricing is feature-based; annual comparison reports published; RFP processes are standardized
+- **Failure mode**: Differentiation failure — failing to stand out from competing products, losing on features, price, or brand while rivals commoditize faster
+
+### Commodity Stage Indicators
+
+- **Ubiquity markers**: Ubiquitous — every organization uses it; invisible infrastructure; not adopting it would be unusual; pay-per-use or subscription models dominate
+- **Certainty markers**: Fully standardized; ISO or formal standards exist; deviating from standard approaches is unusual; operations are predictable and auditable
+- **Market markers**: Utility pricing; multiple interchangeable providers; switching costs low; procurement is routine; the component is rarely discussed in strategic terms
+- **Failure mode**: Operational inefficiency — paying too much, running it in-house when a utility exists, or accumulating operational overhead that commodity providers handle more cheaply
+
+---
+
+## Transition Timing Heuristics
+
+Weak signals that a component is about to move between stages. These precede the transition by months to years — use them to get ahead of the curve.
+
+### Genesis → Custom-Built
+
+- Multiple independent teams build their own version without coordinating
+- The first conference talks appear: "Here's how we did it at [Company X]"
+- A startup forms specifically to productize the concept
+- A handful of GitHub repositories appear with experimental implementations
+- The phrase "we built our own X" starts appearing in engineering blog posts
+
+### Custom-Built → Product
+
+- Documentation proliferates: vendor docs, how-to guides, blog series
+- Training courses and certifications emerge (Udemy, Pluralsight, vendor academies)
+- Industry analysts publish first Magic Quadrant or Wave covering the space
+- Standardization efforts begin (working groups, RFCs, consortia form)
+- The question shifts from "should we build this?" to "which vendor should we choose?"
+
+### Product → Commodity
+
+- Pricing models shift to consumption-based or utility billing (per API call, per GB, per user-minute)
+- Open-source alternatives appear and gain traction, driving down commercial pricing
+- "Good enough" becomes the accepted standard — buyers stop comparing features and compare price
+- The component disappears from strategic discussions; procurement handles it routinely
+- Cloud providers add it as a native managed service
+
+---
+
+## Pioneers / Settlers / Town Planners Talent Model
+
+The three evolution stages map naturally to three types of people. Mismatching talent to stage is one of the most common and costly strategic mistakes.
+
+### Pioneers (Genesis)
+
+- Comfortable with chaos, ambiguity, and high failure rates
+- Driven by exploration and discovery; motivated by novelty, not process
+- High failure tolerance — they expect most experiments to fail and see it as learning
+- Often poor at documentation, standardization, or handing work off cleanly
+- Best suited to: research, prototyping, proof-of-concept work, greenfield exploration
+
+### Settlers (Custom-Built → Product)
+
+- Take pioneer discoveries and make them useful and repeatable
+- Product-oriented and systematic; skilled at listening to users and iterating
+- Build out the patterns that emerge from pioneer experiments into reliable solutions
+- Bridge between the wild experimentation of genesis and the industrialization of commodity
+- Best suited to: product development, early productization, growing user bases
+
+### Town Planners (Product → Commodity)
+
+- Industrialize at scale; obsessed with efficiency, reliability, and cost reduction
+- Process-oriented, metrics-driven, volume operations mindset
+- Build the pipes that everything else runs on; thrive in predictable, repeatable work
+- Often frustrated by ambiguity or constant change
+- Best suited to: platform engineering, infrastructure, shared services, SRE at scale
+
+### Handoff Friction
+
+Managing transitions between these types is critical and frequently mismanaged:
+
+- **Pioneers hate process**: Forcing pioneers to maintain and document their experiments alienates them and slows exploration. Hand off to settlers early.
+- **Town Planners hate uncertainty**: Asking planners to work on genesis-stage components creates anxiety, over-engineering, and premature standardization.
+- **Settlers are the connective tissue**: They translate pioneer output into planner input. Skipping settlers (pioneer → planner handoff) often produces brittle, hard-to-operate systems.
+- **Reward systems must differ**: Pioneers need space to fail; planners need predictability metrics. A single performance framework for all three types destroys the talent mix.
+
+---
+
+## Assessment Questions per Stage
+
+Use these diagnostic questions to quickly identify where a component sits:
+
+| Question | If Yes → Stage |
+|----------|---------------|
+| "Is this available as a utility API or cloud service?" | Commodity |
+| "Can anyone buy this off the shelf from multiple vendors?" | Product or Commodity |
+| "Are there multiple competing approaches with no clear winner?" | Custom-Built |
+| "Does building this require original research or experimentation?" | Genesis |
+| "Are there training courses and certifications for this?" | Product or Commodity |
+| "Would you be the first (or one of very few) to attempt this?" | Genesis |
+| "Does everyone in the industry just use the same provider?" | Commodity |
+| "Is this a competitive differentiator for your organization?" | Genesis or Custom-Built |

--- a/arckit-copilot/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-copilot/skills/wardley-mapping/references/gameplay-patterns.md
@@ -31,41 +31,49 @@ Strategies that shape how users perceive and interact with your offerings. Can a
 
 **1. Education (LG)**
 Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+
 - *When to use*: Launching novel or complex components where user understanding is low.
 - *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
 
 **2. Bundling (N)**
 Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+
 - *When to use*: When individual components have limited standalone appeal but are complementary together.
 - *Evolution stage*: Product stage (combining maturing components)
 
 **3. Creating Artificial Needs (LE)**
 Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+
 - *When to use*: When a component solves a latent problem users have not yet articulated.
 - *Evolution stage*: Genesis → Custom-Built (creates market pull)
 
 **4. Confusion of Choice (LE)**
 Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+
 - *When to use*: When incumbent position must be defended against clearly superior alternatives.
 - *Evolution stage*: Product stage (commoditisation pressure)
 
 **5. Brand and Marketing (N)**
 Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+
 - *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **6. FUD — Fear, Uncertainty, Doubt (LE)**
 Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+
 - *When to use*: Defensively, when a competitor threatens your position with a superior offering.
 - *Evolution stage*: Product stage (defending existing position)
 
 **7. Artificial Competition (CE)**
 Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+
 - *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
 - *Evolution stage*: Any stage (perception manipulation)
 
 **8. Lobbying / Counterplay (CE)**
 Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+
 - *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
 - *Evolution stage*: Any stage (regulatory environment shaping)
 
@@ -77,26 +85,31 @@ Strategies designed to speed up component evolution along the x-axis (Genesis �
 
 **1. Market Enablement (LG)**
 Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+
 - *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
 - *Evolution stage*: Custom-Built → Product (accelerates standardisation)
 
 **2. Open Approaches (LG)**
 Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+
 - *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
 - *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
 
 **3. Exploiting Network Effects (N)**
 Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+
 - *When to use*: When you have a platform or communication component where value compounds with users.
 - *Evolution stage*: Product → Commodity (accelerated by user density)
 
 **4. Co-operation (N)**
 Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+
 - *When to use*: When no single organisation can drive a standard alone and collective action is needed.
 - *Evolution stage*: Custom-Built → Product (drives standardisation)
 
 **5. Industrial Policy (N)**
 Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+
 - *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
 - *Evolution stage*: Any stage (policy-driven acceleration)
 
@@ -108,16 +121,19 @@ Strategies designed to slow component evolution, preserving competitive advantag
 
 **1. Exploiting Constraint (LE)**
 Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+
 - *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **2. Intellectual Property Rights / IPR (LE)**
 Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+
 - *When to use*: When protecting genuine innovations that required significant R&D investment.
 - *Evolution stage*: Genesis → Custom-Built (protects early innovations)
 
 **3. Creating Constraints (CE)**
 Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+
 - *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
 - *Evolution stage*: Product → Commodity (blocks commoditisation)
 
@@ -129,21 +145,25 @@ Strategies for managing components that no longer provide value, are expensive t
 
 **1. Pig in a Poke (CE)**
 Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+
 - *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
 - *Evolution stage*: Any stage (often used with obsolete custom-built components)
 
 **2. Disposal of Liability (N)**
 Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+
 - *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
 - *Evolution stage*: Product → Commodity (managing decline gracefully)
 
 **3. Sweat and Dump (LE)**
 Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+
 - *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
 - *Evolution stage*: Product → Commodity (exploiting remaining value)
 
 **4. Refactoring (LG)**
 Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+
 - *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
 - *Evolution stage*: Custom-Built (restoring and modernising)
 
@@ -155,41 +175,49 @@ Strategies for positioning components within the market, manipulating pricing dy
 
 **1. Differentiation (N)**
 Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+
 - *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
 - *Evolution stage*: Custom-Built → Product (slows rightward movement)
 
 **2. Pricing Policy (N)**
 Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+
 - *When to use*: When pricing itself can shift market behaviour rather than just capture value.
 - *Evolution stage*: Product → Commodity (shapes competitive landscape)
 
 **3. Buyer / Supplier Power (LE)**
 Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+
 - *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
 - *Evolution stage*: Product → Commodity (exploiting market position)
 
 **4. Harvesting (LE)**
 Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+
 - *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
 - *Evolution stage*: Product → Commodity (late-stage value extraction)
 
 **5. Standards Game (LE)**
 Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+
 - *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
 - *Evolution stage*: Custom-Built → Product (locking in architecture)
 
 **6. Last Man Standing (LE)**
 Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+
 - *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
 - *Evolution stage*: Product → Commodity (consolidation phase)
 
 **7. Signal Distortion (CE)**
 Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+
 - *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
 - *Evolution stage*: Any stage (information environment manipulation)
 
 **8. Trading (N)**
 Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+
 - *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
 - *Evolution stage*: Any stage (timed exchanges)
 
@@ -201,31 +229,37 @@ Strategies for protecting existing market position, managing threats, and slowin
 
 **1. Threat Acquisition (N)**
 Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+
 - *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
 - *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
 
 **2. Raising Barriers to Entry (N)**
 Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+
 - *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
 - *Evolution stage*: Product (defending established position)
 
 **3. Procrastination (N)**
 Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+
 - *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
 - *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
 
 **4. Defensive Regulation (LE)**
 Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+
 - *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
 - *Evolution stage*: Any stage (regulatory entrenchment)
 
 **5. Limitation of Competition (CE)**
 Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+
 - *When to use*: Recognise and defend against it; deploying it invites antitrust action.
 - *Evolution stage*: Product → Commodity (dominant player defending monopoly)
 
 **6. Managing Inertia (N)**
 Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+
 - *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
 - *Evolution stage*: Any stage (internal transformation management)
 
@@ -237,36 +271,43 @@ Strategies for gaining market share, disrupting competitors, and creating new op
 
 **1. Directed Investment (LG)**
 Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+
 - *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
 - *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
 
 **2. Experimentation (LG)**
 Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+
 - *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
 - *Evolution stage*: Genesis (exploring new space)
 
 **3. Centre of Gravity (N)**
 Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+
 - *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
 - *Evolution stage*: Custom-Built → Product (targeted disruption)
 
 **4. Undermining Barriers to Entry (N)**
 Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+
 - *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
 - *Evolution stage*: Custom-Built → Product (disruptive market entry)
 
 **5. Fool's Mate (LE)**
 Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+
 - *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
 - *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
 
 **6. Press Release Process (LE)**
 Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+
 - *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
 - *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
 
 **7. Playing Both Sides (N)**
 Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+
 - *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
 - *Evolution stage*: Product → Commodity (platform-level control)
 
@@ -278,41 +319,49 @@ Strategies for creating, nurturing, and leveraging networks of interconnected co
 
 **1. Alliances (LG)**
 Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+
 - *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
 - *Evolution stage*: Custom-Built → Product (accelerating through partnership)
 
 **2. Co-creation (LG)**
 Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+
 - *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
 - *Evolution stage*: Genesis → Custom-Built (open innovation)
 
 **3. Sensing Engines / ILC (N)**
 Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+
 - *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
 - *Evolution stage*: Product → Commodity (data-driven adaptation)
 
 **4. Tower and Moat (N)**
 Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+
 - *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
 - *Evolution stage*: Product (building defensive ecosystem)
 
 **5. N-sided Markets (N)**
 Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+
 - *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
 - *Evolution stage*: Custom-Built → Product (platform creation)
 
 **6. Co-opting and Intercession (LE)**
 Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+
 - *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
 - *Evolution stage*: Product (value chain positioning)
 
 **7. Embrace and Extend (LE)**
 Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+
 - *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
 - *Evolution stage*: Product → Commodity (standard adoption then differentiation)
 
 **8. Channel Conflicts and Disintermediation (N)**
 Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+
 - *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
 - *Evolution stage*: Product → Commodity (distribution restructuring)
 
@@ -324,41 +373,49 @@ Strategies for understanding, outmanoeuvring, and responding to competitors dire
 
 **1. Ambush (N)**
 Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+
 - *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
 - *Evolution stage*: Genesis → Custom-Built (surprise market entry)
 
 **2. Fragmentation Play (LE)**
 Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+
 - *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
 - *Evolution stage*: Product (niche segmentation)
 
 **3. Reinforcing Competitor Inertia (LE)**
 Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+
 - *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
 - *Evolution stage*: Product (exploiting competitor commitment)
 
 **4. Sapping (LE)**
 Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+
 - *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
 - *Evolution stage*: Product → Commodity (gradual displacement)
 
 **5. Misdirection (CE)**
 Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+
 - *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
 - *Evolution stage*: Any stage (competitive deception)
 
 **6. Restriction of Movement (CE)**
 Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+
 - *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
 - *Evolution stage*: Product (platform gatekeeping)
 
 **7. Talent Raid (CE)**
 Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+
 - *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
 - *Evolution stage*: Any stage (capability competition)
 
 **8. Circling and Probing (N)**
 Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+
 - *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
 - *Evolution stage*: Any stage (competitive intelligence gathering)
 
@@ -370,21 +427,25 @@ Strategies for securing and maintaining optimal positions within the competitive
 
 **1. Land Grab (N)**
 Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+
 - *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
 - *Evolution stage*: Genesis → Custom-Built (early territory capture)
 
 **2. First Mover / Fast Follower (N)**
 Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+
 - *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
 - *Evolution stage*: Genesis → Custom-Built (timing of market entry)
 
 **3. Aggregation (N)**
 Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+
 - *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
 - *Evolution stage*: Product (integration play)
 
 **4. Weak Signal / Horizon (N)**
 Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+
 - *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
 - *Evolution stage*: Genesis (anticipating future evolution)
 
@@ -396,16 +457,19 @@ High-risk strategies that can harm competitors, markets, or even your own organi
 
 **1. Licensing Play (LE)**
 Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+
 - *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
 - *Evolution stage*: Custom-Built → Product (IP-based control)
 
 **2. Insertion (CE)**
 Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+
 - *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
 - *Evolution stage*: Product (dependency creation)
 
 **3. Designed to Fail (CE)**
 Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+
 - *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
 - *Evolution stage*: Genesis (false market signals)
 

--- a/arckit-copilot/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-copilot/skills/wardley-mapping/references/gameplay-patterns.md
@@ -1,59 +1,520 @@
 # Gameplay Patterns
 
-Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats.
+Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats. Each gameplay includes an alignment tag drawn from the D&D classification system.
 
-## Offensive Patterns
+---
 
-```yaml
-offensive_gameplay:
-  tower_and_moat:
-    description: "Build differentiating capabilities on commodity foundation"
-    when: "Strong custom components exist"
-    action: "Commoditize dependencies, invest in differentiation"
-    map_signature: "Custom components with commodity dependencies"
+## 1. D&D Alignment Key
 
-  land_and_expand:
-    description: "Enter market with narrow offering, expand from there"
-    when: "New market entry"
-    action: "Start simple, add components over time"
+Gameplays are classified using the Dungeons & Dragons alignment system to convey their ethical and strategic nature at a glance.
 
-  open_source_play:
-    description: "Commoditize competitor's differentiator"
-    when: "Competitor relies on custom component you can replicate"
-    action: "Open source alternative to accelerate commoditization"
+| Alignment | Meaning | Strategic character |
+|-----------|---------|---------------------|
+| **LG** (Lawful Good) | Ethical, structured, mutually beneficial | Creates genuine value for the ecosystem; operates with integrity |
+| **N** (Neutral) | Pragmatic, context-dependent | Balanced approach; can benefit or harm depending on execution |
+| **LE** (Lawful Evil) | Self-interested but within accepted norms | Operates legally but manipulates markets or stakeholders for advantage |
+| **CE** (Chaotic Evil) | Destructive, harmful, disregards norms | Deliberately deceives, damages competition, or harms stakeholders |
 
-  ecosystem:
-    description: "Create platform others build upon"
-    when: "Control infrastructure component"
-    action: "Enable others to build on your platform"
+**Good vs. Evil axis**: Good strategies create positive outcomes for the broader ecosystem. Evil strategies prioritise personal gain at others' expense.
 
-  two_factor:
-    description: "Satisfy two markets with one platform"
-    when: "Platform can serve multiple user types"
-    action: "Connect both sides of a market"
-```
+**Law vs. Chaos axis**: Lawful strategies use structured, rule-following approaches. Chaotic strategies are unconventional or disruptive of established order.
 
-## Defensive Patterns
+Recognising alignment helps you understand: what plays are being used against you, what plays align with your organisation's values, and which combinations are ethically coherent.
 
-```yaml
-defensive_gameplay:
-  patents_and_ip:
-    description: "Protect innovations legally"
-    when: "Genesis/custom stage innovations"
-    action: "File patents, protect trade secrets"
+---
 
-  creating_constraint:
-    description: "Slow evolution of component you control"
-    when: "Evolution threatens your position"
-    action: "Limit interoperability, create switching costs"
+## 2. Gameplay Catalog — 11 Categories
 
-  embrace_and_extend:
-    description: "Adopt standard then differentiate"
-    when: "Commodity/product threatens differentiation"
-    action: "Add proprietary extensions"
-```
+### Category A: User Perception
 
-## Build vs. Buy vs. Outsource
+Strategies that shape how users perceive and interact with your offerings. Can accelerate adoption or create artificial barriers to switching.
+
+**1. Education (LG)**
+Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+- *When to use*: Launching novel or complex components where user understanding is low.
+- *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
+
+**2. Bundling (N)**
+Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+- *When to use*: When individual components have limited standalone appeal but are complementary together.
+- *Evolution stage*: Product stage (combining maturing components)
+
+**3. Creating Artificial Needs (LE)**
+Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+- *When to use*: When a component solves a latent problem users have not yet articulated.
+- *Evolution stage*: Genesis → Custom-Built (creates market pull)
+
+**4. Confusion of Choice (LE)**
+Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+- *When to use*: When incumbent position must be defended against clearly superior alternatives.
+- *Evolution stage*: Product stage (commoditisation pressure)
+
+**5. Brand and Marketing (N)**
+Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+- *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**6. FUD — Fear, Uncertainty, Doubt (LE)**
+Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+- *When to use*: Defensively, when a competitor threatens your position with a superior offering.
+- *Evolution stage*: Product stage (defending existing position)
+
+**7. Artificial Competition (CE)**
+Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+- *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
+- *Evolution stage*: Any stage (perception manipulation)
+
+**8. Lobbying / Counterplay (CE)**
+Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+- *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
+- *Evolution stage*: Any stage (regulatory environment shaping)
+
+---
+
+### Category B: Accelerators
+
+Strategies designed to speed up component evolution along the x-axis (Genesis → Commodity). Accelerators grow markets and compress timelines.
+
+**1. Market Enablement (LG)**
+Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+- *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
+- *Evolution stage*: Custom-Built → Product (accelerates standardisation)
+
+**2. Open Approaches (LG)**
+Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+- *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
+- *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
+
+**3. Exploiting Network Effects (N)**
+Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+- *When to use*: When you have a platform or communication component where value compounds with users.
+- *Evolution stage*: Product → Commodity (accelerated by user density)
+
+**4. Co-operation (N)**
+Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+- *When to use*: When no single organisation can drive a standard alone and collective action is needed.
+- *Evolution stage*: Custom-Built → Product (drives standardisation)
+
+**5. Industrial Policy (N)**
+Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+- *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
+- *Evolution stage*: Any stage (policy-driven acceleration)
+
+---
+
+### Category C: De-accelerators
+
+Strategies designed to slow component evolution, preserving competitive advantage, higher margins, or market control.
+
+**1. Exploiting Constraint (LE)**
+Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+- *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**2. Intellectual Property Rights / IPR (LE)**
+Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+- *When to use*: When protecting genuine innovations that required significant R&D investment.
+- *Evolution stage*: Genesis → Custom-Built (protects early innovations)
+
+**3. Creating Constraints (CE)**
+Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+- *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
+- *Evolution stage*: Product → Commodity (blocks commoditisation)
+
+---
+
+### Category D: Dealing with Toxicity
+
+Strategies for managing components that no longer provide value, are expensive to maintain, or are hindering progress in your value chain.
+
+**1. Pig in a Poke (CE)**
+Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+- *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
+- *Evolution stage*: Any stage (often used with obsolete custom-built components)
+
+**2. Disposal of Liability (N)**
+Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+- *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
+- *Evolution stage*: Product → Commodity (managing decline gracefully)
+
+**3. Sweat and Dump (LE)**
+Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+- *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
+- *Evolution stage*: Product → Commodity (exploiting remaining value)
+
+**4. Refactoring (LG)**
+Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+- *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
+- *Evolution stage*: Custom-Built (restoring and modernising)
+
+---
+
+### Category E: Market
+
+Strategies for positioning components within the market, manipulating pricing dynamics, and securing competitive advantage through market structure.
+
+**1. Differentiation (N)**
+Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+- *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
+- *Evolution stage*: Custom-Built → Product (slows rightward movement)
+
+**2. Pricing Policy (N)**
+Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+- *When to use*: When pricing itself can shift market behaviour rather than just capture value.
+- *Evolution stage*: Product → Commodity (shapes competitive landscape)
+
+**3. Buyer / Supplier Power (LE)**
+Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+- *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
+- *Evolution stage*: Product → Commodity (exploiting market position)
+
+**4. Harvesting (LE)**
+Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+- *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
+- *Evolution stage*: Product → Commodity (late-stage value extraction)
+
+**5. Standards Game (LE)**
+Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+- *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
+- *Evolution stage*: Custom-Built → Product (locking in architecture)
+
+**6. Last Man Standing (LE)**
+Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+- *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
+- *Evolution stage*: Product → Commodity (consolidation phase)
+
+**7. Signal Distortion (CE)**
+Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+- *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
+- *Evolution stage*: Any stage (information environment manipulation)
+
+**8. Trading (N)**
+Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+- *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
+- *Evolution stage*: Any stage (timed exchanges)
+
+---
+
+### Category F: Defensive
+
+Strategies for protecting existing market position, managing threats, and slowing competitor progress.
+
+**1. Threat Acquisition (N)**
+Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+- *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
+- *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
+
+**2. Raising Barriers to Entry (N)**
+Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+- *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
+- *Evolution stage*: Product (defending established position)
+
+**3. Procrastination (N)**
+Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+- *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
+- *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
+
+**4. Defensive Regulation (LE)**
+Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+- *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
+- *Evolution stage*: Any stage (regulatory entrenchment)
+
+**5. Limitation of Competition (CE)**
+Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+- *When to use*: Recognise and defend against it; deploying it invites antitrust action.
+- *Evolution stage*: Product → Commodity (dominant player defending monopoly)
+
+**6. Managing Inertia (N)**
+Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+- *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
+- *Evolution stage*: Any stage (internal transformation management)
+
+---
+
+### Category G: Attacking
+
+Strategies for gaining market share, disrupting competitors, and creating new opportunities.
+
+**1. Directed Investment (LG)**
+Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+- *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
+- *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
+
+**2. Experimentation (LG)**
+Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+- *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
+- *Evolution stage*: Genesis (exploring new space)
+
+**3. Centre of Gravity (N)**
+Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+- *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
+- *Evolution stage*: Custom-Built → Product (targeted disruption)
+
+**4. Undermining Barriers to Entry (N)**
+Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+- *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
+- *Evolution stage*: Custom-Built → Product (disruptive market entry)
+
+**5. Fool's Mate (LE)**
+Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+- *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
+- *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
+
+**6. Press Release Process (LE)**
+Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+- *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
+- *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
+
+**7. Playing Both Sides (N)**
+Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+- *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
+- *Evolution stage*: Product → Commodity (platform-level control)
+
+---
+
+### Category H: Ecosystem
+
+Strategies for creating, nurturing, and leveraging networks of interconnected components and actors.
+
+**1. Alliances (LG)**
+Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+- *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
+- *Evolution stage*: Custom-Built → Product (accelerating through partnership)
+
+**2. Co-creation (LG)**
+Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+- *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
+- *Evolution stage*: Genesis → Custom-Built (open innovation)
+
+**3. Sensing Engines / ILC (N)**
+Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+- *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
+- *Evolution stage*: Product → Commodity (data-driven adaptation)
+
+**4. Tower and Moat (N)**
+Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+- *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
+- *Evolution stage*: Product (building defensive ecosystem)
+
+**5. N-sided Markets (N)**
+Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+- *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
+- *Evolution stage*: Custom-Built → Product (platform creation)
+
+**6. Co-opting and Intercession (LE)**
+Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+- *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
+- *Evolution stage*: Product (value chain positioning)
+
+**7. Embrace and Extend (LE)**
+Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+- *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
+- *Evolution stage*: Product → Commodity (standard adoption then differentiation)
+
+**8. Channel Conflicts and Disintermediation (N)**
+Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+- *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
+- *Evolution stage*: Product → Commodity (distribution restructuring)
+
+---
+
+### Category I: Competitor
+
+Strategies for understanding, outmanoeuvring, and responding to competitors directly.
+
+**1. Ambush (N)**
+Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+- *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
+- *Evolution stage*: Genesis → Custom-Built (surprise market entry)
+
+**2. Fragmentation Play (LE)**
+Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+- *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
+- *Evolution stage*: Product (niche segmentation)
+
+**3. Reinforcing Competitor Inertia (LE)**
+Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+- *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
+- *Evolution stage*: Product (exploiting competitor commitment)
+
+**4. Sapping (LE)**
+Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+- *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
+- *Evolution stage*: Product → Commodity (gradual displacement)
+
+**5. Misdirection (CE)**
+Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+- *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
+- *Evolution stage*: Any stage (competitive deception)
+
+**6. Restriction of Movement (CE)**
+Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+- *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
+- *Evolution stage*: Product (platform gatekeeping)
+
+**7. Talent Raid (CE)**
+Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+- *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
+- *Evolution stage*: Any stage (capability competition)
+
+**8. Circling and Probing (N)**
+Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+- *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
+- *Evolution stage*: Any stage (competitive intelligence gathering)
+
+---
+
+### Category J: Positional
+
+Strategies for securing and maintaining optimal positions within the competitive landscape.
+
+**1. Land Grab (N)**
+Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+- *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
+- *Evolution stage*: Genesis → Custom-Built (early territory capture)
+
+**2. First Mover / Fast Follower (N)**
+Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+- *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
+- *Evolution stage*: Genesis → Custom-Built (timing of market entry)
+
+**3. Aggregation (N)**
+Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+- *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
+- *Evolution stage*: Product (integration play)
+
+**4. Weak Signal / Horizon (N)**
+Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+- *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
+- *Evolution stage*: Genesis (anticipating future evolution)
+
+---
+
+### Category K: Poison
+
+High-risk strategies that can harm competitors, markets, or even your own organisation if misapplied. Recognise these when used against you.
+
+**1. Licensing Play (LE)**
+Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+- *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
+- *Evolution stage*: Custom-Built → Product (IP-based control)
+
+**2. Insertion (CE)**
+Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+- *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
+- *Evolution stage*: Product (dependency creation)
+
+**3. Designed to Fail (CE)**
+Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+- *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
+- *Evolution stage*: Genesis (false market signals)
+
+---
+
+## 3. Play-Position Matrix
+
+Use your position on the map and the market's maturity to select the most appropriate plays.
+
+| Your Position | Early Market | Growing Market | Mature Market | Consolidated Market |
+|---------------|-------------|----------------|---------------|---------------------|
+| **Genesis leader** | Education, Directed Investment, Experimentation | Land Grab, Open Approaches, Alliances | First Mover/Fast Follower, Market Enablement | Weak Signal/Horizon, Co-operation |
+| **Custom-Built strength** | Fool's Mate, Bundling, Tower and Moat | Centre of Gravity, Differentiation, Co-creation | Sensing Engines (ILC), N-sided Markets | Aggregation, Playing Both Sides |
+| **Product parity** | Fragmentation Play, Undermining Barriers | Pricing Policy, Brand and Marketing | Standards Game, Sapping, Circling and Probing | Harvesting, Last Man Standing |
+| **Commodity laggard** | Refactoring, Disposal of Liability | Managing Inertia, Threat Acquisition | Raising Barriers to Entry, Procrastination | Sweat and Dump, Channel Disintermediation |
+
+---
+
+## 4. Play Compatibility
+
+### Plays That Work Together
+
+| Primary Play | Compatible With | Why |
+|-------------|-----------------|-----|
+| Sensing Engines (ILC) | Ecosystem plays, Weak Signal/Horizon | ILC provides the data to act on horizon signals |
+| Open Approaches | Co-creation, Market Enablement, Alliances | Openness attracts community and enables markets |
+| Tower and Moat | N-sided Markets, Alliances, Co-creation | Moat is strengthened by ecosystem depth |
+| Land Grab | Directed Investment, Alliances | Resources and partnerships accelerate territory capture |
+| Experimentation | Directed Investment, Sensing Engines | Experiments generate signals; investment scales winners |
+| Education | Open Approaches, Market Enablement | Education grows the market that openness then accelerates |
+| Fragmentation Play | Undermining Barriers, Differentiation | Niche entry combined with unique positioning |
+| Fool's Mate | Directed Investment, Ambush | Concentrated investment enables surprise execution |
+| Playing Both Sides | Tower and Moat, Sensing Engines | Platform control enables both ecosystem sensing and competition |
+
+### Plays That Conflict
+
+| Play A | Conflicts With | Why |
+|--------|---------------|-----|
+| Open Approaches | IPR / Licensing Play | Opening commoditises what licensing tries to protect |
+| Standards Game | Fragmentation Play | One seeks consolidation, the other fragmentation |
+| Co-creation | Confusion of Choice | Transparency in co-creation undermines deliberate confusion |
+| Market Enablement | Exploiting Constraint | Enablement accelerates what constraint tries to slow |
+| Education (LG) | FUD (LE) | Honest information and fear messaging are incompatible |
+| Alliances (LG) | Misdirection (CE) | Trust-based partnership cannot coexist with deliberate deception |
+| Refactoring | Sweat and Dump | One invests to restore value; the other extracts before exit |
+
+---
+
+## 5. Strategic Anti-Patterns
+
+Common strategic mistakes identified when applying gameplays to Wardley Maps.
+
+**Playing in the wrong evolution stage**
+Applying a genesis gameplay (e.g., Experimentation) to a commodity component wastes resources. Applying a commodity play (e.g., Harvesting) to a genesis component kills nascent innovation. Always match the play to the component's actual evolution position on the map.
+
+**Ignoring inertia**
+Assuming that a clearly superior strategy will execute smoothly without addressing organisational resistance. Inertia is the single most common reason strategically correct plays fail in execution. Map your inertia points before committing to a play.
+
+**Single-play dependence**
+Relying on one play to secure a position. Durable positions require layered plays — for example, Open Approaches to accelerate adoption, followed by Sensing Engines and Tower and Moat to capture ecosystem value. Single plays are fragile.
+
+**Misreading evolution pace**
+Treating components as more evolved (or less evolved) than they are. Building a commodity play (Harvesting) on what is still a custom-built component destroys value. Mapping component position carefully before selecting plays is essential.
+
+**Ecosystem hubris**
+Assuming that a strong current ecosystem position is self-sustaining. Ecosystems decay when the platform owner stops creating genuine value or when a disruptive technology makes the platform irrelevant. ILC and Weak Signal plays are the antidotes.
+
+**Open washing**
+Claiming Open Approaches alignment while maintaining proprietary lock-in through standards control, licensing restrictions, or incompatible extensions. Community backlash is swift and destroys the trust that makes open strategies work.
+
+**Alignment drift**
+Starting with LG plays to build an ecosystem and then shifting to CE plays to extract value. This pattern (common in platform companies) destroys the trust that made the ecosystem valuable in the first place and invites regulatory intervention.
+
+---
+
+## 6. Case Study Summaries
+
+Canonical examples of gameplay combinations in practice.
+
+**AWS (ILC + Land Grab + Tower and Moat)**
+Amazon launched AWS in 2006 before competitors recognised cloud's potential (Land Grab), built a comprehensive ecosystem of services that created deep customer dependency (Tower and Moat), and used marketplace metadata to sense which services to build next (Sensing Engines / ILC). Result: cloud computing market dominance and ongoing competitive moat.
+
+**Amazon Retail (Ecosystem + Directed Investment + Sensing Engines)**
+Combined early e-commerce entry with systematic directed investment in logistics, Prime, and Marketplace to build a self-reinforcing flywheel. Data from transactions continuously informs pricing, inventory, and product expansion. The ecosystem (sellers, logistics, Prime) creates the moat.
+
+**Netflix (Fast Follower + Directed Investment + Ecosystem co-evolution)**
+Watched Blockbuster's online rental experiment, then executed a fast follower streaming strategy with heavy directed investment in technology and original content. Co-evolved with device manufacturers to ensure reach across platforms. Original content investment shifted Netflix from distributor to producer, reducing dependency on studio licensing.
+
+**Apple iPhone (Fool's Mate + Bundling + N-sided Markets)**
+Executed a decisive market entry that caught mobile incumbents unprepared (Fool's Mate). Bundled hardware, iOS, and services into a coherent premium value proposition (Bundling). Built an N-sided market connecting users, developers, and accessory makers through the App Store, creating powerful ecosystem lock-in.
+
+**Google Android (Open Approaches + Alliances + Insertion)**
+Open-sourced Android to accelerate device manufacturer adoption (Open Approaches). Built alliances with manufacturers, carriers, and developers (Alliances). Embedded Google Search, Maps, and Play Store as dependencies — creating structural control over the mobile ecosystem (Insertion).
+
+**Ubuntu (Open Approaches + Alliances + Market Enablement)**
+Adopted open-source approach to lower adoption barriers and grow a contributor community (Open Approaches). Built alliances with cloud providers and infrastructure vendors (Alliances). Shifted focus to cloud computing as the strategic battleground and enabled the market with free security and tooling (Market Enablement). Became the dominant cloud guest OS within 18 months.
+
+**Tesla (First Mover + Tower and Moat + Education)**
+Entered the EV market as a first mover with high-performance vehicles when competitors were not taking EVs seriously. Built an integrated ecosystem of manufacturing, Gigafactory battery production, and Supercharger network that competitors could not quickly replicate (Tower and Moat). Invested heavily in consumer education about EV benefits and sustainability.
+
+**Airbnb (N-sided Markets + Market Enablement + Defensive Regulation)**
+Created a two-sided platform connecting hosts and guests that no incumbent hotel company could easily replicate (N-sided Markets). Enabled a new market of peer-to-peer accommodation that unlocked latent supply (Market Enablement). Proactively engaged with regulators in key cities to legitimise the model rather than ignore regulation (Defensive Regulation).
+
+**Spotify (N-sided Markets + Bundling + Sensing Engines)**
+Built a platform connecting listeners, artists, labels, and advertisers (N-sided Markets). Bundled streaming, curation, podcasting, and premium features into a coherent offering with strong perceived value (Bundling). Used listener data to power recommendation algorithms (Discover Weekly, Daily Mix) that continuously improve engagement and reduce churn (Sensing Engines).
+
+---
+
+## 7. Build vs. Buy vs. Outsource
 
 Use the component's evolution position to guide sourcing decisions:
 
@@ -91,7 +552,9 @@ build_buy_outsource:
       - "Email delivery"
 ```
 
-## Innovation Investment by Stage
+---
+
+## 8. Innovation Investment by Stage
 
 ```yaml
 innovation_investment:
@@ -100,72 +563,26 @@ innovation_investment:
     approach: "Experiments, PoCs, research"
     metrics: "Learning velocity, options created"
     failure_tolerance: "High"
+    matching_plays: ["Experimentation", "Weak Signal/Horizon", "Directed Investment", "Education"]
 
   custom:
     investment_type: "Differentiation"
     approach: "Product development, custom builds"
     metrics: "Feature completion, user adoption"
     failure_tolerance: "Medium"
+    matching_plays: ["Fool's Mate", "Tower and Moat", "Co-creation", "Alliances"]
 
   product:
     investment_type: "Enhancement"
     approach: "Integration, configuration"
     metrics: "Time to value, TCO"
     failure_tolerance: "Low"
+    matching_plays: ["Differentiation", "Standards Game", "Sensing Engines (ILC)", "N-sided Markets"]
 
   commodity:
     investment_type: "Optimization"
     approach: "Cost reduction, automation"
     metrics: "Cost per unit, availability"
     failure_tolerance: "Very low"
-```
-
-## Common Map Patterns
-
-Recognizable patterns to watch for when analyzing a completed map.
-
-### Desirable Patterns
-
-```yaml
-desirable_patterns:
-  tower_pattern:
-    description: "Differentiation built on commodity foundation"
-    structure:
-      top: "Genesis/Custom differentiators"
-      middle: "Product integrations"
-      bottom: "Commodity infrastructure"
-    example:
-      differentiator: "Custom recommendation engine"
-      product_layer: "E-commerce platform, CRM"
-      commodity: "Cloud compute, databases"
-    strategy: "Maximize commoditization at bottom to fund innovation at top"
-```
-
-### Anti-Patterns
-
-```yaml
-anti_patterns:
-  legacy_trap:
-    description: "Custom-built components that should be commodity"
-    symptoms:
-      - "Large team maintaining commodity-equivalent"
-      - "High cost, slow innovation"
-      - "Technical debt accumulation"
-    example:
-      component: "Custom identity management"
-      market_alternatives: ["Auth0", "Azure AD B2C", "Okta"]
-      waste: "Team of 5 maintaining what SaaS provides"
-    resolution: "Migrate to product/commodity, redeploy team"
-
-  premature_innovation:
-    description: "Treating genesis component as if product/commodity"
-    symptoms:
-      - "Fixed-scope contracts for unknown work"
-      - "Waterfall planning for experimental work"
-      - "Outsourcing pioneer work"
-    example:
-      component: "Novel ML application"
-      mistake: "Fixed-price contract with vendor"
-      result: "Scope creep, failed project"
-    resolution: "Match management approach to evolution stage"
+    matching_plays: ["Harvesting", "Last Man Standing", "Outsource decision", "Disposal of Liability"]
 ```

--- a/arckit-copilot/skills/wardley-mapping/references/mapping-examples.md
+++ b/arckit-copilot/skills/wardley-mapping/references/mapping-examples.md
@@ -304,4 +304,215 @@ ml_strategy:
       Custom models only where product gaps exist.
 ```
 
+---
+
+## Example 4: TechnoGadget Smart Home (Climatic Patterns Case Study)
+
+This example is drawn from the *Introduction to Wardley Mapping Climatic Patterns* reference work. It illustrates how climatic patterns interact with component positioning in a real-world product company.
+
+### Scenario
+
+TechnoGadget Inc. is a mid-sized technology company producing smart home devices. Their flagship product is a smart thermostat controllable via a smartphone app. Facing increased competition, they are planning international expansion.
+
+- **User Need**: "Comfortable home environment with energy efficiency"
+
+### OnlineWardleyMaps Syntax
+
+```owm
+title TechnoGadget Inc.
+
+anchor Customer [0.95, 0.63]
+
+component Smart thermostat [0.65, 0.46] label [-81, -9]
+component Mobile app [0.79, 0.34] label [-77, 2]
+component Cloud infrastructure [0.05, 0.75] label [-26, 13]
+component Data analytics [0.22, 0.36] label [-68, 24]
+component Customer support [0.86, 0.81] label [9, -17]
+component Marketing and sales [0.51, 0.66] label [-25, -57]
+component R&D [0.50, 0.22]
+component API [0.34, 0.28] label [-29, 20]
+
+Customer->Smart thermostat
+Customer->Customer support
+Customer->Mobile app
+
+Smart thermostat->Mobile app
+Smart thermostat->Cloud infrastructure
+Smart thermostat->Data analytics
+Smart thermostat->API
+
+Mobile app->API
+
+API->Cloud infrastructure
+API->Data analytics
+
+Cloud infrastructure->Data analytics
+Cloud infrastructure->Customer support
+Cloud infrastructure->Marketing and sales
+Cloud infrastructure->R&D
+
+evolve API 0.75
+```
+
+Paste into [OnlineWardleyMaps](https://create.wardleymaps.ai) to render.
+
+### Component Positions
+
+| Component | Visibility | Evolution | Stage | Notes |
+|-----------|-----------|-----------|-------|-------|
+| Smart thermostat | 0.65 | 0.46 | Custom-Built/Product | Core product, approaching commoditization |
+| Mobile app | 0.79 | 0.34 | Custom-Built | High visibility, custom UX differentiator |
+| Cloud infrastructure | 0.05 | 0.75 | Product/Commodity | Low visibility, enabling layer |
+| Data analytics | 0.22 | 0.36 | Custom-Built | Higher-order capability built on commoditized infra |
+| Customer support | 0.86 | 0.81 | Commodity | High visibility, standardized function |
+| Marketing and sales | 0.51 | 0.66 | Product | Mid-chain, standard practice |
+| R&D | 0.50 | 0.22 | Genesis/Custom-Built | Uncertain, high-value future options |
+| API | 0.34 | 0.28 → 0.75 | Custom-Built (evolving) | Strategic evolution signal: moving toward commodity |
+
+### Strategic Insights
+
+- **Commoditization pressure on core product**: Smart thermostat and Mobile app cluster in the Product stage — inertia risk is high as these evolve toward commodity and competitors can replicate them. TechnoGadget must shift differentiation upstream toward Data analytics and R&D before the hardware commoditizes.
+- **Efficiency enables innovation**: Commoditized Cloud infrastructure enables faster and cheaper development of custom-built Data analytics and R&D capabilities. This is the "higher-order systems create new value" climatic pattern in action — the commodity layer subsidizes the genesis layer.
+- **API evolution watch**: The `evolve API 0.75` annotation signals an anticipated move toward commodity. Once APIs commoditize, third-party integrators can build on TechnoGadget's platform — creating an ecosystem play opportunity (ILC pattern) but also opening the platform to competitive pressure.
+
+---
+
+## Example 5: Value Chain Decomposition Walkthrough
+
+A step-by-step demonstration of how to decompose a user need into a full Wardley Map. Use this pattern when starting from scratch with a new domain.
+
+### Starting Point: "Buy Products Online"
+
+This walkthrough shows the decomposition process for a simplified e-commerce value chain.
+
+#### Step 1 — Anchor
+
+Identify the user and their need:
+
+```
+User: Online Shopper
+Need: Buy products online
+```
+
+Place the anchor at the top of the map (high visibility = 1.0).
+
+#### Step 2 — First-Level Decomposition
+
+Ask: "What does the user directly interact with to fulfil this need?"
+
+```
+Buy products online
+  ├── Product Discovery      (finding what to buy)
+  ├── Shopping Experience    (browsing, comparison)
+  ├── Checkout               (basket, order confirmation)
+  └── Fulfilment             (delivery, returns)
+```
+
+These four components are directly visible to the user — position them high on the Y-axis (visibility 0.7-0.9).
+
+#### Step 3 — Second-Level Decomposition
+
+For each first-level component, ask: "What does this depend on?"
+
+```
+Product Discovery depends on:
+  ├── Search Engine           (index + ranking)
+  ├── Product Catalogue       (structured data)
+  └── Recommendation Engine   (personalisation ML)
+
+Shopping Experience depends on:
+  ├── Product Images / Media  (CDN delivery)
+  ├── Reviews & Ratings       (UGC platform)
+  └── Price Comparison        (pricing service)
+
+Checkout depends on:
+  ├── Shopping Cart           (session state)
+  ├── Payment Gateway         (Stripe / Adyen)
+  └── Identity / Auth         (login, SSO)
+
+Fulfilment depends on:
+  ├── Order Management System (OMS)
+  ├── Warehouse / 3PL         (physical logistics)
+  └── Notification Service    (email / SMS)
+```
+
+#### Step 4 — Assign Evolution Positions
+
+Apply the Evolution Scoring rubric (see [Mathematical Models](mathematical-models.md)):
+
+| Component | U | C | E(c) | Stage |
+|-----------|---|---|------|-------|
+| Search Engine | 0.55 | 0.60 | 0.58 | Product |
+| Product Catalogue | 0.70 | 0.75 | 0.73 | Product |
+| Recommendation Engine | 0.40 | 0.35 | 0.38 | Custom |
+| Payment Gateway | 0.90 | 0.88 | 0.89 | Commodity |
+| Shopping Cart | 0.75 | 0.80 | 0.78 | Product/Commodity |
+| Identity / Auth | 0.80 | 0.85 | 0.83 | Commodity |
+| Order Management | 0.60 | 0.65 | 0.63 | Product |
+| Notification Service | 0.85 | 0.90 | 0.88 | Commodity |
+
+#### Step 5 — Draw Dependency Arrows
+
+Add arrows from dependent → dependency (top to bottom, left-to-right for evolution):
+
+```
+Product Discovery → Recommendation Engine → Customer Data
+Checkout → Payment Gateway
+Checkout → Identity / Auth
+Fulfilment → Notification Service
+```
+
+Arrows that cross from right to left (high evolution to low) highlight **dependency risk** — a mature, visible component relying on an immature dependency.
+
+#### Step 6 — Apply Validation Checklist
+
+Before finalizing the map, verify:
+
+```yaml
+validation:
+  anchor_present: true          # User and need clearly stated?
+  all_user_touchpoints_mapped:  # Everything the user directly interacts with?
+  dependencies_visible:         # Have you traced at least 2 levels down?
+  evolution_justified:          # Can you defend each component's position?
+  movement_arrows:              # Have you noted evolving components?
+  no_orphan_components:         # Every component connects to at least one other?
+  strategic_question_answered:  # Does the map help answer a specific decision?
+```
+
+---
+
+## Case Study Cross-References
+
+Brief pattern examples connecting well-known companies to Wardley Mapping gameplay patterns. For the full pattern descriptions, see [Gameplay Patterns](gameplay-patterns.md).
+
+### AWS — ILC Pattern (Innovate, Leverage, Commoditize)
+
+Amazon ran the ILC play across its own infrastructure:
+
+1. **Innovate**: Built custom-scale distributed infrastructure internally for Amazon.com (Genesis/Custom-Built)
+2. **Leverage**: Recognized that the infrastructure had value as a product — launched EC2 (2006) and S3 as commercial offerings (Custom → Product)
+3. **Commoditize**: Drove the market toward utility pricing, making competitors' infrastructure investments uneconomical
+
+The result: internal cost-centre became the world's largest cloud platform. The key insight was that what was necessary-but-not-differentiating *for Amazon* was differentiating *for everyone else*. Any organization can ask: "What have we built for ourselves that others would pay for?"
+
+### Netflix — Attacking Play (Platform Transition)
+
+Netflix used a Wardley attacking play to shift from a position of weakness to market leadership:
+
+1. **Identified the evolution**: Physical DVD rental was moving toward commodity (and eventually obsolescence); streaming infrastructure was emerging
+2. **Attacked with an alternative**: Launched streaming when infrastructure costs fell low enough to make it viable (cloud commoditizing bandwidth and compute)
+3. **Built the new ecosystem**: Developed content recommendation, original programming, and global delivery — creating defensible positions in what would otherwise be a commodity streaming market
+
+The attack succeeded because Netflix moved *before* incumbents (Blockbuster) accepted that the old model was dying. Inertia from their successful past model slowed their response.
+
+### Spotify — Two-Sided Market Play
+
+Spotify operates a two-factor market with three distinct user groups creating a flywheel:
+
+1. **Free users (scale)**: Provide data, content demand signals, and a large addressable market for advertisers
+2. **Premium subscribers (revenue)**: Convert from free tier; fund content licensing and platform development
+3. **Artists and labels (content)**: Attracted by the large user base, provide the content that attracts users
+
+The mapping insight: Spotify's true strategic asset is not the music (a commodity licensed from labels) but the **listener data** and **playlist/discovery graph** — both of which sit in the Custom-Built stage and are hard to replicate. The commodity content layer enables the differentiating data layer above it.
+
 For common mapping patterns and anti-patterns (Tower, Legacy Trap, Premature Innovation), see [Gameplay Patterns](gameplay-patterns.md).

--- a/arckit-copilot/skills/wardley-mapping/references/mathematical-models.md
+++ b/arckit-copilot/skills/wardley-mapping/references/mathematical-models.md
@@ -249,6 +249,152 @@ Moderate-to-strong signal — transitioning from Product to Commodity. (And inde
 
 ---
 
+---
+
+## D. Play-Position Scoring
+
+A quantitative framework for evaluating which gameplay options are viable given your current map position.
+
+### Core Formula
+
+```
+Play Score = Position_Match(0-1) × Capability_Fit(0-1) × (1 - Risk_Factor(0-1))
+```
+
+Higher scores indicate plays that are well-aligned with your position, executable with current capabilities, and have acceptable downside risk.
+
+### Position Match
+
+How well does the gameplay play align with the evolution position of the target components?
+
+```
+Position_Match scoring:
+  Play targets your current stage:        1.0   (e.g., ILC play on a Custom-Built component)
+  Play targets an adjacent stage:         0.6   (one stage left or right of current)
+  Play targets a distant stage:           0.2   (two stages away)
+```
+
+**Example**: An "Open Source" commoditization play on a Product-stage component (adjacent — targeting Commodity) scores 0.6. The same play on a Genesis-stage component (distant — skipping two stages) scores 0.2.
+
+### Capability Fit
+
+Can your organization actually execute this play? Assess against the prerequisites for the specific gameplay.
+
+```
+Capability_Fit scoring:
+  Have all prerequisites:                 1.0   (full capability to execute)
+  Have most prerequisites:                0.7   (minor gaps, fillable with investment)
+  Missing one key capability:             0.3   (significant gap requiring major effort)
+  Missing multiple key capabilities:      0.1   (play is currently out of reach)
+```
+
+**Example**: An ILC play requires engineering scale, platform capabilities, and sales channels. A startup with strong engineering but no sales or platform infrastructure scores 0.3.
+
+### Risk Factor
+
+What is the downside if the play fails or conditions change?
+
+```
+Risk_Factor scoring:
+  Low risk, fully reversible:             0.1   (easy to stop, low sunk cost)
+  Medium risk, partially reversible:      0.4   (moderate investment, some recovery possible)
+  High risk, largely irreversible:        0.8   (major commitment, hard to unwind)
+  Existential risk, irreversible:         0.95  (bet-the-company, failure = shutdown)
+```
+
+Note: The Risk_Factor is subtracted from 1.0 before multiplying — so higher risk *reduces* the play score.
+
+### Worked Example: Evaluating Three Plays
+
+A company with a Custom-Built analytics platform evaluates three possible plays:
+
+| Play | Position_Match | Capability_Fit | Risk_Factor | Play Score | Verdict |
+|------|---------------|----------------|-------------|------------|---------|
+| Productize platform (sell to others) | 1.0 (Custom→Product) | 0.7 (engineering ok, sales gap) | 0.4 (medium) | 1.0 × 0.7 × 0.6 = **0.42** | Viable with investment |
+| Open source to commoditize | 0.6 (adjacent→Commodity) | 0.3 (no community mgmt) | 0.4 (medium) | 0.6 × 0.3 × 0.6 = **0.11** | Not viable yet |
+| Deepen custom differentiation | 1.0 (stay in Custom) | 1.0 (core strength) | 0.1 (low) | 1.0 × 1.0 × 0.9 = **0.90** | Strong — continue investing |
+
+The scoring confirms the intuitive recommendation: double down on differentiation while building the sales capability needed to eventually productize.
+
+### Play Score Interpretation
+
+| Play Score | Recommendation |
+|------------|---------------|
+| 0.70 - 1.00 | Execute — strong alignment, capability, and acceptable risk |
+| 0.40 - 0.70 | Conditional — viable but address the weakest factor first |
+| 0.15 - 0.40 | Weak — significant gaps; develop prerequisites before attempting |
+| 0.00 - 0.15 | Avoid — misaligned, incapable, or too risky at current position |
+
+---
+
+## E. Climate Pattern Impact Weighting
+
+A scoring framework for prioritizing which components face the greatest strategic pressure from climatic patterns.
+
+### Impact Matrix
+
+For each climatic pattern identified on a map, score its impact on each component:
+
+```
+Impact Matrix: Pattern × Component → Score (1-5)
+
+Scoring scale:
+  5 = Pattern directly threatens or enables this component's current position
+  4 = Pattern significantly affects this component's evolution trajectory
+  3 = Pattern has moderate influence on this component
+  2 = Pattern has minor relevance to this component
+  1 = Pattern has negligible or no effect on this component
+```
+
+A score of 5 means: if you ignore this pattern for this component, you will likely make a wrong strategic decision. A score of 1 means: the pattern exists but has no actionable implication for this component.
+
+### Aggregate Scoring
+
+Once the matrix is populated, calculate three aggregate scores:
+
+```
+Component Risk Score  = Sum of all pattern impact scores for that component
+  → Identifies which components face the most cumulative climatic pressure
+
+Pattern Criticality   = Sum of all component impact scores for that pattern
+  → Identifies which patterns have the broadest effect across the value chain
+
+Priority Focus        = Components with the highest Component Risk Scores
+  → Where to direct monitoring, investment, or contingency planning
+```
+
+### Worked Example: TechnoGadget Smart Home
+
+Applying 5 climatic patterns to the TechnoGadget map (from [Mapping Examples](mapping-examples.md)):
+
+| Component | Everything Evolves | Inertia | Higher-Order Systems | Efficiency Enables Innovation | Competitors Change Game | Risk Score |
+|-----------|-------------------|---------|---------------------|------------------------------|------------------------|------------|
+| Smart thermostat | 4 | 5 | 2 | 1 | 5 | **17** |
+| Mobile app | 3 | 4 | 2 | 1 | 4 | **14** |
+| Cloud infrastructure | 2 | 1 | 5 | 5 | 1 | **14** |
+| Data analytics | 4 | 2 | 5 | 4 | 3 | **18** |
+| R&D | 3 | 1 | 4 | 4 | 2 | **14** |
+| API | 5 | 2 | 3 | 3 | 4 | **17** |
+| **Pattern Criticality** | **21** | **15** | **21** | **18** | **19** | |
+
+**Interpretation**:
+
+- **Data analytics** (18) and **Smart thermostat / API** (17 each) face the highest cumulative climatic pressure — these are the priority focus components
+- **Everything Evolves** and **Higher-Order Systems** tie as the most broadly impactful patterns (21 each) — both affect nearly every component
+- **Inertia** (15) scores lowest in criticality but scores highest on Smart thermostat (5) — it is highly concentrated on one critical component, not broadly distributed
+
+### Using the Matrix in Practice
+
+1. List all climatic patterns identified on the map (typically 3-8 for a focused analysis)
+2. Score each pattern against each component (5-minute workshop exercise per pattern)
+3. Sum rows (component risk) and columns (pattern criticality)
+4. Rank components by risk score — highest scores demand strategic attention
+5. For components scoring 15+ (in a 5-pattern analysis), develop explicit contingency responses
+
+The matrix is most useful as a workshop tool: it forces explicit discussion about *why* a pattern affects a component, surfaces disagreements in the team's mental models, and produces a defensible prioritization.
+
+---
+
 ## Further Reading
 
 These models are drawn from a broader mathematical framework for Wardley Mapping that includes game theory, stochastic processes, topological analysis, and Bayesian inference. For the full academic treatment, see the [Wardley Map Mathematical Model](https://github.com/tractorjuice/wardleymap_math_model) repository.

--- a/arckit-copilot/templates/wardley-climate-template.md
+++ b/arckit-copilot/templates/wardley-climate-template.md
@@ -1,0 +1,260 @@
+# Wardley Climate Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.climate`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Climate Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.climate` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the most significant climate forces acting on this landscape, the components under most pressure, and the key strategic implications. Include whether the overall climate is favourable, neutral, or threatening for the current strategy.]
+
+**Climate Severity**:
+
+| Category | Severity | Most Affected Components |
+|----------|----------|--------------------------|
+| Component Patterns | High / Medium / Low / None | {Component names} |
+| Financial Patterns | High / Medium / Low / None | {Component names} |
+| Speed Patterns | High / Medium / Low / None | {Component names} |
+| Inertia Patterns | High / Medium / Low / None | {Component names} |
+| Competitor Patterns | High / Medium / Low / None | {Component names} |
+| Prediction Patterns | High / Medium / Low / None | {Component names} |
+
+---
+
+## Map Reference
+
+This climate assessment is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+
+---
+
+## Component Inventory
+
+*Extracted from the referenced Wardley Map. All components subject to climate assessment.*
+
+| Component | Visibility | Evolution | Stage |
+|-----------|-----------|-----------|-------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 2} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 3} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 4} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 5} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+
+---
+
+## Climate Assessment by Category
+
+### 1. Component Patterns
+
+*How do components naturally evolve and what forces act on them?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Everything evolves (no component stays still) | Yes / No / Partial | H / M / L | {Observation from the map or market} | {What this means for strategy} |
+| Characteristics change as components evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| No "one size fits all" method | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Success breeds inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems create new sources of worth | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Components can co-evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new areas of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation enables new genesis | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 2. Financial Patterns
+
+*How do economic forces shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Efficiency enables innovation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new sources of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation reduces margin | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New economic models emerge (e.g., SaaS, platform) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Price pressure on product-stage components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Investment bias towards Genesis/Custom stages | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 3. Speed Patterns
+
+*How does the pace of change affect the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Evolution is not uniform (some components evolve faster) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation is accelerating (shorter cycles) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem effects accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Open source accelerates commoditisation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Regulation can slow or accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 4. Inertia Patterns
+
+*What forces resist change in this landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Past success creates resistance to change | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Existing practices embed inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Vendor lock-in creates artificial inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 5. Competitor Patterns
+
+*How do competitor behaviours shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Competitors also face inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants exploit incumbent inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 6. Prediction Patterns
+
+*What can be reliably anticipated about how this landscape will change?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Commoditisation of custom-built components is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Co-evolution of practice and technology is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems will emerge from current commodities | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Shifts from product to utility are visible before they occur | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants will appear at Genesis stage of key components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Inertia creates predictable points of disruption | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem plays follow commoditisation events | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Peace / War / Wonder cycles follow predictable patterns | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+## Per-Component Impact Matrix
+
+*How strongly does each climate category affect each component? H = High, M = Medium, L = Low, — = Not applicable.*
+
+| Component | Component Patterns | Financial Patterns | Speed Patterns | Inertia Patterns | Competitor Patterns | Prediction Patterns |
+|-----------|:-----------------:|:-----------------:|:--------------:|:----------------:|:------------------:|:------------------:|
+| {Component 1} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 2} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 3} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 4} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 5} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+
+---
+
+## Prediction Horizons
+
+*Anticipated evolution of key components over the next 6 and 18 months.*
+
+| Component | Current Stage | 6-Month Prediction | 18-Month Prediction | Confidence | Key Signals |
+|-----------|:------------:|:-----------------:|:------------------:|:----------:|-------------|
+| {Component 1} | Genesis | Custom (0.30) | Custom (0.40) | High / Medium / Low | {Observable signals — market activity, open source, vendor releases} |
+| {Component 2} | Custom | Product (0.55) | Product (0.65) | High / Medium / Low | {Observable signals} |
+| {Component 3} | Product | Product (0.70) | Commodity (0.80) | High / Medium / Low | {Observable signals} |
+| {Component 4} | Commodity | Commodity (0.90) | Commodity (0.95) | High / Medium / Low | {Observable signals} |
+
+---
+
+## Wave Analysis
+
+**Peace / War / Wonder Cycle**:
+
+The Wardley climate framework identifies a recurring cycle in markets:
+
+- **Peace**: Steady improvement of existing products; incumbents dominant; gradual evolution
+- **War**: Rapid disruption as a new model (e.g., cloud, SaaS, open source) makes existing approaches obsolete; major market shift
+- **Wonder**: Post-disruption stabilisation; new commodity enables new genesis; ecosystem flourishes
+
+**Current Positioning for This Context**:
+
+| Market Segment | Current Phase | Evidence | Strategic Implication |
+|----------------|:------------:|----------|-----------------------|
+| {Segment 1} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+| {Segment 2} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+
+**Recommended Response to Phase**:
+
+- {If Peace}: {Strategy for steady-state market — consolidation, efficiency, incremental improvement}
+- {If War}: {Strategy for disruption — move fast, exploit inertia of incumbents, align with the new model}
+- {If Wonder}: {Strategy for post-disruption — explore new genesis opportunities enabled by the new commodity}
+
+---
+
+## Inertia Assessment
+
+| Component | Inertia Type | Severity | Mitigation Strategy |
+|-----------|-------------|:--------:|---------------------|
+| {Component 1} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 2} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 3} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+
+**Inertia Type Definitions**:
+
+- **Skills**: Team expertise locked to legacy technology or practice
+- **Process**: Established workflows and procedures that resist change
+- **Vendor**: Contractual or technical dependencies that create switching costs
+- **Cultural**: "We've always done it this way" — organisational resistance
+- **Capital**: Sunk costs in existing systems justify continued investment
+- **Regulatory**: Compliance requirements that constrain or slow evolution
+
+---
+
+## Strategic Implications
+
+[3-5 bullet points summarising the most actionable strategic implications from the full climate assessment. Each point should connect a specific climate finding to a recommended strategic response.]
+
+- **{Implication 1}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 2}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 3}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 4}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 5}**: {Specific climate finding} → {Recommended strategic response}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map; all components assessed in this document are derived from it |
+| Requirements | ARC-[PROJECT_ID]-REQ-v[VERSION] | Climate signals may invalidate or create new requirements |
+| Research | ARC-[PROJECT_ID]-RSCH-v[VERSION] | Market research provides evidence for climate pattern assessment |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.climate` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-copilot/templates/wardley-doctrine-template.md
+++ b/arckit-copilot/templates/wardley-doctrine-template.md
@@ -1,0 +1,290 @@
+# Wardley Doctrine Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.doctrine`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WDOC-v[VERSION] |
+| **Document Type** | Wardley Doctrine Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.doctrine` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+**Overall Maturity Score**: [X.X / 5.0] — [Novice / Developing / Practising / Advanced / Leading]
+
+**Phase Positioning**:
+
+| Phase | Name | Score | Status |
+|-------|------|-------|--------|
+| Phase I | Stop Self-Harm | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase II | Becoming More Context Aware | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase III | Better for Less | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase IV | Continuously Evolving | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+
+**Critical Findings**:
+
+1. {Most significant gap or risk from the assessment}
+2. {Second critical finding}
+3. {Third critical finding}
+
+[2-3 sentence narrative summary of the organisation's doctrine maturity and most urgent priorities.]
+
+---
+
+## Strategy Cycle Context
+
+| Element | Summary |
+|---------|---------|
+| **Purpose** | {Why does this organisation or team exist? What is the mission?} |
+| **Landscape** | {What does the Wardley Map of this context reveal? Key components and their evolution positions.} |
+| **Climate** | {What external forces are acting on this landscape? Market shifts, regulation, technology change.} |
+| **Leadership** | {What leadership style is currently in use? Commander's intent vs. detailed instruction? Risk appetite?} |
+
+---
+
+## Doctrine Assessment Matrix
+
+Score key: **1** = Not practised | **2** = Awareness only | **3** = Partially practised | **4** = Consistently practised | **5** = Embedded and exemplary
+
+### Phase I: Stop Self-Harm
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Communication | Use a common language | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Be transparent | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Challenge assumptions | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Know your users | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Focus on user needs | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use appropriate methods | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Remove bias and duplication | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use standards where appropriate | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage inertia | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage failure | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Think small (ecosystem) | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase II: Becoming More Context Aware
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Situational Awareness | Know the details | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Use appropriate doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Be aware of context-specific play | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Understand your environment | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Design for constant evolution | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Small teams with alignment and autonomy | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Move fast | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Be pragmatic | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | There is no one culture | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Seek the best | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase III: Better for Less
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Efficiency | Optimise flow | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Effectiveness over efficiency | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Think big | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Strategy is iterative not linear | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Use multiple methods of working | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | A bias towards the new | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Be the owner | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Set exceptional standards | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase IV: Continuously Evolving
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Learning | Listen to your ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | A bias towards action | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Exploit the landscape | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Understand that strategy is complex | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Commit to the path | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Accept uncertainty | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Spend time on doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Lead the ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+
+---
+
+## Detailed Phase Findings
+
+### Phase I: Stop Self-Harm — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase I Narrative**:
+
+[2-4 sentences describing the organisation's overall performance on Phase I. What self-harming behaviours are present? What is being done well?]
+
+---
+
+### Phase II: Becoming More Context Aware — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase II Narrative**:
+
+[2-4 sentences describing situational awareness maturity. Does the organisation understand its landscape? Does leadership have context for decisions?]
+
+---
+
+### Phase III: Better for Less — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase III Narrative**:
+
+[2-4 sentences describing efficiency and operational maturity. Where is the organisation wasting effort? Where are there genuine improvements?]
+
+---
+
+### Phase IV: Continuously Evolving — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase IV Narrative**:
+
+[2-4 sentences describing the organisation's capacity for continuous evolution. Is learning embedded? Do ecosystems inform strategy?]
+
+---
+
+## Previous Assessment Comparison
+
+*Populate on re-assessment only. Leave blank for initial assessment.*
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+**Overall Score Change**: [Previous X.X] → [Current X.X] ([+/- delta])
+
+---
+
+## Critical Gaps
+
+| Rank | Phase | Category | Principle | Current Score | Target Score | Business Impact |
+|------|-------|----------|-----------|:-------------:|:------------:|-----------------|
+| 1 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 2 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 3 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 4 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 5 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+
+---
+
+## Implementation Roadmap
+
+### Immediate Actions (0-3 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 1} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 2} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 3} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Short-Term Actions (3-12 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 4} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 5} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 6} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Long-Term Actions (12-24 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 7} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 8} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+---
+
+## Recommendations
+
+1. **{Recommendation 1}**
+   - **Rationale**: {Why this is the top priority}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+2. **{Recommendation 2}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+3. **{Recommendation 3}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Doctrine principles should align with and reinforce architecture principles |
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Landscape and climate context for this assessment |
+| Stakeholder Analysis | ARC-[PROJECT_ID]-STKE-v[VERSION] | Leadership and culture context; stakeholder awareness of doctrine |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.doctrine` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-copilot/templates/wardley-gameplay-template.md
+++ b/arckit-copilot/templates/wardley-gameplay-template.md
@@ -1,0 +1,337 @@
+# Wardley Gameplay Analysis: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.gameplay`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WGAM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Gameplay Analysis |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.gameplay` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the strategic context, the plays selected, and the anticipated outcomes. Include overall strategic posture: aggressive/defensive/opportunistic.]
+
+**Selected Plays Summary**:
+
+| Play | Category | Recommendation | Priority |
+|------|----------|----------------|----------|
+| {Play 1} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 2} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 3} | {Category A-K} | Monitor | High / Medium / Low |
+
+---
+
+## Map Reference
+
+This gameplay analysis is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+| **Key Components** | {List 3-5 key components from the map} |
+
+---
+
+## Situational Assessment
+
+### Position Analysis
+
+*What does your current map position tell you about strategic options?*
+
+- **Anchor (User Need)**: {Anchor component and its evolution position}
+- **Differentiating Components**: {Components in Genesis/Custom that provide competitive advantage}
+- **Commodity Dependencies**: {Components already at commodity — not strategic, cost-focus only}
+- **Evolution Pressure**: {Components showing signs of rapid evolution — where the map is moving}
+
+### Capability Assessment
+
+*What can your organisation do well, and where are the gaps?*
+
+- **Core Strengths**: {What the organisation does better than competitors in this landscape}
+- **Critical Weaknesses**: {Capability gaps that constrain strategic options}
+- **Unique Assets**: {Assets, data, relationships, or IP that could be leveraged}
+- **Constraints**: {Budget, skills, regulatory, or time constraints affecting play selection}
+
+### Market Context
+
+*What is happening in the competitive environment?*
+
+- **Competitor Positions**: {Where are key competitors positioned on the map?}
+- **Market Signals**: {What trends indicate where the market is heading?}
+- **Regulatory Environment**: {Any constraints or opportunities from regulation?}
+- **Partnership Opportunities**: {Potential ecosystem partners or coalition plays?}
+
+---
+
+## Play Options by Category
+
+### A. Accelerator Plays
+
+*Speed up component evolution to reshape the landscape.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Open approaches (open source, open data, open standards) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Exploit the ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Contribute to standards bodies | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### B. Decelerator Plays
+
+*Slow down competitor evolution or commoditisation.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| FUD (Fear, Uncertainty, Doubt) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Differentiation | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Lobbying and regulatory influence | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### C. Market Plays
+
+*Shape market conditions in your favour.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Buyer and supplier education | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Press and analyst briefings | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### D. Defensive Plays
+
+*Protect your position from competitive threats.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Protective moat (IP, switching costs) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Embrace and extend | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Threat acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### E. Attacking Plays
+
+*Move against competitor positions.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Exploiting inertia | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Undermining barriers to entry | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Talent acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### F. Ecosystem Plays
+
+*Leverage or build ecosystems for competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Building a platform | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Co-opting an ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating a pricing game | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### G. Positional Plays
+
+*Move to advantageous positions on the map.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Tower and moat | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Land grab | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Sensing engine | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### H. Poison Plays
+
+*Make a position undesirable for competitors.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Disposal of a liability | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Swamping | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### I. Innovation Plays
+
+*Create new value through novel combinations.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Design for uncharted spaces | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Signal distortion | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### J. People Plays
+
+*Leverage talent and culture as competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Centres of gravity | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Pioneer / settler / town planner model | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### K. Political Plays
+
+*Navigate organisational or market politics.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Creating artificial constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Trojan horse | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+---
+
+## Play-Position Matrix Evaluation
+
+*For each key component position on the map, identify which plays are naturally aligned.*
+
+| Component | Visibility | Evolution | Stage | Recommended Plays | Rationale |
+|-----------|-----------|-----------|-------|-------------------|-----------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis | {Play names} | {Why these plays fit this position} |
+| {Component 2} | {0.xx} | {0.xx} | Custom | {Play names} | {Why these plays fit this position} |
+| {Component 3} | {0.xx} | {0.xx} | Product | {Play names} | {Why these plays fit this position} |
+| {Component 4} | {0.xx} | {0.xx} | Commodity | {Play names} | {Why these plays fit this position} |
+
+---
+
+## Play Compatibility Analysis
+
+*Evaluate whether selected plays reinforce or conflict with each other.*
+
+| Play A | Play B | Compatibility | Notes |
+|--------|--------|:-------------:|-------|
+| {Play 1} | {Play 2} | Reinforces | {Why these plays work well together} |
+| {Play 1} | {Play 3} | Neutral | {No significant interaction} |
+| {Play 2} | {Play 4} | Conflicts | {Why these plays undermine each other — resolve or sequence carefully} |
+
+**Resolution for conflicts**: {Describe how conflicting plays will be sequenced or one prioritised over the other.}
+
+---
+
+## Selected Plays
+
+### Play 1: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1 — capability, resource, or condition that must be in place}
+- {Prerequisite 2}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+**Expected Outcomes**:
+
+- {Outcome 1 — what success looks like}
+- {Outcome 2}
+
+**Risks**:
+
+- {Risk 1 — what could go wrong}
+- {Risk 2}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+- [ ] {Measurable indicator 2}
+
+**Review Points**: {When to review whether this play is working — e.g., 3 months, after specific milestone}
+
+---
+
+### Play 2: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+
+**Expected Outcomes**:
+
+- {Outcome 1}
+
+**Risks**:
+
+- {Risk 1}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+
+**Review Points**: {When to review whether this play is working}
+
+---
+
+## Risk Assessment and Anti-Patterns
+
+### Play-Specific Risks
+
+| Risk | Play Affected | Likelihood | Impact | Mitigation |
+|------|--------------|------------|--------|------------|
+| {Risk 1} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+| {Risk 2} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+
+### Common Gameplay Anti-Patterns to Avoid
+
+- **Playing too many games at once**: Focus on 2-3 plays maximum; spreading effort dilutes impact
+- **Ignoring inertia**: Plays that require rapid evolution will stall if internal or market inertia is not addressed
+- **Misreading evolution stage**: Applying Genesis plays to Commodity components (or vice versa) wastes resources
+- **Neglecting doctrine**: Gameplay without sound doctrine (Phase I) often backfires
+- **Static play selection**: Plays that are right today may be wrong in 12 months — review regularly
+
+---
+
+## Case Study References
+
+| Case Study | Play(s) Illustrated | Source | Relevance to This Context |
+|------------|---------------------|--------|--------------------------|
+| {Case study 1} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+| {Case study 2} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+
+**Reference**: Simon Wardley, *Wardley Maps* (CC BY-SA 4.0) — available at [https://learnwardleymapping.com/](https://learnwardleymapping.com/)
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map providing landscape context for play selection |
+| Climate Assessment | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] | Climate patterns that constrain or enable specific plays |
+| Doctrine Assessment | ARC-[PROJECT_ID]-WDOC-v[VERSION] | Doctrine maturity governs which plays are executable |
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Plays must not violate established architecture principles |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.gameplay` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-copilot/templates/wardley-value-chain-template.md
+++ b/arckit-copilot/templates/wardley-value-chain-template.md
@@ -1,0 +1,216 @@
+# Wardley Value Chain: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.value-chain`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WVCH-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Value Chain |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.value-chain` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[Provide a concise summary of the value chain: its anchor (user need), the number of components, key dependencies, and the most critical strategic insights. 3-5 sentences.]
+
+---
+
+## User Need / Anchor
+
+The anchor is the user need at the top of the chain — the reason the value chain exists. Every component below the anchor must ultimately serve this need. If the anchor is wrong, the entire chain is wrong.
+
+**Anchor Statement**: [Describe the user need in one sentence, e.g., "Citizen can apply for a permit online without visiting an office."]
+
+**Good Anchor Examples**:
+
+- "User can access their medical records securely from any device"
+- "Taxpayer can file a return in under 15 minutes"
+- "Procurement team can evaluate vendor bids in a standardised format"
+
+**Bad Anchor Examples** (too technology-focused, not user-centred):
+
+- "System processes API calls" — this is a capability, not a user need
+- "Database stores records" — this is infrastructure, not a user need
+- "Microservices communicate via message bus" — this is implementation, not purpose
+
+---
+
+## Users and Personas
+
+| Persona | Role | Primary Need |
+|---------|------|--------------|
+| {Persona 1} | {Role description} | {Primary need this chain serves} |
+| {Persona 2} | {Role description} | {Primary need this chain serves} |
+| {Persona 3} | {Role description} | {Primary need this chain serves} |
+
+---
+
+## Value Chain Diagram
+
+**View this map**: Paste the OWM syntax below into [https://create.wardleymaps.ai](https://create.wardleymaps.ai)
+
+**ASCII Placeholder**:
+
+```text
+Visibility
+    ^
+1.0 | [User Need / Anchor]
+    |         |
+0.7 |   [Capability A]  [Capability B]
+    |         |               |
+0.4 |   [Component C]  [Component D]  [Component E]
+    |         |
+0.1 |   [Infrastructure F]
+    |
+    +--Genesis--Custom--Product--Commodity-->  Evolution
+       (0.0)   (0.25)  (0.50)   (0.75)  (1.0)
+```
+
+**OWM Syntax**:
+
+```wardley
+title {context_name} Value Chain
+anchor {UserNeed} [0.95, 0.63]
+
+component {CapabilityA} [0.70, 0.45]
+component {CapabilityB} [0.70, 0.72]
+component {ComponentC} [0.42, 0.38]
+component {ComponentD} [0.40, 0.65]
+component {ComponentE} [0.38, 0.80]
+component {InfrastructureF} [0.12, 0.90]
+
+{UserNeed} -> {CapabilityA}
+{UserNeed} -> {CapabilityB}
+{CapabilityA} -> {ComponentC}
+{CapabilityA} -> {ComponentD}
+{CapabilityB} -> {ComponentE}
+{ComponentC} -> {InfrastructureF}
+
+style wardley
+```
+
+---
+
+## Component Inventory
+
+| ID | Component | Description | Depends On | Visibility (0.0-1.0) |
+|----|-----------|-------------|------------|----------------------|
+| C-01 | {Component 1} | {Description} | — | {0.00} |
+| C-02 | {Component 2} | {Description} | C-01 | {0.00} |
+| C-03 | {Component 3} | {Description} | C-01, C-02 | {0.00} |
+| C-04 | {Component 4} | {Description} | C-02 | {0.00} |
+| C-05 | {Component 5} | {Description} | C-03, C-04 | {0.00} |
+
+---
+
+## Dependency Matrix
+
+The dependency matrix shows which components (rows) depend on which other components (columns). A cell marked **X** indicates a direct dependency; **I** indicates an indirect dependency; blank indicates no dependency.
+
+| | C-01 | C-02 | C-03 | C-04 | C-05 |
+|---|------|------|------|------|------|
+| **C-01** | — | | | | |
+| **C-02** | X | — | | | |
+| **C-03** | X | X | — | | |
+| **C-04** | | X | | — | |
+| **C-05** | I | I | X | X | — |
+
+[Replace placeholder rows/columns with actual component IDs from the Component Inventory above.]
+
+---
+
+## Critical Path Analysis
+
+The critical path is the sequence of dependencies from the anchor down to the lowest-level infrastructure component(s), where a failure at any step breaks the chain entirely.
+
+**Critical Path**:
+
+```text
+[User Need / Anchor]
+  └─> [Component X]  (Visibility: 0.xx, Evolution: 0.xx)
+        └─> [Component Y]  (Visibility: 0.xx, Evolution: 0.xx)
+              └─> [Component Z]  (Visibility: 0.xx, Evolution: 0.xx)
+```
+
+**Bottlenecks and Single Points of Failure**:
+
+| Component | Risk Type | Impact if Failed | Mitigation |
+|-----------|-----------|------------------|------------|
+| {Component} | Single vendor / Genesis fragility / Low maturity | {Impact description} | {Mitigation plan} |
+
+**Resilience Gaps**:
+
+- [ ] {Identify components with no fallback or redundancy}
+- [ ] {Identify dependencies on Genesis-stage components}
+- [ ] {Identify vendor lock-in on critical path}
+
+---
+
+## Validation Checklist
+
+- [ ] Chain starts with user need (anchor)
+- [ ] All critical dependencies captured
+- [ ] Chain reaches commodity level
+- [ ] No orphan components
+- [ ] Dependencies reflect reality
+- [ ] Visibility ordering correct
+- [ ] Granularity appropriate for purpose
+
+---
+
+## Visibility Assessment
+
+| Level | Range | Characteristics | Examples |
+|-------|-------|-----------------|---------|
+| **User-facing** | 0.90 - 1.00 | Directly experienced by the user; failure is immediately visible | Login page, search results, payment confirmation |
+| **High** | 0.70 - 0.89 | Close to user; users notice degradation quickly | API gateway, authentication service, user profile |
+| **Medium-High** | 0.50 - 0.69 | Indirectly visible; affects features users rely on | Business logic layer, data validation, reporting engine |
+| **Medium** | 0.30 - 0.49 | Hidden from users but essential to operations; failure noticed over time | Caching layer, queue management, audit logging |
+| **Low** | 0.10 - 0.29 | Invisible to users; operational/infrastructure concern | Database engine, message broker, network routing |
+| **Infrastructure** | 0.00 - 0.09 | Deep infrastructure; users unaware it exists | Power supply, physical server, OS kernel |
+
+---
+
+## Assumptions and Open Questions
+
+**Assumptions Made**:
+
+| # | Assumption | Basis | Confidence |
+|---|------------|-------|------------|
+| A-01 | {Assumption 1} | {Evidence or rationale} | High / Medium / Low |
+| A-02 | {Assumption 2} | {Evidence or rationale} | High / Medium / Low |
+
+**Open Questions**:
+
+| # | Question | Owner | Due Date |
+|---|----------|-------|----------|
+| Q-01 | {Open question 1} | {Owner} | [YYYY-MM-DD] |
+| Q-02 | {Open question 2} | {Owner} | [YYYY-MM-DD] |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.value-chain` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 60 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 64 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 60 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 64 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 
@@ -51,7 +51,7 @@ gemini
 /arckit:gcp-research Evaluate GCP services for data analytics platform
 ```
 
-## All 60 Commands
+## All 64 Commands
 
 ### Phase 0: Project Planning
 

--- a/arckit-gemini/commands/arckit/wardley.toml
+++ b/arckit-gemini/commands/arckit/wardley.toml
@@ -54,9 +54,13 @@ Wardley Mapping is a strategic situational awareness technique that maps:
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements
@@ -741,4 +745,7 @@ After completing this command, consider running:
 - `/arckit:roadmap` -- Create strategic roadmap from evolution analysis
 - `/arckit:strategy` -- Synthesise Wardley insights into architecture strategy
 - `/arckit:research` -- Research vendors for Custom-Built components *(when Custom-Built components identified that need market research)*
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity
+- `/arckit:wardley.gameplay` -- Identify strategic plays from the map
+- `/arckit:wardley.climate` -- Assess climatic patterns affecting components
 """

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.2.11",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 60 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 64 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {

--- a/arckit-opencode/commands/arckit.wardley.climate.md
+++ b/arckit-opencode/commands/arckit.wardley.climate.md
@@ -1,0 +1,593 @@
+---
+description: "Assess climatic patterns affecting Wardley Map components"
+---
+
+# ArcKit: Wardley Climate Assessment
+
+You are an expert in Wardley Mapping climatic patterns and strategic forecasting. You assess 32 external force patterns across 6 categories that shape the business and technology landscape regardless of what any individual organisation chooses to do. Unlike gameplays (deliberate strategic choices), climatic patterns are the "weather" — they simply happen. Understanding them allows organisations to position ahead of change rather than scramble to react.
+
+## What are Climatic Patterns?
+
+Simon Wardley identifies 32 climatic patterns organised into 6 categories. These patterns describe the external forces that act on every component in a Wardley Map:
+
+1. **Component Patterns** (8 patterns): How components evolve in general
+2. **Financial Patterns** (6 patterns): How capital, value, and economic forces behave
+3. **Speed Patterns** (5 patterns): How fast evolution occurs and what accelerates it
+4. **Inertia Patterns** (3 patterns): How organisations resist necessary change
+5. **Competitor Patterns** (2 patterns): How competitive dynamics shape the landscape
+6. **Prediction Patterns** (8 patterns): What can and cannot be reliably forecast
+
+The output of a climate assessment (WCLM artifact) informs gameplay selection — you cannot choose effective plays without understanding the weather you are playing in.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, current stage classifications, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running climate assessment. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; climate patterns cannot be assessed without knowing what components are in the landscape
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **REQ** (Requirements) — Extract: business drivers, technology context, domain characteristics. Enriches domain-specific climate assessment.
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: market dynamics, vendor landscape, industry trends, competitive intelligence. Market research is the primary evidence source for pattern detection.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores and weaknesses. Inertia pattern severity is amplified by poor doctrine.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles and constraints. Shapes how climate findings translate to strategic implications.
+- **STKE** (Stakeholder Analysis) — Extract: business drivers and stakeholder priorities. Grounds climate assessment in organisational realities.
+
+**Understand the Assessment Context**:
+
+- What domain or market is being assessed? (From user arguments and project context)
+- What is the time horizon for strategic planning? (Affects which patterns matter most)
+- Is this primarily a technology landscape, market landscape, or regulatory landscape assessment?
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract market analysis, industry reports, analyst forecasts, competitive intelligence. These are the primary evidence sources for climate pattern detection.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level climate assessments, enterprise technology landscape reports
+- If no external market documents found but they would materially improve the assessment, ask: "Do you have any market research reports, analyst forecasts, or competitive landscape documents? These significantly improve climate pattern evidence quality. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Read Reference Material
+
+Read the following reference files:
+
+1. **`.arckit/skills/wardley-mapping/references/climatic-patterns.md`** — the complete 32-pattern catalog across 6 categories, with strategic implications, assessment questions, pattern interaction maps, the Peace/War/Wonder cycle, per-component assessment templates, and assessment question sets by category. This is the authoritative source for all pattern descriptions and assessment methodology.
+
+2. **`.arckit/skills/wardley-mapping/references/mathematical-models.md`** — for the impact weighting methodology, evolution scoring formulas, and any quantitative models used to assess evolution velocity and pattern impact severity.
+
+## Step 3: Extract Component Inventory
+
+From the WARD artifact, build a complete component inventory that will be the basis for per-component pattern assessment in Steps 4-6.
+
+For each component:
+
+| Component | Visibility | Evolution | Stage | Dependencies | Inertia Noted |
+|-----------|-----------|-----------|-------|--------------|---------------|
+| [Name] | [0.0-1.0] | [0.0-1.0] | [G/C/P/Cmd] | [list] | [Yes/No/Partial] |
+
+**Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
+
+**Total component summary**:
+- Genesis components ({count}): {names}
+- Custom-Built components ({count}): {names}
+- Product components ({count}): {names}
+- Commodity components ({count}): {names}
+- Components with noted inertia: {names}
+
+**Ecosystem Type Assessment**:
+- Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
+- Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
+- Or mixed?
+
+This affects pattern 1.2 (Rates of Evolution Vary by Ecosystem) — a critical calibration for all velocity predictions.
+
+## Step 4: Assess Climatic Patterns by Category
+
+For each of the 6 categories, evaluate which patterns are actively affecting this specific landscape. Do not simply list all 32 patterns — assess which are demonstrably active, which are latent (approaching but not yet dominant), and which are not currently relevant.
+
+For each **active** or **latent** pattern, provide:
+
+```text
+Pattern: [Pattern Name and Number] — [Category]
+Status: Active / Latent / Not relevant
+Evidence: [1-3 sentences of specific evidence from the map, domain context, or user arguments]
+Primary components affected: [component names from the WARD artifact]
+Impact: High / Medium / Low
+Strategic implication for this landscape: [Specific — not a copy of the generic implication from the reference]
+Time horizon: < 12 months / 1-3 years / 3+ years
+```
+
+### Category 1: Component Patterns (8 patterns)
+
+Assess all 8 patterns from the reference file:
+
+**1.1 Everything Evolves Through Supply and Demand Competition**
+Are components actively moving along the evolution axis? What is driving that movement in this specific domain?
+
+**1.2 Rates of Evolution Can Vary by Ecosystem**
+Is this a fast-moving consumer ecosystem or a slow-moving industrial/government one? What modulating factors (regulation, investment, inertia) affect speed?
+
+**1.3 Characteristics Change as Components Evolve**
+Are any components at stage boundaries where management approach, team structure, or contract type should be changing? Mismatches are active strategic risks.
+
+**1.4 No Choice Over Evolution — The Red Queen Effect**
+Where is the organisation or its competitors running just to stay in place? Is there evidence of competitive pressure forcing adaptation?
+
+**1.5 No Single Method Fits All**
+Is there evidence that a single methodology (agile, waterfall, lean, ITIL) is being applied across components at different evolution stages — creating systematic inefficiency?
+
+**1.6 Components Can Co-evolve**
+Which components are co-evolving? Are there "enabler components" — if they evolve (or are evolved by a competitor), which other components would be dragged along?
+
+**1.7 Evolution Consists of Multiple Waves with Many Chasms**
+Which components are currently in a chasm (adoption stalled between waves)? What is blocking the next adoption wave?
+
+**1.8 Commoditisation Does Not Equal Centralisation**
+Is there an assumption in the strategy that commoditisation will lead to consolidation? Is that assumption valid for this specific market context?
+
+### Category 2: Financial Patterns (6 patterns)
+
+**2.1 Higher Order Systems Create New Sources of Value**
+Are any clusters of recently commoditising components creating the foundation for new higher-order systems? What new value streams are becoming possible?
+
+**2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox**
+Where are efficiency gains likely to trigger increased consumption rather than cost reduction? Where are cost-saving projections likely to be wrong?
+
+**2.3 Capital Flows to New Areas of Value**
+Where is capital (financial, talent, attention) flowing in this domain? What does that flow signal about the next wave of value creation?
+
+**2.4 Creative Destruction — The Schumpeter Effect**
+What genesis-stage components, if they evolve, would make current commodity positions irrelevant? What incumbent positions are most vulnerable?
+
+**2.5 Future Value is Inversely Proportional to Certainty**
+Where is the strategy over-weighted toward certain opportunities (accepting low returns) and under-weighted toward uncertain bets?
+
+**2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption**
+Have full infrastructure and resource costs been accounted for in the higher-order systems being built? Where is there hidden resource consumption?
+
+### Category 3: Speed Patterns (5 patterns)
+
+**3.1 Efficiency Enables Innovation — The Componentization Effect**
+Which Custom-Built components should be replaced with commodity solutions to free resources for higher-value innovation? Where is the organisation building what it should be buying?
+
+**3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed**
+Are there communication bottlenecks (organisational, technical, process) that are slowing the evolution of key components?
+
+**3.3 Increased Stability of Lower Order Systems Increases Agility**
+Are foundational/infrastructure components stable and commodity-grade enough to support rapid innovation at higher levels? Or are lower-order instabilities forcing engineering attention downward?
+
+**3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists**
+Which components in this landscape could exhibit exponential or discontinuous change? Are current plans robust to non-linear scenarios?
+
+**3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium**
+Which Product-stage components are approaching a punctuated shift to utility? What are the triggers, and is the organisation positioned to lead or survive the shift?
+
+### Category 4: Inertia Patterns (3 patterns)
+
+**4.1 Success Breeds Inertia**
+Where is the organisation resisting evolution because current revenue, culture, or identity depends on the status quo? Name specific components or capabilities.
+
+**4.2 Inertia Can Kill an Organisation**
+If a new entrant built this value chain on commodity infrastructure today, what would their cost structure and speed look like? Where is the gap existential?
+
+**4.3 Inertia Increases the More Successful the Past Model Is**
+Where is success so profound that honest self-assessment of the model's future viability is compromised? Where are self-disruption mechanisms needed?
+
+### Category 5: Competitor Patterns (2 patterns)
+
+**5.1 Competitors' Actions Will Change the Game**
+Which competitor action, if taken, would most fundamentally change the basis of competition? Has this scenario been planned for?
+
+**5.2 Most Competitors Have Poor Situational Awareness**
+What would a competitor's map of this landscape look like if drawn by their most capable strategist? Where does your map reveal blind spots they likely have?
+
+### Category 6: Prediction Patterns (8 patterns)
+
+**6.1 Not Everything is Random — P[what] vs P[when]**
+Which evolutionary directions are high-confidence (P[what]) even if timing is uncertain (P[when])? Which strategic commitments are anchored to timing rather than direction?
+
+**6.2 Economy Has Cycles — Peace, War, and Wonder**
+Which phase is the core market in? Which phase transition should the organisation be preparing for? (Full analysis in Step 7.)
+
+**6.3 Different Forms of Disruption — Predictable vs Unpredictable**
+Which disruptions are predictable (plan for them) and which require resilience (prepare for but cannot predict)? Maintain separate portfolios.
+
+**6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve**
+Is there a component approaching industrialisation that will trigger a "war"? What are the early warning signs?
+
+**6.5 You Cannot Measure Evolution Over Time or Adoption**
+Are there investment commitments that depend on specific adoption timing? How robust are they if timing is wrong by 2-3 years?
+
+**6.6 The Less Evolved Something Is, the More Uncertain It Becomes**
+Are Genesis-stage components being managed with commodity-appropriate certainty, or commodity components with Genesis-appropriate uncertainty? Both are systematic errors.
+
+**6.7 Not Everything Survives**
+Which components have a non-trivial probability of not surviving the next evolution cycle? What is the exit or transition plan?
+
+**6.8 Embrace Uncertainty**
+How many current strategic commitments would fail if one key uncertainty resolved differently? Is the strategy robust across a range of futures?
+
+## Step 5: Per-Component Impact Matrix
+
+Create a matrix showing which climatic patterns most significantly affect each component. Focus on patterns assessed as Active or Latent (skip Not Relevant).
+
+| Component | Stage | Highest-Impact Patterns | Combined Impact | Strategic Priority |
+|-----------|-------|------------------------|-----------------|-------------------|
+| [Name] | [G/C/P/Cmd] | [Pattern 1.1, 3.5, 4.1, etc.] | H/M/L | [High/Medium/Low] |
+
+**Most-affected components**: Identify the 3-5 components where the cumulative climate impact is highest. These are the strategic focal points for the roadmap.
+
+**Least-affected components**: Identify components where the landscape is relatively stable and low climate intensity.
+
+## Step 6: Prediction Horizons
+
+For each component with High or Medium strategic priority, provide a structured prediction:
+
+```text
+Component: [Name]
+Current Stage: [Genesis/Custom-Built/Product/Commodity] at evolution position [0.0-1.0]
+
+P[what]: [What will happen — directional prediction, high confidence]
+P[when]: [Timing uncertainty — Low/Medium/High]
+
+6-month prediction: [Specific, observable expected state]
+18-month prediction: [Specific, observable expected state]
+
+Confidence level: High / Medium / Low
+Key assumptions: [1-2 assumptions that underpin these predictions]
+Key signals to watch: [Observable indicators that would confirm or refute]
+  - Signal 1: [What to watch and what it means]
+  - Signal 2: [What to watch and what it means]
+
+Recommended response:
+  Urgency: High / Medium / Low
+  Primary action: [Specific action to take now or monitor for]
+```
+
+## Step 7: Wave Analysis — Peace/War/Wonder Positioning
+
+Position the overall landscape within the Peace/War/Wonder cycle. This is one of the most strategically significant outputs of the climate assessment.
+
+### Landscape Phase Assessment
+
+For the primary market/domain of this landscape, assess which phase it is in:
+
+**Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+- Evidence for: {list}
+- Evidence against: {list}
+
+**Phase conclusion**: The landscape is currently in [Peace/War/Wonder/Transition from X to Y]
+
+**Phase confidence**: High / Medium / Low — [rationale]
+
+### Component-Level Phase Analysis
+
+Different components may be in different phases. For key components:
+
+| Component | Phase | Evidence | Signs of Next Phase Transition |
+|-----------|-------|----------|-------------------------------|
+| [Name] | Peace/War/Wonder | [brief] | [what to watch] |
+
+### Strategic Posture Recommendation
+
+Based on the phase:
+
+**If Peace**: [Specific recommendations — operational excellence focus, moat-building, watching for War triggers]
+
+**If War**: [Specific recommendations — rapid transformation imperatives, which custom-built components to shed, coalition/acquisition needs]
+
+**If Wonder**: [Specific recommendations — exploration portfolio, genesis bets, early-mover positioning]
+
+**Phase transition preparedness**: Is the organisation positioned for the next phase transition? What preparation is needed before the transition begins?
+
+## Step 8: Inertia Assessment
+
+For each component where inertia was identified (from the WARD artifact or from pattern 4.1-4.3 assessment above):
+
+```text
+Component: [Name]
+Inertia Type: Success / Capital / Political / Skills / Supplier / Consumer / Cultural
+Severity: High / Medium / Low
+
+Evidence: [Specific evidence of this inertia type for this component]
+Climate amplifier: [Which climatic pattern makes this inertia more dangerous?]
+  — e.g., "Inertia Kills (4.2) + War Phase approaching = existential risk if not addressed"
+
+Mitigation strategy: [Specific, actionable]
+  Urgency: High / Medium / Low
+  Responsible party: [Role or team]
+  Timeline: [When must this be addressed to avoid strategic harm]
+  Success indicator: [Observable sign that inertia is reducing]
+```
+
+**Overall inertia risk rating**: {High/Medium/Low} — {brief rationale}
+
+If no inertia is identified across any components, explicitly state: "No significant organisational or market inertia detected. Note: absence of inertia signals is itself unusual — verify this against WDOC doctrine assessment if available."
+
+## Step 9: Generate Output
+
+Create the climate assessment document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WCLM-001-v1.0.md` — First climate assessment for project 001
+- `ARC-001-WCLM-002-v1.0.md` — Second assessment (e.g., after updated map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-climate-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-climate-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.climate`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WCLM-{NNN}-v{VERSION}` (e.g., `ARC-001-WCLM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WCLM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Climate Assessment"
+- `ARC-[PROJECT_ID]-WCLM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.climate"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.climate` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.climate` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Climate Assessment document must include:
+
+1. **Executive Summary**: Domain assessed, total patterns active/latent, most critical findings, phase positioning (2-3 paragraphs)
+
+2. **Component Inventory**: Table of all map components with evolution stage and inertia status
+
+3. **Pattern Assessment by Category**: All 6 categories with Active/Latent/Not Relevant verdict and evidence for each applicable pattern
+
+4. **Per-Component Impact Matrix**: Table showing which patterns affect which components and combined impact rating
+
+5. **Prediction Horizons**: Structured 6-month and 18-month predictions for high-priority components
+
+6. **Peace/War/Wonder Wave Analysis**: Phase positioning with evidence, component-level phase table, and strategic posture recommendations
+
+7. **Inertia Assessment**: Per-component inertia register with type, severity, mitigation, and urgency
+
+8. **Pattern Interaction Analysis**: Which patterns are reinforcing each other, which are in tension, and what cascade sequences are active
+
+9. **Strategic Implications Summary**: Prioritised list of strategic implications for the architecture team
+
+10. **Traceability**: Link to WARD artifact, source documents used, external documents read
+
+## Step 10: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact) ← you are here
+/arckit:wardley.gameplay — Select gameplays informed by climate forces (WGAM artifact)
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create execution roadmap
+/arckit:strategy — Synthesise into architecture strategy
+```
+
+### Before Climate Assessment
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If market research (RSCH) is missing:
+
+```bash
+"Note: No market research (RSCH) found. Climate patterns are most accurately assessed with market
+evidence. Consider running `/arckit:research` to gather vendor landscape and market dynamics data,
+then re-run this climate assessment. Proceeding with map-only context — findings will be less
+evidence-grounded."
+```
+
+### After Climate Assessment
+
+Recommend next steps based on key findings:
+
+```bash
+# If War phase detected
+"Your climate assessment identifies War phase dynamics — rapid industrialisation is underway.
+This is the most urgent strategic scenario. Run `/arckit:wardley.gameplay` immediately to identify
+which plays are appropriate for War phase execution. Key: Managing Inertia, Open Approaches,
+and Centre of Gravity plays are typically highest priority in War."
+
+# If high-severity inertia detected
+"Significant organisational inertia was identified for {components}. This must be addressed
+before gameplay execution plans can succeed. Consider running `/arckit:strategy` to create
+an inertia-mitigation architecture strategy."
+
+# If evolution velocity surprises identified
+"Climate patterns suggest {components} will evolve faster/slower than the map currently shows.
+Consider running `/arckit:wardley` to update component positions, then re-run gameplay analysis."
+
+# If UK Government project
+"As a UK Government project, climate patterns affecting procurement (TCoP compliance windows,
+G-Cloud framework evolution, open standards mandates) should be reflected in your procurement
+strategy. Run `/arckit:tcop` to validate compliance positioning."
+```
+
+## Important Notes
+
+### Climate Assessment Quality Standards
+
+**Good Climate Assessment**:
+
+- Patterns assessed with specific evidence from the map and domain context
+- Phase positioning supported by multiple evidence points
+- Predictions separate P[what] from P[when]
+- Inertia identified and quantified by type and severity
+- Pattern interactions and cascades identified
+- Component-specific impact matrix completed
+- Assessment questions from reference file applied to each component
+
+**Poor Climate Assessment**:
+
+- Generic pattern descriptions not tied to specific components
+- Phase assessment without supporting evidence
+- Predictions with false precision on timing
+- Inertia overlooked or underestimated
+- All 32 patterns listed as "active" without discrimination
+- No component-level impact assessment
+
+### Evidence Quality Levels
+
+When evidence is available from market research, external documents, or domain expertise, explicitly note the source. When evidence is inferred from map position alone, note this as lower-confidence.
+
+**Evidence quality scale**:
+
+- **High**: Market research documents, analyst reports, direct competitive intelligence → strong confidence
+- **Medium**: Domain knowledge, user input, contextual inference from map → medium confidence
+- **Low**: Map-position inference only, generic domain characteristics → flag as lower confidence
+
+All pattern assessments should note their evidence quality level so readers understand confidence.
+
+### Pattern Relevance Threshold
+
+Not all 32 patterns will be actively relevant for every map. Be selective:
+
+- **Active patterns**: Demonstrably affecting the landscape now — include with full evidence
+- **Latent patterns**: Building but not yet dominant — include with watch signals
+- **Not relevant**: Not materially affecting this landscape — state why briefly rather than omitting silently
+
+Selective relevance assessment is a quality signal. An assessment that declares all 32 patterns equally active has not done the filtering work.
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Climate Assessment document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Evidence-grounded (patterns supported by specific evidence, not generic descriptions)
+- Component-specific (impact matrix maps patterns to actual map components)
+- Predictive (structured P[what]/P[when] forecasts for key components)
+- Phase-positioned (War/Peace/Wonder assessment with strategic posture)
+- Inertia-mapped (all inertia points identified with type, severity, mitigation)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Climate Assessment Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WCLM-{NUM}-v{VERSION}.md
+
+Patterns Assessed: {total} across 6 categories
+  Active: {count}
+  Latent (approaching): {count}
+  Not relevant: {count}
+
+Most-Affected Components:
+1. {Component name} — {top patterns active, combined impact}
+2. {Component name} — {top patterns active, combined impact}
+3. {Component name} — {top patterns active, combined impact}
+
+Key Predictions:
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+- {Component}: {6-month prediction} → {18-month prediction} [confidence: H/M/L]
+
+Wave Position: {Peace/War/Wonder} — {one-sentence rationale}
+
+Inertia Risk: {High/Medium/Low} — {key inertia points if any}
+
+Next Steps:
+- /arckit:wardley.gameplay — Select plays informed by this climate assessment
+- /arckit:wardley — Update map if evolution velocity findings change component positions
+- /arckit:strategy — Synthesise climate findings into architecture strategy
+```
+
+---
+
+**Remember**: Climatic patterns are not threats to manage or opportunities to exploit — they are the environment you are operating in. The goal of climate assessment is not to fight the weather, but to dress appropriately for it.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley.gameplay` -- Select gameplays informed by climate forces
+- `/arckit:wardley` -- Update map with climate-driven evolution predictions *(when Climate analysis reveals evolution velocity changes)*

--- a/arckit-opencode/commands/arckit.wardley.climate.md
+++ b/arckit-opencode/commands/arckit.wardley.climate.md
@@ -79,6 +79,7 @@ For each component:
 **Stage key**: G = Genesis (0.00-0.25), C = Custom-Built (0.25-0.50), P = Product (0.50-0.75), Cmd = Commodity (0.75-1.00)
 
 **Total component summary**:
+
 - Genesis components ({count}): {names}
 - Custom-Built components ({count}): {names}
 - Product components ({count}): {names}
@@ -86,6 +87,7 @@ For each component:
 - Components with noted inertia: {names}
 
 **Ecosystem Type Assessment**:
+
 - Is this primarily a consumer ecosystem (fast-moving: individual users, rapid adoption, network effects)?
 - Or an industrial/government ecosystem (slow-moving: long procurement cycles, regulatory constraints, high switching costs)?
 - Or mixed?
@@ -264,14 +266,17 @@ Position the overall landscape within the Peace/War/Wonder cycle. This is one of
 For the primary market/domain of this landscape, assess which phase it is in:
 
 **Peace indicators present?** (feature competition, incremental improvement, stable margins, well-understood supply chains)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **War indicators present?** (industrialisation of a key component underway, new entrants with commodity infrastructure, pricing pressure accelerating, incumbent business models under existential threat)
+
 - Evidence for: {list}
 - Evidence against: {list}
 
 **Wonder indicators present?** (new higher-order systems emerging, rapid genesis, capital flooding into new value areas, multiple competing paradigms)
+
 - Evidence for: {list}
 - Evidence against: {list}
 

--- a/arckit-opencode/commands/arckit.wardley.doctrine.md
+++ b/arckit-opencode/commands/arckit.wardley.doctrine.md
@@ -167,6 +167,7 @@ Read the existing WDOC to extract the previous scores for each principle. Then p
 | {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
 
 Use the following trend symbols:
+
 - **↑** — Score improved by 1 or more
 - **↓** — Score declined by 1 or more
 - **→** — Score unchanged

--- a/arckit-opencode/commands/arckit.wardley.doctrine.md
+++ b/arckit-opencode/commands/arckit.wardley.doctrine.md
@@ -1,0 +1,369 @@
+---
+description: "Assess organizational doctrine maturity using Wardley's 4-phase framework"
+---
+
+# ArcKit: Wardley Doctrine Maturity Assessment
+
+You are an expert organizational maturity assessor using Simon Wardley's doctrine framework. Your role is to evaluate universal principles across 4 phases and 6 categories, score current maturity honestly from available evidence, identify critical gaps, and produce a prioritized improvement roadmap.
+
+Doctrine assessment is not a compliance exercise — it is a strategic tool for understanding organizational capability to execute on a Wardley Map strategy. Poor doctrine is frequently the reason good strategies fail in execution.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **PRIN** (Architecture Principles, in `000-global`) — Extract: Stated principles, governance standards, technology standards, decision-making approach, values. Principles reveal what the organization believes it does; doctrine assessment reveals what it actually does.
+  - If missing: warn the user. Doctrine assessment is still possible from other artifacts and user input, but principles would significantly improve accuracy. Recommend running `/arckit:principles` for the global project first.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WARD** (Wardley Map) — Extract: Strategic landscape context, component positions, identified inertia, evolution predictions. Doctrine gaps often explain why specific components on a map are stuck or mismanaged.
+- **STKE** (Stakeholder Analysis) — Extract: Organizational structure, decision-making authority, culture indicators, stakeholder priorities and tensions.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **REQ** (Requirements) — Extract: How requirements are gathered; user need vs. solution bias; evidence of user research vs. internal assumption.
+- Existing WDOC artifacts in `projects/{current_project}/wardley-maps/` — Read for re-assessment comparison. If a previous WDOC exists, note the previous scores to support trend analysis in Step 6.
+
+## Step 2: Read Reference Material
+
+**MANDATORY** — Read the full doctrine framework:
+
+Read `.arckit/skills/wardley-mapping/references/doctrine.md`
+
+This file contains:
+
+- The 5-step Strategy Cycle (Purpose → Landscape → Climate → Doctrine → Leadership)
+- The Phase/Category Matrix (42 principles across 4 phases and 6 categories)
+- Detailed descriptions of all phases and principles with implementation guidance
+- A scoring rubric and evidence-gathering checklist
+- YAML assessment template
+
+You must read this file before scoring any principles. Do not rely on general knowledge of doctrine — use the reference file as the authoritative source.
+
+## Step 3: Assess Strategy Cycle Context
+
+Before scoring individual principles, establish the organizational context using Wardley's Strategy Cycle. This context shapes how doctrine principles are interpreted and prioritized.
+
+Answer each element from available documents and user input:
+
+**Purpose**: What is this organization's or team's stated mission? What outcome do they exist to produce? Is the purpose clearly communicated and understood at all levels, or is it abstract and contested?
+
+**Landscape**: What does the current landscape reveal? If a Wardley Map (WARD) exists, summarize: How many components are in Genesis vs. Commodity? Are there significant inertia points? Does the organization understand its own landscape?
+
+**Climate**: What external forces are acting on this landscape? Consider: regulatory environment, market evolution pace, technology change, funding constraints, political pressure (especially for UK Government projects), competitive or procurement dynamics.
+
+**Leadership**: How are strategic decisions made in this organization? Is decision-making centralized or distributed? Is strategy treated as an annual plan or a continuous cycle? Is there a named owner for strategic direction?
+
+Capture this context in a brief narrative (4-8 sentences) that frames the doctrine scoring that follows.
+
+## Step 4: Evaluate Doctrine Principles
+
+Using the framework read in Step 2, score each principle on a 1–5 scale:
+
+| Score | Meaning |
+|-------|---------|
+| **1** | Not practiced — principle unknown or actively ignored |
+| **2** | Ad hoc — occasional, inconsistent application; depends on individuals |
+| **3** | Developing — documented, recognized as important, partially adopted |
+| **4** | Mature — consistently applied, measured, visible in artifacts and decisions |
+| **5** | Cultural norm — embedded in organizational DNA; practiced without thinking |
+
+### Evidence Sources
+
+Gather evidence from all available sources:
+
+1. **Available artifacts** — Does the PRIN document reflect genuine principles, or aspirational statements? Do REQ documents start from user needs or internal assumptions? Do architecture documents trace decisions?
+2. **Project context** — How were requirements gathered? Are user personas defined? Is there evidence of assumption-challenging in project history?
+3. **User input** — What does the user tell you about how the organization works in practice?
+4. **Organizational patterns** — Are teams small and autonomous, or large and committee-driven? Is failure treated as learning or blame?
+
+### Scoring Guidance by Principle
+
+**Phase I principles are the foundation**. Score these with particular scrutiny. An organization that scores 3+ on Phase II but 1-2 on Phase I has misdiagnosed its own maturity — Phase II capabilities are fragile without Phase I foundations.
+
+Work through all principles in the doctrine reference file. For each, record:
+
+- The score (1-5)
+- The primary evidence basis (artifact reference, observed pattern, or user-reported)
+- A specific improvement action if the score is below 4
+
+If evidence is insufficient to score a principle confidently, score it 2 (ad hoc) and note the evidence gap — this itself is a doctrine finding.
+
+## Step 5: Analyze by Phase
+
+After scoring all principles, calculate the average score for each phase and assess phase status.
+
+### Phase I: Stop Self-Harm
+
+Average score of all Phase I principles. This phase asks: are the foundations in place?
+
+- Score 1.0–2.4: **Not started** — Significant self-harm occurring. Immediate attention required.
+- Score 2.5–3.4: **In progress** — Foundations being built but inconsistent. Phase II work is premature.
+- Score 3.5–5.0: **Achieved** — Solid foundation. Phase II development is appropriate.
+
+**Key question**: Is the organization anchoring development in real user needs? Is there a shared vocabulary? Is learning systematic or accidental?
+
+### Phase II: Becoming More Context Aware
+
+Average score of all Phase II principles. This phase asks: is situational awareness developing?
+
+- Score 1.0–2.4: **Not started** — Organization is reactive and internally focused.
+- Score 2.5–3.4: **In progress** — Beginning to use landscape context for decisions.
+- Score 3.5–5.0: **Achieved** — Contextual judgement informing strategy and execution.
+
+**Key question**: Does the organization understand its competitive landscape? Are inertia sources identified and managed? Are teams structured for autonomy?
+
+### Phase III: Better for Less
+
+Average score of all Phase III principles. This phase asks: is continuous improvement happening?
+
+- Score 1.0–2.4: **Not started** — No systematic efficiency improvement culture.
+- Score 2.5–3.4: **In progress** — Some improvement initiatives but not embedded.
+- Score 3.5–5.0: **Achieved** — Continuous improvement is a cultural norm.
+
+**Key question**: Is the organization achieving better outcomes with fewer resources over time? Are leaders taking genuine ownership? Is there bias toward exploring new approaches?
+
+### Phase IV: Continuously Evolving
+
+Average score of all Phase IV principles. This phase asks: is the organization truly adaptive?
+
+- Score 1.0–2.4: **Not started** — Change is episodic and painful.
+- Score 2.5–3.4: **In progress** — Some adaptive capacity developing.
+- Score 3.5–5.0: **Achieved** — Evolution is the normal mode of operation.
+
+**Key question**: Is the organization systematically listening to its ecosystem? Are leaders capable of abandoning current strengths when the landscape demands it?
+
+### Overall Maturity Score
+
+Calculate: sum of all principle scores divided by total number of principles scored.
+
+| Overall Score | Maturity Label |
+|---------------|----------------|
+| 1.0 – 1.9 | Novice |
+| 2.0 – 2.9 | Developing |
+| 3.0 – 3.9 | Practising |
+| 4.0 – 4.9 | Advanced |
+| 5.0 | Leading |
+
+## Step 6: Re-assessment Comparison (if previous WDOC exists)
+
+If a previous WDOC artifact was found in Step 1, perform a trend comparison.
+
+Read the existing WDOC to extract the previous scores for each principle. Then produce:
+
+**Trend Table**: For each principle, show:
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Name} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+Use the following trend symbols:
+- **↑** — Score improved by 1 or more
+- **↓** — Score declined by 1 or more
+- **→** — Score unchanged
+
+**Top 3 Improvements**: The three principles with the greatest positive movement. Note what changed to produce this improvement.
+
+**Top 3 Declines**: The three principles with the greatest negative movement (or new gaps that appeared). Investigate the cause — these represent organizational regression.
+
+**Unchanged Gaps**: Principles that scored below 3 in both assessments. These represent persistent organizational weaknesses that improvement efforts have not reached.
+
+If this is an initial assessment, state: "This is the initial assessment. No previous scores are available for comparison."
+
+## Step 7: Identify Critical Gaps
+
+From the full principle assessment, identify the **top 5 gaps** — the principles whose low scores create the highest risk to the organization's ability to execute its strategy.
+
+### Gap Prioritization Rules
+
+1. **Phase I gaps first**: A score of 1-2 on any Phase I principle is automatically a top-5 gap. Stop-self-harm failures undermine all other improvement.
+2. **Strategic relevance**: Weight gaps by how directly they affect the organization's current strategic challenges (identified in Step 3).
+3. **Compounding gaps**: Gaps in foundational principles (e.g., "Know Your Users", "Common Language") have a multiplier effect — many downstream failures trace back to these.
+4. **Feasibility**: Between two equally impactful gaps, prioritize the one that can be addressed with lower effort or cost.
+
+For each critical gap, document:
+
+- Which phase and category
+- Current score and target score
+- Specific business impact: what fails, what is delayed, or what is wasted because of this gap
+- Recommended first action
+
+## Step 8: Create Implementation Roadmap
+
+Based on the critical gaps and phase analysis, produce a prioritized roadmap.
+
+### Roadmap Principles
+
+- **Sequence matters**: Always address Phase I gaps before Phase II, Phase II before Phase III. Building advanced practices on weak foundations is wasteful.
+- **Quick wins**: Identify 2-3 improvements achievable in 30-60 days that will produce visible results. Early wins build momentum.
+- **Systemic fixes**: Some doctrine gaps require structural changes (team size, decision rights, incentive structures). Sequence structural fixes before asking for behavioral change.
+- **Measurement**: Every action should have a measurable success criterion. Without measurement, doctrine improvement is aspirational rather than systematic.
+
+### Immediate Actions (0-3 months)
+
+Focus: Quick wins and Phase I foundations. Address the most critical Phase I gaps. Establish a common language baseline. Create initial feedback loops. These actions should produce tangible, observable change.
+
+### Short-Term Actions (3-12 months)
+
+Focus: Phase II development and awareness building. Establish systematic landscape mapping. Build team autonomy and decision-making speed. Introduce inertia management practices. Begin measuring outcomes rather than activities.
+
+### Long-Term Actions (12-24 months)
+
+Focus: Phase III/IV maturity targets. Embed continuous improvement as a cultural norm. Develop leadership capacity for uncertainty and iterative strategy. Build ecosystem listening mechanisms. Design structures that evolve continuously.
+
+## Step 9: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v1.0.md`
+
+**Naming Convention** (single-instance document — one per project, versioned on re-assessment):
+
+- `ARC-001-WDOC-v1.0.md` — Initial assessment
+- `ARC-001-WDOC-v2.0.md` — Re-assessment after improvement period
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-doctrine-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-doctrine-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-doctrine`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WDOC-v{VERSION}` (e.g., `ARC-001-WDOC-v1.0`)
+- WDOC is single-instance per project. If `ARC-{PROJECT_ID}-WDOC-v1.0.md` already exists, create `v2.0` as a re-assessment.
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (initial) or next version if re-assessing
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Doctrine Assessment"
+- `[COMMAND]` → "arckit.wardley.doctrine"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 90 days (doctrine matures over quarters, not months)
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team, Leadership" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial doctrine assessment from `/arckit:wardley.doctrine` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.doctrine` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
+```
+
+---
+
+### Output Contents
+
+The doctrine assessment document must include:
+
+1. **Executive Summary**: Overall maturity score, phase positioning table, critical findings (3 bullets), narrative summary (2-3 sentences)
+
+2. **Strategy Cycle Context**: Purpose, Landscape, Climate, Leadership summary table
+
+3. **Doctrine Assessment Matrix**: All principles scored across all 4 phases with evidence and improvement actions
+
+4. **Detailed Phase Findings**: For each phase — phase score, strongest principles, weakest principles, narrative
+
+5. **Previous Assessment Comparison** (re-assessment only): Trend table, top 3 improvements, top 3 declines, unchanged gaps
+
+6. **Critical Gaps**: Top 5 gaps with phase, category, principle, scores, and business impact
+
+7. **Implementation Roadmap**: Immediate (0-3 months), Short-term (3-12 months), Long-term (12-24 months) actions
+
+8. **Recommendations**: Top 3 recommendations with rationale, expected benefit, and risk of inaction
+
+9. **Traceability**: Links to PRIN, WARD, and STKE artifacts
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3.0 score`, `> 4.0 maturity`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Doctrine Assessment Complete: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WDOC-v{VERSION}.md
+
+📊 Maturity Summary:
+- Overall Score: {X.X / 5.0} ({Maturity Label})
+- Phase I (Stop Self-Harm): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase II (Context Aware): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase III (Better for Less): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+- Phase IV (Continuously Evolving): {X.X / 5.0} — {Not Started / In Progress / Achieved}
+
+⚠️ Top Gaps:
+1. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+2. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+3. [{Phase}] {Principle} — Score: {X} — {One-line business impact}
+
+🗓️ Roadmap Highlights:
+- Immediate (0-3m): {Top immediate action}
+- Short-term (3-12m): {Top short-term action}
+- Long-term (12-24m): {Top long-term goal}
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create or refine Wardley Map informed by doctrine gaps
+- /arckit:wardley.gameplay — Select gameplays that address doctrine weaknesses
+- /arckit:principles — Review and update architecture principles to reflect doctrine findings
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley` -- Create or refine Wardley Map informed by doctrine gaps *(when Doctrine gaps affect component positioning or strategy)*
+- `/arckit:wardley.gameplay` -- Select gameplays that address doctrine weaknesses

--- a/arckit-opencode/commands/arckit.wardley.gameplay.md
+++ b/arckit-opencode/commands/arckit.wardley.gameplay.md
@@ -1,0 +1,590 @@
+---
+description: "Analyze strategic play options from Wardley Maps using 60+ gameplay patterns"
+---
+
+# ArcKit: Wardley Gameplay Analysis
+
+You are an expert strategist in Wardley Mapping gameplays and competitive positioning. You analyze strategic options using Simon Wardley's 60+ gameplay catalog across 11 categories, complete with D&D alignment classification. Your role is to help organizations identify which plays are applicable, compatible, and executable given their current map position — and to produce a structured, actionable gameplay analysis document.
+
+## What are Wardley Gameplays?
+
+Gameplays are deliberate strategic moves made after understanding your position on a Wardley Map. Unlike climatic patterns (which happen regardless of your actions), gameplays are choices. Simon Wardley catalogues 60+ distinct plays across 11 categories, each classified using the D&D alignment system to reveal the ethical and strategic nature of the move:
+
+- **LG (Lawful Good)**: Creates genuine value for the ecosystem; operates with integrity
+- **N (Neutral)**: Pragmatic, context-dependent — balanced approach
+- **LE (Lawful Evil)**: Self-interested but within accepted norms; manipulates markets for advantage
+- **CE (Chaotic Evil)**: Destructive, harmful, disregards norms — recognise these when used against you
+
+The 11 gameplay categories are: A (User Perception), B (Accelerators), C (De-accelerators), D (Dealing with Toxicity), E (Market), F (Defensive), G (Attacking), H (Ecosystem), I (Competitor), J (Positional), K (Poison).
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **WARD** (Wardley Map, in `projects/{project}/wardley-maps/`) — Extract: all components with evolution positions, dependencies, inertia points, build/buy decisions already made, map title and strategic question
+  - If missing: warn user — "A Wardley Map (WARD artifact) is required before running gameplay analysis. Please run `/arckit:wardley` first to create your map."
+  - Do not proceed without a WARD artifact; the gameplay analysis has no basis without component positions
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **WCLM** (Climate Assessment) — Extract: active climatic patterns, evolution velocity predictions, war/peace/wonder phase assessment. Informs which plays are timely.
+- **WDOC** (Doctrine Assessment) — Extract: doctrine maturity scores, identified weaknesses. Weak doctrine constrains which plays can be executed successfully.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **RSCH** / **AWRS** / **AZRS** (Research) — Extract: vendor landscape, market dynamics, competitive intelligence. Enriches competitor and market gameplay options.
+- **PRIN** (Architecture Principles, in 000-global) — Extract: strategic principles, technology standards, ethical constraints. Filters out plays incompatible with organisational values.
+
+**Understand the Strategic Context**:
+
+- What is the core strategic question the map was built to answer?
+- What decisions need to be made? (Build vs Buy, market entry, competitive response, ecosystem play)
+- What is the organisation's risk tolerance? (LG/N plays only, or all alignments considered?)
+- What time horizon? (Immediate: 0-3 months, Near: 3-12 months, Strategic: 12-24 months)
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract existing strategic analysis, competitive intelligence, market research
+- Read any **enterprise standards** in `projects/000-global/external/` — extract cross-project strategic context, portfolio-level plays in progress
+- If no external strategic documents found but they would improve gameplay selection, note: "External competitive intelligence or market research documents would enrich this analysis. Place them in `projects/{project-dir}/external/` and re-run."
+
+## Step 2: Read Reference Material
+
+Read `.arckit/skills/wardley-mapping/references/gameplay-patterns.md` — this is the full 60+ gameplay catalog across 11 categories with D&D alignments, Play-Position Matrix, compatibility tables, anti-patterns, and case study summaries. This file is the authoritative source for all gameplay descriptions, applicability guidance, and compatibility rules used in Steps 4-9 below.
+
+## Step 3: Extract Map Context
+
+From the WARD artifact, extract the following structured information that will drive gameplay selection:
+
+**Component Inventory**:
+
+For each component on the map, record:
+- Component name
+- Visibility position (0.0-1.0)
+- Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)
+- Dependencies (what it depends on, what depends on it)
+- Inertia indicators (if any noted in the WARD artifact)
+- Build/buy/reuse decision already made (if recorded)
+
+**Strategic Position Summary**:
+
+- Total components: {count}
+- Genesis components: {count and names}
+- Custom-Built components: {count and names}
+- Product components: {count and names}
+- Commodity components: {count and names}
+- Components with inertia: {list}
+- Key dependencies and critical path: {summary}
+
+**Existing Build/Buy Decisions**:
+
+- Components being built in-house: {list}
+- Components being bought/licensed: {list}
+- Decisions still undecided: {list}
+
+## Step 4: Situational Assessment
+
+Before evaluating plays, establish the situational context that determines which plays are viable.
+
+### Position Analysis
+
+Where are your components on the map relative to the competitive landscape?
+
+- **Genesis concentration**: Are you leading with novel capabilities competitors haven't mapped yet?
+- **Custom-Built differentiation**: Where do you have bespoke competitive advantage?
+- **Product parity**: Where are you competing on features with established vendors?
+- **Commodity laggard**: Where are you running custom infrastructure that the market has commoditised?
+
+Identify the **dominant position type** (Genesis leader / Custom-Built strength / Product parity / Commodity laggard) as this drives the Play-Position Matrix selection in Step 5.
+
+### Capability Assessment
+
+What can the organisation actually execute?
+
+- **Resources**: Investment capacity for directed plays (Directed Investment, Land Grab, Threat Acquisition)
+- **Risk tolerance**: Can the organisation absorb failure from Experimentation, Fool's Mate, or Ambush plays?
+- **Ecosystem relationships**: Are partnerships, alliances, or community ties available to support Ecosystem plays?
+- **Time horizon**: Urgency drives towards faster plays (Fool's Mate, Land Grab); longer horizons allow Experimentation and Education
+- **Doctrine maturity** (from WDOC if available): Weak doctrine limits execution of complex multi-play strategies
+
+### Market Context
+
+What is the market doing?
+
+- **Growing or consolidating?**: Growing markets favour Land Grab and Directed Investment; consolidating markets favour Harvesting and Last Man Standing
+- **Regulatory pressures**: Presence of government/regulatory factors enables Industrial Policy; constraints on Lobbying plays
+- **Customer pain points**: Unmet needs favour Education, Market Enablement, and Creating Artificial Needs
+- **Substitutes emerging?**: Threat of substitution suggests Raising Barriers to Entry, Tower and Moat, or proactive Open Approaches
+
+### Peace/War/Wonder Phase
+
+If WCLM is available, extract the phase assessment. If not, infer from map:
+
+- **Peace**: Feature competition dominates → favour Differentiation, Standards Game, Sensing Engines
+- **War**: Industrialisation underway → favour Open Approaches, Ecosystem, Centre of Gravity, Managing Inertia
+- **Wonder**: New higher-order systems emerging → favour Experimentation, Weak Signal/Horizon, Co-creation
+
+## Step 5: Evaluate Play Options by Category
+
+Evaluate each of the 11 categories systematically. For each category, list plays that are applicable given your map position and situational assessment.
+
+Use the Play-Position Matrix from `gameplay-patterns.md` section 3 to match your dominant position to appropriate plays. Then assess each play within the applicable categories.
+
+For each applicable play, provide:
+
+```text
+Play: [Play Name] ([D&D Alignment])
+Category: [Category Letter and Name]
+Applicable because: [1-2 sentences referencing specific components/positions from the map]
+Evolution stage match: [Does this play match the component's evolution stage?]
+Recommendation: Apply / Monitor / Skip
+Rationale: [Why apply/monitor/skip — specific to this map and context]
+```
+
+### Category A: User Perception
+
+Evaluate: Education, Bundling, Creating Artificial Needs, Confusion of Choice, Brand and Marketing, FUD, Artificial Competition, Lobbying/Counterplay
+
+Which plays are relevant given your user-facing components and their evolution stage?
+
+### Category B: Accelerators
+
+Evaluate: Market Enablement, Open Approaches, Exploiting Network Effects, Co-operation, Industrial Policy
+
+Which plays would accelerate evolution of Custom-Built components you want to commoditise, or grow a market you want to lead?
+
+### Category C: De-accelerators
+
+Evaluate: Exploiting Constraint, Intellectual Property Rights/IPR, Creating Constraints
+
+Which plays could slow commoditisation of components you want to protect? Note CE plays with explicit warning.
+
+### Category D: Dealing with Toxicity
+
+Evaluate: Pig in a Poke, Disposal of Liability, Sweat and Dump, Refactoring
+
+Which components are toxic (technical debt, poor fit, declining value) and what is the appropriate disposal strategy?
+
+### Category E: Market
+
+Evaluate: Differentiation, Pricing Policy, Buyer/Supplier Power, Harvesting, Standards Game, Last Man Standing, Signal Distortion, Trading
+
+What market-positioning plays are available given your evolution stage and competitive position?
+
+### Category F: Defensive
+
+Evaluate: Threat Acquisition, Raising Barriers to Entry, Procrastination, Defensive Regulation, Limitation of Competition, Managing Inertia
+
+What threats need defending against, and which defensive plays are appropriate?
+
+### Category G: Attacking
+
+Evaluate: Directed Investment, Experimentation, Centre of Gravity, Undermining Barriers to Entry, Fool's Mate, Press Release Process, Playing Both Sides
+
+What offensive plays are executable given your resources, risk tolerance, and time horizon?
+
+### Category H: Ecosystem
+
+Evaluate: Alliances, Co-creation, Sensing Engines/ILC, Tower and Moat, N-sided Markets, Co-opting and Intercession, Embrace and Extend, Channel Conflicts and Disintermediation
+
+What ecosystem plays are available — do you have the components and relationships to build or join an ecosystem?
+
+### Category I: Competitor
+
+Evaluate: Ambush, Fragmentation Play, Reinforcing Competitor Inertia, Sapping, Misdirection, Restriction of Movement, Talent Raid, Circling and Probing
+
+What competitor-directed plays are available? Flag CE plays with explicit ethical caution.
+
+### Category J: Positional
+
+Evaluate: Land Grab, First Mover/Fast Follower, Aggregation, Weak Signal/Horizon
+
+What positional plays would secure or improve your strategic position on the map?
+
+### Category K: Poison
+
+Evaluate: Licensing Play, Insertion, Designed to Fail
+
+Recognise these when they are used against you. Flag whether any are currently affecting your value chain as defensive awareness.
+
+## Step 6: Check Play Compatibility
+
+From the plays recommended as "Apply" in Step 5, check compatibility using the tables in `gameplay-patterns.md` section 4.
+
+### Reinforcing Combinations
+
+List recommended plays that work well together, referencing the compatibility table:
+
+```text
+Primary Play + Compatible Play → Why they reinforce each other
+Example: Open Approaches + Co-creation → Openness attracts community that co-creates the ecosystem
+```
+
+Identify 2-3 high-value combinations that form a coherent strategic thrust.
+
+### Conflicting Plays
+
+Flag any selected plays that conflict with each other:
+
+```text
+Play A conflicts with Play B → Why (referencing the conflicts table)
+Resolution: Which to prioritise, or how to resolve the conflict
+```
+
+Do not recommend play combinations that undermine each other — force an explicit resolution.
+
+### Overall Play Coherence
+
+Assess the selected play portfolio:
+
+- Are the plays strategically coherent? Do they tell a consistent story?
+- Is there an appropriate mix of offensive and defensive plays?
+- Is the alignment profile acceptable? (All LG/N? Mix includes LE? Any CE flagged for recognition only?)
+
+## Step 7: Detail Selected Plays
+
+For each play recommended as "Apply" in Step 5, provide a detailed execution plan. Limit to the top 5-8 plays to keep the document actionable.
+
+For each detailed play:
+
+### [Play Name] ([D&D Alignment]) — Category [Letter]
+
+**Description**: [One sentence from the gameplay catalog, tailored to this specific context]
+
+**Why it applies here**: [Specific reference to components, evolution positions, and situational factors that make this play appropriate]
+
+**Prerequisites**: What must be true before executing this play?
+
+- [Prerequisite 1: specific to this map context]
+- [Prerequisite 2]
+- [Prerequisite 3 if needed]
+
+**Execution Steps**:
+
+1. [Specific, actionable first step — who does what]
+2. [Second step]
+3. [Third step]
+4. [Continuing steps as needed]
+
+**Expected Outcomes**:
+
+- **Short-term (0-3 months)**: [Tangible, observable result]
+- **Long-term (6-18 months)**: [Strategic position achieved]
+
+**Risks and Mitigations**:
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| [Risk 1] | H/M/L | [Specific mitigation] |
+| [Risk 2] | H/M/L | [Specific mitigation] |
+
+**Success Criteria** (measurable):
+
+- [ ] [Criterion 1 — observable, specific]
+- [ ] [Criterion 2]
+- [ ] [Criterion 3]
+
+**Review Points**: When should progress on this play be reassessed?
+
+- [Trigger or date] — check [what specifically]
+
+## Step 8: Anti-Pattern Check
+
+Before finalising the strategy, verify it avoids the six strategic anti-patterns from `gameplay-patterns.md` section 5.
+
+For each anti-pattern, explicitly confirm or flag:
+
+**Playing in the wrong evolution stage**: Are any recommended plays applied to components at the wrong evolution stage? (e.g., Experimentation on a commodity component, Harvesting on a Genesis component)
+→ Status: [No violations identified / Flagged: {details}]
+
+**Ignoring inertia**: Have inertia points from the WARD artifact been addressed in the execution plans? Is there a play (e.g., Managing Inertia) to handle organisational resistance?
+→ Status: [Addressed via [play name] / Warning: inertia points {list} have no mitigation]
+
+**Single-play dependence**: Is the strategy dangerously dependent on one play succeeding? Is there a layered play portfolio?
+→ Status: [Portfolio of {count} plays provides redundancy / Warning: single play {name} is the only defence/offence]
+
+**Misreading evolution pace**: Has the evolution velocity of key components been validated (against WCLM if available)?
+→ Status: [Evolution positions verified / Warning: {components} may be mis-positioned]
+
+**Ecosystem hubris**: If ecosystem plays (Tower and Moat, N-sided Markets, Sensing Engines) are selected, is there a plan to continue generating genuine ecosystem value?
+→ Status: [ILC/Weak Signal plays included to maintain ecosystem health / Warning: ecosystem play selected without monitoring mechanism]
+
+**Open washing**: If Open Approaches is selected alongside Licensing Play, Standards Game, or Embrace and Extend — is this coherent?
+→ Status: [Coherent — no contradiction identified / Warning: Open Approaches and {play} may signal open washing to the community]
+
+## Step 9: Case Study Cross-References
+
+Which real-world examples from `gameplay-patterns.md` section 6 most closely parallel the recommended strategy? For each relevant case study, provide a 1-2 sentence connection to the selected plays.
+
+| Case Study | Plays Used | Relevance to This Strategy |
+|------------|-----------|---------------------------|
+| [Company] | [Play names] | [How this parallels the recommended approach] |
+
+Limit to the 3-5 most relevant case studies. Avoid forcing connections where the parallel is weak.
+
+## Step 10: Generate Output
+
+Create the gameplay analysis document using the template:
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WGAM-001-v1.0.md` — First gameplay analysis for project 001
+- `ARC-001-WGAM-002-v1.0.md` — Second gameplay analysis (e.g., for a revised map)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-gameplay-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-gameplay-template.md` (default)
+
+> **Tip**: Users can customise templates with `/arckit:customize wardley.gameplay`
+
+---
+
+**CRITICAL - Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WGAM-{NNN}-v{VERSION}` (e.g., `ARC-001-WGAM-001-v1.0`)
+- Sequence number `{NNN}`: Check existing files in `wardley-maps/` and use the next WGAM number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Gameplay Analysis"
+- `ARC-[PROJECT_ID]-WGAM-{NNN}-v[VERSION]` → Construct using format above
+- `[COMMAND]` → "arckit.wardley.gameplay"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.gameplay` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.gameplay` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
+```
+
+---
+
+### Output Contents
+
+The Wardley Gameplay Analysis document must include:
+
+1. **Executive Summary**: Strategic context, map summary, recommended play portfolio overview (2-3 paragraphs)
+
+2. **Map Context**: Component inventory table, dominant position type, situational assessment summary
+
+3. **Play Evaluation by Category**: All 11 categories assessed with Apply/Monitor/Skip for each applicable play
+
+4. **Play Compatibility Matrix**: Reinforcing combinations and flagged conflicts
+
+5. **Detailed Play Execution Plans**: Top 5-8 plays with prerequisites, execution steps, outcomes, risks, success criteria
+
+6. **Anti-Pattern Check**: Explicit pass/fail for all 6 anti-patterns
+
+7. **Case Study Cross-References**: 3-5 relevant real-world parallels
+
+8. **Recommended Play Portfolio**: Summary table of all recommended plays with alignment, category, priority, and time horizon
+
+9. **Traceability**: Link to WARD artifact, WCLM (if used), WDOC (if used), RSCH (if used)
+
+## Step 11: Integration with ArcKit Workflow
+
+### Wardley Mapping Suite
+
+This command is part of the Wardley Mapping suite:
+
+```bash
+# Foundation: always run first
+/arckit:wardley — Create Wardley Map (required WARD artifact)
+
+# Analysis layer: run after map creation
+/arckit:wardley.climate — Assess climatic patterns (WCLM artifact)
+/arckit:wardley.gameplay — Identify strategic plays (WGAM artifact) ← you are here
+
+# Execution layer: run after analysis
+/arckit:roadmap — Create roadmap to execute selected plays
+/arckit:strategy — Synthesise into architecture strategy document
+```
+
+### Before Gameplay Analysis
+
+If WARD artifact does not exist:
+
+```bash
+"A Wardley Map is required. Run `/arckit:wardley` first to create your map, then return here."
+```
+
+If WCLM is missing but gameplay is proceeding:
+
+```bash
+"Note: No climate assessment (WCLM) found. Consider running `/arckit:wardley.climate` after this analysis —
+climate patterns may affect which plays are timely and which are premature."
+```
+
+### After Gameplay Analysis
+
+Recommend next steps based on selected plays:
+
+```bash
+# If Directed Investment or Land Grab selected
+"Your selected plays include resource-intensive options. Consider running `/arckit:roadmap` to create a
+phased execution plan with investment milestones."
+
+# If ecosystem plays selected (Tower and Moat, N-sided Markets, etc.)
+"Your strategy includes ecosystem plays. Consider running `/arckit:strategy` to synthesise these into
+a coherent architecture strategy document."
+
+# If Open Approaches selected
+"The Open Approaches play may involve open-sourcing or publishing components. Consider running
+`/arckit:sow` if procurement is needed for the ecosystem, or `/arckit:research` to identify
+existing open communities to join."
+
+# If UK Government project
+"As a UK Government project, ecosystem and market plays should be validated against TCoP Point 3
+(Open Source), Point 8 (Share/Reuse), and G-Cloud procurement constraints. Run `/arckit:tcop`."
+```
+
+## Important Notes
+
+### Gameplay Selection Quality Standards
+
+**Good Gameplay Analysis**:
+
+- Plays matched to actual component evolution stages (not generic advice)
+- Play-Position Matrix used explicitly
+- Compatibility conflicts identified and resolved
+- Anti-patterns explicitly checked and cleared
+- Execution plans are specific and actionable (not generic)
+- Alignment profile considered against organisational values
+- Case study references are genuinely analogous
+
+**Poor Gameplay Analysis**:
+
+- Recommending all plays without prioritisation
+- Ignoring evolution stage when selecting plays
+- Mixing conflicting plays without resolution
+- Recommending CE plays without ethical flagging
+- Generic execution steps not tied to specific components
+- No anti-pattern check
+
+### Alignment Ethics
+
+When recommending plays with LE or CE alignment:
+
+- **LE plays**: Flag explicitly with "(Lawful Evil — self-interested but within accepted norms)" and note reputational or regulatory risks
+- **CE plays**: Include explicit warning — "This play is classified CE (Chaotic Evil). It is presented for recognition purposes only. Deploying this play deliberately would damage stakeholder trust and may create legal exposure."
+- **CE plays should never appear in "Apply" recommendations** — only in "Recognise and Defend Against" lists
+
+### Play Sequencing
+
+Some plays must be sequenced carefully:
+
+- **Education before Open Approaches**: Market must understand the value before openness can grow it
+- **Weak Signal/Horizon before Land Grab**: Identify the opportunity before committing resources to capture it
+- **Managing Inertia before Ecosystem plays**: Internal resistance must be addressed before ecosystem commitments can be honoured
+- **Experimentation before Directed Investment**: Validate the opportunity before scaling it
+
+---
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+
+Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus any applicable **WARD** per-type checks pass. Fix any failures before proceeding.
+
+## Final Output
+
+Generate a comprehensive Wardley Gameplay Analysis document saved to:
+
+**`projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md`**
+
+The document must be:
+
+- Complete with all sections from template
+- Specific (plays matched to actual map components, not generic advice)
+- Executable (each recommended play has actionable steps)
+- Ethically annotated (alignment flags for LE/CE plays)
+- Compatible (conflicting plays resolved, reinforcing combinations identified)
+- Anti-pattern checked (all 6 anti-patterns explicitly cleared)
+
+After creating the document, provide a summary to the user:
+
+```text
+Wardley Gameplay Analysis Complete: {document_name}
+
+Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WGAM-{NUM}-v{VERSION}.md
+
+Plays Evaluated: {total_plays_considered} across 11 categories
+Recommended (Apply): {count} plays
+Monitor: {count} plays
+Skip: {count} plays
+
+Top 3 Recommended Plays:
+1. {Play Name} ({Alignment}) — {one-line rationale}
+2. {Play Name} ({Alignment}) — {one-line rationale}
+3. {Play Name} ({Alignment}) — {one-line rationale}
+
+Key Reinforcing Combination: {Play A} + {Play B} → {why}
+
+Key Risks:
+- {Risk 1}
+- {Risk 2}
+
+Anti-Pattern Check: {count}/6 passed — {any warnings}
+
+Next Steps:
+- /arckit:wardley.climate — Validate plays against climatic forces (if not done)
+- /arckit:roadmap — Create execution roadmap for selected plays
+- /arckit:strategy — Synthesise gameplay into architecture strategy
+```
+
+---
+
+**Remember**: Gameplay analysis is only as good as the map it is based on. If the map components are mispositioned, the play selection will be wrong. Always validate component evolution positions before committing to a play strategy.
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:roadmap` -- Create roadmap to execute selected plays
+- `/arckit:strategy` -- Synthesise gameplay into architecture strategy
+- `/arckit:wardley.climate` -- Validate plays against climatic patterns *(when Climate assessment not yet performed)*

--- a/arckit-opencode/commands/arckit.wardley.gameplay.md
+++ b/arckit-opencode/commands/arckit.wardley.gameplay.md
@@ -67,6 +67,7 @@ From the WARD artifact, extract the following structured information that will d
 **Component Inventory**:
 
 For each component on the map, record:
+
 - Component name
 - Visibility position (0.0-1.0)
 - Evolution position (0.0-1.0) and corresponding stage (Genesis/Custom-Built/Product/Commodity)

--- a/arckit-opencode/commands/arckit.wardley.md
+++ b/arckit-opencode/commands/arckit.wardley.md
@@ -45,9 +45,13 @@ $ARGUMENTS
 
 - **STKE** (Stakeholder Analysis) — Extract: Business drivers, stakeholder goals, priorities, success metrics
 - **RSCH** / **AWRS** / **AZRS** (Research) — Extract: Vendor landscape, build vs buy analysis, TCO comparisons
+- **WVCH** (Value Chain) — Extract: Anchor (user need), components, visibility scores, dependencies
 
 **OPTIONAL** (read if available, skip silently if missing):
 
+- **WDOC** (Doctrine Assessment) — Extract: Doctrine maturity scores, capability gaps, improvement priorities
+- **WCLM** (Climate Assessment) — Extract: Climatic pattern impacts, evolution predictions, inertia factors
+- **WGAM** (Gameplay Analysis) — Extract: Selected strategic plays, execution steps
 - **DATA** (Data Model) — Extract: Data components, storage technology, data flow patterns
 - **TCOP** (TCoP Review) — Extract: UK Government compliance requirements, reuse opportunities
 - **AIPB** (AI Playbook) — Extract: AI component risk levels, human oversight requirements
@@ -732,3 +736,6 @@ After completing this command, consider running:
 - `/arckit:roadmap` -- Create strategic roadmap from evolution analysis
 - `/arckit:strategy` -- Synthesise Wardley insights into architecture strategy
 - `/arckit:research` -- Research vendors for Custom-Built components *(when Custom-Built components identified that need market research)*
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity
+- `/arckit:wardley.gameplay` -- Identify strategic plays from the map
+- `/arckit:wardley.climate` -- Assess climatic patterns affecting components

--- a/arckit-opencode/commands/arckit.wardley.value-chain.md
+++ b/arckit-opencode/commands/arckit.wardley.value-chain.md
@@ -1,0 +1,358 @@
+---
+description: "Decompose user needs into value chains for Wardley Mapping"
+---
+
+# ArcKit: Value Chain Decomposition for Wardley Mapping
+
+You are an expert value chain analyst using Wardley Mapping methodology. Your role is to decompose user needs into complete dependency chains — identifying components, establishing visibility positions, and producing OWM-ready syntax for use in a full Wardley Map.
+
+## User Input
+
+```text
+$ARGUMENTS
+```
+
+## Step 1: Read Available Documents
+
+> **Note**: Before generating, scan `projects/` for existing project directories. For each project, list all `ARC-*.md` artifacts, check `external/` for reference documents, and check `000-global/` for cross-project policies. If no external docs exist but they would improve output, ask the user.
+
+**MANDATORY** (warn if missing):
+
+- **REQ** (Requirements) — Extract: User needs, business requirements, functional capabilities, system components, integration points. Anchor the value chain in genuine user needs, not internal assumptions.
+  - If missing: warn the user and recommend running `/arckit:requirements` first. A value chain without requirements risks anchoring on solutions rather than needs.
+
+**RECOMMENDED** (read if available, note if missing):
+
+- **STKE** (Stakeholder Analysis) — Extract: User personas, stakeholder goals, success metrics, priority outcomes. Helps establish who sits at the top of the value chain.
+  - If missing: note that stakeholder context is unavailable; you will infer user personas from the requirements or user input.
+
+**OPTIONAL** (read if available, skip silently if missing):
+
+- **PRIN** (Architecture Principles) — Extract: Technology standards, cloud-first policy, reuse requirements, build vs buy preferences.
+- Existing WVCH artifacts in `projects/{current_project}/wardley-maps/` — Extract: Previous value chain analysis, component positions, known dependencies.
+
+## Step 1b: Read external documents and policies
+
+- Read any **external documents** listed in the project context (`external/` files) — extract: existing component lists, system architecture diagrams, dependency maps, integration catalogues.
+- Read any **enterprise standards** in `projects/000-global/external/` — extract: enterprise component library, shared service catalogue, cross-project reuse opportunities.
+- If no existing value chain documents are found but they would improve accuracy, ask: "Do you have any existing architecture diagrams, component lists, or dependency maps? I can read images and PDFs directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
+
+## Step 2: Identify the Anchor (User Need)
+
+The **anchor** is the user need at the top of the value chain. Everything below it exists to satisfy this need. Getting the anchor right is the most important step — a wrong anchor produces a wrong chain.
+
+### Good vs. Bad Anchors
+
+**GOOD anchors** — genuine user needs:
+
+- "User can communicate with their team in real time"
+- "Patient can book an appointment without calling the surgery"
+- "Taxpayer can file a return in under 15 minutes"
+- "Citizen can check their benefits eligibility online"
+
+**BAD anchors** — solutions masquerading as needs:
+
+- "User needs Slack" — this is a solution, not a need
+- "User needs a microservices platform" — this is an implementation choice
+- "System processes API calls" — this is a capability, not a purpose
+- "Database stores records" — this is infrastructure, not a user outcome
+
+**Anchor test**: Can this need be satisfied in multiple different ways? If the need is tightly tied to a specific product or technology, it is a solution, not a need. Strip it back to the underlying outcome the user requires.
+
+### Anchor Identification Questions
+
+Ask these questions to refine the anchor from the user input and available documents:
+
+1. **Who is the user?** — Be specific. A persona, role, or citizen type. Not "the system."
+2. **What outcome do they want?** — What changes for them when their need is met? What can they do, know, or decide?
+3. **Why do they need this?** — What is the underlying motivation? Remove one layer of abstraction from the stated need.
+
+State the anchor clearly before proceeding:
+
+```text
+Anchor: [User need statement]
+User: [Who has this need]
+Outcome: [What changes when this need is met]
+```
+
+## Step 3: Decompose into Components
+
+Starting from the anchor, decompose the value chain by asking "What is required to satisfy this?" at each level. Repeat recursively until you reach commodity-level infrastructure.
+
+### Recursive Decomposition Method
+
+```text
+Level 0 (Anchor): [User Need]
+  ↓ "What is required to provide this?"
+Level 1: [Capability A], [Capability B]
+  ↓ "What is required to provide Capability A?"
+Level 2: [Component C], [Component D]
+  ↓ "What is required to provide Component C?"
+Level 3: [Component E], [Component F]
+  ↓ Continue until commodities are reached
+```
+
+### Component Identification Checklist
+
+For each candidate component, verify:
+
+- [ ] Is it a capability, activity, or practice? (Not an actor, person, or team)
+- [ ] Does it directly or indirectly serve the anchor user need?
+- [ ] Can it evolve independently on the evolution axis?
+- [ ] Does it provide value to components above it in the chain?
+
+### Dependency Types
+
+When establishing connections between components, classify the relationship:
+
+- **REQUIRES** (hard dependency): Component A cannot function without Component B. Failure in B causes failure in A. Represented as `A -> B` in OWM syntax.
+- **USES** (soft dependency): Component A uses Component B to improve quality or performance, but can degrade gracefully without it.
+- **ENABLES** (reverse): Component B enables Component A to exist; B is not strictly required but makes A possible or better.
+
+For OWM syntax, use `->` for REQUIRES and USES relationships. Note ENABLES relationships in the component inventory.
+
+### Stop Conditions
+
+Stop decomposing when:
+
+1. The component is a genuine commodity (widely available utility: cloud compute, DNS, SMTP, payment rails)
+2. Further decomposition adds no strategic value for the mapping exercise
+3. You have reached common shared infrastructure that all chains eventually depend on
+
+Aim for 8–20 components total. Fewer than 8 may be too shallow; more than 25 may be too granular for strategic clarity.
+
+## Step 4: Establish Dependencies
+
+With all components identified, map the full dependency structure. Dependencies flow **down** the chain — higher-visibility components depend on lower-visibility ones.
+
+### Dependency Rules
+
+1. **Direction**: Dependencies flow downward. If Component A depends on Component B, A appears higher on the Y-axis than B.
+2. **Causality**: A dependency must be real and direct. Do not draw arrows because it "feels related."
+3. **No cycles**: A component cannot depend on itself or on a component that depends on it.
+4. **Completeness**: Every component except the anchor should have at least one dependency going down (or be a terminal commodity).
+
+### Dependency Validation
+
+For each dependency you draw, verify:
+
+- Would Component A fail or degrade significantly if Component B were removed?
+- Is this a direct dependency, or does it go via an intermediate component?
+- Have you captured all meaningful dependencies, or only the obvious ones?
+
+## Step 5: Assess Visibility (Y-axis)
+
+Read `.arckit/skills/wardley-mapping/references/evolution-stages.md` for supporting context on component characteristics.
+
+Visibility represents how directly visible a component is to the user at the top of the chain. Assign a value from 0.0 (invisible infrastructure) to 1.0 (directly experienced by the user).
+
+### Visibility Guide
+
+| Range | Level | Characteristics |
+|-------|-------|-----------------|
+| 0.90 – 1.00 | User-facing | Directly experienced; failure is immediately visible to the user |
+| 0.70 – 0.89 | High | Close to the user; degradation noticed quickly |
+| 0.50 – 0.69 | Medium-High | Indirectly visible; affects features the user relies on |
+| 0.30 – 0.49 | Medium | Hidden from users but essential to operations |
+| 0.10 – 0.29 | Low | Invisible to users; purely operational or infrastructure |
+| 0.00 – 0.09 | Infrastructure | Deep infrastructure; users unaware it exists |
+
+### Visibility Assessment Questions
+
+For each component, ask:
+
+1. Does the user interact with this component directly? (Yes → high visibility)
+2. Would the user notice immediately if this component failed? (Yes → high visibility)
+3. Could you swap out this component without the user knowing? (Yes → low visibility)
+4. Is this component one step removed from user interaction? (One step → medium-high)
+
+The anchor always receives a visibility of 0.90 or above (typically 0.95). Infrastructure reaches 0.05–0.15.
+
+## Step 6: Validate the Chain
+
+Before generating output, validate the value chain against these criteria.
+
+### Completeness Checks
+
+- [ ] Chain starts with a genuine user need (not a solution or capability)
+- [ ] All significant dependencies between components are captured
+- [ ] Chain reaches commodity level (cloud hosting, DNS, payment infrastructure, etc.)
+- [ ] No orphan components (every component has at least one connection)
+- [ ] All components are activities, capabilities, or practices — not people, teams, or actors
+
+### Accuracy Checks
+
+- [ ] Dependencies reflect real-world technical and operational relationships
+- [ ] Visibility ordering is consistent with dependency direction (higher visibility = higher Y-axis)
+- [ ] No component is both a high-level user-facing capability and a low-level infrastructure component
+
+### Usefulness Checks
+
+- [ ] Granularity is appropriate for strategic decision-making (not too fine, not too coarse)
+- [ ] Each component can be meaningfully positioned on the evolution axis for the subsequent Wardley Map
+- [ ] The chain reveals at least one strategic insight about build vs. buy, inertia, or differentiation
+
+### Common Issues to Avoid
+
+**Too shallow**: The chain has only 2-3 levels and jumps straight from user need to commodity. Add the intermediate capabilities and components.
+
+**Too deep**: The chain has 6+ levels and decomposes network packets and OS internals. Stop at the level where strategic decisions occur.
+
+**Missing components**: Common omissions include authentication, notification, monitoring, logging, and access control. Check for these.
+
+**Solution bias**: Components named after specific products (e.g., "Salesforce CRM" instead of "Customer Relationship Management") anchor the chain to current solutions. Name by capability unless you are deliberately mapping a specific vendor.
+
+**Activity confusion**: Components should be activities ("Payment Processing", "Identity Verification") not states ("Payment", "Identity"). Activities can evolve; nouns are ambiguous.
+
+## Step 7: Generate Output
+
+**File Location**: `projects/{project_number}-{project_name}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v1.0.md`
+
+**Naming Convention**:
+
+- `ARC-001-WVCH-001-v1.0.md` — First value chain
+- `ARC-001-WVCH-002-v1.0.md` — Second value chain (different user need or domain)
+
+**Read the template** (with user override support):
+
+- **First**, check if `.arckit/templates/wardley-value-chain-template.md` exists in the project root
+- **If found**: Read the user's customized template (user override takes precedence)
+- **If not found**: Read `.arckit/templates/wardley-value-chain-template.md` (default)
+
+> **Tip**: Users can customize templates with `/arckit:customize wardley-value-chain`
+
+---
+
+**Get or create project path**:
+
+Run `bash .arckit/scripts/bash/create-project.sh --json` to get the current project path. Extract `project_id` and `project_path` from the JSON response.
+
+---
+
+**CRITICAL — Auto-Populate Document Control Fields**:
+
+Before completing the document, populate ALL document control fields in the header:
+
+**Construct Document ID**:
+
+- **Document ID**: `ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}` (e.g., `ARC-001-WVCH-001-v1.0`)
+- Sequence number `{NNN}`: Check existing WVCH files in `wardley-maps/` and use the next number (001, 002, ...)
+
+**Populate Required Fields**:
+
+*Auto-populated fields* (populate these automatically):
+
+- `[PROJECT_ID]` → Extract from project path (e.g., "001" from "projects/001-project-name")
+- `[VERSION]` → "1.0" (or increment if previous version exists)
+- `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
+- `[DOCUMENT_TYPE_NAME]` → "Wardley Value Chain"
+- `[COMMAND]` → "arckit.wardley.value-chain"
+
+*User-provided fields* (extract from project metadata or user input):
+
+- `[PROJECT_NAME]` → Full project name from project metadata or user input
+- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
+- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+
+*Calculated fields*:
+
+- `[YYYY-MM-DD]` for Review Date → Current date + 30 days
+
+*Pending fields* (leave as [PENDING] until manually updated):
+
+- `[REVIEWER_NAME]` → [PENDING]
+- `[APPROVER_NAME]` → [PENDING]
+- `[DISTRIBUTION_LIST]` → Default to "Project Team, Architecture Team" or [PENDING]
+
+**Populate Revision History**:
+
+```markdown
+| 1.0 | {DATE} | ArcKit AI | Initial creation from `/arckit:wardley.value-chain` command | [PENDING] | [PENDING] |
+```
+
+**Populate Generation Metadata Footer**:
+
+```markdown
+**Generated by**: ArcKit `/arckit:wardley.value-chain` command
+**Generated on**: {DATE} {TIME} GMT
+**ArcKit Version**: {ARCKIT_VERSION}
+**Project**: {PROJECT_NAME} (Project {PROJECT_ID})
+**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**Generation Context**: [Brief note about source documents used]
+```
+
+---
+
+### Output Contents
+
+The value chain document must include:
+
+1. **Executive Summary**: Anchor statement, component count, key strategic insights (3-5 sentences)
+
+2. **Users and Personas**: Table of user types and their primary needs
+
+3. **Value Chain Diagram**:
+   - ASCII placeholder showing the chain structure (visibility levels and component names)
+   - Complete OWM syntax for https://create.wardleymaps.ai
+
+4. **Component Inventory**: All components with visibility scores, descriptions, and dependency references
+
+5. **Dependency Matrix**: Cross-reference table showing direct (X) and indirect (I) dependencies
+
+6. **Critical Path Analysis**:
+   - The sequence from anchor to deepest infrastructure
+   - Bottlenecks and single points of failure
+   - Resilience gaps
+
+7. **Validation Checklist**: Completed checklist confirming chain quality
+
+8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+
+9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
+
+**Use the Write tool** to save the document. Do not output the full document to the conversation — it will exceed token limits.
+
+---
+
+**Before writing the file**, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+
+- **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 0.5 visibility`, `> 0.75 evolution`) to prevent markdown renderers from interpreting them as HTML tags or emoji.
+
+## Final Output
+
+After saving the file, provide a concise summary to the user:
+
+```text
+✅ Value Chain Created: {context_name}
+
+📁 Location: projects/{project}/wardley-maps/ARC-{PROJECT_ID}-WVCH-{NNN}-v{VERSION}.md
+
+🗺️ View Chain: Paste the OWM code into https://create.wardleymaps.ai
+
+📊 Key Insights:
+- Anchor: {user need statement}
+- {N} components identified across {N} dependency levels
+- Critical path: {anchor} → {key component} → {commodity}
+- {Notable strategic insight, e.g., "Authentication is a commodity dependency shared across 4 capabilities"}
+
+⚠️ Potential Issues:
+- {Any validation warnings, e.g., "No commodity-level components found — chain may be incomplete"}
+- {Any missing prerequisite artifacts}
+
+🎯 Next Steps:
+- Run /arckit:wardley to create a full Wardley Map using this value chain
+- Assign evolution positions to each component for strategic analysis
+- Validate the chain with your team before proceeding to mapping
+
+🔗 Recommended Commands:
+- /arckit:wardley — Create full Wardley Map with evolution axis positioning
+- /arckit:wardley.doctrine — Assess organizational maturity to execute the strategy
+- /arckit:requirements — Strengthen the requirements before refining the chain (if incomplete)
+```
+
+## Suggested Next Steps
+
+After completing this command, consider running:
+
+- `/arckit:wardley` -- Create Wardley Map from this value chain
+- `/arckit:wardley.doctrine` -- Assess organizational doctrine maturity *(when Value chain reveals organizational capability gaps)*

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 60 slash commands
+- **Commands**: 64 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/remote-control.md
+++ b/arckit-opencode/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 60 ArcKit commands and 6 research agents remain fully available
+- All 64 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 60 commands | Plugin mode
+Version 2.10.0 | 64 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-opencode/docs/guides/wardley-climate.md
+++ b/arckit-opencode/docs/guides/wardley-climate.md
@@ -1,0 +1,122 @@
+# Climate Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.climate` assesses 32 climatic patterns affecting mapped components.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to understand the external forces acting on your components. Climate patterns are the rules of the game -- they apply regardless of your strategy. Understanding them lets you anticipate change, identify inertia, and choose gameplay that works with (not against) external forces.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map whose components are assessed for climatic forces |
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Recommended -- Business context for impact assessment |
+| Research findings (`ARC-<id>-RSCH-*.md`) | Recommended -- Market data to validate pattern detection |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.climate Assess climate for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WCLM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Climate Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being assessed |
+| Pattern Assessment | 32 climatic patterns evaluated against components |
+| Category Summary | Aggregated assessment across 6 pattern categories |
+| Peace/War/Wonder Cycle | Current cycle phase and implications |
+| Inertia Assessment | Components and organizations resisting change |
+| Prediction Horizons | What can be predicted and with what confidence |
+| Strategic Implications | How climate forces shape available strategies |
+
+---
+
+## Key Concepts
+
+### 32 Climatic Patterns Across 6 Categories
+
+| Category | Example Patterns |
+|----------|-----------------|
+| Competition | Competitors will copy successful plays, most competitors have poor situational awareness |
+| Components | Everything evolves through supply and demand competition, characteristics change as components evolve |
+| Financial | Higher-order systems create new sources of value, capital flows to new areas of value |
+| Speed | Evolution does not respect corporate boundaries, no single method fits all |
+| Prediction | Not everything is predictable, you can predict the direction of evolution |
+| Ecosystem | Efficiency enables innovation, evolution of one component affects others |
+
+### Peace / War / Wonder Cycle
+
+The evolution of components follows a repeating cycle:
+
+| Phase | Characteristics |
+|-------|-----------------|
+| Peace | Stable product competition, incremental improvement, predictable |
+| War | Commodity transition, disruption, rapid change, casualties |
+| Wonder | New genesis components emerge from commodity, novel value created |
+
+Identifying which phase each component is in reveals whether stability or disruption is imminent.
+
+### Inertia Assessment
+
+Inertia is resistance to change. Climate assessment identifies:
+
+- **Component inertia** -- Technology or practices that resist evolution
+- **Organizational inertia** -- Cultural resistance, sunk cost, existing contracts
+- **Market inertia** -- Vendor lock-in, switching costs, standards
+
+### Prediction Horizons
+
+Not all climate effects are equally predictable:
+
+| Horizon | Confidence |
+|---------|------------|
+| Direction of evolution | High -- components always evolve toward commodity |
+| Timing of evolution | Medium -- depends on competition and market forces |
+| Specific disruptions | Low -- individual events are unpredictable |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- All 32 climatic patterns assessed against map components.
+- Peace/War/Wonder phase identified for each key component.
+- Inertia sources documented with severity.
+- Prediction horizons are realistic (not overconfident).
+- Strategic implications link back to specific components.
+- Assessment is evidence-based, not speculative.
+
+---
+
+## Tips
+
+1. **Climate before gameplay** -- Climate constrains which plays are viable. Always assess climate first.
+2. **Look for war signals** -- Components approaching commodity transition are the highest-risk, highest-opportunity areas.
+3. **Challenge inertia** -- Organizational inertia is often the hardest to overcome. Name it explicitly.
+4. **Update with the map** -- Climate assessment is tied to a specific map version. When the map changes, re-assess.
+5. **Use research data** -- Market research (`/arckit.research`) provides evidence for pattern detection. Do not assess climate in a vacuum.

--- a/arckit-opencode/docs/guides/wardley-doctrine.md
+++ b/arckit-opencode/docs/guides/wardley-doctrine.md
@@ -1,0 +1,120 @@
+# Doctrine Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.doctrine` assesses organizational doctrine maturity across 4 phases and 40+ principles.
+
+---
+
+## When to Use
+
+Run this command to assess organizational maturity, identify capability gaps, and plan improvements. Doctrine assessment reveals how well an organization applies universal strategic principles -- independent of any specific map or context. Use it to:
+
+- Baseline current organizational maturity
+- Identify systemic weaknesses before they manifest in projects
+- Plan targeted improvement programmes
+- Re-assess periodically to measure progress
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Architecture principles (`ARC-000-PRIN-v1.0.md`) | **Mandatory** -- Governance principles to assess against |
+| Wardley Map (`ARC-<id>-WARD-*.md`) | Recommended -- Provides strategic context for scoring |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- Organizational context and drivers |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.doctrine Assess doctrine maturity for <organisation>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WDOC-v1.0.md` (single instance per project)
+
+---
+
+## Doctrine Structure
+
+| Section | Contents |
+|---------|----------|
+| Phase Assessment | Which of the 4 phases the organization has reached |
+| Category Scores | Maturity scores across 6 doctrine categories |
+| Principle-Level Detail | Individual 1-5 scoring for 40+ principles |
+| Gap Analysis | Weaknesses and improvement priorities |
+| Improvement Roadmap | Phased plan to advance doctrine maturity |
+
+---
+
+## Key Concepts
+
+### The 4 Phases of Doctrine
+
+| Phase | Name | Focus |
+|-------|------|-------|
+| I | Stop Self-Harm | Eliminate basic organizational dysfunctions |
+| II | Becoming Context Aware | Develop situational awareness and mapping capability |
+| III | Better for Less | Optimize through strategic play and efficiency |
+| IV | Continuously Evolving | Anticipate and adapt to change systemically |
+
+Organizations must master each phase before progressing to the next.
+
+### The 6 Categories
+
+| Category | Examples |
+|----------|---------|
+| Communication | Common language, challenge assumptions, listen to ecosystems |
+| Development | Use appropriate methods, think small, know your details |
+| Learning | Use a systematic mechanism of learning, bias towards data |
+| Leading | Move fast, be the owner, think big |
+| Operations | Manage inertia, optimise flow, think aptitude and attitude |
+| Structure | Provide purpose, use small teams, think standards |
+
+### Scoring (1-5)
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Not practiced -- principle is unknown or ignored |
+| 2 | Ad hoc -- applied inconsistently |
+| 3 | Developing -- recognized and partly systematized |
+| 4 | Practiced -- systematically applied across the organization |
+| 5 | Mastered -- deeply embedded, continuously improved |
+
+### Re-Assessment
+
+Doctrine assessments support periodic re-assessment. When re-running the command, the previous assessment is read and scores are compared to show progress, regression, or stagnation.
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Foundation | Establish architecture principles | `/arckit.principles` |
+| Assessment | Score doctrine maturity | `/arckit.wardley.doctrine` |
+| Mapping | Create Wardley Maps with doctrine context | `/arckit.wardley` |
+| Strategy | Synthesise into strategy | `/arckit.strategy` |
+
+---
+
+## Review Checklist
+
+- All 40+ principles scored with evidence.
+- Phase classification is justified.
+- Gap analysis identifies top priority improvements.
+- Improvement roadmap has realistic timelines.
+- Comparison with previous assessment included (if re-assessment).
+- Scores reflect reality, not aspiration.
+
+---
+
+## Tips
+
+1. **Be honest** -- Doctrine assessment only has value if scores reflect reality. Aspirational scoring hides problems.
+2. **Involve multiple stakeholders** -- A single assessor introduces bias; cross-functional input produces better scores.
+3. **Start with Phase I** -- If Phase I principles are not mastered, skip ahead at your peril.
+4. **Re-assess quarterly** -- Doctrine maturity changes slowly; quarterly cadence balances effort and insight.
+5. **Link to principles** -- Map each doctrine principle to your architecture principles for traceability.

--- a/arckit-opencode/docs/guides/wardley-gameplay.md
+++ b/arckit-opencode/docs/guides/wardley-gameplay.md
@@ -1,0 +1,123 @@
+# Gameplay Analysis Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.gameplay` analyzes strategic plays from 60+ gameplay patterns.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to identify strategic plays available to your organization. Gameplay analysis examines your map and recommends actions based on component positions, movements, and the competitive landscape. Best combined with climate assessment (`/arckit.wardley.climate`) for a complete strategic picture.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map to analyze for strategic plays |
+| Climate assessment (`ARC-<id>-WCLM-*.md`) | Recommended -- External forces affecting gameplay choices |
+| Doctrine assessment (`ARC-<id>-WDOC-*.md`) | Recommended -- Organizational readiness for each play |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.gameplay Analyze gameplay for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WGAM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Gameplay Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being analyzed |
+| Applicable Plays | Strategic plays identified from component positions |
+| Play-Position Matrix | Which plays apply to which components |
+| Alignment Classification | D&D alignment for each play (Lawful/Neutral/Chaotic) |
+| Recommended Actions | Prioritized list of strategic actions |
+| Risk Assessment | Risks and counter-plays for each recommendation |
+
+---
+
+## Key Concepts
+
+### 11 Gameplay Categories
+
+| Category | Focus |
+|----------|-------|
+| User Perception | Shaping how users see value |
+| Accelerators | Speeding evolution of components |
+| De-accelerators | Slowing evolution to protect advantage |
+| Market | Creating or reshaping markets |
+| Defensive | Protecting current position |
+| Attacking | Disrupting competitors |
+| Ecosystem | Building or leveraging ecosystems |
+| Positional | Exploiting map position |
+| Poison | Undermining competitor strategies |
+| Military | Direct competitive confrontation |
+| Political | Influencing rules and standards |
+
+### 60+ Plays
+
+Examples include open source (accelerator), create a constraint (de-accelerator), tower and moat (defensive), two-factor markets (ecosystem), and standards game (political). Each play has specific applicability based on component evolution stage and visibility.
+
+### D&D Alignment Classification
+
+Plays are classified on two axes:
+
+| Axis | Options |
+|------|---------|
+| Lawful / Neutral / Chaotic | How the play relates to established norms |
+| Good / Neutral / Evil | The ethical dimension of the play |
+
+This classification helps organizations choose plays that align with their values and governance requirements.
+
+### Play-Position Matrix
+
+The matrix maps each play to the evolution stages where it is most effective:
+
+| Evolution Stage | Example Plays |
+|-----------------|---------------|
+| Genesis | Experimentation, talent raid, first mover |
+| Custom | Sensing engines, co-creation |
+| Product | Industrialisation plays, ecosystem building |
+| Commodity | Standards game, utility plays, commoditisation |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- Wardley Map is current and validated.
+- All applicable plays identified for each component.
+- D&D alignment classification is consistent.
+- Risks and counter-plays documented for each recommendation.
+- Play-position matrix is populated.
+- Recommendations are prioritized by impact and feasibility.
+- Organizational readiness considered (doctrine assessment).
+
+---
+
+## Tips
+
+1. **Map first, play second** -- Never select gameplay without a current Wardley Map.
+2. **Combine with climate** -- Climate patterns constrain which plays are viable. Assess climate first.
+3. **Check doctrine readiness** -- Some plays require organizational maturity. A Phase I organization cannot execute Phase III plays.
+4. **Consider ethics** -- The D&D alignment classification is not decorative. Choose plays consistent with your governance.
+5. **Revisit after map changes** -- When components move or the landscape shifts, gameplay analysis must be refreshed.

--- a/arckit-opencode/docs/guides/wardley-value-chain.md
+++ b/arckit-opencode/docs/guides/wardley-value-chain.md
@@ -1,0 +1,122 @@
+# Value Chain Decomposition Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.value-chain` decomposes user needs into value chains for Wardley Mapping.
+
+---
+
+## When to Use
+
+Run this command **before** creating a Wardley Map when you need to decompose a domain into its constituent components. Value chain decomposition identifies all the capabilities, services, and activities required to meet user needs -- producing the raw material that `/arckit.wardley` then positions on an evolution axis.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | **Mandatory** -- Capabilities, user needs, and business context |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- User roles and business drivers |
+| Architecture diagrams | Optional -- Existing component landscape |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.value-chain Decompose value chain for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WVCH-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Value Chain Structure
+
+| Section | Contents |
+|---------|----------|
+| Anchor Identification | User needs vs internal solution anchors |
+| Recursive Decomposition | Break each need into sub-components until atomic |
+| Visibility Mapping | How visible each component is to the end user |
+| Dependency Analysis | Which components depend on which |
+| Component Catalogue | Full list with descriptions, types, and owners |
+
+---
+
+## Key Concepts
+
+### Anchors: User Needs vs Solutions
+
+Wardley Maps start from **user needs**, not technology. Value chain decomposition distinguishes:
+
+- **User-need anchors** -- What the user actually wants (e.g., "book an appointment")
+- **Solution anchors** -- Internal capabilities that serve the need (e.g., "appointment scheduling service")
+
+Always anchor at user needs; solutions are components in the chain below.
+
+### Recursive Decomposition
+
+Each user need is broken down recursively:
+
+1. Identify the top-level need
+2. Ask "what is needed to provide this?"
+3. For each answer, repeat until you reach atomic components
+4. Atomic = a component that can be sourced as a single unit (build, buy, or utility)
+
+### Visibility Axis
+
+Components sit on a visibility spectrum:
+
+| Position | Description |
+|----------|-------------|
+| Top (visible) | User-facing capabilities, directly experienced |
+| Middle | Supporting services, seen by operators |
+| Bottom (invisible) | Infrastructure and utilities, invisible to users |
+
+### Dependency Types
+
+| Type | Description |
+|------|-------------|
+| Direct | Component A cannot function without Component B |
+| Indirect | Component A benefits from Component B but can operate without it |
+| Shared | Multiple components depend on a common service |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Requirements | Define user needs and capabilities | `/arckit.requirements` |
+| Decomposition | Break needs into value chains | `/arckit.wardley.value-chain` |
+| Mapping | Position components on evolution axis | `/arckit.wardley` |
+| Analysis | Assess doctrine, climate, gameplay | `/arckit.wardley.doctrine`, `/arckit.wardley.climate`, `/arckit.wardley.gameplay` |
+
+---
+
+## Review Checklist
+
+- All user needs identified and used as anchors.
+- Decomposition is recursive to atomic components.
+- Visibility axis reflects real user perspective.
+- Dependencies between components are explicit.
+- No technology assumptions baked into anchors.
+- Component catalogue is complete with descriptions.
+
+---
+
+## Tips
+
+1. **Start with users, not technology** -- If your first anchor is a database, you have started too low.
+2. **Challenge "obvious" components** -- Decompose even well-understood areas; hidden dependencies live there.
+3. **Use stakeholder analysis** -- Stakeholder drivers reveal needs that requirements alone may miss.
+4. **One chain per user need** -- Separate chains keep the analysis focused.
+5. **Feed into Wardley Map** -- The value chain output is the direct input to `/arckit.wardley`.
+
+---
+
+## Feeds Into
+
+- `/arckit.wardley` -- Use the decomposed value chain to create a positioned Wardley Map
+- `/arckit.data-model` -- Components often map to data entities

--- a/arckit-opencode/docs/guides/wardley.md
+++ b/arckit-opencode/docs/guides/wardley.md
@@ -6,6 +6,29 @@
 
 ---
 
+## Wardley Mapping Suite
+
+ArcKit provides a full suite of Wardley Mapping commands that work together as a strategic analysis pipeline:
+
+| Command | Purpose | Output |
+|---------|---------|--------|
+| `/arckit.wardley.value-chain` | Decompose user needs into value chains | WVCH |
+| `/arckit.wardley` | Create positioned Wardley Maps | WARD |
+| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity | WDOC |
+| `/arckit.wardley.climate` | Assess 32 climatic patterns | WCLM |
+| `/arckit.wardley.gameplay` | Analyze 60+ strategic gameplay patterns | WGAM |
+
+**Recommended workflow order:**
+
+1. **Value Chain** -- Decompose domain into components ([guide](wardley-value-chain.md))
+2. **Wardley Map** -- Position components on evolution axis (this guide)
+3. **Doctrine** -- Assess organizational maturity ([guide](wardley-doctrine.md))
+4. **Climate** -- Understand external forces ([guide](wardley-climate.md))
+5. **Gameplay** -- Identify strategic plays ([guide](wardley-gameplay.md))
+6. **Strategy / Roadmap** -- Synthesise findings into actionable plans
+
+---
+
 ## Inputs
 
 | Artefact | Purpose |

--- a/arckit-opencode/skills/wardley-mapping/SKILL.md
+++ b/arckit-opencode/skills/wardley-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wardley-mapping
-description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, gameplay patterns, doctrine, build vs. buy decisions, inertia analysis, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
+description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, value chain decomposition, gameplay patterns, doctrine assessment, doctrine maturity, climatic patterns, climate assessment, build vs. buy decisions, inertia analysis, D&D alignment of strategies, peace/war/wonder cycles, play-position matrix, pioneers/settlers/planners, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
 ---
 
 # Wardley Mapping
@@ -251,15 +251,23 @@ wardley_map:
 
 Consult these reference files for deeper analysis:
 
-- [Evolution Stages](references/evolution-stages.md) — Detailed stage characteristics, indicators, and positioning criteria
-- [Climatic Patterns](references/climatic-patterns.md) — External forces affecting the landscape (economic, competitive, technology, market patterns)
-- [Gameplay Patterns](references/gameplay-patterns.md) — Offensive/defensive strategic moves, build vs. buy vs. outsource, anti-patterns
-- [Doctrine](references/doctrine.md) — Universal strategy patterns and organizational maturity assessment
-- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product
-- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection
+- [Evolution Stages](references/evolution-stages.md) — Stage characteristics, indicators, positioning criteria, transition heuristics, pioneers/settlers/planners talent model
+- [Climatic Patterns](references/climatic-patterns.md) — 32 patterns across 6 categories (component, financial, speed, inertia, competitor, prediction), peace/war/wonder cycle, pattern interactions
+- [Gameplay Patterns](references/gameplay-patterns.md) — 60+ plays across 11 categories with D&D alignment classification, play-position matrix, play compatibility, case studies (AWS, Netflix, Tesla, Spotify)
+- [Doctrine](references/doctrine.md) — 40+ principles across 4 phases and 6 categories, Strategy Cycle framework, implementation journeys, maturity assessment template
+- [Mapping Examples](references/mapping-examples.md) — Worked examples: E-Commerce, DevOps Platform, ML Product, TechnoGadget Smart Home, value chain decomposition walkthrough, case study cross-references
+- [Mathematical Models](references/mathematical-models.md) — Evolution scoring formulas, decision metrics, weak signal detection, play-position scoring, climate pattern impact weighting
 
 ## ArcKit Integration
 
 This skill handles **conversational** Wardley Mapping — quick questions, evolution stage lookups, doctrine assessments, and interactive map creation.
 
-For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the `/arckit:wardley` command instead. It generates versioned Wardley Map artifacts saved to your project directory with full traceability to requirements and architecture principles.
+For **formal architecture documents** with document control, project integration, UK Government compliance (TCoP, GDS, AI Playbook), and OnlineWardleyMaps syntax for https://create.wardleymaps.ai, use the ArcKit Wardley suite:
+
+- `/arckit.wardley.value-chain` — Decompose user needs into value chains (WVCH artifact)
+- `/arckit.wardley` — Create strategic Wardley Maps (WARD artifact)
+- `/arckit.wardley.doctrine` — Assess organizational doctrine maturity across 4 phases, 40+ principles (WDOC artifact)
+- `/arckit.wardley.gameplay` — Analyze strategic plays from 60+ gameplay patterns with D&D alignment (WGAM artifact)
+- `/arckit.wardley.climate` — Assess 32 climatic patterns across 6 categories with prediction horizons (WCLM artifact)
+
+These generate versioned artifacts saved to your project directory with full traceability to requirements and architecture principles. Each command works standalone but gets richer when sibling artifacts exist.

--- a/arckit-opencode/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-opencode/skills/wardley-mapping/references/climatic-patterns.md
@@ -1,260 +1,456 @@
-# Climatic Patterns
+# Climatic Patterns Reference
 
-External forces that affect the landscape, outside organizational control.
+Climatic patterns are external forces that shape the business landscape regardless of your actions. They are the "weather" of strategy — you cannot control them, but you can anticipate and prepare. Unlike gameplays (deliberate choices), climatic patterns simply happen. Understanding them lets you position ahead of change rather than react to it.
 
-## Economic Patterns
+---
 
-### Everything Evolves
+## 1. Component Patterns — Chapter IV
 
-```yaml
-pattern:
-  name: "Everything Evolves"
-  description: "All components evolve through genesis → custom → product → commodity"
+### 1.1 Everything Evolves Through Supply and Demand Competition
 
-  implications:
-    - "No competitive advantage is permanent"
-    - "Today's differentiator is tomorrow's commodity"
-    - "Plan for evolution, don't fight it"
+All components — activities, practices, data, knowledge — move from genesis through custom-built, product, and commodity stages driven by supply and demand forces. Supply-side competition drives standardisation and efficiency; demand-side pressure shifts expectations from "novel capability" to "expected utility." Value perception shifts from scarcity and uniqueness at genesis, to features at product stage, to cost and reliability at commodity stage.
 
-  example: "Cloud computing: mainframe → server → VM → container → serverless"
+**Strategic implication:** No competitive advantage is permanent — plan for evolution, not against it.
+
+**Assessment question:** Which components are actively evolving and what does their next stage look like?
+
+---
+
+### 1.2 Rates of Evolution Can Vary by Ecosystem
+
+Evolution does not occur at a uniform pace. Consumer ecosystems (individual users, rapid adoption, trend-driven, network effects) evolve far faster than industrial ecosystems (B2B, long decision cycles, regulatory constraints, high switching costs). Factors that modulate speed include regulatory environment, investment levels, industry inertia, and how dependent a component is on underlying technologies that are themselves evolving.
+
+**Strategic implication:** Map the evolutionary speed of your specific ecosystem, not a generic average, to time investments and innovation correctly.
+
+**Assessment question:** Is this component in a fast or slow ecosystem, and does your strategy match that cadence?
+
+---
+
+### 1.3 Characteristics Change as Components Evolve
+
+As a component moves along the evolution axis, its fundamental characteristics transform. Genesis: uncertain, rare, high-risk, radical innovation, pioneer teams. Custom-built: emerging understanding, divergent approaches, hypothesis-driven. Product: standardising, feature competition, settler teams. Commodity: well-understood, price-based competition, high reliability required, town planner teams. Management approach, failure tolerance, contract type, and talent profile must all change with the stage.
+
+**Strategic implication:** Applying product-stage management to a genesis component (or vice versa) is a systematic source of failure.
+
+**Assessment question:** Does the management approach, team structure, and contract type match the current evolution stage of this component?
+
+---
+
+### 1.4 No Choice Over Evolution — The Red Queen Effect
+
+Named after Lewis Carroll's Red Queen: "It takes all the running you can do, to keep in the same place." Evolution in business ecosystems is not optional. Competitive pressures, technological advancement, and shifting customer expectations force continuous adaptation. Absolute progress (improving your own capabilities) does not guarantee relative progress if competitors evolve at the same or faster rate. BlackBerry and Nokia improved their products; the market moved past them anyway.
+
+**Strategic implication:** Continuous adaptation is a survival requirement, not a strategic option.
+
+**Assessment question:** Where are we running just to stay still, and are we running fast enough?
+
+---
+
+### 1.5 No Single Method Fits All
+
+Different evolution stages require fundamentally different approaches. Software development: agile for genesis/custom, DevOps for maturing product, Six Sigma/lean for commodity. Contracts: time-and-materials for genesis, fixed-price for commodity. Architecture: disposable PoCs at genesis, standardised patterns at commodity. Amazon exemplifies this — AWS runs on continuous deployment, fulfillment centres on lean manufacturing, Amazon Go on experimental tech. Applying a single methodology across all stages creates systematic inefficiency.
+
+**Strategic implication:** Build a toolkit of methods and the organisational capability to switch between them as components evolve.
+
+**Assessment question:** Are we applying the right management method for each component's current evolution stage?
+
+---
+
+### 1.6 Components Can Co-evolve
+
+Components do not evolve in isolation. The evolution of one component can trigger, accelerate, or constrain the evolution of related components. Types: symbiotic (mobile hardware and mobile apps), practice-based (DevOps emerged with cloud infrastructure), competitive (fintech forcing bank digital evolution). Co-evolution creates new opportunities at intersection points and new risks when dependent components evolve at mismatched speeds.
+
+**Strategic implication:** Watch for "enabler components" — when they evolve, they can unlock rapid evolution in components that depend on them.
+
+**Assessment question:** Which components, if evolved by a competitor, would trigger co-evolutionary pressure on our differentiators?
+
+---
+
+### 1.7 Evolution Consists of Multiple Waves of Diffusion with Many Chasms
+
+Drawing on Rogers' Diffusion of Innovations and Moore's chasm concept: adoption does not flow smoothly. Each wave (innovators/early adopters → early majority → late majority → laggards) has distinct characteristics, and between waves lie chasms where adoption stalls. Cloud computing crossed at least two major chasms — the security concern chasm before enterprise adoption, and the legacy integration chasm before cloud-native architectures. Products can die in a chasm even if the technology is sound.
+
+**Strategic implication:** Crossing a chasm requires a different strategy than riding a wave — segment, adapt the offer, build reference cases, develop ecosystem support.
+
+**Assessment question:** Which chasm is this component currently in, and what is blocking the next adoption wave?
+
+---
+
+### 1.8 Commoditization Does Not Equal Centralisation
+
+A common misconception: if something commoditises, it must consolidate to a single provider. Reality is more nuanced. Many commoditised components remain decentralised due to local regulation, physical constraints, security requirements, resilience needs, or customer preferences for local relationships. Banking services are largely commoditised but thousands of institutions persist. Electricity is standardised but generation is distributed. Cloud computing is commoditised but multiple providers compete.
+
+**Strategic implication:** Commoditised markets may still offer opportunities for differentiation through localisation, specialisation, or distributed models.
+
+**Assessment question:** Are we assuming centralisation will follow commoditisation, and is that assumption valid for our specific market context?
+
+---
+
+## 2. Financial Patterns — Chapter V
+
+### 2.1 Higher Order Systems Create New Sources of Value
+
+When lower-order components commoditise, they become building blocks for new, higher-order systems that exhibit emergent properties not present in constituent parts. Cloud computing (commodity compute + storage + networking) enabled the SaaS economy. Smartphones (commodity hardware) enabled the app economy. IoT = sensors + connectivity + cloud + analytics. Each higher-order system opens new value streams, new business models, and new genesis opportunities above it.
+
+**Strategic implication:** Look for clusters of recently commoditised components — they are the foundation for the next wave of higher-order innovation.
+
+**Assessment question:** What higher-order system could be built on top of components that are now commoditising in our value chain?
+
+---
+
+### 2.2 Efficiency Does Not Mean Reduced Spend — Jevons Paradox
+
+Named after 19th-century economist William Stanley Jevons: improvements in the efficiency of resource use tend to increase total consumption, not reduce it, because lower cost enables new use cases and broader adoption. Cloud computing became more efficient and cheaper — total cloud spend skyrocketed. Fuel-efficient cars led to more driving. More efficient LEDs led to more lighting. In Wardley terms: as components commoditise and efficiency improves, new applications emerge that consume more of that resource overall.
+
+**Strategic implication:** Efficiency gains in a component should be treated as a demand amplifier, not a cost reducer — plan for increased consumption and new use cases, not reduced spend.
+
+**Assessment question:** Where are we planning cost savings from efficiency improvements that will actually be consumed by new demand?
+
+---
+
+### 2.3 Capital Flows to New Areas of Value
+
+Capital (financial, human, intellectual, organisational attention) consistently flows away from commoditised, low-margin areas toward genesis and early custom-built components with high differentiation potential. As an area commoditises, capital exits to fund the next cycle of innovation. This is visible in VC trends (AI/ML, quantum, clean energy), talent migration patterns, and M&A activity. The direction of capital flow is a leading indicator of where value is being created.
+
+**Strategic implication:** Track where capital is flowing — it signals where the next wave of value creation is forming.
+
+**Assessment question:** Is capital flowing toward or away from our core differentiators, and what does that signal about their evolution stage?
+
+---
+
+### 2.4 Creative Destruction — The Schumpeter Effect
+
+Joseph Schumpeter described creative destruction as "a process of industrial mutation that incessantly revolutionises the economic structure from within, incessantly destroying the old one, incessantly creating a new one." New innovations render existing components, business models, and sometimes entire industries obsolete. Digital photography destroyed film. Streaming destroyed video rental. EV is restructuring automotive. In Wardley terms, new genesis components emerge and evolve rapidly to displace commodity incumbents.
+
+**Strategic implication:** No incumbent position is safe from creative destruction — organisations must simultaneously exploit current advantages and invest in the innovations that may replace them.
+
+**Assessment question:** What genesis-stage component, if it evolves, would make our current commodity position irrelevant?
+
+---
+
+### 2.5 Future Value is Inversely Proportional to Certainty
+
+The higher the certainty about an outcome, the lower its potential value — because certainty is priced in by competitors. Genesis components (high uncertainty, low certainty) carry the highest potential value but also the highest risk. Commodity components (high certainty, low uncertainty) offer stable returns but no differentiation. Venture capital portfolios embody this: most investments fail, but the few that succeed return multiples that dwarf the losses. The relationship also applies to timing: the P[what] of a change may be high (EV will dominate) while P[when] remains uncertain.
+
+**Strategic implication:** Pursuing only certain opportunities means accepting low returns — a portfolio of high-uncertainty bets is needed to capture asymmetric upside.
+
+**Assessment question:** Are we systematically avoiding uncertain opportunities in ways that cap our future value potential?
+
+---
+
+### 2.6 Evolution to Higher Order Systems Increases Local Order and Energy Consumption
+
+As systems become more complex and organised locally (higher order), they require more energy and resources overall — not less. More complex systems are more ordered locally but increase entropy in their environment. This manifests as: cloud data centres consuming massive electricity to enable efficient individual applications, AI training consuming enormous compute to enable efficient inference, smart cities consuming more infrastructure to optimise traffic. Jevons Paradox amplifies this — efficiency enables more consumption.
+
+**Strategic implication:** Include energy/resource/infrastructure costs in strategic planning for higher-order systems — the efficiency gains at the application layer are often offset by consumption increases at the infrastructure layer.
+
+**Assessment question:** Have we accounted for the full resource cost of the higher-order systems we are building or depending on?
+
+---
+
+## 3. Speed Patterns — Chapter VI
+
+### 3.1 Efficiency Enables Innovation — The Componentization Effect
+
+When lower-order components become commoditised and efficient, focus and resources shift to higher-level innovation. The mechanism: abstraction hides complexity, standardisation enables reuse, efficiency frees resources, stable components enable rapid recombination. Cloud commoditised infrastructure → rapid innovation in PaaS/SaaS. Smartphone hardware commoditised → app economy. Open source libraries → accelerated development. Each layer of commoditisation is a platform for the genesis of the next layer.
+
+**Strategic implication:** Actively commoditise lower layers to free innovation capacity for higher-value work — don't custom-build what should be utility.
+
+**Assessment question:** Which of our custom-built components should be replaced with commodity solutions to free resources for higher-value innovation?
+
+---
+
+### 3.2 Evolution of Communication Mechanisms Increases Overall Evolution Speed
+
+Improvements in how information is shared, collaboration occurs, and knowledge spreads accelerate the evolution of everything else. GitHub accelerated open source. Social media accelerated trend adoption and customer feedback loops. Slack/Zoom accelerated distributed decision-making. The internet accelerated globalisation. Each improvement in communication creates tighter feedback loops, faster learning cycles, and broader dissemination of innovation — compressing the time from genesis to commodity for dependent components.
+
+**Strategic implication:** Investing in communication infrastructure and culture is not just operational overhead — it is a direct lever on innovation speed.
+
+**Assessment question:** Are there communication bottlenecks in our organisation that are slowing the evolution of key components?
+
+---
+
+### 3.3 Increased Stability of Lower Order Systems Increases Agility
+
+A paradox: stability at lower levels creates agility at higher levels. When foundational components are reliable and well-understood, teams can experiment and innovate at higher levels without worrying about the underlying infrastructure. Stable OS → rapid application development. Stable cloud infrastructure → serverless experimentation. Stable web frameworks → rapid UI prototyping. Conversely, unstable lower-order systems force engineering attention downward, away from higher-value innovation.
+
+**Strategic implication:** Invest in making foundational systems stable and commodity-grade to unlock innovation speed above them.
+
+**Assessment question:** Are our foundational systems stable enough to support rapid recombination and experimentation at higher levels?
+
+---
+
+### 3.4 Change Is Not Always Linear — Discontinuous and Exponential Change Exists
+
+Change can follow linear, exponential, S-curve, or discontinuous (tipping point) patterns. Human cognition defaults to linear extrapolation, systematically underestimating exponential trends and missing discontinuities. AI capabilities improved gradually for decades, then accelerated explosively. Cryptocurrency appeared discontinuously. Social media followed an S-curve. The implication: strategies built on linear forecasts are repeatedly surprised by the world. Scenarios must include non-linear possibilities.
+
+**Strategic implication:** Build strategies that are robust across non-linear scenarios, not just the linear extrapolation of current trends.
+
+**Assessment question:** Which components in our landscape could exhibit exponential or discontinuous change, and are our plans robust to that?
+
+---
+
+### 3.5 Product-to-Utility Shifts Demonstrate Punctuated Equilibrium
+
+The transition from product to utility (commodity/utility stage) is not always gradual. Components often remain stable in the product stage for extended periods, then shift rapidly to utility characteristics — standardised offering, usage-based pricing, cloud delivery, market consolidation. Software licensing → SaaS was punctuated. Music sales → streaming was punctuated. On-premise IT → cloud was punctuated. The equilibrium (product stage) is stable until a trigger collapses it quickly into the utility paradigm.
+
+**Strategic implication:** If you are in a product market, monitor for the triggers that will cause punctuated shift to utility — and decide whether to lead or follow that shift.
+
+**Assessment question:** Which of our product-stage offerings is approaching a punctuated shift to utility, and are we positioned to lead or survive it?
+
+---
+
+## 4. Inertia Patterns — Chapter VII
+
+### 4.1 Success Breeds Inertia
+
+Organisations that achieve success tend to resist change. The very practices, structures, and mindsets that created success become barriers to future adaptation. Mechanisms: complacency reduces urgency, overconfidence inflates belief in current capabilities, resources cluster around profitable existing products, successful practices become culturally entrenched, and risk aversion increases as there is more to lose. Kodak invented digital photography; Nokia built excellent hardware; Blockbuster had massive scale — all failed because success made adaptation psychologically and structurally difficult.
+
+**Strategic implication:** Explicitly identify and name success-induced inertia — it is invisible until it is fatal.
+
+**Assessment question:** Where are we resisting evolution because current revenue or culture depends on the status quo?
+
+---
+
+### 4.2 Inertia Can Kill an Organisation
+
+Unaddressed inertia has existential consequences. The mechanisms of organisational death by inertia: market irrelevance (failing to adapt to shifting user needs), technological obsolescence (clinging to superseded approaches), business model disruption (unable to match new entrants' economics), and resource depletion (continuing to invest in declining areas). Blockbuster (bankruptcy 2010), Kodak (bankruptcy 2012), Nokia's mobile division (sold 2014) — all were dominant market leaders destroyed by inertia, not lack of capability.
+
+**Strategic implication:** Inertia is not a performance problem — it is a survival problem. Treat it as an existential risk, not a management challenge.
+
+**Assessment question:** If a new entrant built our core value chain on commodity infrastructure today, what would their cost structure and speed look like compared to ours?
+
+---
+
+### 4.3 Inertia Increases the More Successful the Past Model Is
+
+The more successful a business model has been, the harder it becomes to abandon — proportionally. Extraordinary success creates deeper entrenchment of processes, stronger cognitive biases toward the current model, greater financial disincentives to change (cannibalism risk), deeper skill specialisation that is hard to pivot, and stronger cultural identity attached to the successful approach. Microsoft initially missed the internet despite its dominant position. IBM resisted personal computing. Xerox failed to commercialise its own GUI innovations.
+
+**Strategic implication:** The organisations most at risk from inertia are the most successful ones — build explicit mechanisms for self-disruption before disruption is forced externally.
+
+**Assessment question:** Where is our success so profound that we cannot honestly assess whether the model will survive the next evolution cycle?
+
+---
+
+## 5. Competitor Patterns — Chapter VIII
+
+### 5.1 Competitors' Actions Will Change the Game
+
+The competitive landscape is not static — competitors' strategic moves can fundamentally alter the rules of engagement. Game-changing action types: disruptive innovation (redefining the market), pricing strategy shifts (changing customer expectations), M&A (creating new capability combinations), ecosystem plays (expanding the scope of competition), and regulatory influence (shaping the playing field). AWS changed cloud. Uber changed transport. Tesla changed automotive. Each action triggered cascading changes across the entire ecosystem.
+
+**Strategic implication:** Strategy must be designed for a reactive system, not a static environment — anticipate competitor moves, not just market trends.
+
+**Assessment question:** Which competitor action, if taken, would most fundamentally change the basis of competition in our market?
+
+---
+
+### 5.2 Most Competitors Have Poor Situational Awareness
+
+The majority of organisations operate without a clear, accurate model of their competitive landscape. Manifestations of poor situational awareness: myopic focus on immediate competitors while missing broader industry shifts, technology blindness (failing to recognise emerging technology impact), customer disconnect (misunderstanding evolving needs), ecosystem ignorance (unaware of adjacent disruptors), and internal bias (overestimating own position). Blockbuster, Nokia, and Kodak all had access to information about emerging threats — they lacked the frameworks to interpret that information correctly.
+
+**Strategic implication:** Superior situational awareness is itself a durable competitive advantage — Wardley Mapping is a tool for building it.
+
+**Assessment question:** What would our map look like if drawn by our most capable competitor, and how would it differ from ours?
+
+---
+
+## 6. Prediction Patterns — Chapter IX
+
+### 6.1 Not Everything is Random — P[what] vs P[when]
+
+The direction of change (what will happen) is often more predictable than its timing (when it will happen). The shift to electric vehicles was widely predictable (high P[what]); the timing of mass adoption was not (uncertain P[when]). The commoditisation of cloud was predictable; the exact speed was not. This distinction enables better strategic planning: prepare capabilities and positioning for the predictable "what" while maintaining flexibility about the "when." Strategies anchored to specific timelines fail when the "when" is wrong; strategies anchored to directions are more robust.
+
+**Strategic implication:** Separate directional bets (high confidence) from timing bets (lower confidence) in strategic planning and investment decisions.
+
+**Assessment question:** Which evolutionary directions in our landscape are high-confidence (P[what]) even if the timing remains uncertain (P[when])?
+
+---
+
+### 6.2 Economy Has Cycles — Peace, War, and Wonder
+
+Industries cycle through three phases. **Peace**: stable market, established players dominate, incremental improvements, efficiency focus, product competition on features. **War**: intense competition triggered by industrialisation of a key component (e.g., cloud), rapid disruption, shifting power, creative destruction, incumbents with inertia are most vulnerable. **Wonder**: emergence of new higher-order systems built on newly commoditised components, rapid genesis, new industries forming, new business models, capital floods in. Each phase transitions to the next as components evolve.
+
+**Strategic implication:** Identify the current phase and position accordingly — survival strategies differ radically between Peace (optimise), War (transform rapidly), and Wonder (explore and capture genesis opportunities).
+
+**Assessment question:** Which phase is our core market currently in, and what phase transition should we be preparing for?
+
+---
+
+### 6.3 Different Forms of Disruption — Predictable vs Unpredictable
+
+Not all disruptions are equal. **Predictable disruptions** follow observable evolutionary patterns — the shift to EV, the move from product to SaaS, the commoditisation of compute. These can be anticipated through careful Wardley mapping and scenario planning. **Unpredictable disruptions** arise from unforeseen combinations of factors — cryptocurrency, ChatGPT's impact timeline, COVID-19 accelerating digital adoption. Strategies for each differ: predictable disruptions warrant directional investment and capability building; unpredictable disruptions require resilience, optionality, and rapid response capability.
+
+**Strategic implication:** Maintain separate portfolios for predictable evolutionary positioning and resilience against unpredictable disruption.
+
+**Assessment question:** Which disruptions in our landscape are predictable (and therefore we should be positioned for), and which require resilience rather than prediction?
+
+---
+
+### 6.4 A "War" (Point of Industrialisation) Causes Organisations to Evolve
+
+When a key component crosses from product to utility (industrialisation), it triggers a "war" — a period of intense competition that forces rapid organisational evolution across the entire ecosystem. Characteristics: accelerated component movement on the map, emergence of new components and disappearance of others, shifting value chains, standardisation pressure, and efficiency focus. The cloud "war" forced every enterprise IT function to evolve. The e-commerce "war" forced every retailer to transform. Organisations with high inertia are most vulnerable during these periods.
+
+**Strategic implication:** Detect the signs of an approaching "war" early — rapid component movement, new entrants with commodity infrastructure, pricing pressure — and begin transformation before the peak.
+
+**Assessment question:** Is there a component in our value chain approaching industrialisation that will trigger a "war" requiring us to evolve rapidly?
+
+---
+
+### 6.5 You Cannot Measure Evolution Over Time or Adoption
+
+Evolution cannot be precisely measured or timed. Adoption rates are highly variable, context-dependent, and non-linear. Attempts to create exact timelines or adoption curves produce false precision that misleads strategy. Cloud adoption varied wildly by industry and region. Social media platform trajectories were unpredictable. AI breakthroughs in natural language processing exceeded predictions; adoption in other sectors lagged them. The evolutionary axis in Wardley maps represents maturity, not time — components should be positioned by their characteristics, not by when they appeared.
+
+**Strategic implication:** Use directional positioning and scenario ranges rather than timeline forecasts — build strategies robust to timing uncertainty.
+
+**Assessment question:** Are we making investment commitments that depend on specific adoption timing predictions, and how robust are those commitments if timing is wrong by 2-3 years?
+
+---
+
+### 6.6 The Less Evolved Something Is, the More Uncertain It Becomes
+
+Uncertainty correlates inversely with evolution stage. Genesis components: high uncertainty about use cases, timelines, applications, and market dynamics. Custom-built: emerging patterns, still divergent. Product: increasing certainty, convergent standards. Commodity: well-understood, predictable. This is why genesis innovation requires different risk tolerance, different management approaches, and different investment models (portfolio/options thinking) compared to commodity management (efficiency, SLAs, incident management). Blockchain remains mostly in high-uncertainty stages; cloud IaaS is low-uncertainty commodity.
+
+**Strategic implication:** Calibrate risk tolerance, management approach, and investment model to the evolution stage — not to a single organisational standard.
+
+**Assessment question:** Are we applying commodity-appropriate certainty assumptions to genesis-stage components, or genesis-appropriate uncertainty assumptions to commodity components?
+
+---
+
+### 6.7 Not Everything Survives
+
+Evolution is a selection process — not all components, technologies, business models, or organisations survive it. Survival requires continuous adaptation. Past success and market leadership do not guarantee survival (Kodak, Nokia, Blockbuster). Creative destruction continuously replaces less-adapted elements with better-adapted alternatives. Strategies must account for exit scenarios, graceful transition pathways, and portfolio diversification to spread survival risk. Some components will become obsolete on a predictable timeline; others will be wiped out by unpredictable disruption.
+
+**Strategic implication:** Include obsolescence scenarios and exit planning in strategy — not as pessimism, but as realism about evolutionary dynamics.
+
+**Assessment question:** Which components in our current value chain have a non-trivial probability of not surviving the next evolution cycle, and what is our plan?
+
+---
+
+### 6.8 Embrace Uncertainty
+
+Uncertainty is not a problem to solve — it is a property of the landscape to work with. Strategies that require uncertainty to be resolved before acting are brittle. Effective approaches: scenario planning across multiple futures, adaptive strategy that adjusts as new information arrives, staged investment (options thinking), rapid experimentation to reduce uncertainty in specific areas, and range-based positioning rather than point predictions. The Wardley map itself is a tool for navigating uncertainty, not eliminating it.
+
+**Strategic implication:** Design strategy to be robust across a range of futures, not optimal for a single predicted future.
+
+**Assessment question:** How many of our current strategic commitments would fail if one key uncertainty resolved differently than we expect?
+
+---
+
+## 7. The Peace/War/Wonder Cycle
+
+The Peace/War/Wonder cycle is one of the most powerful macro-level patterns for strategic timing.
+
+### Peace Phase
+
+Characteristics: stable market structure, established players compete on features and brand, incremental innovation dominates, efficiency and optimization are the primary value drivers, customers have clear expectations, supply chains are well-understood, margins are moderate but predictable.
+
+Strategic posture in Peace: invest in operational excellence, differentiate on features and customer experience, build moats through network effects and switching costs, watch for the signs of approaching War.
+
+Signs Peace is ending: a key component begins rapid commoditisation, new entrants appear with dramatically lower cost structures built on commodity infrastructure, pricing pressure accelerates, customers begin treating differentiated features as expected utilities.
+
+### War Phase
+
+Characteristics: intense competition triggered by industrialisation of a key component, rapid disruption of established business models, creative destruction of incumbents with high inertia, massive investment and risk-taking, shifting value chains, winner-takes-most dynamics, organisations that fail to evolve quickly face existential risk.
+
+Strategic posture in War: transform rapidly, use the commodity infrastructure that triggered the War, shed custom-built components that are now available as utilities, focus on higher-order differentiation, form strategic partnerships, acquire capabilities that cannot be built fast enough organically.
+
+Signs War is ending: market consolidation around a few utility providers, pricing stabilises at commodity levels, the new "normal" becomes established, innovation focus shifts upward to new genesis opportunities.
+
+### Wonder Phase
+
+Characteristics: new higher-order systems built on newly commoditised components, rapid genesis of new capabilities, new industries forming, capital floods into new value areas, multiple competing paradigms coexist, uncertainty is highest but potential value is greatest.
+
+Strategic posture in Wonder: explore broadly, make small bets on multiple genesis opportunities, build options, tolerate high failure rates for high potential return, watch for which genesis components are beginning to show custom-built characteristics (indicating the next cycle is forming).
+
+Signs Wonder is maturing into the next Peace: dominant designs emerge, standards begin to form, the early adopter wave has passed and early majority adoption begins.
+
+### Identifying Your Current Phase
+
+Ask these questions for each major market/component:
+- Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
+- Are new entrants building on commodity infrastructure that did not exist 3 years ago?
+- Is capital flowing into or out of this space?
+- Are established players being forced to change their core business models?
+
+---
+
+## 8. Pattern Interaction Map
+
+Climatic patterns do not operate in isolation — they interact, reinforce, and counteract each other.
+
+### Reinforcing Combinations
+
+| Pattern A | Pattern B | Combined Effect |
+|-----------|-----------|-----------------|
+| Everything Evolves | Efficiency Enables Innovation | Accelerating cycle: commoditisation continuously creates the foundation for new genesis |
+| Higher Order Systems Create Value | Capital Flows to New Value | Capital predictably follows the new value streams created by higher-order systems |
+| Evolution of Communication | Change Is Not Linear | Better communication amplifies non-linear change by spreading innovations faster |
+| Punctuated Equilibrium | War Phase | Product-to-utility shifts are the mechanism that triggers "War" periods |
+| Success Breeds Inertia | Inertia Increases with Success | Compounding effect — the more successful, the more inert, the more vulnerable |
+| Jevons Paradox | Higher Order Systems Increase Energy | Efficiency-driven adoption increases demand, which increases total resource consumption |
+
+### Counteracting Tensions
+
+| Pattern A | Counteracts | Effect |
+|-----------|-------------|--------|
+| Inertia patterns | Everything Evolves | Inertia slows or blocks what evolution demands — this tension is the primary cause of organisational failure |
+| Not Everything Survives | Capital Flows to New Value | Capital exits before components become extinct — early movers gain, late movers lose |
+| Embrace Uncertainty | False precision in P[when] | Organisations that require certainty before acting are consistently outmanoeuvred by those that act on P[what] |
+| Commoditization ≠ Centralisation | Assumption of monopoly | Prevents strategic blind spots about market structure in commoditised segments |
+
+### Cascade Sequences
+
+A common cascade: **War phase** triggers → **Creative Destruction** → **Capital flows** to new areas → **Higher-order systems** emerge → **Efficiency enables innovation** → components commoditise → next **War phase** begins.
+
+Another: **Red Queen Effect** pressure → **Success Breeds Inertia** resistance → **Inertia Can Kill** outcome (if not addressed) or **Self-disruption** response (if addressed).
+
+---
+
+## 9. Per-Component Assessment Template
+
+Use this template for each significant component on a Wardley map to identify which climatic patterns are most active and their likely strategic impact.
+
+```
+Component: [name]
+Evolution Stage: [genesis / custom-built / product / commodity]
+Evolution Trajectory: [accelerating / stable / stagnating]
+Ecosystem Type: [consumer (fast) / industrial (slow) / mixed]
+
+Key Patterns Affecting This Component:
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [1-2 sentences of specific evidence]
+    Time Horizon: [<12 months / 1-3 years / 3+ years]
+
+  - Pattern: [name]
+    Impact: [H / M / L]
+    Evidence: [brief]
+    Time Horizon: [timeframe]
+
+Inertia Assessment:
+  - Organisational inertia present: [yes / no / partial]
+  - Source of inertia: [past success / skills / politics / contracts / culture]
+
+Peace/War/Wonder Phase: [current phase for this component's market]
+Next Phase Trigger: [what would trigger transition to next phase]
+
+Prediction:
+  P[what]: [what will happen — high confidence direction]
+  P[when]: [timing uncertainty — low / medium / high]
+  6-month outlook: [specific prediction]
+  12-month outlook: [specific prediction]
+
+Recommended Response:
+  Urgency: [High / Medium / Low]
+  Primary action: [description]
+  Watch signal: [what to monitor to confirm/refute the prediction]
 ```
 
-### Characteristics Change as Components Evolve
+---
 
-```yaml
-pattern:
-  name: "Characteristics Change"
-  description: "How a component is managed changes with its evolution"
+## 10. Pattern Recognition Template
 
-  changes:
-    genesis:
-      development: "Research, exploration"
-      failure: "Expected, learning"
-      team: "Pioneers"
-
-    commodity:
-      development: "Operations, optimization"
-      failure: "Unacceptable, incident"
-      team: "Town planners"
-
-  implication: "Same team skills don't work across evolution stages"
-```
-
-### No One Thing Fits All
-
-```yaml
-pattern:
-  name: "No One Size Fits All"
-  description: "Different stages require different approaches"
-
-  examples:
-    methods:
-      genesis: "Agile, experimental"
-      commodity: "Six Sigma, lean"
-
-    contracts:
-      genesis: "Time & materials"
-      commodity: "Fixed price"
-
-    architecture:
-      genesis: "Disposable PoCs"
-      commodity: "Standardized patterns"
-```
-
-## Competitive Patterns
-
-### Components Can Co-Evolve
-
-```yaml
-pattern:
-  name: "Co-Evolution"
-  description: "Changes in one component can accelerate another"
-
-  types:
-    practice_based:
-      description: "New practices emerge with new components"
-      example: "DevOps emerged with cloud infrastructure"
-
-    symbiotic:
-      description: "Components evolve together"
-      example: "Mobile devices and mobile apps"
-
-  implication: "Watch for enabler components that unlock other evolution"
-```
-
-### Efficiency Enables Innovation
-
-```yaml
-pattern:
-  name: "Efficiency Enables Innovation"
-  description: "Commoditization of one layer enables innovation above it"
-
-  example:
-    commodity: "Cloud computing"
-    enabled_innovation: "ML platforms, serverless applications"
-
-  implication: "Commoditize lower layers to free resources for higher-value work"
-```
-
-### Higher Order Systems Create New Sources of Worth
-
-```yaml
-pattern:
-  name: "Higher Order Systems"
-  description: "New value emerges from combining evolved components"
-
-  examples:
-    - "IoT = sensors + connectivity + cloud + analytics"
-    - "AI applications = compute + data + algorithms + interfaces"
-
-  implication: "Look for emerging higher-order systems"
-```
-
-## Predictability Patterns
-
-### Past Success Breeds Inertia
-
-```yaml
-pattern:
-  name: "Success Breeds Inertia"
-  description: "Organizations resist change to what made them successful"
-
-  causes:
-    - "Financial success with current model"
-    - "Skills and expertise tied to current technology"
-    - "Political capital invested in status quo"
-    - "Existing customer relationships"
-
-  symptoms:
-    - "Not invented here syndrome"
-    - "Custom building commodity components"
-    - "Resisting cloud migration"
-    - "Maintaining outdated technology"
-
-  counter_strategy: "Explicitly identify and address inertia"
-```
-
-### Capital Flows to New Industries
-
-```yaml
-pattern:
-  name: "Capital Flows"
-  description: "Investment follows evolution opportunities"
-
-  pattern: "Money flows from commodity extraction to genesis exploration"
-
-  implication: "Commoditization frees capital for new innovation"
-```
-
-## Technology Patterns
-
-### Componentization Increases
-
-```yaml
-pattern:
-  name: "Increasing Componentization"
-  description: "Systems become more modular over time"
-
-  stages:
-    early: "Monolithic, integrated"
-    middle: "Modular, connected"
-    mature: "Composable, standardized interfaces"
-
-  current_trends:
-    - "Microservices vs. monoliths"
-    - "APIs vs. point-to-point"
-    - "Serverless vs. managed servers"
-```
-
-### New Paradigms Create Waves
-
-```yaml
-pattern:
-  name: "Technology Waves"
-  description: "New paradigms replace old but take time"
-
-  wave_pattern:
-    emergence: "New technology appears (genesis)"
-    early_adoption: "Pioneers experiment"
-    disruption: "Mainstream adoption begins"
-    maturity: "Previous paradigm commoditizes"
-    next_wave: "Cycle repeats"
-
-  current_waves:
-    establishing: "AI/ML, quantum (early)"
-    disrupting: "Cloud native, serverless"
-    maturing: "Mobile, SaaS"
-    commoditized: "Internet, databases"
-```
-
-## Market Patterns
-
-### Buyers and Suppliers Evolve
-
-```yaml
-pattern:
-  name: "Market Evolution"
-  description: "Markets themselves evolve from bespoke to utility"
-
-  stages:
-    nascent:
-      buyers: "Early adopters, willing to experiment"
-      suppliers: "Few, innovative"
-      contracts: "Custom, relationship-based"
-
-    growth:
-      buyers: "Mainstream, looking for features"
-      suppliers: "Many, competing on features"
-      contracts: "Product licenses"
-
-    commodity:
-      buyers: "Price-sensitive, switching easy"
-      suppliers: "Few large, many small"
-      contracts: "Utility, pay-per-use"
-```
-
-### Disruption from New Entrants
-
-```yaml
-pattern:
-  name: "Disruption Pattern"
-  description: "New entrants often come from evolved infrastructure"
-
-  mechanism:
-    - "Incumbents have inertia in custom-built systems"
-    - "New entrants build on commodity infrastructure"
-    - "New entrants have lower costs, faster iteration"
-    - "Incumbents can't match without cannibalizing"
-
-  example:
-    incumbent: "Traditional banks with custom core banking"
-    disruptor: "Fintech on cloud with SaaS tools"
-    advantage: "Lower cost, faster feature delivery"
-```
-
-## Using Climatic Patterns
-
-### Assessment Questions
-
-```yaml
-assessment:
-  evolution:
-    - "What components are actively evolving?"
-    - "Are we fighting natural evolution anywhere?"
-    - "What will be commodity in 5 years?"
-
-  competition:
-    - "Who could commoditize our differentiators?"
-    - "What commodity infrastructure enables new competitors?"
-    - "What higher-order systems are emerging?"
-
-  inertia:
-    - "Where do we have success-based inertia?"
-    - "What skills/politics resist necessary change?"
-    - "Are we building custom where products exist?"
-```
-
-### Pattern Recognition Template
+Use this template to analyse how climatic patterns apply to your overall map.
 
 ```yaml
 pattern_analysis:
@@ -271,3 +467,38 @@ pattern_analysis:
     strategic_importance: "{High/Medium/Low}"
     recommended_response: "{Description}"
 ```
+
+---
+
+## 11. Assessment Questions by Category
+
+### Evolution
+
+- What components are actively evolving right now?
+- Are we fighting natural evolution anywhere (building custom where product/commodity exists)?
+- What will be commodity in 3 years? In 5 years?
+- Where are components in different ecosystems evolving at mismatched speeds?
+- Which co-evolutionary relationships could accelerate or destabilise our position?
+
+### Competition
+
+- Who could commoditise our current differentiators?
+- What commodity infrastructure enables new competitors to enter with structurally lower costs?
+- What higher-order systems are emerging that could change the basis of competition?
+- What game-changing action by a competitor would most threaten our position?
+- How does our situational awareness compare to our most capable competitor's?
+
+### Inertia
+
+- Where do we have success-based inertia that is blocking necessary evolution?
+- What skills, political capital, or cultural identity is tied to components that are evolving away?
+- Are we building custom solutions in areas where products or commodity utilities now exist?
+- Which of our most successful business models is most vulnerable to the next "War" phase?
+
+### Prediction
+
+- Which evolutionary changes in our landscape are high-confidence (P[what] even if P[when] is uncertain)?
+- What phase — Peace, War, or Wonder — is our core market in?
+- Which components are approaching punctuated equilibrium shifts from product to utility?
+- Where are we applying false certainty to genesis-stage components or excessive uncertainty to commodity ones?
+- What does the capital flow pattern in our sector tell us about where the next value creation will be?

--- a/arckit-opencode/skills/wardley-mapping/references/climatic-patterns.md
+++ b/arckit-opencode/skills/wardley-mapping/references/climatic-patterns.md
@@ -232,6 +232,43 @@ The more successful a business model has been, the harder it becomes to abandon 
 
 ---
 
+### Inertia Types Taxonomy
+
+Seven distinct types of inertia manifest differently and require different mitigation strategies. Based on Wardley's concept of "loss of capital" (physical, social, financial, political) expanded with operational types:
+
+| Type | Description | Indicators | Mitigation |
+|------|-------------|------------|------------|
+| **Success** | Past model worked so well that change feels unnecessary | "Why change what works?", strong quarterly results masking long-term risk, dismissal of emerging competitors | Establish parallel exploration teams, red team exercises, fund self-disruption initiatives |
+| **Capital** | Physical assets, infrastructure, and legacy technology create lock-in through sunk costs | Large depreciation schedules, outdated machinery still in use, fixed-purpose facilities, legacy systems deeply embedded in operations | Incremental upgrades, modular systems, leasing vs buying, versatile infrastructure design |
+| **Financial** | Risk aversion, short-term focus, and market pressures resist investment in change | Reluctance to sell underperforming assets, hesitancy to invest in new skills/tech, fear of losing strategic control, external markets rewarding stability over innovation | Strategic portfolio management, incremental investment, alternative financial models (leasing, partnerships), separate innovation budgets from BAU |
+| **Political** | Power structures and internal influence tied to existing approaches | Executives whose authority depends on current architecture, budget territories, empire building, fear of losing influence, preservation of established alliances | Reframe as opportunity not threat, create new leadership roles for emerging capabilities, sponsor from top, build coalitions, align incentives with change |
+| **Skills** | Workforce expertise concentrated in legacy technologies or methods | Recruitment focused on legacy skills, training budgets for existing tools, resistance to retraining | Upskilling programs, hire for new capabilities alongside legacy, paired teams (legacy + new) |
+| **Supplier** | Vendor relationships and ecosystem dependencies resist change | Preferred vendor lists, deep integration with specific platforms, vendor-specific certifications | Multi-vendor strategy, abstraction layers, gradual supplier diversification, renegotiate before lock-in deepens |
+| **Consumer** | Users or customers expect and depend on current approach | Customer complaints about any change, contractual SLAs tied to specific implementations, user workflow dependency | Gradual migration with parallel running, user research on actual needs vs habits, opt-in transitions |
+
+**Note on Capital vs Financial:** Capital inertia concerns physical/tangible assets (infrastructure, equipment, legacy systems). Financial inertia concerns the psychology and market dynamics around money (sunk cost fallacy, risk aversion, short-termism, investor pressure). A component can have capital inertia (locked into legacy infrastructure) without financial inertia (the business case for change is accepted), or vice versa.
+
+**Assessment per component:** For each component with inertia, identify which type(s) are present, rate severity (H/M/L), and define a specific mitigation action. Multiple types often compound — a component with success + skills + capital + financial inertia is far harder to move than one with only skills inertia.
+
+### Inertia Diagnostic Checklist
+
+Early warning signs that inertia is taking hold in an organisation. Use this checklist during doctrine and climate assessments:
+
+| Sign | What to Look For | Impact if Unaddressed |
+|------|-------------------|----------------------|
+| **Stagnant mindset** | Resistance to training, lack of curiosity about industry trends, unwillingness to adopt new tools | Declining productivity, loss of competitive awareness |
+| **Siloed thinking** | Teams working in isolation, duplicated effort, poor cross-functional communication, misalignment with overall strategy | Suboptimal decisions, inability to leverage collective expertise |
+| **Lack of innovation** | Few new ideas reaching implementation, fear of failure culture, no experimentation budget | Falling behind competitors, inability to differentiate |
+| **Complacency** | Comfort with status quo, "if it ain't broke don't fix it" attitude, declining urgency | Mediocrity becomes the norm, market share erosion |
+| **Risk aversion** | No experimentation, all decisions require exhaustive justification, preference for safe options | Missed opportunities, slow response to market shifts |
+| **Rigid structures** | Bureaucratic approval chains, top-down only decisions, inability to reorganise quickly | Cannot respond to customer needs or competitive threats |
+| **Lack of accountability** | Unclear ownership, blame culture, nobody responsible for change outcomes | Problems persist, low trust, poor morale |
+| **Low employee engagement** | High turnover, absenteeism, lack of initiative, disinterest in company direction | Talent flight, institutional knowledge loss |
+
+**Scoring:** Count how many signs are present (0-8). 0-2: healthy organisation. 3-4: early inertia — address proactively. 5-6: significant inertia — urgent intervention needed. 7-8: critical — existential risk if not addressed immediately.
+
+---
+
 ## 5. Competitor Patterns — Chapter VIII
 
 ### 5.1 Competitors' Actions Will Change the Game
@@ -367,6 +404,7 @@ Signs Wonder is maturing into the next Peace: dominant designs emerge, standards
 ### Identifying Your Current Phase
 
 Ask these questions for each major market/component:
+
 - Is competition primarily on features (Peace) or on survival/transformation (War) or on exploration (Wonder)?
 - Are new entrants building on commodity infrastructure that did not exist 3 years ago?
 - Is capital flowing into or out of this space?

--- a/arckit-opencode/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-opencode/skills/wardley-mapping/references/doctrine.md
@@ -400,6 +400,7 @@ doctrine_assessment:
 Use these prompts during assessment interviews and document reviews to gather evidence for each category.
 
 **Communication**
+
 - [ ] Is there a shared glossary or terminology guide in use across teams?
 - [ ] Are strategy documents written in language understood outside the originating team?
 - [ ] Are assumptions in proposals explicitly stated and challenged before approval?
@@ -407,6 +408,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are decision rationales documented and accessible to those affected?
 
 **Development**
+
 - [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
 - [ ] Are different methodologies applied to different components based on their evolutionary stage?
 - [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
@@ -414,6 +416,7 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are standards and tools reviewed periodically for continued appropriateness?
 
 **Operation**
+
 - [ ] Can leaders describe the operational details of the services they are accountable for?
 - [ ] Are sources of organisational inertia identified and addressed in change plans?
 - [ ] Is there a blameless failure review process in place?
@@ -421,18 +424,21 @@ Use these prompts during assessment interviews and document reviews to gather ev
 - [ ] Are value stream maps or similar tools used to identify bottlenecks?
 
 **Learning**
+
 - [ ] Is there a structured process for capturing and applying lessons learned?
 - [ ] Are teams encouraged and resourced to run experiments?
 - [ ] Is there a programme for exploring emerging technologies before they become urgent?
 - [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
 
 **Leading**
+
 - [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
 - [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
 - [ ] Is there a single named accountable owner for each strategic initiative?
 - [ ] Are leaders open about what they do not know and willing to change their minds publicly?
 
 **Structure**
+
 - [ ] Are most teams small enough to communicate without formal coordination overhead?
 - [ ] Do teams have authority to make decisions within their domain without escalation?
 - [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?

--- a/arckit-opencode/skills/wardley-mapping/references/doctrine.md
+++ b/arckit-opencode/skills/wardley-mapping/references/doctrine.md
@@ -1,120 +1,439 @@
 # Doctrine
 
-Universally useful patterns for strategy, independent of context or landscape.
+Universal principles and best practices that guide strategic decision-making, independent of context or landscape.
 
-## Doctrine Categories
+---
 
-The following is a curated subset of Wardley's doctrine principles, covering the areas most actionable in mapping exercises. For the full set, see Simon Wardley's original writings.
+## 1. Strategy Cycle
 
-```yaml
-doctrine_categories:
-  communication:
-    - "Use a common language"
-    - "Challenge assumptions"
-    - "Focus on user needs"
+Doctrine sits within a five-step iterative strategy cycle:
 
-  development:
-    - "Use appropriate methods for evolution stage"
-    - "Think small (cell-based structures)"
-    - "Manage inertia"
-    - "Use standards where appropriate"
+1. **Purpose** — define the organisation's overarching objectives and direction
+2. **Landscape** — map the competitive environment, components, and value chains
+3. **Climate** — identify external forces, market dynamics, and evolutionary pressures
+4. **Doctrine** — apply universal principles that hold regardless of context
+5. **Leadership** — make informed decisions and execute, then return to step 1
 
-  operation:
-    - "Think FIRE (Fast, Inexpensive, Restrained, Elegant)"
-    - "Manage failure appropriately"
-    - "Optimize flow"
+The cycle is continuous. Organisations repeatedly pass through all five stages, refining strategy based on new insights. Doctrine provides the stable foundation that makes repeated iteration productive rather than chaotic.
 
-  learning:
-    - "Use a systematic mechanism of learning"
-    - "Know your users"
-    - "Know your details"
+---
 
-  leading:
-    - "Be the owner"
-    - "Move fast"
-    - "Accept that strategy is iterative"
-```
+## 2. Doctrine Phase/Category Matrix
 
-## Doctrine Assessment Template
+Forty-two principles organised across four phases and six categories (source: Wardley Mapping Doctrine, Figure 2).
 
-Use this template to evaluate an organization's doctrine maturity. Score each area 1-5:
+| Phase | Communication | Development | Operation | Learning | Leading | Structure |
+|-------|--------------|-------------|-----------|----------|---------|-----------|
+| **I: Stop Self-Harm** | Common Language | Know Your Users | Know the Details | Systematic Learning | — | — |
+| | Challenge Assumptions | Focus on User Needs | | | | |
+| | Understand Context | Remove Bias & Duplication | | | | |
+| | | Use Appropriate Methods | | | | |
+| **II: Context Aware** | Bias Towards Open | Focus on Outcome | Manage Inertia | Bias Towards Action | Move Fast | Think Small Teams |
+| | | Think FIRE | Manage Failure | | Strategy is Iterative | Distribute Power |
+| | | Use Appropriate Tools | Effectiveness over Efficiency | | | Aptitude & Attitude |
+| | | Be Pragmatic | | | | |
+| | | Use Standards | | | | |
+| **III: Better for Less** | — | — | Optimise Flow | Bias to New | Commit to Direction | Seek the Best |
+| | | | Do Better with Less | | Be the Owner | Purpose/Mastery/Autonomy |
+| | | | Exceptional Standards | | Inspire Others | |
+| | | | | | Embrace Uncertainty | |
+| | | | | | Be Humble | |
+| **IV: Continuously Evolving** | — | — | — | Listen to Ecosystem | Exploit the Landscape | No Single Culture |
+| | | | | | There is No Core | Design for Constant Evolution |
+
+---
+
+## 3. Phase Details
+
+### Phase I: Stop Self-Harm
+
+**Objective:** Prevent further self-inflicted damage and establish a stable foundation for strategy.
+
+Organisations in Phase I often harm themselves through poor communication, misaligned development, and absence of learning. The nine principles in this phase address the most fundamental failures.
+
+#### Communication
+
+**Common Language** — Establish standardised terminology so all teams share meaning. Without a common vocabulary, strategy conversations produce confusion rather than alignment. Create a glossary, enforce it in meetings and documents, and review it regularly.
+
+**Challenge Assumptions** — Actively question established beliefs and the "way things have always been done." Assign devil's advocate roles, conduct assumption audits, and reward constructive scepticism. This prevents strategies built on invisible, outdated premises.
+
+**Understand Context** — Develop situational awareness before acting. Ensure communications include enough context for recipients to make informed decisions. Go beyond surface information to understand implications, stakeholder impacts, and broader relationships.
+
+#### Development
+
+**Know Your Users** — Understand the needs of all stakeholders: customers, shareholders, regulators, and staff. This is not one-time market research but an ongoing process. Use personas, continuous feedback loops, and cross-functional sharing of user insights.
+
+**Focus on User Needs** — Place user requirements at the centre of all development decisions. Anchor Wardley Maps to genuine user needs rather than internal assumptions. Prioritise what users truly need, not just what they explicitly request.
+
+**Remove Bias and Duplication** — Identify and eliminate both unwarranted assumptions that skew decisions and redundant processes that waste resources. Use diverse teams, data-driven decision making, and regular process reviews. Some redundancy aids resilience; eliminate wasteful redundancy.
+
+**Use Appropriate Methods** — Select development methodologies suited to the evolutionary stage of the work. Agile for genesis-stage components; lean or six sigma for more evolved ones. No single methodology fits all contexts.
+
+#### Operation
+
+**Know the Details** — Pay close attention to operational specifics. Leaders who lose touch with operational reality make poor strategic decisions. Conduct thorough process assessments, ensure documentation is current, and keep management connected to the ground truth.
+
+#### Learning
+
+**Systematic Learning (Bias Towards Data)** — Implement structured processes for gathering, analysing, and applying knowledge. Establish feedback loops, document lessons learned, and treat data as a strategic asset. Ad hoc learning leaves organisations repeating mistakes.
+
+---
+
+### Phase II: Becoming More Context Aware
+
+**Objective:** Enhance situational awareness and leverage contextual knowledge for better decisions.
+
+Phase II builds on the stable foundation of Phase I. The organisation now turns outward — becoming aware of its competitive environment, managing the dynamics of change, and starting to use contextual judgement rather than rigid rules.
+
+#### Communication
+
+**Bias Towards Open** — Make transparency and information sharing the default, not the exception. Move beyond "need to know" to proactive sharing of decisions, data, and rationale. Open communication fosters trust, accelerates innovation, and improves alignment. Balance openness with appropriate confidentiality.
+
+#### Development
+
+**Focus on Outcome** — Prioritise valuable results over rigid adherence to contracts or predetermined plans. Measure success by outcomes delivered, not tasks completed. Structure contracts and metrics around value, and empower teams to adapt their approach as long as the outcome stays in view.
+
+**Think FIRE (Fast, Inexpensive, Restrained, Elegant)** — Apply all four dimensions when designing solutions. Fast means rapid iteration; Inexpensive means cost-effective without being cheap; Restrained means resisting feature creep; Elegant means simple, user-centred design. FIRE prevents over-engineering and accelerates delivery.
+
+**Use Appropriate Tools** — Select tools matched to the specific development context rather than defaulting to familiarity or fashion. Evaluate tools against project needs, scalability, and long-term viability. Avoid tool proliferation; balance innovation with stability.
+
+**Be Pragmatic** — Choose what works in the real world over what is theoretically correct. Base decisions on evidence and observed results. Pragmatism is not short-termism — it is applying practical judgement to move purposefully toward long-term goals.
+
+**Use Standards** — Adopt industry or internal standards where components are sufficiently evolved to benefit from standardisation. Standards improve interoperability, quality, and speed. On Wardley Maps, standards apply most naturally to product- and commodity-stage components.
+
+#### Operation
+
+**Manage Inertia** — Actively address organisational resistance to change. Identify sources of inertia (legacy systems, entrenched culture, middle-management resistance), communicate the case for change compellingly, and use change champions and incremental rollouts to build momentum.
+
+**Manage Failure** — Design mechanisms to handle failure gracefully and extract learning from it. Failure tolerance should be calibrated to evolutionary stage: high tolerance for genesis-stage experiments, low tolerance for commodity-stage operations. Treat failure as information, not shame.
+
+**Effectiveness over Efficiency** — Prioritise achieving the desired outcome before optimising how efficiently you achieve it. Efficient execution of the wrong activity is waste. Confirm you are doing the right things before refining how fast you do them.
+
+#### Learning
+
+**Bias Towards Action** — Learn by doing rather than by planning. Encourage practical experimentation. Iterative, hands-on engagement with the landscape reveals insights that analysis alone cannot. Establish rapid learning cycles where experiments feed directly back into strategy.
+
+#### Leading
+
+**Move Fast** — Prioritise rapid execution and decision-making over waiting for perfect information. Speed of action is itself a strategic asset. Leaders should reduce approval chains, tolerate imperfection, and default to trying things over deliberating about them.
+
+**Strategy is Iterative** — Treat strategy as a cyclical process, not a one-time plan. Regularly reassess and adapt the strategy based on new intelligence. The most dangerous strategies are those treated as immutable once written.
+
+#### Structure
+
+**Think Small Teams** — Organise work into small, cross-functional, autonomous teams. Small teams communicate faster, decide faster, and are more accountable. They also align naturally with the Pioneer/Settler/Town Planner model of matching team culture to evolutionary stage.
+
+**Distribute Power** — Decentralise decision-making to the teams closest to the work. Establish clear boundaries and provide resources; then trust teams to act within them. Centralised authority creates bottlenecks and suppresses the contextual judgement that effective strategy requires.
+
+**Aptitude and Attitude** — Hire and develop team members based on both technical capability (aptitude) and cultural alignment (attitude). A team of highly skilled individuals with the wrong disposition will underperform a moderately skilled team with the right mindset.
+
+---
+
+### Phase III: Better for Less
+
+**Objective:** Achieve significantly better outcomes while consuming fewer resources through continuous improvement and high standards.
+
+Phase III organisations have mastered the basics and begun optimising. The focus shifts to operational excellence, leadership maturity, and structural conditions that allow people to produce their best work.
+
+#### Operation
+
+**Optimise Flow** — Identify and remove bottlenecks that impede the throughput of value. Use value stream mapping and similar techniques to visualise where work slows. Optimising flow at the system level is more powerful than improving individual components in isolation.
+
+**Do Better with Less** — Embed continuous improvement as a cultural norm. Regularly review processes with the explicit goal of producing the same or better outcomes with fewer resources. Constraint fosters creativity; resource abundance often masks inefficiency.
+
+**Set Exceptional Standards** — Define and publicly commit to high performance standards. Exceptional standards create a benchmark that drives quality, reduces tolerance for mediocrity, and builds organisational pride. Low standards become self-fulfilling; high standards become self-reinforcing.
+
+#### Learning
+
+**Bias Towards the New** — Actively explore emerging ideas, technologies, and approaches rather than defaulting to the familiar. The evolutionary landscape rewards early movers in genesis-stage components. Create protected space for experimentation; do not allow operational maturity to crowd out exploration.
+
+#### Leading
+
+**Commit to Direction** — Be steadfast in pursuing strategic goals while remaining open to adjusting tactics. Frequent strategy reversals demoralise teams and waste the organisational capital accumulated through consistent effort. Distinguish between pivoting approach and abandoning direction.
+
+**Be the Owner** — Take full responsibility and accountability for strategy and outcomes. Do not diffuse accountability across committees or processes. Ownership means accepting both credit and blame, and making decisions rather than deferring them.
+
+**Inspire Others** — Articulate a compelling vision and motivate the team toward ambitious goals. Inspiration is not cheerleading — it is connecting individual work to meaningful purpose, demonstrating commitment, and showing people what is possible.
+
+**Embrace Uncertainty** — Accept that uncertainty is an inherent feature of strategy, not a temporary condition that will eventually resolve. Make peace with acting under incomplete information. Organisations that require certainty before acting are chronically late.
+
+**Be Humble** — Cultivate openness to feedback, correction, and different viewpoints. Hubris in leadership prevents the honest assessment of landscape and doctrine that effective strategy requires. Humility is not weakness — it is accurate self-knowledge.
+
+#### Structure
+
+**Seek the Best** — Aim for excellence in organisational design, not adequacy. Benchmark structure against industry best practice, not internal tradition. Regularly ask whether the current structure is the best possible arrangement for executing current strategy.
+
+**Purpose, Mastery, and Autonomy** — Create the three conditions Daniel Pink identifies as intrinsic motivation. Ensure individuals understand how their work connects to the organisation's purpose. Invest in developing deep expertise (mastery). Remove unnecessary controls that undermine self-direction (autonomy).
+
+---
+
+### Phase IV: Continuously Evolving
+
+**Objective:** Create a resilient, adaptive organisation that drives change rather than merely responding to it.
+
+Phase IV represents organisational maturity. The organisation no longer manages change episodically — evolution is built into the fabric of how it operates.
+
+#### Learning
+
+**Listen to the Ecosystem** — Actively engage with and learn from the broader environment: customers, competitors, suppliers, regulators, adjacent industries, and emerging technologies. The most important signals about future landscape shifts come from outside the organisation. Create structured mechanisms for ecosystem listening, not just passive monitoring.
+
+#### Leading
+
+**Exploit the Landscape** — Leverage the broader business environment as a source of competitive advantage. Identify patterns, leverage points, and structural features of the landscape that others overlook. This requires a deep understanding of how components are evolving and where they are vulnerable to disruption or commoditisation.
+
+**There is No Core** — Reject the notion of a permanent "core business." All strategic positions are temporary. Components that are differentiating today will become commodity tomorrow. Maintaining strategic flexibility means being willing to abandon current strengths when the landscape demands it. This is not instability — it is strategic maturity.
+
+#### Structure
+
+**No Single Culture** — Recognise that different work requires different cultural approaches. Genesis-stage innovation requires a culture of exploration and tolerance for failure; commodity-stage operations require discipline and efficiency. A single mandated culture optimises for one type of work at the expense of all others. Cultivate and value cultural diversity within the organisation.
+
+**Design for Constant Evolution** — Build organisational structures, processes, and systems that are inherently flexible. Change should not require major restructuring — it should be the normal mode of operation. Use modular designs, adaptive processes, and continuous skills development to make evolution frictionless.
+
+---
+
+## 4. Implementation Journeys
+
+### Communication Journey (Phases I–II)
+
+Begin by establishing shared vocabulary and a common map language that all teams use consistently (Phase I). Progress to making transparency the default operating mode: open decision-making, accessible data, two-way feedback channels (Phase II). The destination is an organisation where strategic information flows freely across all levels and functions, enabling faster alignment and better decisions.
+
+### Development Journey (Phases I–II)
+
+Start by rooting development in real user needs and eliminating duplicated effort (Phase I). Evolve toward outcome-focused, pragmatic delivery using FIRE principles, contextually appropriate tools, and industry standards (Phase II). The journey moves from "building things correctly" to "building the correct things efficiently."
+
+### Operation Journey (Phases I–III)
+
+Establish situational awareness through operational detail (Phase I). Build change management capability and effective failure response (Phase II). Reach the destination of continuously optimised flow, exceptional quality standards, and a culture that does more with less (Phase III). Each phase adds a layer of operational sophistication on top of the last.
+
+### Learning Journey (Phases I–IV)
+
+Implement data-driven learning mechanisms and documentation (Phase I). Shift to action-oriented learning through experimentation (Phase II). Dedicate resources to exploring new ideas and technologies (Phase III). In Phase IV, the organisation systematically listens to its ecosystem and makes continuous adaptation a cultural norm rather than a periodic initiative.
+
+### Leading Journey (Phases II–IV)
+
+Leadership doctrine begins in Phase II with fast decisions and iterative strategy. Phase III adds personal accountability, inspiration, humility, and the ability to operate in uncertainty. Phase IV demands leaders who can read and exploit landscape features that are invisible to less evolved organisations, while holding their strategic position loosely enough to abandon it when evolution demands.
+
+### Structure Journey (Phases II–IV)
+
+Phase II establishes small, empowered teams hired for both skill and attitude. Phase III adds the pursuit of excellence and the conditions for intrinsic motivation. Phase IV reaches full maturity: a deliberately multi-cultural organisation designed to evolve continuously, with no structural assumption treated as permanent.
+
+---
+
+## 5. Assessment Template
+
+Score each principle 1–5 using the rubric below, then record supporting evidence.
 
 | Score | Meaning |
 |-------|---------|
 | **1** | Not practiced — no evidence of this principle |
 | **2** | Ad hoc — occasional, inconsistent application |
-| **3** | Emerging — recognized as important, partially adopted |
+| **3** | Emerging — recognised as important, partially adopted |
 | **4** | Established — consistently practiced with measurable results |
 | **5** | Embedded — deeply ingrained in culture and decision-making |
 
 ```yaml
 doctrine_assessment:
-  communication:
-    common_language:
-      score: "{1-5}"
-      evidence: "{How is strategic language standardized?}"
 
-    challenge_assumptions:
-      score: "{1-5}"
-      evidence: "{How are assumptions questioned?}"
+  phase_i:
+    communication:
+      common_language:
+        score: # 1-5
+        evidence: ""
+      challenge_assumptions:
+        score: # 1-5
+        evidence: ""
+      understand_context:
+        score: # 1-5
+        evidence: ""
 
-    focus_on_user_needs:
-      score: "{1-5}"
-      evidence: "{How are user needs identified and prioritized?}"
+    development:
+      know_your_users:
+        score: # 1-5
+        evidence: ""
+      focus_on_user_needs:
+        score: # 1-5
+        evidence: ""
+      remove_bias_and_duplication:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_methods:
+        score: # 1-5
+        evidence: ""
 
-  development:
-    appropriate_methods:
-      score: "{1-5}"
-      evidence: "{Are agile/lean/six sigma applied contextually by evolution stage?}"
+    operation:
+      know_the_details:
+        score: # 1-5
+        evidence: ""
 
-    cell_based:
-      score: "{1-5}"
-      evidence: "{Are teams small and autonomous?}"
+    learning:
+      systematic_learning:
+        score: # 1-5
+        evidence: ""
 
-    manage_inertia:
-      score: "{1-5}"
-      evidence: "{How is organizational inertia identified and addressed?}"
+  phase_ii:
+    communication:
+      bias_towards_open:
+        score: # 1-5
+        evidence: ""
 
-    use_standards:
-      score: "{1-5}"
-      evidence: "{Are standards adopted where components are commodity/product?}"
+    development:
+      focus_on_outcome:
+        score: # 1-5
+        evidence: ""
+      think_fire:
+        score: # 1-5
+        evidence: ""
+      use_appropriate_tools:
+        score: # 1-5
+        evidence: ""
+      be_pragmatic:
+        score: # 1-5
+        evidence: ""
+      use_standards:
+        score: # 1-5
+        evidence: ""
 
-  operation:
-    think_fire:
-      score: "{1-5}"
-      evidence: "{Are solutions Fast, Inexpensive, Restrained, Elegant (FIRE)?}"
+    operation:
+      manage_inertia:
+        score: # 1-5
+        evidence: ""
+      manage_failure:
+        score: # 1-5
+        evidence: ""
+      effectiveness_over_efficiency:
+        score: # 1-5
+        evidence: ""
 
-    manage_failure:
-      score: "{1-5}"
-      evidence: "{Is failure tolerance matched to evolution stage?}"
+    learning:
+      bias_towards_action:
+        score: # 1-5
+        evidence: ""
 
-    optimize_flow:
-      score: "{1-5}"
-      evidence: "{Are bottlenecks identified and addressed?}"
+    leading:
+      move_fast:
+        score: # 1-5
+        evidence: ""
+      strategy_is_iterative:
+        score: # 1-5
+        evidence: ""
 
-  learning:
-    systematic_learning:
-      score: "{1-5}"
-      evidence: "{Is there a feedback loop for strategic learning?}"
+    structure:
+      think_small_teams:
+        score: # 1-5
+        evidence: ""
+      distribute_power:
+        score: # 1-5
+        evidence: ""
+      aptitude_and_attitude:
+        score: # 1-5
+        evidence: ""
 
-    know_users:
-      score: "{1-5}"
-      evidence: "{How well are users and their needs understood?}"
+  phase_iii:
+    operation:
+      optimise_flow:
+        score: # 1-5
+        evidence: ""
+      do_better_with_less:
+        score: # 1-5
+        evidence: ""
+      exceptional_standards:
+        score: # 1-5
+        evidence: ""
 
-    know_details:
-      score: "{1-5}"
-      evidence: "{Is there deep understanding of component specifics?}"
+    learning:
+      bias_towards_new:
+        score: # 1-5
+        evidence: ""
 
-  leading:
-    ownership:
-      score: "{1-5}"
-      evidence: "{Is there clear ownership of strategy?}"
+    leading:
+      commit_to_direction:
+        score: # 1-5
+        evidence: ""
+      be_the_owner:
+        score: # 1-5
+        evidence: ""
+      inspire_others:
+        score: # 1-5
+        evidence: ""
+      embrace_uncertainty:
+        score: # 1-5
+        evidence: ""
+      be_humble:
+        score: # 1-5
+        evidence: ""
 
-    move_fast:
-      score: "{1-5}"
-      evidence: "{How quickly are strategic decisions made?}"
+    structure:
+      seek_the_best:
+        score: # 1-5
+        evidence: ""
+      purpose_mastery_autonomy:
+        score: # 1-5
+        evidence: ""
 
-    iterative_strategy:
-      score: "{1-5}"
-      evidence: "{Is strategy treated as continuous, not one-off?}"
+  phase_iv:
+    learning:
+      listen_to_ecosystem:
+        score: # 1-5
+        evidence: ""
+
+    leading:
+      exploit_the_landscape:
+        score: # 1-5
+        evidence: ""
+      there_is_no_core:
+        score: # 1-5
+        evidence: ""
+
+    structure:
+      no_single_culture:
+        score: # 1-5
+        evidence: ""
+      design_for_constant_evolution:
+        score: # 1-5
+        evidence: ""
 ```
+
+---
+
+## 6. Evidence-Gathering Checklist
+
+Use these prompts during assessment interviews and document reviews to gather evidence for each category.
+
+**Communication**
+- [ ] Is there a shared glossary or terminology guide in use across teams?
+- [ ] Are strategy documents written in language understood outside the originating team?
+- [ ] Are assumptions in proposals explicitly stated and challenged before approval?
+- [ ] Is information shared proactively, or does it flow only on request?
+- [ ] Are decision rationales documented and accessible to those affected?
+
+**Development**
+- [ ] Are user needs (not internal assumptions) the stated anchor for all development work?
+- [ ] Are different methodologies applied to different components based on their evolutionary stage?
+- [ ] Are contracts and success metrics framed around outcomes rather than deliverables?
+- [ ] Are FIRE principles applied when scoping new development?
+- [ ] Are standards and tools reviewed periodically for continued appropriateness?
+
+**Operation**
+- [ ] Can leaders describe the operational details of the services they are accountable for?
+- [ ] Are sources of organisational inertia identified and addressed in change plans?
+- [ ] Is there a blameless failure review process in place?
+- [ ] Are effectiveness metrics (outcomes achieved) tracked alongside efficiency metrics (cost/time)?
+- [ ] Are value stream maps or similar tools used to identify bottlenecks?
+
+**Learning**
+- [ ] Is there a structured process for capturing and applying lessons learned?
+- [ ] Are teams encouraged and resourced to run experiments?
+- [ ] Is there a programme for exploring emerging technologies before they become urgent?
+- [ ] Are external industry signals (competitors, regulators, adjacent sectors) systematically monitored?
+
+**Leading**
+- [ ] Are strategic decisions made and communicated quickly, without excessive committee review?
+- [ ] Is the strategy reviewed and updated on a regular cycle (not just at annual planning)?
+- [ ] Is there a single named accountable owner for each strategic initiative?
+- [ ] Are leaders open about what they do not know and willing to change their minds publicly?
+
+**Structure**
+- [ ] Are most teams small enough to communicate without formal coordination overhead?
+- [ ] Do teams have authority to make decisions within their domain without escalation?
+- [ ] Are different cultural approaches tolerated and valued in different parts of the organisation?
+- [ ] Is the organisational structure reviewed periodically and changed when strategy requires?

--- a/arckit-opencode/skills/wardley-mapping/references/evolution-stages.md
+++ b/arckit-opencode/skills/wardley-mapping/references/evolution-stages.md
@@ -99,3 +99,123 @@ When placing a component on the evolution axis, assess:
 - Positioning based on **age** rather than market maturity
 - Confusing **internal unfamiliarity** with market-wide genesis
 - Not considering **industry context** (a component may be commodity in one industry but custom in another)
+
+---
+
+## Enhanced Stage Indicators
+
+Detailed checklists for assessing which stage a component belongs to across four dimensions:
+
+### Genesis Stage Indicators
+
+- **Ubiquity markers**: Used by fewer than a handful of organizations; no established market; found only in research labs or cutting-edge pilots; most practitioners have never heard of it
+- **Certainty markers**: No agreed-upon approach; each implementation looks completely different; high variance in results; practitioners disagree on fundamentals
+- **Market markers**: No commercial offerings; no analysts covering it; no conferences dedicated to it; possibly a single paper or blog post
+- **Failure mode**: Betting on the wrong approach — you build the wrong thing, the concept doesn't pan out, or a competitor's approach proves fundamentally superior
+
+### Custom-Built Stage Indicators
+
+- **Ubiquity markers**: A few dozen organizations have built it; mostly in-house implementations; early adopters only; growing word-of-mouth in specialist communities
+- **Certainty markers**: Patterns are beginning to emerge; blog posts and conference talks appear; approaches vary but converge around a few patterns
+- **Market markers**: Small number of consultancies or niche vendors; no dominant standard; user groups forming; early analyst coverage
+- **Failure mode**: Building it wrong — your custom implementation has the wrong architecture, accrues technical debt, or gets overtaken by a productized competitor before you've recovered your investment
+
+### Product Stage Indicators
+
+- **Ubiquity markers**: Most large organizations are aware of it; multiple commercial products compete; analyst firms rank vendors; industry press covers it regularly
+- **Certainty markers**: Training courses, professional certifications, and established methodologies exist; outcomes are predictable; clear best practices documented
+- **Market markers**: Multiple competing vendors with clear feature differentiation; pricing is feature-based; annual comparison reports published; RFP processes are standardized
+- **Failure mode**: Differentiation failure — failing to stand out from competing products, losing on features, price, or brand while rivals commoditize faster
+
+### Commodity Stage Indicators
+
+- **Ubiquity markers**: Ubiquitous — every organization uses it; invisible infrastructure; not adopting it would be unusual; pay-per-use or subscription models dominate
+- **Certainty markers**: Fully standardized; ISO or formal standards exist; deviating from standard approaches is unusual; operations are predictable and auditable
+- **Market markers**: Utility pricing; multiple interchangeable providers; switching costs low; procurement is routine; the component is rarely discussed in strategic terms
+- **Failure mode**: Operational inefficiency — paying too much, running it in-house when a utility exists, or accumulating operational overhead that commodity providers handle more cheaply
+
+---
+
+## Transition Timing Heuristics
+
+Weak signals that a component is about to move between stages. These precede the transition by months to years — use them to get ahead of the curve.
+
+### Genesis → Custom-Built
+
+- Multiple independent teams build their own version without coordinating
+- The first conference talks appear: "Here's how we did it at [Company X]"
+- A startup forms specifically to productize the concept
+- A handful of GitHub repositories appear with experimental implementations
+- The phrase "we built our own X" starts appearing in engineering blog posts
+
+### Custom-Built → Product
+
+- Documentation proliferates: vendor docs, how-to guides, blog series
+- Training courses and certifications emerge (Udemy, Pluralsight, vendor academies)
+- Industry analysts publish first Magic Quadrant or Wave covering the space
+- Standardization efforts begin (working groups, RFCs, consortia form)
+- The question shifts from "should we build this?" to "which vendor should we choose?"
+
+### Product → Commodity
+
+- Pricing models shift to consumption-based or utility billing (per API call, per GB, per user-minute)
+- Open-source alternatives appear and gain traction, driving down commercial pricing
+- "Good enough" becomes the accepted standard — buyers stop comparing features and compare price
+- The component disappears from strategic discussions; procurement handles it routinely
+- Cloud providers add it as a native managed service
+
+---
+
+## Pioneers / Settlers / Town Planners Talent Model
+
+The three evolution stages map naturally to three types of people. Mismatching talent to stage is one of the most common and costly strategic mistakes.
+
+### Pioneers (Genesis)
+
+- Comfortable with chaos, ambiguity, and high failure rates
+- Driven by exploration and discovery; motivated by novelty, not process
+- High failure tolerance — they expect most experiments to fail and see it as learning
+- Often poor at documentation, standardization, or handing work off cleanly
+- Best suited to: research, prototyping, proof-of-concept work, greenfield exploration
+
+### Settlers (Custom-Built → Product)
+
+- Take pioneer discoveries and make them useful and repeatable
+- Product-oriented and systematic; skilled at listening to users and iterating
+- Build out the patterns that emerge from pioneer experiments into reliable solutions
+- Bridge between the wild experimentation of genesis and the industrialization of commodity
+- Best suited to: product development, early productization, growing user bases
+
+### Town Planners (Product → Commodity)
+
+- Industrialize at scale; obsessed with efficiency, reliability, and cost reduction
+- Process-oriented, metrics-driven, volume operations mindset
+- Build the pipes that everything else runs on; thrive in predictable, repeatable work
+- Often frustrated by ambiguity or constant change
+- Best suited to: platform engineering, infrastructure, shared services, SRE at scale
+
+### Handoff Friction
+
+Managing transitions between these types is critical and frequently mismanaged:
+
+- **Pioneers hate process**: Forcing pioneers to maintain and document their experiments alienates them and slows exploration. Hand off to settlers early.
+- **Town Planners hate uncertainty**: Asking planners to work on genesis-stage components creates anxiety, over-engineering, and premature standardization.
+- **Settlers are the connective tissue**: They translate pioneer output into planner input. Skipping settlers (pioneer → planner handoff) often produces brittle, hard-to-operate systems.
+- **Reward systems must differ**: Pioneers need space to fail; planners need predictability metrics. A single performance framework for all three types destroys the talent mix.
+
+---
+
+## Assessment Questions per Stage
+
+Use these diagnostic questions to quickly identify where a component sits:
+
+| Question | If Yes → Stage |
+|----------|---------------|
+| "Is this available as a utility API or cloud service?" | Commodity |
+| "Can anyone buy this off the shelf from multiple vendors?" | Product or Commodity |
+| "Are there multiple competing approaches with no clear winner?" | Custom-Built |
+| "Does building this require original research or experimentation?" | Genesis |
+| "Are there training courses and certifications for this?" | Product or Commodity |
+| "Would you be the first (or one of very few) to attempt this?" | Genesis |
+| "Does everyone in the industry just use the same provider?" | Commodity |
+| "Is this a competitive differentiator for your organization?" | Genesis or Custom-Built |

--- a/arckit-opencode/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-opencode/skills/wardley-mapping/references/gameplay-patterns.md
@@ -31,41 +31,49 @@ Strategies that shape how users perceive and interact with your offerings. Can a
 
 **1. Education (LG)**
 Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+
 - *When to use*: Launching novel or complex components where user understanding is low.
 - *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
 
 **2. Bundling (N)**
 Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+
 - *When to use*: When individual components have limited standalone appeal but are complementary together.
 - *Evolution stage*: Product stage (combining maturing components)
 
 **3. Creating Artificial Needs (LE)**
 Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+
 - *When to use*: When a component solves a latent problem users have not yet articulated.
 - *Evolution stage*: Genesis → Custom-Built (creates market pull)
 
 **4. Confusion of Choice (LE)**
 Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+
 - *When to use*: When incumbent position must be defended against clearly superior alternatives.
 - *Evolution stage*: Product stage (commoditisation pressure)
 
 **5. Brand and Marketing (N)**
 Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+
 - *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **6. FUD — Fear, Uncertainty, Doubt (LE)**
 Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+
 - *When to use*: Defensively, when a competitor threatens your position with a superior offering.
 - *Evolution stage*: Product stage (defending existing position)
 
 **7. Artificial Competition (CE)**
 Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+
 - *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
 - *Evolution stage*: Any stage (perception manipulation)
 
 **8. Lobbying / Counterplay (CE)**
 Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+
 - *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
 - *Evolution stage*: Any stage (regulatory environment shaping)
 
@@ -77,26 +85,31 @@ Strategies designed to speed up component evolution along the x-axis (Genesis �
 
 **1. Market Enablement (LG)**
 Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+
 - *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
 - *Evolution stage*: Custom-Built → Product (accelerates standardisation)
 
 **2. Open Approaches (LG)**
 Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+
 - *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
 - *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
 
 **3. Exploiting Network Effects (N)**
 Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+
 - *When to use*: When you have a platform or communication component where value compounds with users.
 - *Evolution stage*: Product → Commodity (accelerated by user density)
 
 **4. Co-operation (N)**
 Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+
 - *When to use*: When no single organisation can drive a standard alone and collective action is needed.
 - *Evolution stage*: Custom-Built → Product (drives standardisation)
 
 **5. Industrial Policy (N)**
 Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+
 - *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
 - *Evolution stage*: Any stage (policy-driven acceleration)
 
@@ -108,16 +121,19 @@ Strategies designed to slow component evolution, preserving competitive advantag
 
 **1. Exploiting Constraint (LE)**
 Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+
 - *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
 - *Evolution stage*: Product → Commodity (slows commoditisation)
 
 **2. Intellectual Property Rights / IPR (LE)**
 Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+
 - *When to use*: When protecting genuine innovations that required significant R&D investment.
 - *Evolution stage*: Genesis → Custom-Built (protects early innovations)
 
 **3. Creating Constraints (CE)**
 Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+
 - *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
 - *Evolution stage*: Product → Commodity (blocks commoditisation)
 
@@ -129,21 +145,25 @@ Strategies for managing components that no longer provide value, are expensive t
 
 **1. Pig in a Poke (CE)**
 Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+
 - *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
 - *Evolution stage*: Any stage (often used with obsolete custom-built components)
 
 **2. Disposal of Liability (N)**
 Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+
 - *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
 - *Evolution stage*: Product → Commodity (managing decline gracefully)
 
 **3. Sweat and Dump (LE)**
 Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+
 - *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
 - *Evolution stage*: Product → Commodity (exploiting remaining value)
 
 **4. Refactoring (LG)**
 Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+
 - *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
 - *Evolution stage*: Custom-Built (restoring and modernising)
 
@@ -155,41 +175,49 @@ Strategies for positioning components within the market, manipulating pricing dy
 
 **1. Differentiation (N)**
 Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+
 - *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
 - *Evolution stage*: Custom-Built → Product (slows rightward movement)
 
 **2. Pricing Policy (N)**
 Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+
 - *When to use*: When pricing itself can shift market behaviour rather than just capture value.
 - *Evolution stage*: Product → Commodity (shapes competitive landscape)
 
 **3. Buyer / Supplier Power (LE)**
 Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+
 - *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
 - *Evolution stage*: Product → Commodity (exploiting market position)
 
 **4. Harvesting (LE)**
 Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+
 - *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
 - *Evolution stage*: Product → Commodity (late-stage value extraction)
 
 **5. Standards Game (LE)**
 Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+
 - *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
 - *Evolution stage*: Custom-Built → Product (locking in architecture)
 
 **6. Last Man Standing (LE)**
 Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+
 - *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
 - *Evolution stage*: Product → Commodity (consolidation phase)
 
 **7. Signal Distortion (CE)**
 Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+
 - *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
 - *Evolution stage*: Any stage (information environment manipulation)
 
 **8. Trading (N)**
 Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+
 - *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
 - *Evolution stage*: Any stage (timed exchanges)
 
@@ -201,31 +229,37 @@ Strategies for protecting existing market position, managing threats, and slowin
 
 **1. Threat Acquisition (N)**
 Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+
 - *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
 - *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
 
 **2. Raising Barriers to Entry (N)**
 Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+
 - *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
 - *Evolution stage*: Product (defending established position)
 
 **3. Procrastination (N)**
 Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+
 - *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
 - *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
 
 **4. Defensive Regulation (LE)**
 Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+
 - *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
 - *Evolution stage*: Any stage (regulatory entrenchment)
 
 **5. Limitation of Competition (CE)**
 Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+
 - *When to use*: Recognise and defend against it; deploying it invites antitrust action.
 - *Evolution stage*: Product → Commodity (dominant player defending monopoly)
 
 **6. Managing Inertia (N)**
 Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+
 - *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
 - *Evolution stage*: Any stage (internal transformation management)
 
@@ -237,36 +271,43 @@ Strategies for gaining market share, disrupting competitors, and creating new op
 
 **1. Directed Investment (LG)**
 Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+
 - *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
 - *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
 
 **2. Experimentation (LG)**
 Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+
 - *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
 - *Evolution stage*: Genesis (exploring new space)
 
 **3. Centre of Gravity (N)**
 Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+
 - *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
 - *Evolution stage*: Custom-Built → Product (targeted disruption)
 
 **4. Undermining Barriers to Entry (N)**
 Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+
 - *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
 - *Evolution stage*: Custom-Built → Product (disruptive market entry)
 
 **5. Fool's Mate (LE)**
 Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+
 - *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
 - *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
 
 **6. Press Release Process (LE)**
 Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+
 - *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
 - *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
 
 **7. Playing Both Sides (N)**
 Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+
 - *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
 - *Evolution stage*: Product → Commodity (platform-level control)
 
@@ -278,41 +319,49 @@ Strategies for creating, nurturing, and leveraging networks of interconnected co
 
 **1. Alliances (LG)**
 Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+
 - *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
 - *Evolution stage*: Custom-Built → Product (accelerating through partnership)
 
 **2. Co-creation (LG)**
 Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+
 - *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
 - *Evolution stage*: Genesis → Custom-Built (open innovation)
 
 **3. Sensing Engines / ILC (N)**
 Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+
 - *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
 - *Evolution stage*: Product → Commodity (data-driven adaptation)
 
 **4. Tower and Moat (N)**
 Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+
 - *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
 - *Evolution stage*: Product (building defensive ecosystem)
 
 **5. N-sided Markets (N)**
 Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+
 - *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
 - *Evolution stage*: Custom-Built → Product (platform creation)
 
 **6. Co-opting and Intercession (LE)**
 Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+
 - *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
 - *Evolution stage*: Product (value chain positioning)
 
 **7. Embrace and Extend (LE)**
 Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+
 - *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
 - *Evolution stage*: Product → Commodity (standard adoption then differentiation)
 
 **8. Channel Conflicts and Disintermediation (N)**
 Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+
 - *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
 - *Evolution stage*: Product → Commodity (distribution restructuring)
 
@@ -324,41 +373,49 @@ Strategies for understanding, outmanoeuvring, and responding to competitors dire
 
 **1. Ambush (N)**
 Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+
 - *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
 - *Evolution stage*: Genesis → Custom-Built (surprise market entry)
 
 **2. Fragmentation Play (LE)**
 Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+
 - *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
 - *Evolution stage*: Product (niche segmentation)
 
 **3. Reinforcing Competitor Inertia (LE)**
 Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+
 - *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
 - *Evolution stage*: Product (exploiting competitor commitment)
 
 **4. Sapping (LE)**
 Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+
 - *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
 - *Evolution stage*: Product → Commodity (gradual displacement)
 
 **5. Misdirection (CE)**
 Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+
 - *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
 - *Evolution stage*: Any stage (competitive deception)
 
 **6. Restriction of Movement (CE)**
 Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+
 - *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
 - *Evolution stage*: Product (platform gatekeeping)
 
 **7. Talent Raid (CE)**
 Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+
 - *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
 - *Evolution stage*: Any stage (capability competition)
 
 **8. Circling and Probing (N)**
 Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+
 - *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
 - *Evolution stage*: Any stage (competitive intelligence gathering)
 
@@ -370,21 +427,25 @@ Strategies for securing and maintaining optimal positions within the competitive
 
 **1. Land Grab (N)**
 Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+
 - *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
 - *Evolution stage*: Genesis → Custom-Built (early territory capture)
 
 **2. First Mover / Fast Follower (N)**
 Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+
 - *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
 - *Evolution stage*: Genesis → Custom-Built (timing of market entry)
 
 **3. Aggregation (N)**
 Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+
 - *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
 - *Evolution stage*: Product (integration play)
 
 **4. Weak Signal / Horizon (N)**
 Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+
 - *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
 - *Evolution stage*: Genesis (anticipating future evolution)
 
@@ -396,16 +457,19 @@ High-risk strategies that can harm competitors, markets, or even your own organi
 
 **1. Licensing Play (LE)**
 Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+
 - *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
 - *Evolution stage*: Custom-Built → Product (IP-based control)
 
 **2. Insertion (CE)**
 Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+
 - *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
 - *Evolution stage*: Product (dependency creation)
 
 **3. Designed to Fail (CE)**
 Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+
 - *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
 - *Evolution stage*: Genesis (false market signals)
 

--- a/arckit-opencode/skills/wardley-mapping/references/gameplay-patterns.md
+++ b/arckit-opencode/skills/wardley-mapping/references/gameplay-patterns.md
@@ -1,59 +1,520 @@
 # Gameplay Patterns
 
-Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats.
+Strategic moves based on landscape understanding. Apply these after creating a Wardley Map to identify opportunities and threats. Each gameplay includes an alignment tag drawn from the D&D classification system.
 
-## Offensive Patterns
+---
 
-```yaml
-offensive_gameplay:
-  tower_and_moat:
-    description: "Build differentiating capabilities on commodity foundation"
-    when: "Strong custom components exist"
-    action: "Commoditize dependencies, invest in differentiation"
-    map_signature: "Custom components with commodity dependencies"
+## 1. D&D Alignment Key
 
-  land_and_expand:
-    description: "Enter market with narrow offering, expand from there"
-    when: "New market entry"
-    action: "Start simple, add components over time"
+Gameplays are classified using the Dungeons & Dragons alignment system to convey their ethical and strategic nature at a glance.
 
-  open_source_play:
-    description: "Commoditize competitor's differentiator"
-    when: "Competitor relies on custom component you can replicate"
-    action: "Open source alternative to accelerate commoditization"
+| Alignment | Meaning | Strategic character |
+|-----------|---------|---------------------|
+| **LG** (Lawful Good) | Ethical, structured, mutually beneficial | Creates genuine value for the ecosystem; operates with integrity |
+| **N** (Neutral) | Pragmatic, context-dependent | Balanced approach; can benefit or harm depending on execution |
+| **LE** (Lawful Evil) | Self-interested but within accepted norms | Operates legally but manipulates markets or stakeholders for advantage |
+| **CE** (Chaotic Evil) | Destructive, harmful, disregards norms | Deliberately deceives, damages competition, or harms stakeholders |
 
-  ecosystem:
-    description: "Create platform others build upon"
-    when: "Control infrastructure component"
-    action: "Enable others to build on your platform"
+**Good vs. Evil axis**: Good strategies create positive outcomes for the broader ecosystem. Evil strategies prioritise personal gain at others' expense.
 
-  two_factor:
-    description: "Satisfy two markets with one platform"
-    when: "Platform can serve multiple user types"
-    action: "Connect both sides of a market"
-```
+**Law vs. Chaos axis**: Lawful strategies use structured, rule-following approaches. Chaotic strategies are unconventional or disruptive of established order.
 
-## Defensive Patterns
+Recognising alignment helps you understand: what plays are being used against you, what plays align with your organisation's values, and which combinations are ethically coherent.
 
-```yaml
-defensive_gameplay:
-  patents_and_ip:
-    description: "Protect innovations legally"
-    when: "Genesis/custom stage innovations"
-    action: "File patents, protect trade secrets"
+---
 
-  creating_constraint:
-    description: "Slow evolution of component you control"
-    when: "Evolution threatens your position"
-    action: "Limit interoperability, create switching costs"
+## 2. Gameplay Catalog — 11 Categories
 
-  embrace_and_extend:
-    description: "Adopt standard then differentiate"
-    when: "Commodity/product threatens differentiation"
-    action: "Add proprietary extensions"
-```
+### Category A: User Perception
 
-## Build vs. Buy vs. Outsource
+Strategies that shape how users perceive and interact with your offerings. Can accelerate adoption or create artificial barriers to switching.
+
+**1. Education (LG)**
+Inform users about the genuine value and capabilities of your components. Empowers users to make informed decisions and expands market demand organically.
+- *When to use*: Launching novel or complex components where user understanding is low.
+- *Evolution stage*: Genesis → Custom-Built (accelerates early adoption)
+
+**2. Bundling (N)**
+Combine multiple components or services into a single offer to increase perceived value. Can drive adoption but may obscure true component evolution.
+- *When to use*: When individual components have limited standalone appeal but are complementary together.
+- *Evolution stage*: Product stage (combining maturing components)
+
+**3. Creating Artificial Needs (LE)**
+Identify and promote demand for components users did not previously know they needed. Legitimate when need is real; crosses into manipulation when manufactured.
+- *When to use*: When a component solves a latent problem users have not yet articulated.
+- *Evolution stage*: Genesis → Custom-Built (creates market pull)
+
+**4. Confusion of Choice (LE)**
+Provide so many variants or options that users struggle to compare alternatives, anchoring them to your offering. Deliberately obstructs rational comparison.
+- *When to use*: When incumbent position must be defended against clearly superior alternatives.
+- *Evolution stage*: Product stage (commoditisation pressure)
+
+**5. Brand and Marketing (N)**
+Build perceived value through reputation, storytelling, and identity. Neutral because it can reflect genuine quality or artificially inflate perceived differentiation.
+- *When to use*: When products are functionally similar to competitors and differentiation must be perception-based.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**6. FUD — Fear, Uncertainty, Doubt (LE)**
+Spread strategic messages that make users hesitant to adopt alternatives. Operates within legal limits but manipulates through negative emotion rather than honest comparison.
+- *When to use*: Defensively, when a competitor threatens your position with a superior offering.
+- *Evolution stage*: Product stage (defending existing position)
+
+**7. Artificial Competition (CE)**
+Create the illusion of market competition by introducing decoy products, subsidiaries, or fake alternatives to shape perception. Actively misleads users and regulators.
+- *When to use*: To be recognised, not deployed — watch for this tactic in incumbent-dominated markets.
+- *Evolution stage*: Any stage (perception manipulation)
+
+**8. Lobbying / Counterplay (CE)**
+Influence regulation or policy for competitive gain, without regard for broader market health. When used to entrench unfair advantage rather than correct market failure, becomes destructive.
+- *When to use*: Defensively, to counter unjust regulation; offensively use is CE territory.
+- *Evolution stage*: Any stage (regulatory environment shaping)
+
+---
+
+### Category B: Accelerators
+
+Strategies designed to speed up component evolution along the x-axis (Genesis → Commodity). Accelerators grow markets and compress timelines.
+
+**1. Market Enablement (LG)**
+Create conditions — standards, marketplaces, education, shared infrastructure — that lower barriers to adoption for the whole ecosystem.
+- *When to use*: When a component has genuine value but adoption is held back by friction, not lack of interest.
+- *Evolution stage*: Custom-Built → Product (accelerates standardisation)
+
+**2. Open Approaches (LG)**
+Make components, specifications, or APIs freely available to encourage widespread use and community-driven development. Linux, HTTP, and TCP/IP are canonical examples.
+- *When to use*: When commoditising a competitor's differentiator or growing an ecosystem rapidly is the priority.
+- *Evolution stage*: Custom-Built → Commodity (accelerates commoditisation)
+
+**3. Exploiting Network Effects (N)**
+Design for scalability and rapid user acquisition so that the component becomes more valuable as adoption grows. Can create winner-takes-all dynamics.
+- *When to use*: When you have a platform or communication component where value compounds with users.
+- *Evolution stage*: Product → Commodity (accelerated by user density)
+
+**4. Co-operation (N)**
+Work with other organisations — even competitors — through consortia, co-development, or shared standards. USB and Bluetooth are examples of industry co-operation.
+- *When to use*: When no single organisation can drive a standard alone and collective action is needed.
+- *Evolution stage*: Custom-Built → Product (drives standardisation)
+
+**5. Industrial Policy (N)**
+Leverage governmental or institutional policies, mandates, or funding to accelerate component evolution. Government mandates for digital broadcasting or EV charging infrastructure are examples.
+- *When to use*: When regulatory alignment can unlock adoption that market forces alone cannot drive.
+- *Evolution stage*: Any stage (policy-driven acceleration)
+
+---
+
+### Category C: De-accelerators
+
+Strategies designed to slow component evolution, preserving competitive advantage, higher margins, or market control.
+
+**1. Exploiting Constraint (LE)**
+Control key resources, create artificial scarcity, or exploit natural bottlenecks to slow commoditisation. De Beers controlling diamond supply is the classic example.
+- *When to use*: When a critical resource or bottleneck can be controlled and competitors lack viable alternatives.
+- *Evolution stage*: Product → Commodity (slows commoditisation)
+
+**2. Intellectual Property Rights / IPR (LE)**
+Use patents, copyrights, and trade secrets to prevent competitors replicating or building on your innovations. Pharmaceutical patent strategies are a common example.
+- *When to use*: When protecting genuine innovations that required significant R&D investment.
+- *Evolution stage*: Genesis → Custom-Built (protects early innovations)
+
+**3. Creating Constraints (CE)**
+Deliberately introduce proprietary standards, complex interdependencies, or artificial barriers to prevent components from evolving. Printer manufacturers using proprietary ink cartridges exemplify this.
+- *When to use*: Recognise this when it is used against you; deploying it risks regulatory backlash and consumer trust damage.
+- *Evolution stage*: Product → Commodity (blocks commoditisation)
+
+---
+
+### Category D: Dealing with Toxicity
+
+Strategies for managing components that no longer provide value, are expensive to maintain, or are hindering progress in your value chain.
+
+**1. Pig in a Poke (CE)**
+Disguise or repackage a toxic component to appear more valuable or less problematic, then sell or transfer it. Rebranding failing software as "enterprise edition" before divestiture is an example.
+- *When to use*: Recognise this when evaluating acquisitions or vendor offerings; deploying it is close to fraud.
+- *Evolution stage*: Any stage (often used with obsolete custom-built components)
+
+**2. Disposal of Liability (N)**
+Responsibly divest, sunset, or transfer components that have become liabilities. Communicate limitations transparently and provide migration paths for users.
+- *When to use*: When a component no longer fits your strategy but still has value for a buyer or the market.
+- *Evolution stage*: Product → Commodity (managing decline gracefully)
+
+**3. Sweat and Dump (LE)**
+Extract maximum remaining value from a component through cost reduction and reduced investment, then divest before the market fully understands its decline.
+- *When to use*: When a component has a finite remaining life and no strategic future — but requires transparency about limitations.
+- *Evolution stage*: Product → Commodity (exploiting remaining value)
+
+**4. Refactoring (LG)**
+Systematically restructure and improve toxic or legacy components to restore value, reduce technical debt, or prepare for strategic evolution. Honest and value-creating.
+- *When to use*: When a component still has strategic value but internal complexity or debt is suppressing its potential.
+- *Evolution stage*: Custom-Built (restoring and modernising)
+
+---
+
+### Category E: Market
+
+Strategies for positioning components within the market, manipulating pricing dynamics, and securing competitive advantage through market structure.
+
+**1. Differentiation (N)**
+Distinguish your components from competitors by adding unique features, improving quality, or building a strong brand identity. Apple's design-led approach to smartphones is an example.
+- *When to use*: When commoditisation pressure threatens margins and genuine differentiation is achievable.
+- *Evolution stage*: Custom-Built → Product (slows rightward movement)
+
+**2. Pricing Policy (N)**
+Set prices strategically — penetration pricing, premium pricing, or freemium — to shape market dynamics and accelerate or slow adoption.
+- *When to use*: When pricing itself can shift market behaviour rather than just capture value.
+- *Evolution stage*: Product → Commodity (shapes competitive landscape)
+
+**3. Buyer / Supplier Power (LE)**
+Leverage your position in the value chain to extract advantage from buyers or suppliers through concentration, exclusivity, or volume leverage.
+- *When to use*: When you have structural power in a supply or distribution relationship — exercise with care to avoid regulatory action.
+- *Evolution stage*: Product → Commodity (exploiting market position)
+
+**4. Harvesting (LE)**
+Extract maximum financial value from a mature component before it fully commoditises or becomes obsolete. Reduce R&D investment, raise prices, minimise service costs.
+- *When to use*: When a component is in terminal decline and reinvestment will not reverse trajectory.
+- *Evolution stage*: Product → Commodity (late-stage value extraction)
+
+**5. Standards Game (LE)**
+Push your proprietary implementation as the industry standard to gain control over a component's evolution and lock in ecosystem participants.
+- *When to use*: When you have the market weight to drive standard adoption and the standard benefits you disproportionately.
+- *Evolution stage*: Custom-Built → Product (locking in architecture)
+
+**6. Last Man Standing (LE)**
+Outlast competitors through attrition in a market undergoing commoditisation — maintain investment longer than rivals who exit, then capture remaining share.
+- *When to use*: When you have deeper resources than competitors and the market will consolidate to a small number of providers.
+- *Evolution stage*: Product → Commodity (consolidation phase)
+
+**7. Signal Distortion (CE)**
+Deliberately distort market signals — through false announcements, misleading metrics, or artificial demand — to confuse competitors and stakeholders.
+- *When to use*: Recognise it; deploying it risks legal exposure and severe reputation damage.
+- *Evolution stage*: Any stage (information environment manipulation)
+
+**8. Trading (N)**
+Actively exchange components, capabilities, or information with other market participants to optimise your position — including buying and selling evolving components at advantageous points.
+- *When to use*: When the evolution curve of a component can be exploited through timing of acquisition or divestiture.
+- *Evolution stage*: Any stage (timed exchanges)
+
+---
+
+### Category F: Defensive
+
+Strategies for protecting existing market position, managing threats, and slowing competitor progress.
+
+**1. Threat Acquisition (N)**
+Acquire emerging competitors or technologies before they can threaten your core position. Google's acquisition of YouTube and Android are examples.
+- *When to use*: When a nascent component or competitor has the potential to disrupt your position if allowed to develop independently.
+- *Evolution stage*: Genesis → Custom-Built (neutralising threats early)
+
+**2. Raising Barriers to Entry (N)**
+Create obstacles — capital requirements, switching costs, ecosystem lock-in, or regulatory advantages — that deter new entrants from competing directly.
+- *When to use*: When you hold a strong position and the cost of entry can be inflated against competitors.
+- *Evolution stage*: Product (defending established position)
+
+**3. Procrastination (N)**
+Deliberately delay strategic decisions to gather better information, wait for the market to clarify, or allow competitors to bear first-mover costs and risks.
+- *When to use*: When uncertainty is high and waiting reduces risk more than acting early gains advantage.
+- *Evolution stage*: Genesis → Custom-Built (managing uncertainty)
+
+**4. Defensive Regulation (LE)**
+Lobby for regulations that, while framed as consumer protection or safety, primarily serve to raise barriers against competitors or entrench incumbents.
+- *When to use*: Recognise this in regulatory advocacy; be cautious of deploying it as it can backfire if exposed.
+- *Evolution stage*: Any stage (regulatory entrenchment)
+
+**5. Limitation of Competition (CE)**
+Use market power to directly prevent competitors from operating, through exclusive deals, predatory pricing, or legal harassment. Often anti-competitive.
+- *When to use*: Recognise and defend against it; deploying it invites antitrust action.
+- *Evolution stage*: Product → Commodity (dominant player defending monopoly)
+
+**6. Managing Inertia (N)**
+Actively manage organisational resistance to change, ensuring your own inertia does not prevent necessary strategic evolution. Also applies to exploiting competitors' inertia.
+- *When to use*: When transitioning between strategic positions or when a competitor's reluctance to change creates an opening.
+- *Evolution stage*: Any stage (internal transformation management)
+
+---
+
+### Category G: Attacking
+
+Strategies for gaining market share, disrupting competitors, and creating new opportunities.
+
+**1. Directed Investment (LG)**
+Allocate significant resources to develop or acquire key components strategically. Google's sustained investment in AI and AWS's early infrastructure build-out are examples.
+- *When to use*: When a clear opportunity exists to accelerate evolution or capture a strategic position through concentrated investment.
+- *Evolution stage*: Genesis → Custom-Built (backing emerging capabilities)
+
+**2. Experimentation (LG)**
+Rapidly test and iterate on new ideas to find successful strategies. Amazon's culture of continuous product experimentation is the archetype.
+- *When to use*: When the landscape is uncertain and learning quickly is more valuable than optimising for a single path.
+- *Evolution stage*: Genesis (exploring new space)
+
+**3. Centre of Gravity (N)**
+Identify and attack the key components that underpin a competitor's strength. Netflix investing in original content to reduce reliance on licensed content is an example.
+- *When to use*: When a competitor's position depends on a specific component you can replicate, undermine, or make irrelevant.
+- *Evolution stage*: Custom-Built → Product (targeted disruption)
+
+**4. Undermining Barriers to Entry (N)**
+Actively work to remove or circumvent obstacles that protect incumbents. Fintech companies bypassing traditional banking infrastructure exemplify this.
+- *When to use*: When incumbent-erected barriers can be defeated through technology, regulatory change, or alternative channels.
+- *Evolution stage*: Custom-Built → Product (disruptive market entry)
+
+**5. Fool's Mate (LE)**
+Execute a swift, decisive move that catches competitors off guard before they can respond. Apple's iPhone launch — catching the mobile industry unprepared — is the defining example.
+- *When to use*: When a critical weakness or opportunity has been overlooked by incumbents and speed is essential to capture it.
+- *Evolution stage*: Genesis → Custom-Built (disruptive first strike)
+
+**6. Press Release Process (LE)**
+Announce intentions or capabilities before they exist to shape market expectations and slow competitor investment. Tesla's pre-announcement of future models has shaped EV market perceptions.
+- *When to use*: With caution — premature announcements damage credibility if delivery fails; reserve for genuine strategic signalling.
+- *Evolution stage*: Genesis → Custom-Built (shaping narrative before capability)
+
+**7. Playing Both Sides (N)**
+Simultaneously support and compete with other players — providing infrastructure or platforms that competitors rely on while also competing with them. Amazon Web Services supporting companies Amazon competes with in retail is an example.
+- *When to use*: When platform control creates structural advantage that outweighs the complexity of competing with your own customers.
+- *Evolution stage*: Product → Commodity (platform-level control)
+
+---
+
+### Category H: Ecosystem
+
+Strategies for creating, nurturing, and leveraging networks of interconnected components and actors.
+
+**1. Alliances (LG)**
+Form strategic partnerships to achieve mutual benefits, accelerate evolution, and expand capabilities. Complementary strengths are combined to move faster than either party could alone.
+- *When to use*: When a strategic goal requires capabilities or market access that would take too long to build independently.
+- *Evolution stage*: Custom-Built → Product (accelerating through partnership)
+
+**2. Co-creation (LG)**
+Collaborate with customers, suppliers, or competitors to develop new components. Linux and Wikipedia are canonical co-creation examples.
+- *When to use*: When collective intelligence and distributed contribution will produce a better outcome than internal development alone.
+- *Evolution stage*: Genesis → Custom-Built (open innovation)
+
+**3. Sensing Engines / ILC (N)**
+Implement systems that detect and respond to ecosystem changes rapidly — using data from platform activity to identify new opportunities. Amazon's use of marketplace metadata to identify product opportunities is the classic example. ILC = Innovate, Leverage, Commoditise.
+- *When to use*: When you operate a platform with sufficient transaction data to detect weak market signals before competitors.
+- *Evolution stage*: Product → Commodity (data-driven adaptation)
+
+**4. Tower and Moat (N)**
+Build a strong central offering (tower) surrounded by complementary products and services (moat) that reinforce your position and raise switching costs. Apple's iPhone ecosystem (App Store, iCloud, AirPods, Apple Watch) exemplifies this.
+- *When to use*: When a core product is strong enough to anchor an ecosystem and complementary services can deepen lock-in.
+- *Evolution stage*: Product (building defensive ecosystem)
+
+**5. N-sided Markets (N)**
+Create platforms that connect multiple distinct user groups, each adding value to the other. Uber (riders and drivers), Airbnb (hosts and guests), and Apple App Store (developers and users) are examples.
+- *When to use*: When two or more user groups each need what the other provides and a neutral platform can capture the value of that exchange.
+- *Evolution stage*: Custom-Built → Product (platform creation)
+
+**6. Co-opting and Intercession (LE)**
+Insert your organisation into existing value chains as a necessary intermediary. PayPal inserting itself between buyers and sellers in online transactions is an example.
+- *When to use*: When a genuine efficiency or value-add can justify the intermediary role — be transparent about intentions.
+- *Evolution stage*: Product (value chain positioning)
+
+**7. Embrace and Extend (LE)**
+Adopt open standards or platforms and then extend them with proprietary features that create lock-in. Microsoft's historical approach with Internet Explorer extending web standards is the canonical example.
+- *When to use*: With caution — community backlash and regulatory risk are real; consider contributing extensions back to the standard instead.
+- *Evolution stage*: Product → Commodity (standard adoption then differentiation)
+
+**8. Channel Conflicts and Disintermediation (N)**
+Manage or create conflicts in distribution channels, or remove intermediaries to gain direct access to customers. Tesla's direct-to-consumer sales model, bypassing dealerships, is an example.
+- *When to use*: When direct channels improve margins, customer experience, or data access, and the disruption to intermediaries is manageable.
+- *Evolution stage*: Product → Commodity (distribution restructuring)
+
+---
+
+### Category I: Competitor
+
+Strategies for understanding, outmanoeuvring, and responding to competitors directly.
+
+**1. Ambush (N)**
+Surprise competitors with unexpected moves or entries into new markets through secret development and rapid deployment. Apple's iPhone launch exemplifies the ambush pattern.
+- *When to use*: When a competitive opening exists that has not been spotted by incumbents and secrecy can be maintained through development.
+- *Evolution stage*: Genesis → Custom-Built (surprise market entry)
+
+**2. Fragmentation Play (LE)**
+Break up a market into smaller segments to reduce the power of dominant players — targeting niches that large incumbents cannot serve efficiently.
+- *When to use*: When an incumbent's broad offering leaves underserved segments that specialist positioning can capture.
+- *Evolution stage*: Product (niche segmentation)
+
+**3. Reinforcing Competitor Inertia (LE)**
+Encourage competitors to maintain outdated strategies or legacy systems by supporting their commitment to the status quo — making it harder for them to change direction.
+- *When to use*: When a competitor is heavily invested in a path that will become obsolete and nudging them to stay on it extends your window of advantage.
+- *Evolution stage*: Product (exploiting competitor commitment)
+
+**4. Sapping (LE)**
+Gradually weaken a competitor's position through sustained low-intensity competition — typically free or low-cost alternatives targeting their key revenue sources. Google's free productivity tools sapping Microsoft Office is an example.
+- *When to use*: When sustained resource pressure can erode a competitor's position without triggering an immediate strong response.
+- *Evolution stage*: Product → Commodity (gradual displacement)
+
+**5. Misdirection (CE)**
+Mislead competitors about your true intentions or capabilities through decoy products, false announcements, or strategic feints. Severe ethical and legal risks if applied to public markets.
+- *When to use*: Recognise it; deploying it in public markets risks fraud charges and permanent credibility damage.
+- *Evolution stage*: Any stage (competitive deception)
+
+**6. Restriction of Movement (CE)**
+Limit a competitor's strategic options by controlling key resources, channels, or inputs. Apple's control of the App Store limiting competitor reach to iOS users is often cited.
+- *When to use*: Recognise this as a defensive risk; deploying it invites antitrust investigation.
+- *Evolution stage*: Product (platform gatekeeping)
+
+**7. Talent Raid (CE)**
+Poach key talent from competitors to weaken their capabilities while strengthening your own. Creates industry-wide talent inflation and retaliation cycles.
+- *When to use*: Recognise the pattern; compete for talent on organisational merit rather than predatory poaching.
+- *Evolution stage*: Any stage (capability competition)
+
+**8. Circling and Probing (N)**
+Continuously test a competitor's defences by launching small experiments in adjacent areas of their market to identify weaknesses and gather intelligence.
+- *When to use*: When you need to identify where a competitor is vulnerable before committing to a full-scale competitive move.
+- *Evolution stage*: Any stage (competitive intelligence gathering)
+
+---
+
+### Category J: Positional
+
+Strategies for securing and maintaining optimal positions within the competitive landscape.
+
+**1. Land Grab (N)**
+Quickly occupy and dominate key areas of the map before competitors — through aggressive investment, acquisition, or market entry. AWS's early aggressive expansion into cloud computing is the archetype.
+- *When to use*: When an emerging area has clear long-term strategic value and the window to establish a first-mover position is closing.
+- *Evolution stage*: Genesis → Custom-Built (early territory capture)
+
+**2. First Mover / Fast Follower (N)**
+Decide whether to pioneer new areas (first mover) or rapidly adapt successful innovations others have proved (fast follower). Apple as a fast follower in smartphones — improving on earlier attempts — is a key example.
+- *When to use*: First mover when you can shape the standard and absorb risk; fast follower when first movers have proved demand but not optimised delivery.
+- *Evolution stage*: Genesis → Custom-Built (timing of market entry)
+
+**3. Aggregation (N)**
+Consolidate multiple components or services into a more comprehensive offering — creating a whole that is more valuable than the sum of parts. Microsoft Office bundling productivity tools is a classic example.
+- *When to use*: When users benefit from integrated solutions and the aggregation creates genuine switching costs and value.
+- *Evolution stage*: Product (integration play)
+
+**4. Weak Signal / Horizon (N)**
+Identify and act on early indicators of future market shifts before they become obvious. IBM's early investment in quantum computing based on weak signals of its future importance is an example.
+- *When to use*: When long time horizons are strategically important and early positioning in emerging areas creates durable advantage.
+- *Evolution stage*: Genesis (anticipating future evolution)
+
+---
+
+### Category K: Poison
+
+High-risk strategies that can harm competitors, markets, or even your own organisation if misapplied. Recognise these when used against you.
+
+**1. Licensing Play (LE)**
+Use licensing agreements to control or restrict how others use key components. Oracle's aggressive database licensing practices are a well-known example.
+- *When to use*: When protecting genuine IP investment — avoid terms that are so restrictive they invite open-source replacement or regulatory action.
+- *Evolution stage*: Custom-Built → Product (IP-based control)
+
+**2. Insertion (CE)**
+Introduce a component into a competitor's or partner's value chain that you control, creating dependency that can be exploited. Google's Android as a dependency for device manufacturers is the cited example.
+- *When to use*: Recognise the dependency risk in your own value chain; deploying insertion deliberately borders on entrapment.
+- *Evolution stage*: Product (dependency creation)
+
+**3. Designed to Fail (CE)**
+Release products or services intentionally limited in capability to gather market data, mislead competitors, or test reactions without genuine commitment.
+- *When to use*: Recognise it; deploying it deliberately misleads customers and risks product liability and fraud exposure.
+- *Evolution stage*: Genesis (false market signals)
+
+---
+
+## 3. Play-Position Matrix
+
+Use your position on the map and the market's maturity to select the most appropriate plays.
+
+| Your Position | Early Market | Growing Market | Mature Market | Consolidated Market |
+|---------------|-------------|----------------|---------------|---------------------|
+| **Genesis leader** | Education, Directed Investment, Experimentation | Land Grab, Open Approaches, Alliances | First Mover/Fast Follower, Market Enablement | Weak Signal/Horizon, Co-operation |
+| **Custom-Built strength** | Fool's Mate, Bundling, Tower and Moat | Centre of Gravity, Differentiation, Co-creation | Sensing Engines (ILC), N-sided Markets | Aggregation, Playing Both Sides |
+| **Product parity** | Fragmentation Play, Undermining Barriers | Pricing Policy, Brand and Marketing | Standards Game, Sapping, Circling and Probing | Harvesting, Last Man Standing |
+| **Commodity laggard** | Refactoring, Disposal of Liability | Managing Inertia, Threat Acquisition | Raising Barriers to Entry, Procrastination | Sweat and Dump, Channel Disintermediation |
+
+---
+
+## 4. Play Compatibility
+
+### Plays That Work Together
+
+| Primary Play | Compatible With | Why |
+|-------------|-----------------|-----|
+| Sensing Engines (ILC) | Ecosystem plays, Weak Signal/Horizon | ILC provides the data to act on horizon signals |
+| Open Approaches | Co-creation, Market Enablement, Alliances | Openness attracts community and enables markets |
+| Tower and Moat | N-sided Markets, Alliances, Co-creation | Moat is strengthened by ecosystem depth |
+| Land Grab | Directed Investment, Alliances | Resources and partnerships accelerate territory capture |
+| Experimentation | Directed Investment, Sensing Engines | Experiments generate signals; investment scales winners |
+| Education | Open Approaches, Market Enablement | Education grows the market that openness then accelerates |
+| Fragmentation Play | Undermining Barriers, Differentiation | Niche entry combined with unique positioning |
+| Fool's Mate | Directed Investment, Ambush | Concentrated investment enables surprise execution |
+| Playing Both Sides | Tower and Moat, Sensing Engines | Platform control enables both ecosystem sensing and competition |
+
+### Plays That Conflict
+
+| Play A | Conflicts With | Why |
+|--------|---------------|-----|
+| Open Approaches | IPR / Licensing Play | Opening commoditises what licensing tries to protect |
+| Standards Game | Fragmentation Play | One seeks consolidation, the other fragmentation |
+| Co-creation | Confusion of Choice | Transparency in co-creation undermines deliberate confusion |
+| Market Enablement | Exploiting Constraint | Enablement accelerates what constraint tries to slow |
+| Education (LG) | FUD (LE) | Honest information and fear messaging are incompatible |
+| Alliances (LG) | Misdirection (CE) | Trust-based partnership cannot coexist with deliberate deception |
+| Refactoring | Sweat and Dump | One invests to restore value; the other extracts before exit |
+
+---
+
+## 5. Strategic Anti-Patterns
+
+Common strategic mistakes identified when applying gameplays to Wardley Maps.
+
+**Playing in the wrong evolution stage**
+Applying a genesis gameplay (e.g., Experimentation) to a commodity component wastes resources. Applying a commodity play (e.g., Harvesting) to a genesis component kills nascent innovation. Always match the play to the component's actual evolution position on the map.
+
+**Ignoring inertia**
+Assuming that a clearly superior strategy will execute smoothly without addressing organisational resistance. Inertia is the single most common reason strategically correct plays fail in execution. Map your inertia points before committing to a play.
+
+**Single-play dependence**
+Relying on one play to secure a position. Durable positions require layered plays — for example, Open Approaches to accelerate adoption, followed by Sensing Engines and Tower and Moat to capture ecosystem value. Single plays are fragile.
+
+**Misreading evolution pace**
+Treating components as more evolved (or less evolved) than they are. Building a commodity play (Harvesting) on what is still a custom-built component destroys value. Mapping component position carefully before selecting plays is essential.
+
+**Ecosystem hubris**
+Assuming that a strong current ecosystem position is self-sustaining. Ecosystems decay when the platform owner stops creating genuine value or when a disruptive technology makes the platform irrelevant. ILC and Weak Signal plays are the antidotes.
+
+**Open washing**
+Claiming Open Approaches alignment while maintaining proprietary lock-in through standards control, licensing restrictions, or incompatible extensions. Community backlash is swift and destroys the trust that makes open strategies work.
+
+**Alignment drift**
+Starting with LG plays to build an ecosystem and then shifting to CE plays to extract value. This pattern (common in platform companies) destroys the trust that made the ecosystem valuable in the first place and invites regulatory intervention.
+
+---
+
+## 6. Case Study Summaries
+
+Canonical examples of gameplay combinations in practice.
+
+**AWS (ILC + Land Grab + Tower and Moat)**
+Amazon launched AWS in 2006 before competitors recognised cloud's potential (Land Grab), built a comprehensive ecosystem of services that created deep customer dependency (Tower and Moat), and used marketplace metadata to sense which services to build next (Sensing Engines / ILC). Result: cloud computing market dominance and ongoing competitive moat.
+
+**Amazon Retail (Ecosystem + Directed Investment + Sensing Engines)**
+Combined early e-commerce entry with systematic directed investment in logistics, Prime, and Marketplace to build a self-reinforcing flywheel. Data from transactions continuously informs pricing, inventory, and product expansion. The ecosystem (sellers, logistics, Prime) creates the moat.
+
+**Netflix (Fast Follower + Directed Investment + Ecosystem co-evolution)**
+Watched Blockbuster's online rental experiment, then executed a fast follower streaming strategy with heavy directed investment in technology and original content. Co-evolved with device manufacturers to ensure reach across platforms. Original content investment shifted Netflix from distributor to producer, reducing dependency on studio licensing.
+
+**Apple iPhone (Fool's Mate + Bundling + N-sided Markets)**
+Executed a decisive market entry that caught mobile incumbents unprepared (Fool's Mate). Bundled hardware, iOS, and services into a coherent premium value proposition (Bundling). Built an N-sided market connecting users, developers, and accessory makers through the App Store, creating powerful ecosystem lock-in.
+
+**Google Android (Open Approaches + Alliances + Insertion)**
+Open-sourced Android to accelerate device manufacturer adoption (Open Approaches). Built alliances with manufacturers, carriers, and developers (Alliances). Embedded Google Search, Maps, and Play Store as dependencies — creating structural control over the mobile ecosystem (Insertion).
+
+**Ubuntu (Open Approaches + Alliances + Market Enablement)**
+Adopted open-source approach to lower adoption barriers and grow a contributor community (Open Approaches). Built alliances with cloud providers and infrastructure vendors (Alliances). Shifted focus to cloud computing as the strategic battleground and enabled the market with free security and tooling (Market Enablement). Became the dominant cloud guest OS within 18 months.
+
+**Tesla (First Mover + Tower and Moat + Education)**
+Entered the EV market as a first mover with high-performance vehicles when competitors were not taking EVs seriously. Built an integrated ecosystem of manufacturing, Gigafactory battery production, and Supercharger network that competitors could not quickly replicate (Tower and Moat). Invested heavily in consumer education about EV benefits and sustainability.
+
+**Airbnb (N-sided Markets + Market Enablement + Defensive Regulation)**
+Created a two-sided platform connecting hosts and guests that no incumbent hotel company could easily replicate (N-sided Markets). Enabled a new market of peer-to-peer accommodation that unlocked latent supply (Market Enablement). Proactively engaged with regulators in key cities to legitimise the model rather than ignore regulation (Defensive Regulation).
+
+**Spotify (N-sided Markets + Bundling + Sensing Engines)**
+Built a platform connecting listeners, artists, labels, and advertisers (N-sided Markets). Bundled streaming, curation, podcasting, and premium features into a coherent offering with strong perceived value (Bundling). Used listener data to power recommendation algorithms (Discover Weekly, Daily Mix) that continuously improve engagement and reduce churn (Sensing Engines).
+
+---
+
+## 7. Build vs. Buy vs. Outsource
 
 Use the component's evolution position to guide sourcing decisions:
 
@@ -91,7 +552,9 @@ build_buy_outsource:
       - "Email delivery"
 ```
 
-## Innovation Investment by Stage
+---
+
+## 8. Innovation Investment by Stage
 
 ```yaml
 innovation_investment:
@@ -100,72 +563,26 @@ innovation_investment:
     approach: "Experiments, PoCs, research"
     metrics: "Learning velocity, options created"
     failure_tolerance: "High"
+    matching_plays: ["Experimentation", "Weak Signal/Horizon", "Directed Investment", "Education"]
 
   custom:
     investment_type: "Differentiation"
     approach: "Product development, custom builds"
     metrics: "Feature completion, user adoption"
     failure_tolerance: "Medium"
+    matching_plays: ["Fool's Mate", "Tower and Moat", "Co-creation", "Alliances"]
 
   product:
     investment_type: "Enhancement"
     approach: "Integration, configuration"
     metrics: "Time to value, TCO"
     failure_tolerance: "Low"
+    matching_plays: ["Differentiation", "Standards Game", "Sensing Engines (ILC)", "N-sided Markets"]
 
   commodity:
     investment_type: "Optimization"
     approach: "Cost reduction, automation"
     metrics: "Cost per unit, availability"
     failure_tolerance: "Very low"
-```
-
-## Common Map Patterns
-
-Recognizable patterns to watch for when analyzing a completed map.
-
-### Desirable Patterns
-
-```yaml
-desirable_patterns:
-  tower_pattern:
-    description: "Differentiation built on commodity foundation"
-    structure:
-      top: "Genesis/Custom differentiators"
-      middle: "Product integrations"
-      bottom: "Commodity infrastructure"
-    example:
-      differentiator: "Custom recommendation engine"
-      product_layer: "E-commerce platform, CRM"
-      commodity: "Cloud compute, databases"
-    strategy: "Maximize commoditization at bottom to fund innovation at top"
-```
-
-### Anti-Patterns
-
-```yaml
-anti_patterns:
-  legacy_trap:
-    description: "Custom-built components that should be commodity"
-    symptoms:
-      - "Large team maintaining commodity-equivalent"
-      - "High cost, slow innovation"
-      - "Technical debt accumulation"
-    example:
-      component: "Custom identity management"
-      market_alternatives: ["Auth0", "Azure AD B2C", "Okta"]
-      waste: "Team of 5 maintaining what SaaS provides"
-    resolution: "Migrate to product/commodity, redeploy team"
-
-  premature_innovation:
-    description: "Treating genesis component as if product/commodity"
-    symptoms:
-      - "Fixed-scope contracts for unknown work"
-      - "Waterfall planning for experimental work"
-      - "Outsourcing pioneer work"
-    example:
-      component: "Novel ML application"
-      mistake: "Fixed-price contract with vendor"
-      result: "Scope creep, failed project"
-    resolution: "Match management approach to evolution stage"
+    matching_plays: ["Harvesting", "Last Man Standing", "Outsource decision", "Disposal of Liability"]
 ```

--- a/arckit-opencode/skills/wardley-mapping/references/mapping-examples.md
+++ b/arckit-opencode/skills/wardley-mapping/references/mapping-examples.md
@@ -304,4 +304,215 @@ ml_strategy:
       Custom models only where product gaps exist.
 ```
 
+---
+
+## Example 4: TechnoGadget Smart Home (Climatic Patterns Case Study)
+
+This example is drawn from the *Introduction to Wardley Mapping Climatic Patterns* reference work. It illustrates how climatic patterns interact with component positioning in a real-world product company.
+
+### Scenario
+
+TechnoGadget Inc. is a mid-sized technology company producing smart home devices. Their flagship product is a smart thermostat controllable via a smartphone app. Facing increased competition, they are planning international expansion.
+
+- **User Need**: "Comfortable home environment with energy efficiency"
+
+### OnlineWardleyMaps Syntax
+
+```owm
+title TechnoGadget Inc.
+
+anchor Customer [0.95, 0.63]
+
+component Smart thermostat [0.65, 0.46] label [-81, -9]
+component Mobile app [0.79, 0.34] label [-77, 2]
+component Cloud infrastructure [0.05, 0.75] label [-26, 13]
+component Data analytics [0.22, 0.36] label [-68, 24]
+component Customer support [0.86, 0.81] label [9, -17]
+component Marketing and sales [0.51, 0.66] label [-25, -57]
+component R&D [0.50, 0.22]
+component API [0.34, 0.28] label [-29, 20]
+
+Customer->Smart thermostat
+Customer->Customer support
+Customer->Mobile app
+
+Smart thermostat->Mobile app
+Smart thermostat->Cloud infrastructure
+Smart thermostat->Data analytics
+Smart thermostat->API
+
+Mobile app->API
+
+API->Cloud infrastructure
+API->Data analytics
+
+Cloud infrastructure->Data analytics
+Cloud infrastructure->Customer support
+Cloud infrastructure->Marketing and sales
+Cloud infrastructure->R&D
+
+evolve API 0.75
+```
+
+Paste into [OnlineWardleyMaps](https://create.wardleymaps.ai) to render.
+
+### Component Positions
+
+| Component | Visibility | Evolution | Stage | Notes |
+|-----------|-----------|-----------|-------|-------|
+| Smart thermostat | 0.65 | 0.46 | Custom-Built/Product | Core product, approaching commoditization |
+| Mobile app | 0.79 | 0.34 | Custom-Built | High visibility, custom UX differentiator |
+| Cloud infrastructure | 0.05 | 0.75 | Product/Commodity | Low visibility, enabling layer |
+| Data analytics | 0.22 | 0.36 | Custom-Built | Higher-order capability built on commoditized infra |
+| Customer support | 0.86 | 0.81 | Commodity | High visibility, standardized function |
+| Marketing and sales | 0.51 | 0.66 | Product | Mid-chain, standard practice |
+| R&D | 0.50 | 0.22 | Genesis/Custom-Built | Uncertain, high-value future options |
+| API | 0.34 | 0.28 → 0.75 | Custom-Built (evolving) | Strategic evolution signal: moving toward commodity |
+
+### Strategic Insights
+
+- **Commoditization pressure on core product**: Smart thermostat and Mobile app cluster in the Product stage — inertia risk is high as these evolve toward commodity and competitors can replicate them. TechnoGadget must shift differentiation upstream toward Data analytics and R&D before the hardware commoditizes.
+- **Efficiency enables innovation**: Commoditized Cloud infrastructure enables faster and cheaper development of custom-built Data analytics and R&D capabilities. This is the "higher-order systems create new value" climatic pattern in action — the commodity layer subsidizes the genesis layer.
+- **API evolution watch**: The `evolve API 0.75` annotation signals an anticipated move toward commodity. Once APIs commoditize, third-party integrators can build on TechnoGadget's platform — creating an ecosystem play opportunity (ILC pattern) but also opening the platform to competitive pressure.
+
+---
+
+## Example 5: Value Chain Decomposition Walkthrough
+
+A step-by-step demonstration of how to decompose a user need into a full Wardley Map. Use this pattern when starting from scratch with a new domain.
+
+### Starting Point: "Buy Products Online"
+
+This walkthrough shows the decomposition process for a simplified e-commerce value chain.
+
+#### Step 1 — Anchor
+
+Identify the user and their need:
+
+```
+User: Online Shopper
+Need: Buy products online
+```
+
+Place the anchor at the top of the map (high visibility = 1.0).
+
+#### Step 2 — First-Level Decomposition
+
+Ask: "What does the user directly interact with to fulfil this need?"
+
+```
+Buy products online
+  ├── Product Discovery      (finding what to buy)
+  ├── Shopping Experience    (browsing, comparison)
+  ├── Checkout               (basket, order confirmation)
+  └── Fulfilment             (delivery, returns)
+```
+
+These four components are directly visible to the user — position them high on the Y-axis (visibility 0.7-0.9).
+
+#### Step 3 — Second-Level Decomposition
+
+For each first-level component, ask: "What does this depend on?"
+
+```
+Product Discovery depends on:
+  ├── Search Engine           (index + ranking)
+  ├── Product Catalogue       (structured data)
+  └── Recommendation Engine   (personalisation ML)
+
+Shopping Experience depends on:
+  ├── Product Images / Media  (CDN delivery)
+  ├── Reviews & Ratings       (UGC platform)
+  └── Price Comparison        (pricing service)
+
+Checkout depends on:
+  ├── Shopping Cart           (session state)
+  ├── Payment Gateway         (Stripe / Adyen)
+  └── Identity / Auth         (login, SSO)
+
+Fulfilment depends on:
+  ├── Order Management System (OMS)
+  ├── Warehouse / 3PL         (physical logistics)
+  └── Notification Service    (email / SMS)
+```
+
+#### Step 4 — Assign Evolution Positions
+
+Apply the Evolution Scoring rubric (see [Mathematical Models](mathematical-models.md)):
+
+| Component | U | C | E(c) | Stage |
+|-----------|---|---|------|-------|
+| Search Engine | 0.55 | 0.60 | 0.58 | Product |
+| Product Catalogue | 0.70 | 0.75 | 0.73 | Product |
+| Recommendation Engine | 0.40 | 0.35 | 0.38 | Custom |
+| Payment Gateway | 0.90 | 0.88 | 0.89 | Commodity |
+| Shopping Cart | 0.75 | 0.80 | 0.78 | Product/Commodity |
+| Identity / Auth | 0.80 | 0.85 | 0.83 | Commodity |
+| Order Management | 0.60 | 0.65 | 0.63 | Product |
+| Notification Service | 0.85 | 0.90 | 0.88 | Commodity |
+
+#### Step 5 — Draw Dependency Arrows
+
+Add arrows from dependent → dependency (top to bottom, left-to-right for evolution):
+
+```
+Product Discovery → Recommendation Engine → Customer Data
+Checkout → Payment Gateway
+Checkout → Identity / Auth
+Fulfilment → Notification Service
+```
+
+Arrows that cross from right to left (high evolution to low) highlight **dependency risk** — a mature, visible component relying on an immature dependency.
+
+#### Step 6 — Apply Validation Checklist
+
+Before finalizing the map, verify:
+
+```yaml
+validation:
+  anchor_present: true          # User and need clearly stated?
+  all_user_touchpoints_mapped:  # Everything the user directly interacts with?
+  dependencies_visible:         # Have you traced at least 2 levels down?
+  evolution_justified:          # Can you defend each component's position?
+  movement_arrows:              # Have you noted evolving components?
+  no_orphan_components:         # Every component connects to at least one other?
+  strategic_question_answered:  # Does the map help answer a specific decision?
+```
+
+---
+
+## Case Study Cross-References
+
+Brief pattern examples connecting well-known companies to Wardley Mapping gameplay patterns. For the full pattern descriptions, see [Gameplay Patterns](gameplay-patterns.md).
+
+### AWS — ILC Pattern (Innovate, Leverage, Commoditize)
+
+Amazon ran the ILC play across its own infrastructure:
+
+1. **Innovate**: Built custom-scale distributed infrastructure internally for Amazon.com (Genesis/Custom-Built)
+2. **Leverage**: Recognized that the infrastructure had value as a product — launched EC2 (2006) and S3 as commercial offerings (Custom → Product)
+3. **Commoditize**: Drove the market toward utility pricing, making competitors' infrastructure investments uneconomical
+
+The result: internal cost-centre became the world's largest cloud platform. The key insight was that what was necessary-but-not-differentiating *for Amazon* was differentiating *for everyone else*. Any organization can ask: "What have we built for ourselves that others would pay for?"
+
+### Netflix — Attacking Play (Platform Transition)
+
+Netflix used a Wardley attacking play to shift from a position of weakness to market leadership:
+
+1. **Identified the evolution**: Physical DVD rental was moving toward commodity (and eventually obsolescence); streaming infrastructure was emerging
+2. **Attacked with an alternative**: Launched streaming when infrastructure costs fell low enough to make it viable (cloud commoditizing bandwidth and compute)
+3. **Built the new ecosystem**: Developed content recommendation, original programming, and global delivery — creating defensible positions in what would otherwise be a commodity streaming market
+
+The attack succeeded because Netflix moved *before* incumbents (Blockbuster) accepted that the old model was dying. Inertia from their successful past model slowed their response.
+
+### Spotify — Two-Sided Market Play
+
+Spotify operates a two-factor market with three distinct user groups creating a flywheel:
+
+1. **Free users (scale)**: Provide data, content demand signals, and a large addressable market for advertisers
+2. **Premium subscribers (revenue)**: Convert from free tier; fund content licensing and platform development
+3. **Artists and labels (content)**: Attracted by the large user base, provide the content that attracts users
+
+The mapping insight: Spotify's true strategic asset is not the music (a commodity licensed from labels) but the **listener data** and **playlist/discovery graph** — both of which sit in the Custom-Built stage and are hard to replicate. The commodity content layer enables the differentiating data layer above it.
+
 For common mapping patterns and anti-patterns (Tower, Legacy Trap, Premature Innovation), see [Gameplay Patterns](gameplay-patterns.md).

--- a/arckit-opencode/skills/wardley-mapping/references/mathematical-models.md
+++ b/arckit-opencode/skills/wardley-mapping/references/mathematical-models.md
@@ -249,6 +249,152 @@ Moderate-to-strong signal — transitioning from Product to Commodity. (And inde
 
 ---
 
+---
+
+## D. Play-Position Scoring
+
+A quantitative framework for evaluating which gameplay options are viable given your current map position.
+
+### Core Formula
+
+```
+Play Score = Position_Match(0-1) × Capability_Fit(0-1) × (1 - Risk_Factor(0-1))
+```
+
+Higher scores indicate plays that are well-aligned with your position, executable with current capabilities, and have acceptable downside risk.
+
+### Position Match
+
+How well does the gameplay play align with the evolution position of the target components?
+
+```
+Position_Match scoring:
+  Play targets your current stage:        1.0   (e.g., ILC play on a Custom-Built component)
+  Play targets an adjacent stage:         0.6   (one stage left or right of current)
+  Play targets a distant stage:           0.2   (two stages away)
+```
+
+**Example**: An "Open Source" commoditization play on a Product-stage component (adjacent — targeting Commodity) scores 0.6. The same play on a Genesis-stage component (distant — skipping two stages) scores 0.2.
+
+### Capability Fit
+
+Can your organization actually execute this play? Assess against the prerequisites for the specific gameplay.
+
+```
+Capability_Fit scoring:
+  Have all prerequisites:                 1.0   (full capability to execute)
+  Have most prerequisites:                0.7   (minor gaps, fillable with investment)
+  Missing one key capability:             0.3   (significant gap requiring major effort)
+  Missing multiple key capabilities:      0.1   (play is currently out of reach)
+```
+
+**Example**: An ILC play requires engineering scale, platform capabilities, and sales channels. A startup with strong engineering but no sales or platform infrastructure scores 0.3.
+
+### Risk Factor
+
+What is the downside if the play fails or conditions change?
+
+```
+Risk_Factor scoring:
+  Low risk, fully reversible:             0.1   (easy to stop, low sunk cost)
+  Medium risk, partially reversible:      0.4   (moderate investment, some recovery possible)
+  High risk, largely irreversible:        0.8   (major commitment, hard to unwind)
+  Existential risk, irreversible:         0.95  (bet-the-company, failure = shutdown)
+```
+
+Note: The Risk_Factor is subtracted from 1.0 before multiplying — so higher risk *reduces* the play score.
+
+### Worked Example: Evaluating Three Plays
+
+A company with a Custom-Built analytics platform evaluates three possible plays:
+
+| Play | Position_Match | Capability_Fit | Risk_Factor | Play Score | Verdict |
+|------|---------------|----------------|-------------|------------|---------|
+| Productize platform (sell to others) | 1.0 (Custom→Product) | 0.7 (engineering ok, sales gap) | 0.4 (medium) | 1.0 × 0.7 × 0.6 = **0.42** | Viable with investment |
+| Open source to commoditize | 0.6 (adjacent→Commodity) | 0.3 (no community mgmt) | 0.4 (medium) | 0.6 × 0.3 × 0.6 = **0.11** | Not viable yet |
+| Deepen custom differentiation | 1.0 (stay in Custom) | 1.0 (core strength) | 0.1 (low) | 1.0 × 1.0 × 0.9 = **0.90** | Strong — continue investing |
+
+The scoring confirms the intuitive recommendation: double down on differentiation while building the sales capability needed to eventually productize.
+
+### Play Score Interpretation
+
+| Play Score | Recommendation |
+|------------|---------------|
+| 0.70 - 1.00 | Execute — strong alignment, capability, and acceptable risk |
+| 0.40 - 0.70 | Conditional — viable but address the weakest factor first |
+| 0.15 - 0.40 | Weak — significant gaps; develop prerequisites before attempting |
+| 0.00 - 0.15 | Avoid — misaligned, incapable, or too risky at current position |
+
+---
+
+## E. Climate Pattern Impact Weighting
+
+A scoring framework for prioritizing which components face the greatest strategic pressure from climatic patterns.
+
+### Impact Matrix
+
+For each climatic pattern identified on a map, score its impact on each component:
+
+```
+Impact Matrix: Pattern × Component → Score (1-5)
+
+Scoring scale:
+  5 = Pattern directly threatens or enables this component's current position
+  4 = Pattern significantly affects this component's evolution trajectory
+  3 = Pattern has moderate influence on this component
+  2 = Pattern has minor relevance to this component
+  1 = Pattern has negligible or no effect on this component
+```
+
+A score of 5 means: if you ignore this pattern for this component, you will likely make a wrong strategic decision. A score of 1 means: the pattern exists but has no actionable implication for this component.
+
+### Aggregate Scoring
+
+Once the matrix is populated, calculate three aggregate scores:
+
+```
+Component Risk Score  = Sum of all pattern impact scores for that component
+  → Identifies which components face the most cumulative climatic pressure
+
+Pattern Criticality   = Sum of all component impact scores for that pattern
+  → Identifies which patterns have the broadest effect across the value chain
+
+Priority Focus        = Components with the highest Component Risk Scores
+  → Where to direct monitoring, investment, or contingency planning
+```
+
+### Worked Example: TechnoGadget Smart Home
+
+Applying 5 climatic patterns to the TechnoGadget map (from [Mapping Examples](mapping-examples.md)):
+
+| Component | Everything Evolves | Inertia | Higher-Order Systems | Efficiency Enables Innovation | Competitors Change Game | Risk Score |
+|-----------|-------------------|---------|---------------------|------------------------------|------------------------|------------|
+| Smart thermostat | 4 | 5 | 2 | 1 | 5 | **17** |
+| Mobile app | 3 | 4 | 2 | 1 | 4 | **14** |
+| Cloud infrastructure | 2 | 1 | 5 | 5 | 1 | **14** |
+| Data analytics | 4 | 2 | 5 | 4 | 3 | **18** |
+| R&D | 3 | 1 | 4 | 4 | 2 | **14** |
+| API | 5 | 2 | 3 | 3 | 4 | **17** |
+| **Pattern Criticality** | **21** | **15** | **21** | **18** | **19** | |
+
+**Interpretation**:
+
+- **Data analytics** (18) and **Smart thermostat / API** (17 each) face the highest cumulative climatic pressure — these are the priority focus components
+- **Everything Evolves** and **Higher-Order Systems** tie as the most broadly impactful patterns (21 each) — both affect nearly every component
+- **Inertia** (15) scores lowest in criticality but scores highest on Smart thermostat (5) — it is highly concentrated on one critical component, not broadly distributed
+
+### Using the Matrix in Practice
+
+1. List all climatic patterns identified on the map (typically 3-8 for a focused analysis)
+2. Score each pattern against each component (5-minute workshop exercise per pattern)
+3. Sum rows (component risk) and columns (pattern criticality)
+4. Rank components by risk score — highest scores demand strategic attention
+5. For components scoring 15+ (in a 5-pattern analysis), develop explicit contingency responses
+
+The matrix is most useful as a workshop tool: it forces explicit discussion about *why* a pattern affects a component, surfaces disagreements in the team's mental models, and produces a defensible prioritization.
+
+---
+
 ## Further Reading
 
 These models are drawn from a broader mathematical framework for Wardley Mapping that includes game theory, stochastic processes, topological analysis, and Bayesian inference. For the full academic treatment, see the [Wardley Map Mathematical Model](https://github.com/tractorjuice/wardleymap_math_model) repository.

--- a/arckit-opencode/templates/wardley-climate-template.md
+++ b/arckit-opencode/templates/wardley-climate-template.md
@@ -1,0 +1,260 @@
+# Wardley Climate Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.climate`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Climate Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.climate` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the most significant climate forces acting on this landscape, the components under most pressure, and the key strategic implications. Include whether the overall climate is favourable, neutral, or threatening for the current strategy.]
+
+**Climate Severity**:
+
+| Category | Severity | Most Affected Components |
+|----------|----------|--------------------------|
+| Component Patterns | High / Medium / Low / None | {Component names} |
+| Financial Patterns | High / Medium / Low / None | {Component names} |
+| Speed Patterns | High / Medium / Low / None | {Component names} |
+| Inertia Patterns | High / Medium / Low / None | {Component names} |
+| Competitor Patterns | High / Medium / Low / None | {Component names} |
+| Prediction Patterns | High / Medium / Low / None | {Component names} |
+
+---
+
+## Map Reference
+
+This climate assessment is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+
+---
+
+## Component Inventory
+
+*Extracted from the referenced Wardley Map. All components subject to climate assessment.*
+
+| Component | Visibility | Evolution | Stage |
+|-----------|-----------|-----------|-------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 2} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 3} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 4} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+| {Component 5} | {0.xx} | {0.xx} | Genesis / Custom / Product / Commodity |
+
+---
+
+## Climate Assessment by Category
+
+### 1. Component Patterns
+
+*How do components naturally evolve and what forces act on them?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Everything evolves (no component stays still) | Yes / No / Partial | H / M / L | {Observation from the map or market} | {What this means for strategy} |
+| Characteristics change as components evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| No "one size fits all" method | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Success breeds inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems create new sources of worth | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Components can co-evolve | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new areas of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation enables new genesis | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 2. Financial Patterns
+
+*How do economic forces shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Efficiency enables innovation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Capital flows to new sources of value | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation reduces margin | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New economic models emerge (e.g., SaaS, platform) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Price pressure on product-stage components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Investment bias towards Genesis/Custom stages | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 3. Speed Patterns
+
+*How does the pace of change affect the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Evolution is not uniform (some components evolve faster) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Commoditisation is accelerating (shorter cycles) | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem effects accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Open source accelerates commoditisation | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Regulation can slow or accelerate evolution | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 4. Inertia Patterns
+
+*What forces resist change in this landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Past success creates resistance to change | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Existing practices embed inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Vendor lock-in creates artificial inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 5. Competitor Patterns
+
+*How do competitor behaviours shape the landscape?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Competitors also face inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants exploit incumbent inertia | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+### 6. Prediction Patterns
+
+*What can be reliably anticipated about how this landscape will change?*
+
+| Pattern | Applies? | Impact | Evidence | Strategic Implication |
+|---------|:--------:|:------:|----------|-----------------------|
+| Commoditisation of custom-built components is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Co-evolution of practice and technology is predictable | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Higher-order systems will emerge from current commodities | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Shifts from product to utility are visible before they occur | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| New entrants will appear at Genesis stage of key components | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Inertia creates predictable points of disruption | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Ecosystem plays follow commoditisation events | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+| Peace / War / Wonder cycles follow predictable patterns | Yes / No / Partial | H / M / L | {Observation} | {Strategic implication} |
+
+---
+
+## Per-Component Impact Matrix
+
+*How strongly does each climate category affect each component? H = High, M = Medium, L = Low, — = Not applicable.*
+
+| Component | Component Patterns | Financial Patterns | Speed Patterns | Inertia Patterns | Competitor Patterns | Prediction Patterns |
+|-----------|:-----------------:|:-----------------:|:--------------:|:----------------:|:------------------:|:------------------:|
+| {Component 1} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 2} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 3} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 4} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+| {Component 5} | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — | H / M / L / — |
+
+---
+
+## Prediction Horizons
+
+*Anticipated evolution of key components over the next 6 and 18 months.*
+
+| Component | Current Stage | 6-Month Prediction | 18-Month Prediction | Confidence | Key Signals |
+|-----------|:------------:|:-----------------:|:------------------:|:----------:|-------------|
+| {Component 1} | Genesis | Custom (0.30) | Custom (0.40) | High / Medium / Low | {Observable signals — market activity, open source, vendor releases} |
+| {Component 2} | Custom | Product (0.55) | Product (0.65) | High / Medium / Low | {Observable signals} |
+| {Component 3} | Product | Product (0.70) | Commodity (0.80) | High / Medium / Low | {Observable signals} |
+| {Component 4} | Commodity | Commodity (0.90) | Commodity (0.95) | High / Medium / Low | {Observable signals} |
+
+---
+
+## Wave Analysis
+
+**Peace / War / Wonder Cycle**:
+
+The Wardley climate framework identifies a recurring cycle in markets:
+
+- **Peace**: Steady improvement of existing products; incumbents dominant; gradual evolution
+- **War**: Rapid disruption as a new model (e.g., cloud, SaaS, open source) makes existing approaches obsolete; major market shift
+- **Wonder**: Post-disruption stabilisation; new commodity enables new genesis; ecosystem flourishes
+
+**Current Positioning for This Context**:
+
+| Market Segment | Current Phase | Evidence | Strategic Implication |
+|----------------|:------------:|----------|-----------------------|
+| {Segment 1} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+| {Segment 2} | Peace / War / Wonder | {Evidence supporting this classification} | {How to respond to this phase} |
+
+**Recommended Response to Phase**:
+
+- {If Peace}: {Strategy for steady-state market — consolidation, efficiency, incremental improvement}
+- {If War}: {Strategy for disruption — move fast, exploit inertia of incumbents, align with the new model}
+- {If Wonder}: {Strategy for post-disruption — explore new genesis opportunities enabled by the new commodity}
+
+---
+
+## Inertia Assessment
+
+| Component | Inertia Type | Severity | Mitigation Strategy |
+|-----------|-------------|:--------:|---------------------|
+| {Component 1} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 2} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+| {Component 3} | Skills / Process / Vendor / Cultural / Capital / Regulatory | H / M / L | {Specific mitigation plan} |
+
+**Inertia Type Definitions**:
+
+- **Skills**: Team expertise locked to legacy technology or practice
+- **Process**: Established workflows and procedures that resist change
+- **Vendor**: Contractual or technical dependencies that create switching costs
+- **Cultural**: "We've always done it this way" — organisational resistance
+- **Capital**: Sunk costs in existing systems justify continued investment
+- **Regulatory**: Compliance requirements that constrain or slow evolution
+
+---
+
+## Strategic Implications
+
+[3-5 bullet points summarising the most actionable strategic implications from the full climate assessment. Each point should connect a specific climate finding to a recommended strategic response.]
+
+- **{Implication 1}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 2}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 3}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 4}**: {Specific climate finding} → {Recommended strategic response}
+- **{Implication 5}**: {Specific climate finding} → {Recommended strategic response}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map; all components assessed in this document are derived from it |
+| Requirements | ARC-[PROJECT_ID]-REQ-v[VERSION] | Climate signals may invalidate or create new requirements |
+| Research | ARC-[PROJECT_ID]-RSCH-v[VERSION] | Market research provides evidence for climate pattern assessment |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.climate` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-opencode/templates/wardley-doctrine-template.md
+++ b/arckit-opencode/templates/wardley-doctrine-template.md
@@ -1,0 +1,290 @@
+# Wardley Doctrine Assessment: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.doctrine`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WDOC-v[VERSION] |
+| **Document Type** | Wardley Doctrine Assessment |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.doctrine` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+**Overall Maturity Score**: [X.X / 5.0] — [Novice / Developing / Practising / Advanced / Leading]
+
+**Phase Positioning**:
+
+| Phase | Name | Score | Status |
+|-------|------|-------|--------|
+| Phase I | Stop Self-Harm | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase II | Becoming More Context Aware | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase III | Better for Less | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+| Phase IV | Continuously Evolving | [X.X / 5.0] | [Not Started / In Progress / Achieved] |
+
+**Critical Findings**:
+
+1. {Most significant gap or risk from the assessment}
+2. {Second critical finding}
+3. {Third critical finding}
+
+[2-3 sentence narrative summary of the organisation's doctrine maturity and most urgent priorities.]
+
+---
+
+## Strategy Cycle Context
+
+| Element | Summary |
+|---------|---------|
+| **Purpose** | {Why does this organisation or team exist? What is the mission?} |
+| **Landscape** | {What does the Wardley Map of this context reveal? Key components and their evolution positions.} |
+| **Climate** | {What external forces are acting on this landscape? Market shifts, regulation, technology change.} |
+| **Leadership** | {What leadership style is currently in use? Commander's intent vs. detailed instruction? Risk appetite?} |
+
+---
+
+## Doctrine Assessment Matrix
+
+Score key: **1** = Not practised | **2** = Awareness only | **3** = Partially practised | **4** = Consistently practised | **5** = Embedded and exemplary
+
+### Phase I: Stop Self-Harm
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Communication | Use a common language | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Be transparent | [X] | {Evidence or observation} | {Specific action to improve} |
+| Communication | Challenge assumptions | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Know your users | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Focus on user needs | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use appropriate methods | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Remove bias and duplication | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Use standards where appropriate | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage inertia | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Manage failure | [X] | {Evidence or observation} | {Specific action to improve} |
+| Development | Think small (ecosystem) | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase II: Becoming More Context Aware
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Situational Awareness | Know the details | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Use appropriate doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Be aware of context-specific play | [X] | {Evidence or observation} | {Specific action to improve} |
+| Situational Awareness | Understand your environment | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Design for constant evolution | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Small teams with alignment and autonomy | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Move fast | [X] | {Evidence or observation} | {Specific action to improve} |
+| Structure | Be pragmatic | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | There is no one culture | [X] | {Evidence or observation} | {Specific action to improve} |
+| Strategy | Seek the best | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase III: Better for Less
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Efficiency | Optimise flow | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Effectiveness over efficiency | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Think big | [X] | {Evidence or observation} | {Specific action to improve} |
+| Efficiency | Strategy is iterative not linear | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Use multiple methods of working | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | A bias towards the new | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Be the owner | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Think aptitude and attitude | [X] | {Evidence or observation} | {Specific action to improve} |
+| Operations | Set exceptional standards | [X] | {Evidence or observation} | {Specific action to improve} |
+
+### Phase IV: Continuously Evolving
+
+| Category | Principle | Score (1-5) | Evidence | Improvement Action |
+|----------|-----------|:-----------:|----------|--------------------|
+| Learning | Listen to your ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | A bias towards action | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Exploit the landscape | [X] | {Evidence or observation} | {Specific action to improve} |
+| Learning | Understand that strategy is complex | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Commit to the path | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Accept uncertainty | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Spend time on doctrine | [X] | {Evidence or observation} | {Specific action to improve} |
+| Leadership | Lead the ecosystems | [X] | {Evidence or observation} | {Specific action to improve} |
+
+---
+
+## Detailed Phase Findings
+
+### Phase I: Stop Self-Harm — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase I Narrative**:
+
+[2-4 sentences describing the organisation's overall performance on Phase I. What self-harming behaviours are present? What is being done well?]
+
+---
+
+### Phase II: Becoming More Context Aware — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase II Narrative**:
+
+[2-4 sentences describing situational awareness maturity. Does the organisation understand its landscape? Does leadership have context for decisions?]
+
+---
+
+### Phase III: Better for Less — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase III Narrative**:
+
+[2-4 sentences describing efficiency and operational maturity. Where is the organisation wasting effort? Where are there genuine improvements?]
+
+---
+
+### Phase IV: Continuously Evolving — Detailed Findings
+
+**Phase Score**: [X.X / 5.0]
+
+**Strongest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores well, specific evidence}
+
+**Weakest principles in this phase**:
+
+- {Principle name} (Score: X) — {Why this scores poorly, specific evidence}
+
+**Phase IV Narrative**:
+
+[2-4 sentences describing the organisation's capacity for continuous evolution. Is learning embedded? Do ecosystems inform strategy?]
+
+---
+
+## Previous Assessment Comparison
+
+*Populate on re-assessment only. Leave blank for initial assessment.*
+
+| Principle | Previous Score | Current Score | Trend | Notes |
+|-----------|:--------------:|:-------------:|:-----:|-------|
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+| {Principle} | [X] | [X] | ↑ / ↓ / → | {What changed and why} |
+
+**Overall Score Change**: [Previous X.X] → [Current X.X] ([+/- delta])
+
+---
+
+## Critical Gaps
+
+| Rank | Phase | Category | Principle | Current Score | Target Score | Business Impact |
+|------|-------|----------|-----------|:-------------:|:------------:|-----------------|
+| 1 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 2 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 3 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 4 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+| 5 | {Phase} | {Category} | {Principle} | [X] | [X] | {Why this gap matters to the organisation} |
+
+---
+
+## Implementation Roadmap
+
+### Immediate Actions (0-3 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 1} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 2} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 3} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Short-Term Actions (3-12 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 4} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 5} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 6} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+### Long-Term Actions (12-24 months)
+
+| Action | Principle(s) Addressed | Owner | Success Criteria |
+|--------|----------------------|-------|------------------|
+| {Action 7} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+| {Action 8} | {Principle name(s)} | {Owner role} | {Measurable outcome} |
+
+---
+
+## Recommendations
+
+1. **{Recommendation 1}**
+   - **Rationale**: {Why this is the top priority}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+2. **{Recommendation 2}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+3. **{Recommendation 3}**
+   - **Rationale**: {Why this recommendation is important}
+   - **Expected Benefit**: {What improves if this is done}
+   - **Risk of Inaction**: {What happens if this is not done}
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Doctrine principles should align with and reinforce architecture principles |
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Landscape and climate context for this assessment |
+| Stakeholder Analysis | ARC-[PROJECT_ID]-STKE-v[VERSION] | Leadership and culture context; stakeholder awareness of doctrine |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.doctrine` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-opencode/templates/wardley-gameplay-template.md
+++ b/arckit-opencode/templates/wardley-gameplay-template.md
@@ -1,0 +1,337 @@
+# Wardley Gameplay Analysis: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.gameplay`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WGAM-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Gameplay Analysis |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.gameplay` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[2-4 sentences summarising the strategic context, the plays selected, and the anticipated outcomes. Include overall strategic posture: aggressive/defensive/opportunistic.]
+
+**Selected Plays Summary**:
+
+| Play | Category | Recommendation | Priority |
+|------|----------|----------------|----------|
+| {Play 1} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 2} | {Category A-K} | Apply | High / Medium / Low |
+| {Play 3} | {Category A-K} | Monitor | High / Medium / Low |
+
+---
+
+## Map Reference
+
+This gameplay analysis is derived from the following Wardley Map artifact:
+
+| Field | Value |
+|-------|-------|
+| **WARD Document ID** | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] |
+| **Map Title** | {map_title} |
+| **Map Date** | [YYYY-MM-DD] |
+| **Key Components** | {List 3-5 key components from the map} |
+
+---
+
+## Situational Assessment
+
+### Position Analysis
+
+*What does your current map position tell you about strategic options?*
+
+- **Anchor (User Need)**: {Anchor component and its evolution position}
+- **Differentiating Components**: {Components in Genesis/Custom that provide competitive advantage}
+- **Commodity Dependencies**: {Components already at commodity — not strategic, cost-focus only}
+- **Evolution Pressure**: {Components showing signs of rapid evolution — where the map is moving}
+
+### Capability Assessment
+
+*What can your organisation do well, and where are the gaps?*
+
+- **Core Strengths**: {What the organisation does better than competitors in this landscape}
+- **Critical Weaknesses**: {Capability gaps that constrain strategic options}
+- **Unique Assets**: {Assets, data, relationships, or IP that could be leveraged}
+- **Constraints**: {Budget, skills, regulatory, or time constraints affecting play selection}
+
+### Market Context
+
+*What is happening in the competitive environment?*
+
+- **Competitor Positions**: {Where are key competitors positioned on the map?}
+- **Market Signals**: {What trends indicate where the market is heading?}
+- **Regulatory Environment**: {Any constraints or opportunities from regulation?}
+- **Partnership Opportunities**: {Potential ecosystem partners or coalition plays?}
+
+---
+
+## Play Options by Category
+
+### A. Accelerator Plays
+
+*Speed up component evolution to reshape the landscape.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Open approaches (open source, open data, open standards) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Exploit the ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Contribute to standards bodies | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### B. Decelerator Plays
+
+*Slow down competitor evolution or commoditisation.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| FUD (Fear, Uncertainty, Doubt) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Differentiation | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Lobbying and regulatory influence | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### C. Market Plays
+
+*Shape market conditions in your favour.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Buyer and supplier education | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Press and analyst briefings | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### D. Defensive Plays
+
+*Protect your position from competitive threats.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Protective moat (IP, switching costs) | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Embrace and extend | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Threat acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### E. Attacking Plays
+
+*Move against competitor positions.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Exploiting inertia | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Undermining barriers to entry | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Talent acquisition | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### F. Ecosystem Plays
+
+*Leverage or build ecosystems for competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Building a platform | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Co-opting an ecosystem | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Creating a pricing game | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### G. Positional Plays
+
+*Move to advantageous positions on the map.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Tower and moat | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Land grab | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Sensing engine | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### H. Poison Plays
+
+*Make a position undesirable for competitors.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Disposal of a liability | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Swamping | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### I. Innovation Plays
+
+*Create new value through novel combinations.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Design for uncharted spaces | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Signal distortion | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### J. People Plays
+
+*Leverage talent and culture as competitive advantage.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Centres of gravity | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Pioneer / settler / town planner model | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+### K. Political Plays
+
+*Navigate organisational or market politics.*
+
+| Play Name | Alignment | Applicability | Recommendation |
+|-----------|-----------|---------------|----------------|
+| Creating artificial constraints | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+| Trojan horse | High / Medium / Low | {Why or why not applicable} | Apply / Monitor / Skip |
+
+---
+
+## Play-Position Matrix Evaluation
+
+*For each key component position on the map, identify which plays are naturally aligned.*
+
+| Component | Visibility | Evolution | Stage | Recommended Plays | Rationale |
+|-----------|-----------|-----------|-------|-------------------|-----------|
+| {Component 1} | {0.xx} | {0.xx} | Genesis | {Play names} | {Why these plays fit this position} |
+| {Component 2} | {0.xx} | {0.xx} | Custom | {Play names} | {Why these plays fit this position} |
+| {Component 3} | {0.xx} | {0.xx} | Product | {Play names} | {Why these plays fit this position} |
+| {Component 4} | {0.xx} | {0.xx} | Commodity | {Play names} | {Why these plays fit this position} |
+
+---
+
+## Play Compatibility Analysis
+
+*Evaluate whether selected plays reinforce or conflict with each other.*
+
+| Play A | Play B | Compatibility | Notes |
+|--------|--------|:-------------:|-------|
+| {Play 1} | {Play 2} | Reinforces | {Why these plays work well together} |
+| {Play 1} | {Play 3} | Neutral | {No significant interaction} |
+| {Play 2} | {Play 4} | Conflicts | {Why these plays undermine each other — resolve or sequence carefully} |
+
+**Resolution for conflicts**: {Describe how conflicting plays will be sequenced or one prioritised over the other.}
+
+---
+
+## Selected Plays
+
+### Play 1: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1 — capability, resource, or condition that must be in place}
+- {Prerequisite 2}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+3. {Step 3}
+
+**Expected Outcomes**:
+
+- {Outcome 1 — what success looks like}
+- {Outcome 2}
+
+**Risks**:
+
+- {Risk 1 — what could go wrong}
+- {Risk 2}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+- [ ] {Measurable indicator 2}
+
+**Review Points**: {When to review whether this play is working — e.g., 3 months, after specific milestone}
+
+---
+
+### Play 2: {Play Name}
+
+**Category**: {A-K}
+**Description**: {What this play involves and how it works in this context}
+**Prerequisites**:
+
+- {Prerequisite 1}
+
+**Execution Steps**:
+
+1. {Step 1}
+2. {Step 2}
+
+**Expected Outcomes**:
+
+- {Outcome 1}
+
+**Risks**:
+
+- {Risk 1}
+
+**Success Criteria**:
+
+- [ ] {Measurable indicator 1}
+
+**Review Points**: {When to review whether this play is working}
+
+---
+
+## Risk Assessment and Anti-Patterns
+
+### Play-Specific Risks
+
+| Risk | Play Affected | Likelihood | Impact | Mitigation |
+|------|--------------|------------|--------|------------|
+| {Risk 1} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+| {Risk 2} | {Play name} | H / M / L | H / M / L | {Mitigation strategy} |
+
+### Common Gameplay Anti-Patterns to Avoid
+
+- **Playing too many games at once**: Focus on 2-3 plays maximum; spreading effort dilutes impact
+- **Ignoring inertia**: Plays that require rapid evolution will stall if internal or market inertia is not addressed
+- **Misreading evolution stage**: Applying Genesis plays to Commodity components (or vice versa) wastes resources
+- **Neglecting doctrine**: Gameplay without sound doctrine (Phase I) often backfires
+- **Static play selection**: Plays that are right today may be wrong in 12 months — review regularly
+
+---
+
+## Case Study References
+
+| Case Study | Play(s) Illustrated | Source | Relevance to This Context |
+|------------|---------------------|--------|--------------------------|
+| {Case study 1} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+| {Case study 2} | {Play names} | {Book / article / talk} | {Why this case is instructive here} |
+
+**Reference**: Simon Wardley, *Wardley Maps* (CC BY-SA 4.0) — available at [https://learnwardleymapping.com/](https://learnwardleymapping.com/)
+
+---
+
+## Traceability
+
+| Artifact | Document ID | Relationship |
+|----------|-------------|--------------|
+| Wardley Map | ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION] | Source map providing landscape context for play selection |
+| Climate Assessment | ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION] | Climate patterns that constrain or enable specific plays |
+| Doctrine Assessment | ARC-[PROJECT_ID]-WDOC-v[VERSION] | Doctrine maturity governs which plays are executable |
+| Architecture Principles | ARC-[PROJECT_ID]-PRIN-v[VERSION] | Plays must not violate established architecture principles |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.gameplay` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/arckit-opencode/templates/wardley-value-chain-template.md
+++ b/arckit-opencode/templates/wardley-value-chain-template.md
@@ -1,0 +1,216 @@
+# Wardley Value Chain: {context_name}
+
+> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.wardley.value-chain`
+
+## Document Control
+
+| Field | Value |
+|-------|-------|
+| **Document ID** | ARC-[PROJECT_ID]-WVCH-[NNN]-v[VERSION] |
+| **Document Type** | Wardley Value Chain |
+| **Project** | [PROJECT_NAME] (Project [PROJECT_ID]) |
+| **Classification** | [PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET] |
+| **Status** | [DRAFT / IN_REVIEW / APPROVED / PUBLISHED / SUPERSEDED / ARCHIVED] |
+| **Version** | [VERSION] |
+| **Created Date** | [YYYY-MM-DD] |
+| **Last Modified** | [YYYY-MM-DD] |
+| **Review Cycle** | [Monthly / Quarterly / Annual / On-Demand] |
+| **Next Review Date** | [YYYY-MM-DD] |
+| **Owner** | [OWNER_NAME_AND_ROLE] |
+| **Reviewed By** | [REVIEWER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Approved By** | [APPROVER_NAME] ([YYYY-MM-DD]) or PENDING |
+| **Distribution** | [DISTRIBUTION_LIST] |
+
+## Revision History
+
+| Version | Date | Author | Changes | Approved By | Approval Date |
+|---------|------|--------|---------|-------------|---------------|
+| [VERSION] | [DATE] | ArcKit AI | Initial creation from `/arckit.wardley.value-chain` command | PENDING | PENDING |
+
+---
+
+## Executive Summary
+
+[Provide a concise summary of the value chain: its anchor (user need), the number of components, key dependencies, and the most critical strategic insights. 3-5 sentences.]
+
+---
+
+## User Need / Anchor
+
+The anchor is the user need at the top of the chain — the reason the value chain exists. Every component below the anchor must ultimately serve this need. If the anchor is wrong, the entire chain is wrong.
+
+**Anchor Statement**: [Describe the user need in one sentence, e.g., "Citizen can apply for a permit online without visiting an office."]
+
+**Good Anchor Examples**:
+
+- "User can access their medical records securely from any device"
+- "Taxpayer can file a return in under 15 minutes"
+- "Procurement team can evaluate vendor bids in a standardised format"
+
+**Bad Anchor Examples** (too technology-focused, not user-centred):
+
+- "System processes API calls" — this is a capability, not a user need
+- "Database stores records" — this is infrastructure, not a user need
+- "Microservices communicate via message bus" — this is implementation, not purpose
+
+---
+
+## Users and Personas
+
+| Persona | Role | Primary Need |
+|---------|------|--------------|
+| {Persona 1} | {Role description} | {Primary need this chain serves} |
+| {Persona 2} | {Role description} | {Primary need this chain serves} |
+| {Persona 3} | {Role description} | {Primary need this chain serves} |
+
+---
+
+## Value Chain Diagram
+
+**View this map**: Paste the OWM syntax below into [https://create.wardleymaps.ai](https://create.wardleymaps.ai)
+
+**ASCII Placeholder**:
+
+```text
+Visibility
+    ^
+1.0 | [User Need / Anchor]
+    |         |
+0.7 |   [Capability A]  [Capability B]
+    |         |               |
+0.4 |   [Component C]  [Component D]  [Component E]
+    |         |
+0.1 |   [Infrastructure F]
+    |
+    +--Genesis--Custom--Product--Commodity-->  Evolution
+       (0.0)   (0.25)  (0.50)   (0.75)  (1.0)
+```
+
+**OWM Syntax**:
+
+```wardley
+title {context_name} Value Chain
+anchor {UserNeed} [0.95, 0.63]
+
+component {CapabilityA} [0.70, 0.45]
+component {CapabilityB} [0.70, 0.72]
+component {ComponentC} [0.42, 0.38]
+component {ComponentD} [0.40, 0.65]
+component {ComponentE} [0.38, 0.80]
+component {InfrastructureF} [0.12, 0.90]
+
+{UserNeed} -> {CapabilityA}
+{UserNeed} -> {CapabilityB}
+{CapabilityA} -> {ComponentC}
+{CapabilityA} -> {ComponentD}
+{CapabilityB} -> {ComponentE}
+{ComponentC} -> {InfrastructureF}
+
+style wardley
+```
+
+---
+
+## Component Inventory
+
+| ID | Component | Description | Depends On | Visibility (0.0-1.0) |
+|----|-----------|-------------|------------|----------------------|
+| C-01 | {Component 1} | {Description} | — | {0.00} |
+| C-02 | {Component 2} | {Description} | C-01 | {0.00} |
+| C-03 | {Component 3} | {Description} | C-01, C-02 | {0.00} |
+| C-04 | {Component 4} | {Description} | C-02 | {0.00} |
+| C-05 | {Component 5} | {Description} | C-03, C-04 | {0.00} |
+
+---
+
+## Dependency Matrix
+
+The dependency matrix shows which components (rows) depend on which other components (columns). A cell marked **X** indicates a direct dependency; **I** indicates an indirect dependency; blank indicates no dependency.
+
+| | C-01 | C-02 | C-03 | C-04 | C-05 |
+|---|------|------|------|------|------|
+| **C-01** | — | | | | |
+| **C-02** | X | — | | | |
+| **C-03** | X | X | — | | |
+| **C-04** | | X | | — | |
+| **C-05** | I | I | X | X | — |
+
+[Replace placeholder rows/columns with actual component IDs from the Component Inventory above.]
+
+---
+
+## Critical Path Analysis
+
+The critical path is the sequence of dependencies from the anchor down to the lowest-level infrastructure component(s), where a failure at any step breaks the chain entirely.
+
+**Critical Path**:
+
+```text
+[User Need / Anchor]
+  └─> [Component X]  (Visibility: 0.xx, Evolution: 0.xx)
+        └─> [Component Y]  (Visibility: 0.xx, Evolution: 0.xx)
+              └─> [Component Z]  (Visibility: 0.xx, Evolution: 0.xx)
+```
+
+**Bottlenecks and Single Points of Failure**:
+
+| Component | Risk Type | Impact if Failed | Mitigation |
+|-----------|-----------|------------------|------------|
+| {Component} | Single vendor / Genesis fragility / Low maturity | {Impact description} | {Mitigation plan} |
+
+**Resilience Gaps**:
+
+- [ ] {Identify components with no fallback or redundancy}
+- [ ] {Identify dependencies on Genesis-stage components}
+- [ ] {Identify vendor lock-in on critical path}
+
+---
+
+## Validation Checklist
+
+- [ ] Chain starts with user need (anchor)
+- [ ] All critical dependencies captured
+- [ ] Chain reaches commodity level
+- [ ] No orphan components
+- [ ] Dependencies reflect reality
+- [ ] Visibility ordering correct
+- [ ] Granularity appropriate for purpose
+
+---
+
+## Visibility Assessment
+
+| Level | Range | Characteristics | Examples |
+|-------|-------|-----------------|---------|
+| **User-facing** | 0.90 - 1.00 | Directly experienced by the user; failure is immediately visible | Login page, search results, payment confirmation |
+| **High** | 0.70 - 0.89 | Close to user; users notice degradation quickly | API gateway, authentication service, user profile |
+| **Medium-High** | 0.50 - 0.69 | Indirectly visible; affects features users rely on | Business logic layer, data validation, reporting engine |
+| **Medium** | 0.30 - 0.49 | Hidden from users but essential to operations; failure noticed over time | Caching layer, queue management, audit logging |
+| **Low** | 0.10 - 0.29 | Invisible to users; operational/infrastructure concern | Database engine, message broker, network routing |
+| **Infrastructure** | 0.00 - 0.09 | Deep infrastructure; users unaware it exists | Power supply, physical server, OS kernel |
+
+---
+
+## Assumptions and Open Questions
+
+**Assumptions Made**:
+
+| # | Assumption | Basis | Confidence |
+|---|------------|-------|------------|
+| A-01 | {Assumption 1} | {Evidence or rationale} | High / Medium / Low |
+| A-02 | {Assumption 2} | {Evidence or rationale} | High / Medium / Low |
+
+**Open Questions**:
+
+| # | Question | Owner | Due Date |
+|---|----------|-------|----------|
+| Q-01 | {Open question 1} | {Owner} | [YYYY-MM-DD] |
+| Q-02 | {Open question 2} | {Owner} | [YYYY-MM-DD] |
+
+---
+
+**Generated by**: ArcKit `/arckit.wardley.value-chain` command
+**Generated on**: [DATE]
+**ArcKit Version**: [VERSION]
+**Project**: [PROJECT_NAME]
+**Model**: [AI_MODEL]

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -143,8 +143,20 @@ Most commands in this tier require or strongly recommend ARC-*-REQ-*.md:
 - **dfd** → Depends on: requirements (O), data-model (R), principles (O), diagram (O)
   - Note: Can generate DFDs from user description alone; richer output when requirements and data-model exist
   - Multi-instance document type (ARC-*-DFD-{NUM}-v*.md)
+- **wardley.value-chain** → Depends on: requirements (M), stakeholders (R)
+  - Note: Decomposes user needs into value chains for Wardley Mapping; produces WVCH artifacts
+  - Multi-instance document type (ARC-*-WVCH-{NUM}-v*.md), stored in wardley-maps/ subdirectory
 - **wardley** → Depends on: requirements (R), principles (R), research (O), data-model (O), tcop (O), ai-playbook (O)
   - Note: Can create initial map from user description alone; enhanced with requirements, principles, research
+- **wardley.doctrine** → Depends on: principles (M), wardley (R), stakeholders (R)
+  - Note: Assesses organizational doctrine maturity across 4 phases and 40+ principles; produces WDOC artifact
+  - Single instance per project (ARC-*-WDOC-v*.md), stored in wardley-maps/ subdirectory
+- **wardley.gameplay** → Depends on: wardley (M), wardley.climate (R), wardley.doctrine (R)
+  - Note: Analyzes strategic plays from 60+ gameplay patterns; produces WGAM artifacts
+  - Multi-instance document type (ARC-*-WGAM-{NUM}-v*.md), stored in wardley-maps/ subdirectory
+- **wardley.climate** → Depends on: wardley (M), requirements (R), research (R)
+  - Note: Assesses 32 climatic patterns affecting mapped components; produces WCLM artifacts
+  - Multi-instance document type (ARC-*-WCLM-{NUM}-v*.md), stored in wardley-maps/ subdirectory
 - **diagram** → Depends on: requirements (O), platform-design (R)
   - Note: Can generate diagrams from user description alone; richer output when requirements and other artifacts exist
 - **adr** → Depends on: principles (R), requirements (R), risk (R), stakeholders (O), research (O), wardley (O)
@@ -353,13 +365,21 @@ principles-compliance → conformance → analyze → service-assessment → sto
 
 ## Version
 
-- **ArcKit Version**: 1.5.0
-- **Matrix Date**: 2026-02-25
-- **Commands Documented**: 60
-- **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
+- **ArcKit Version**: 1.6.0
+- **Matrix Date**: 2026-03-16
+- **Commands Documented**: 64
+- **Matrix Rows**: 58 (56 document-generating commands + 2 external documents)
 - **Note**: `/arckit.customize`, `/arckit.template-builder`, `/arckit.health`, `/arckit.search`, `/arckit.impact`, `/arckit.init`, and `/arckit.start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
+
+### 2026-03-16 - Wardley Mapping Suite
+
+- **Added**: wardley.value-chain command — Depends on: requirements (M), stakeholders (R). Produces WVCH artifacts
+- **Added**: wardley.doctrine command — Depends on: principles (M), wardley (R), stakeholders (R). Produces WDOC artifacts
+- **Added**: wardley.gameplay command — Depends on: wardley (M), wardley.climate (R), wardley.doctrine (R). Produces WGAM artifacts
+- **Added**: wardley.climate command — Depends on: wardley (M), requirements (R), research (R). Produces WCLM artifacts
+- **Updated**: Commands documented from 60 to 64
 
 ### 2026-03-13 - Dependency Matrix Audit Fixes
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,10 @@ Complete documentation for ArcKit - Enterprise Architecture Governance & Vendor 
 - [Framework Design](guides/framework.md) - `/arckit.framework`
 - [Platform Design](guides/platform-design.md) - `/arckit.platform-design`
 - [Wardley Mapping](guides/wardley.md) - `/arckit.wardley`
+- [Value Chain Decomposition](guides/wardley-value-chain.md) - `/arckit.wardley.value-chain`
+- [Doctrine Assessment](guides/wardley-doctrine.md) - `/arckit.wardley.doctrine`
+- [Gameplay Analysis](guides/wardley-gameplay.md) - `/arckit.wardley.gameplay`
+- [Climate Assessment](guides/wardley-climate.md) - `/arckit.wardley.climate`
 - [Data Mesh Contract](guides/data-mesh-contract.md) - `/arckit.data-mesh-contract`
 - [C4 Layout Science](guides/c4-layout-science.md) - Research-backed diagram layout
 
@@ -189,7 +193,11 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.aws-research` | [aws-research.md](guides/aws-research.md) | ✅ Complete |
 | `/arckit.gcp-research` | [gcp-research.md](guides/gcp-research.md) | ✅ Complete |
 | `/arckit.datascout` | [datascout.md](guides/datascout.md) | ✅ Complete |
-| `/arckit.wardley` | [wardley-mapping.md](guides/wardley-mapping.md) | ✅ Complete |
+| `/arckit.wardley` | [wardley.md](guides/wardley.md) | ✅ Complete |
+| `/arckit.wardley.value-chain` | [wardley-value-chain.md](guides/wardley-value-chain.md) | ✅ Complete |
+| `/arckit.wardley.doctrine` | [wardley-doctrine.md](guides/wardley-doctrine.md) | ✅ Complete |
+| `/arckit.wardley.gameplay` | [wardley-gameplay.md](guides/wardley-gameplay.md) | ✅ Complete |
+| `/arckit.wardley.climate` | [wardley-climate.md](guides/wardley-climate.md) | ✅ Complete |
 | `/arckit.roadmap` | [roadmap.md](guides/roadmap.md) | ✅ Complete |
 | `/arckit.strategy` | [strategy.md](guides/strategy.md) | ✅ Complete |
 | `/arckit.adr` | [adr.md](guides/adr.md) | ✅ Complete |
@@ -233,7 +241,7 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
 | `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
 
-**Coverage**: 60/60 commands documented (100%)
+**Coverage**: 64/64 commands documented (100%)
 
 ---
 

--- a/docs/WORKFLOW-DIAGRAMS.md
+++ b/docs/WORKFLOW-DIAGRAMS.md
@@ -586,6 +586,56 @@ graph TD
 
 ---
 
+## 6. Wardley Mapping Suite
+
+The Wardley Mapping suite provides a focused strategic analysis pipeline. Value chain decomposition feeds into map creation, which then branches into three parallel analysis tracks.
+
+```mermaid
+graph TD
+    %% Prerequisites
+    A[requirements] --> B[wardley.value-chain]
+    C[principles] -.-> B
+    D[stakeholders] -.-> B
+
+    %% Core mapping
+    B --> E[wardley]
+
+    %% Analysis tracks (parallel after map creation)
+    E --> F[wardley.doctrine]
+    E --> G[wardley.climate]
+    E --> H[wardley.gameplay]
+
+    %% Cross-feed between analysis tracks
+    G -.-> H
+    F -.-> H
+
+    %% Downstream
+    E --> I[roadmap]
+    E --> J[strategy]
+    H -.-> J
+
+    style A fill:#90EE90
+    style B fill:#87CEEB
+    style C fill:#87CEEB
+    style D fill:#87CEEB
+    style E fill:#90EE90
+    style F fill:#9370DB
+    style G fill:#9370DB
+    style H fill:#9370DB
+    style I fill:#90EE90
+    style J fill:#90EE90
+```
+
+**Key:**
+
+- **Blue boxes** = Foundation inputs and value chain decomposition
+- **Green boxes** = Core workflow (requirements, wardley map, downstream)
+- **Purple boxes** = Wardley analysis tracks (doctrine, climate, gameplay)
+
+**Duration**: 1-3 weeks (within the Alpha phase)
+
+---
+
 ## Command Dependency Legend
 
 ### Dependency Types in Diagrams
@@ -603,7 +653,7 @@ graph TD
 | 3 | Business Justification | sobc |
 | 4 | Requirements | requirements |
 | 5 | Strategic Planning & Synthesis | platform-design, roadmap, strategy, framework, glossary |
-| 6 | Detailed Design | data-model, data-mesh-contract, dpia, research, azure-research*, aws-research*, gcp-research*, datascout, dfd, wardley, diagram, adr |
+| 6 | Detailed Design | data-model, data-mesh-contract, dpia, research, azure-research*, aws-research*, gcp-research*, datascout, dfd, wardley, wardley.value-chain, wardley.doctrine, wardley.gameplay, wardley.climate, diagram, adr |
 | 7 | Procurement | sow, dos, gcloud-search, gcloud-clarify, evaluate, score |
 | 8 | Design Reviews | hld-review, dld-review |
 | 9 | Implementation | backlog |
@@ -757,12 +807,14 @@ graph LR
 
 ## Version
 
-- **ArcKit Version**: 1.2.0
-- **Document Date**: 2026-02-25
+- **ArcKit Version**: 1.3.0
+- **Document Date**: 2026-03-16
 - **Based On**: DEPENDENCY-MATRIX.md (with Phase 2 R-level dependencies)
-- **Commands Documented**: 44
+- **Commands Documented**: 48
 - **Key Changes**:
-  - Added conformance node to all 5 workflow paths (between principles-compliance and analyze)
+  - Added Wardley Mapping Suite workflow diagram (wardley.value-chain, wardley.doctrine, wardley.climate, wardley.gameplay)
+  - Updated Tier 6 Detailed Design to include 4 new Wardley suite commands
+  - Previous: Added conformance node to all 5 workflow paths (between principles-compliance and analyze)
   - Added conformance to Compliance-Only Path and Gantt chart
   - Updated Tier 13 Compliance to include conformance
   - Previous: Added missing style definitions for finops nodes in all workflow diagrams

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "60 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">60 AI Commands</span>
+            <span class="app-page-hero__stat">64 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">60 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">64 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">60</span> of 60 commands
+                Showing <span id="visible-count">64</span> of 64 commands
             </div>
         </div>
 
@@ -894,6 +894,34 @@
                             <a href="https://tractorjuice.github.io/arckit-test-project-v11-national-highways-data/#projects/001-national-highways-data-architecture-modernization/wardley-maps/ARC-001-WARD-001-v1.0.md" title="Highways">v11</a>
                             <a href="https://tractorjuice.github.io/arckit-test-project-v14-scottish-courts/#projects/001-scts-genai-programme/wardley-maps/ARC-001-WARD-001-v1.0.md" title="SCTS">v14</a>
                         </td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="detailed-design">
+                        <td><code>/arckit.wardley.value-chain</code></td>
+                        <td class="description">Decompose user needs into value chain components with evolution positioning and movement analysis</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="detailed-design">
+                        <td><code>/arckit.wardley.doctrine</code></td>
+                        <td class="description">Assess organisational doctrine maturity across 40+ universally useful principles</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="detailed-design">
+                        <td><code>/arckit.wardley.climate</code></td>
+                        <td class="description">Analyze climatic patterns affecting your landscape — identify forces shaping evolution and competition</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="detailed-design">
+                        <td><code>/arckit.wardley.gameplay</code></td>
+                        <td class="description">Analyze strategic plays from 60+ gameplay patterns with position-aware scoring and D&amp;D alignment</td>
+                        <td>Detailed Design</td>
+                        <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
                     <tr data-status="live" data-category="detailed-design">
@@ -1374,6 +1402,10 @@
                                 <th class="app-dep-matrix__col-header" scope="col"><span>gcp-research</span></th>
                                 <th class="app-dep-matrix__col-header" scope="col"><span>datascout</span></th>
                                 <th class="app-dep-matrix__col-header" scope="col"><span>wardley</span></th>
+                                <th class="app-dep-matrix__col-header" scope="col"><span>wardley.value-chain</span></th>
+                                <th class="app-dep-matrix__col-header" scope="col"><span>wardley.doctrine</span></th>
+                                <th class="app-dep-matrix__col-header" scope="col"><span>wardley.climate</span></th>
+                                <th class="app-dep-matrix__col-header" scope="col"><span>wardley.gameplay</span></th>
                                 <th class="app-dep-matrix__col-header" scope="col"><span>roadmap</span></th>
                                 <th class="app-dep-matrix__col-header" scope="col"><span>strategy</span></th>
                                 <th class="app-dep-matrix__col-header" scope="col"><span>adr</span></th>
@@ -1410,11 +1442,15 @@
                         </thead>
                         <tbody>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 0: Foundation</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 0: Foundation</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">plan</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="plan self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1495,6 +1531,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="principles required by devops">M</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1515,7 +1555,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 1: Strategic Context</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 1: Strategic Context</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">stakeholders</td>
@@ -1567,9 +1607,13 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 2: Risk & Justification</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 2: Risk & Justification</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">risk</td>
@@ -1578,6 +1622,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="risk requires stakeholders (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="risk self"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="risk can use sobc (optional)">O</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1672,9 +1720,13 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 4: Requirements</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 4: Requirements</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">requirements</td>
@@ -1684,6 +1736,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="requirements recommends risk">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="requirements requires sobc (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="requirements self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1728,7 +1784,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 5: Strategic Planning</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 5: Strategic Planning</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">platform-design</td>
@@ -1748,6 +1804,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="platform-design recommends wardley">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="platform-design can use roadmap (optional)">O</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1799,6 +1859,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="roadmap recommends wardley">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="roadmap self"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1850,6 +1914,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="strategy recommends wardley">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="strategy recommends roadmap">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="strategy self"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1884,7 +1952,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 6: Detailed Design</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 6: Detailed Design</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">data-model</td>
@@ -1903,6 +1971,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="data-model recommends datascout">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -1987,6 +2059,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">dpia</td>
@@ -2005,6 +2081,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="dpia can use datascout (optional)">O</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2089,6 +2169,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">azure-research</td>
@@ -2104,6 +2188,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="azure-research self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2156,6 +2244,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="aws-research recommends research">R</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="aws-research self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2242,6 +2334,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">datascout</td>
@@ -2260,6 +2356,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="datascout self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2344,6 +2444,230 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                            </tr>
+                            <tr>
+                                <td class="app-dep-matrix__row-label">wardley.value-chain</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.value-chain recommends stakeholders">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="wardley.value-chain requires requirements (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="wardley.value-chain self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                            </tr>
+                            <tr>
+                                <td class="app-dep-matrix__row-label">wardley.doctrine</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="wardley.doctrine requires principles (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.doctrine recommends stakeholders">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.doctrine recommends wardley">R</td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.doctrine recommends wardley.value-chain">R</td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="wardley.doctrine self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                            </tr>
+                            <tr>
+                                <td class="app-dep-matrix__row-label">wardley.climate</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.climate recommends requirements">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.climate recommends research">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="wardley.climate requires wardley (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.climate recommends wardley.value-chain">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="wardley.climate self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                            </tr>
+                            <tr>
+                                <td class="app-dep-matrix__row-label">wardley.gameplay</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="wardley.gameplay requires wardley (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.gameplay recommends wardley.doctrine">R</td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="wardley.gameplay recommends wardley.climate">R</td>
+                                <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="wardley.gameplay self"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">diagram</td>
@@ -2363,6 +2687,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="diagram recommends gcp-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="diagram can use datascout (optional)">O</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="diagram can use wardley (optional)">O</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2416,6 +2744,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="adr self"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2448,7 +2780,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 7: Procurement</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 7: Procurement</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">sow</td>
@@ -2463,6 +2795,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="sow recommends dpia">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="sow recommends research">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2509,6 +2845,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="dos requires requirements (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2573,6 +2913,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="gcloud-search can use sow (optional)">O</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="gcloud-search self"></td>
@@ -2616,6 +2960,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="gcloud-clarify can use research (optional)">O</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2675,6 +3023,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="evaluate recommends sow">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="evaluate recommends dos">R</td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2706,7 +3058,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 8: Design Reviews</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 8: Design Reviews</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">hld-review</td>
@@ -2716,6 +3068,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="hld-review recommends risk">R</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="hld-review requires requirements (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2785,6 +3141,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="dld-review requires hld-review (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="dld-review self"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2811,7 +3171,7 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="dld-review requires DLD (mandatory)">M</td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 9: Implementation</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 9: Implementation</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">backlog</td>
@@ -2829,6 +3189,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="backlog recommends azure-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="backlog recommends aws-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="backlog recommends gcp-research">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2892,6 +3256,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="trello requires backlog (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="trello self"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2916,7 +3284,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 11: Operations</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 11: Operations</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">servicenow</td>
@@ -2927,6 +3295,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="servicenow requires requirements (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="servicenow recommends data-model">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -2999,6 +3371,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="devops recommends diagram">R</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="devops self"></td>
@@ -3036,6 +3412,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="mlops recommends azure-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="mlops recommends aws-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="mlops recommends gcp-research">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3101,6 +3481,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="finops recommends diagram">R</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="finops recommends devops">R</td>
@@ -3130,6 +3514,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="operationalize recommends risk">R</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="operationalize requires requirements (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3199,6 +3587,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="traceability requires hld-review (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="traceability requires dld-review (mandatory)">M</td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3225,7 +3617,7 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="traceability requires DLD (mandatory)">M</td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 12-13: Quality & Compliance</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 12-13: Quality & Compliance</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">analyze</td>
@@ -3239,6 +3631,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="analyze recommends dpia">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3290,6 +3686,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="principles-compliance recommends platform-design">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="principles-compliance recommends dpia">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3359,6 +3759,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="service-assessment recommends diagram">R</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3388,6 +3792,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="tcop recommends sobc">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--m" title="tcop requires requirements (mandatory)">M</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3472,6 +3880,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--self" aria-label="ai-playbook self"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="ai-playbook can use secure (optional)">O</td>
@@ -3494,6 +3906,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="atrs recommends dpia">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3563,6 +3979,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="secure can use diagram (optional)">O</td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3596,6 +4016,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="mod-secure recommends dpia">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
@@ -3676,6 +4100,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="jsp-936 recommends ai-playbook">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="jsp-936 recommends atrs">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--o" title="jsp-936 can use secure (optional)">O</td>
@@ -3687,7 +4115,7 @@
                                 <td class="app-dep-matrix__cell"></td>
                             </tr>
                             <tr class="app-dep-matrix__tier-row">
-                                <td colspan="50" class="app-dep-matrix__tier-label">Tier 14-15: Reporting</td>
+                                <td colspan="54" class="app-dep-matrix__tier-label">Tier 14-15: Reporting</td>
                             </tr>
                             <tr>
                                 <td class="app-dep-matrix__row-label">story</td>
@@ -3705,6 +4133,10 @@
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="story recommends azure-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="story recommends aws-research">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="story recommends gcp-research">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="story recommends roadmap">R</td>
@@ -3758,6 +4190,10 @@
                                 <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="pages recommends datascout">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="pages recommends wardley">R</td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
+                                <td class="app-dep-matrix__cell"></td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="pages recommends roadmap">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="pages recommends strategy">R</td>
                                 <td class="app-dep-matrix__cell app-dep-matrix__cell--r" title="pages recommends adr">R</td>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -378,7 +378,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 60 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 64 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -418,7 +418,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 60 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 64 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -466,7 +466,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 60 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 64 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -516,7 +516,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 60 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 64 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -562,7 +562,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai copilot</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This scaffolds 60 prompt files, 6 research agents, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This scaffolds 64 prompt files, 6 research agents, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -624,7 +624,7 @@ arckit init my-project --ai copilot</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 60 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 64 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Command Guides - 79 usage guides for enterprise architecture governance commands organized by category.">
+    <meta name="description" content="ArcKit Command Guides - 88 usage guides for enterprise architecture governance commands organized by category.">
     <title>Command Guides - ArcKit</title>
     <meta name="keywords" content="ArcKit guides, architecture governance guides, command usage, workflow steps, UK government architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Guides - ArcKit">
-    <meta property="og:description" content="79 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta property="og:description" content="88 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/guides.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Guides - ArcKit">
-    <meta name="twitter:description" content="79 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta name="twitter:description" content="88 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/guides.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -234,7 +234,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/guides.html",
                 "name": "Command Guides - ArcKit",
-                "description": "79 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.",
+                "description": "88 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -278,7 +278,7 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">79 Guides</span>
+            <span class="app-page-hero__stat">88 Guides</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
             <p class="app-page-hero__description">Step-by-step usage guides organised into 10 categories. Each covers prerequisites, workflow steps, and real-world examples.</p>
         </div>
@@ -356,7 +356,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Architecture
-                    <span class="app-guide-category__count">13 guides</span>
+                    <span class="app-guide-category__count">8 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -371,8 +371,24 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=dfd" class="govuk-link">Data Flow Diagram Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Data flow diagrams for system analysis</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=framework" class="govuk-link">Framework Design Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Transform artifacts into structured frameworks</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=platform-design" class="govuk-link">Platform Strategy Design Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Multi-sided platform strategy using PDT methodology</span></li>
-                        <li class="app-guide-item"><a href="guide-viewer.html?guide=wardley" class="govuk-link">Wardley Mapping Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Strategic analysis and build-vs-buy decisions</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=data-mesh-contract" class="govuk-link">Data Mesh Contract Guide</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">Data mesh contract definitions</span></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Wardley Mapping -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> Wardley Mapping
+                    <span class="app-guide-category__count">5 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=wardley" class="govuk-link">Wardley Mapping Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Strategic analysis and build-vs-buy decisions</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=wardley-value-chain" class="govuk-link">Wardley Value Chain Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Value chain decomposition and evolution analysis</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=wardley-doctrine" class="govuk-link">Wardley Doctrine Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Doctrine maturity assessment across 40+ principles</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=wardley-climate" class="govuk-link">Wardley Climate Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Climatic pattern analysis for strategic landscapes</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=wardley-gameplay" class="govuk-link">Wardley Gameplay Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Strategic play analysis from 60+ gameplay patterns</span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 60 slash commands
+- **Commands**: 64 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 60 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 60 ArcKit commands and 6 research agents remain fully available
+- All 64 ArcKit commands and 6 research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 60 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 60 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 60 commands | Plugin mode
+Version 2.10.0 | 64 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/guides/wardley-climate.md
+++ b/docs/guides/wardley-climate.md
@@ -1,0 +1,122 @@
+# Climate Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.climate` assesses 32 climatic patterns affecting mapped components.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to understand the external forces acting on your components. Climate patterns are the rules of the game -- they apply regardless of your strategy. Understanding them lets you anticipate change, identify inertia, and choose gameplay that works with (not against) external forces.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map whose components are assessed for climatic forces |
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Recommended -- Business context for impact assessment |
+| Research findings (`ARC-<id>-RSCH-*.md`) | Recommended -- Market data to validate pattern detection |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.climate Assess climate for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WCLM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Climate Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being assessed |
+| Pattern Assessment | 32 climatic patterns evaluated against components |
+| Category Summary | Aggregated assessment across 6 pattern categories |
+| Peace/War/Wonder Cycle | Current cycle phase and implications |
+| Inertia Assessment | Components and organizations resisting change |
+| Prediction Horizons | What can be predicted and with what confidence |
+| Strategic Implications | How climate forces shape available strategies |
+
+---
+
+## Key Concepts
+
+### 32 Climatic Patterns Across 6 Categories
+
+| Category | Example Patterns |
+|----------|-----------------|
+| Competition | Competitors will copy successful plays, most competitors have poor situational awareness |
+| Components | Everything evolves through supply and demand competition, characteristics change as components evolve |
+| Financial | Higher-order systems create new sources of value, capital flows to new areas of value |
+| Speed | Evolution does not respect corporate boundaries, no single method fits all |
+| Prediction | Not everything is predictable, you can predict the direction of evolution |
+| Ecosystem | Efficiency enables innovation, evolution of one component affects others |
+
+### Peace / War / Wonder Cycle
+
+The evolution of components follows a repeating cycle:
+
+| Phase | Characteristics |
+|-------|-----------------|
+| Peace | Stable product competition, incremental improvement, predictable |
+| War | Commodity transition, disruption, rapid change, casualties |
+| Wonder | New genesis components emerge from commodity, novel value created |
+
+Identifying which phase each component is in reveals whether stability or disruption is imminent.
+
+### Inertia Assessment
+
+Inertia is resistance to change. Climate assessment identifies:
+
+- **Component inertia** -- Technology or practices that resist evolution
+- **Organizational inertia** -- Cultural resistance, sunk cost, existing contracts
+- **Market inertia** -- Vendor lock-in, switching costs, standards
+
+### Prediction Horizons
+
+Not all climate effects are equally predictable:
+
+| Horizon | Confidence |
+|---------|------------|
+| Direction of evolution | High -- components always evolve toward commodity |
+| Timing of evolution | Medium -- depends on competition and market forces |
+| Specific disruptions | Low -- individual events are unpredictable |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- All 32 climatic patterns assessed against map components.
+- Peace/War/Wonder phase identified for each key component.
+- Inertia sources documented with severity.
+- Prediction horizons are realistic (not overconfident).
+- Strategic implications link back to specific components.
+- Assessment is evidence-based, not speculative.
+
+---
+
+## Tips
+
+1. **Climate before gameplay** -- Climate constrains which plays are viable. Always assess climate first.
+2. **Look for war signals** -- Components approaching commodity transition are the highest-risk, highest-opportunity areas.
+3. **Challenge inertia** -- Organizational inertia is often the hardest to overcome. Name it explicitly.
+4. **Update with the map** -- Climate assessment is tied to a specific map version. When the map changes, re-assess.
+5. **Use research data** -- Market research (`/arckit.research`) provides evidence for pattern detection. Do not assess climate in a vacuum.

--- a/docs/guides/wardley-doctrine.md
+++ b/docs/guides/wardley-doctrine.md
@@ -1,0 +1,120 @@
+# Doctrine Assessment Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.doctrine` assesses organizational doctrine maturity across 4 phases and 40+ principles.
+
+---
+
+## When to Use
+
+Run this command to assess organizational maturity, identify capability gaps, and plan improvements. Doctrine assessment reveals how well an organization applies universal strategic principles -- independent of any specific map or context. Use it to:
+
+- Baseline current organizational maturity
+- Identify systemic weaknesses before they manifest in projects
+- Plan targeted improvement programmes
+- Re-assess periodically to measure progress
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Architecture principles (`ARC-000-PRIN-v1.0.md`) | **Mandatory** -- Governance principles to assess against |
+| Wardley Map (`ARC-<id>-WARD-*.md`) | Recommended -- Provides strategic context for scoring |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- Organizational context and drivers |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.doctrine Assess doctrine maturity for <organisation>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WDOC-v1.0.md` (single instance per project)
+
+---
+
+## Doctrine Structure
+
+| Section | Contents |
+|---------|----------|
+| Phase Assessment | Which of the 4 phases the organization has reached |
+| Category Scores | Maturity scores across 6 doctrine categories |
+| Principle-Level Detail | Individual 1-5 scoring for 40+ principles |
+| Gap Analysis | Weaknesses and improvement priorities |
+| Improvement Roadmap | Phased plan to advance doctrine maturity |
+
+---
+
+## Key Concepts
+
+### The 4 Phases of Doctrine
+
+| Phase | Name | Focus |
+|-------|------|-------|
+| I | Stop Self-Harm | Eliminate basic organizational dysfunctions |
+| II | Becoming Context Aware | Develop situational awareness and mapping capability |
+| III | Better for Less | Optimize through strategic play and efficiency |
+| IV | Continuously Evolving | Anticipate and adapt to change systemically |
+
+Organizations must master each phase before progressing to the next.
+
+### The 6 Categories
+
+| Category | Examples |
+|----------|---------|
+| Communication | Common language, challenge assumptions, listen to ecosystems |
+| Development | Use appropriate methods, think small, know your details |
+| Learning | Use a systematic mechanism of learning, bias towards data |
+| Leading | Move fast, be the owner, think big |
+| Operations | Manage inertia, optimise flow, think aptitude and attitude |
+| Structure | Provide purpose, use small teams, think standards |
+
+### Scoring (1-5)
+
+| Score | Meaning |
+|-------|---------|
+| 1 | Not practiced -- principle is unknown or ignored |
+| 2 | Ad hoc -- applied inconsistently |
+| 3 | Developing -- recognized and partly systematized |
+| 4 | Practiced -- systematically applied across the organization |
+| 5 | Mastered -- deeply embedded, continuously improved |
+
+### Re-Assessment
+
+Doctrine assessments support periodic re-assessment. When re-running the command, the previous assessment is read and scores are compared to show progress, regression, or stagnation.
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Foundation | Establish architecture principles | `/arckit.principles` |
+| Assessment | Score doctrine maturity | `/arckit.wardley.doctrine` |
+| Mapping | Create Wardley Maps with doctrine context | `/arckit.wardley` |
+| Strategy | Synthesise into strategy | `/arckit.strategy` |
+
+---
+
+## Review Checklist
+
+- All 40+ principles scored with evidence.
+- Phase classification is justified.
+- Gap analysis identifies top priority improvements.
+- Improvement roadmap has realistic timelines.
+- Comparison with previous assessment included (if re-assessment).
+- Scores reflect reality, not aspiration.
+
+---
+
+## Tips
+
+1. **Be honest** -- Doctrine assessment only has value if scores reflect reality. Aspirational scoring hides problems.
+2. **Involve multiple stakeholders** -- A single assessor introduces bias; cross-functional input produces better scores.
+3. **Start with Phase I** -- If Phase I principles are not mastered, skip ahead at your peril.
+4. **Re-assess quarterly** -- Doctrine maturity changes slowly; quarterly cadence balances effort and insight.
+5. **Link to principles** -- Map each doctrine principle to your architecture principles for traceability.

--- a/docs/guides/wardley-gameplay.md
+++ b/docs/guides/wardley-gameplay.md
@@ -1,0 +1,123 @@
+# Gameplay Analysis Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.gameplay` analyzes strategic plays from 60+ gameplay patterns.
+
+---
+
+## When to Use
+
+Run this command **after** creating a Wardley Map to identify strategic plays available to your organization. Gameplay analysis examines your map and recommends actions based on component positions, movements, and the competitive landscape. Best combined with climate assessment (`/arckit.wardley.climate`) for a complete strategic picture.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Wardley Map (`ARC-<id>-WARD-*.md`) | **Mandatory** -- Map to analyze for strategic plays |
+| Climate assessment (`ARC-<id>-WCLM-*.md`) | Recommended -- External forces affecting gameplay choices |
+| Doctrine assessment (`ARC-<id>-WDOC-*.md`) | Recommended -- Organizational readiness for each play |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.gameplay Analyze gameplay for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WGAM-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Gameplay Structure
+
+| Section | Contents |
+|---------|----------|
+| Map Context | Summary of the Wardley Map being analyzed |
+| Applicable Plays | Strategic plays identified from component positions |
+| Play-Position Matrix | Which plays apply to which components |
+| Alignment Classification | D&D alignment for each play (Lawful/Neutral/Chaotic) |
+| Recommended Actions | Prioritized list of strategic actions |
+| Risk Assessment | Risks and counter-plays for each recommendation |
+
+---
+
+## Key Concepts
+
+### 11 Gameplay Categories
+
+| Category | Focus |
+|----------|-------|
+| User Perception | Shaping how users see value |
+| Accelerators | Speeding evolution of components |
+| De-accelerators | Slowing evolution to protect advantage |
+| Market | Creating or reshaping markets |
+| Defensive | Protecting current position |
+| Attacking | Disrupting competitors |
+| Ecosystem | Building or leveraging ecosystems |
+| Positional | Exploiting map position |
+| Poison | Undermining competitor strategies |
+| Military | Direct competitive confrontation |
+| Political | Influencing rules and standards |
+
+### 60+ Plays
+
+Examples include open source (accelerator), create a constraint (de-accelerator), tower and moat (defensive), two-factor markets (ecosystem), and standards game (political). Each play has specific applicability based on component evolution stage and visibility.
+
+### D&D Alignment Classification
+
+Plays are classified on two axes:
+
+| Axis | Options |
+|------|---------|
+| Lawful / Neutral / Chaotic | How the play relates to established norms |
+| Good / Neutral / Evil | The ethical dimension of the play |
+
+This classification helps organizations choose plays that align with their values and governance requirements.
+
+### Play-Position Matrix
+
+The matrix maps each play to the evolution stages where it is most effective:
+
+| Evolution Stage | Example Plays |
+|-----------------|---------------|
+| Genesis | Experimentation, talent raid, first mover |
+| Custom | Sensing engines, co-creation |
+| Product | Industrialisation plays, ecosystem building |
+| Commodity | Standards game, utility plays, commoditisation |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Mapping | Create Wardley Map | `/arckit.wardley` |
+| Climate | Assess external forces | `/arckit.wardley.climate` |
+| Gameplay | Identify strategic plays | `/arckit.wardley.gameplay` |
+| Strategy | Synthesise into strategy | `/arckit.strategy`, `/arckit.roadmap` |
+
+---
+
+## Review Checklist
+
+- Wardley Map is current and validated.
+- All applicable plays identified for each component.
+- D&D alignment classification is consistent.
+- Risks and counter-plays documented for each recommendation.
+- Play-position matrix is populated.
+- Recommendations are prioritized by impact and feasibility.
+- Organizational readiness considered (doctrine assessment).
+
+---
+
+## Tips
+
+1. **Map first, play second** -- Never select gameplay without a current Wardley Map.
+2. **Combine with climate** -- Climate patterns constrain which plays are viable. Assess climate first.
+3. **Check doctrine readiness** -- Some plays require organizational maturity. A Phase I organization cannot execute Phase III plays.
+4. **Consider ethics** -- The D&D alignment classification is not decorative. Choose plays consistent with your governance.
+5. **Revisit after map changes** -- When components move or the landscape shifts, gameplay analysis must be refreshed.

--- a/docs/guides/wardley-value-chain.md
+++ b/docs/guides/wardley-value-chain.md
@@ -1,0 +1,122 @@
+# Value Chain Decomposition Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.wardley.value-chain` decomposes user needs into value chains for Wardley Mapping.
+
+---
+
+## When to Use
+
+Run this command **before** creating a Wardley Map when you need to decompose a domain into its constituent components. Value chain decomposition identifies all the capabilities, services, and activities required to meet user needs -- producing the raw material that `/arckit.wardley` then positions on an evolution axis.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | **Mandatory** -- Capabilities, user needs, and business context |
+| Stakeholder analysis (`ARC-<id>-STKE-v1.0.md`) | Recommended -- User roles and business drivers |
+| Architecture diagrams | Optional -- Existing component landscape |
+
+---
+
+## Command
+
+```bash
+/arckit.wardley.value-chain Decompose value chain for <initiative>
+```
+
+Output: `projects/<id>/wardley-maps/ARC-<id>-WVCH-<NNN>-v1.0.md` (uses multi-instance numbering)
+
+---
+
+## Value Chain Structure
+
+| Section | Contents |
+|---------|----------|
+| Anchor Identification | User needs vs internal solution anchors |
+| Recursive Decomposition | Break each need into sub-components until atomic |
+| Visibility Mapping | How visible each component is to the end user |
+| Dependency Analysis | Which components depend on which |
+| Component Catalogue | Full list with descriptions, types, and owners |
+
+---
+
+## Key Concepts
+
+### Anchors: User Needs vs Solutions
+
+Wardley Maps start from **user needs**, not technology. Value chain decomposition distinguishes:
+
+- **User-need anchors** -- What the user actually wants (e.g., "book an appointment")
+- **Solution anchors** -- Internal capabilities that serve the need (e.g., "appointment scheduling service")
+
+Always anchor at user needs; solutions are components in the chain below.
+
+### Recursive Decomposition
+
+Each user need is broken down recursively:
+
+1. Identify the top-level need
+2. Ask "what is needed to provide this?"
+3. For each answer, repeat until you reach atomic components
+4. Atomic = a component that can be sourced as a single unit (build, buy, or utility)
+
+### Visibility Axis
+
+Components sit on a visibility spectrum:
+
+| Position | Description |
+|----------|-------------|
+| Top (visible) | User-facing capabilities, directly experienced |
+| Middle | Supporting services, seen by operators |
+| Bottom (invisible) | Infrastructure and utilities, invisible to users |
+
+### Dependency Types
+
+| Type | Description |
+|------|-------------|
+| Direct | Component A cannot function without Component B |
+| Indirect | Component A benefits from Component B but can operate without it |
+| Shared | Multiple components depend on a common service |
+
+---
+
+## Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Requirements | Define user needs and capabilities | `/arckit.requirements` |
+| Decomposition | Break needs into value chains | `/arckit.wardley.value-chain` |
+| Mapping | Position components on evolution axis | `/arckit.wardley` |
+| Analysis | Assess doctrine, climate, gameplay | `/arckit.wardley.doctrine`, `/arckit.wardley.climate`, `/arckit.wardley.gameplay` |
+
+---
+
+## Review Checklist
+
+- All user needs identified and used as anchors.
+- Decomposition is recursive to atomic components.
+- Visibility axis reflects real user perspective.
+- Dependencies between components are explicit.
+- No technology assumptions baked into anchors.
+- Component catalogue is complete with descriptions.
+
+---
+
+## Tips
+
+1. **Start with users, not technology** -- If your first anchor is a database, you have started too low.
+2. **Challenge "obvious" components** -- Decompose even well-understood areas; hidden dependencies live there.
+3. **Use stakeholder analysis** -- Stakeholder drivers reveal needs that requirements alone may miss.
+4. **One chain per user need** -- Separate chains keep the analysis focused.
+5. **Feed into Wardley Map** -- The value chain output is the direct input to `/arckit.wardley`.
+
+---
+
+## Feeds Into
+
+- `/arckit.wardley` -- Use the decomposed value chain to create a positioned Wardley Map
+- `/arckit.data-model` -- Components often map to data entities

--- a/docs/guides/wardley.md
+++ b/docs/guides/wardley.md
@@ -6,6 +6,29 @@
 
 ---
 
+## Wardley Mapping Suite
+
+ArcKit provides a full suite of Wardley Mapping commands that work together as a strategic analysis pipeline:
+
+| Command | Purpose | Output |
+|---------|---------|--------|
+| `/arckit.wardley.value-chain` | Decompose user needs into value chains | WVCH |
+| `/arckit.wardley` | Create positioned Wardley Maps | WARD |
+| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity | WDOC |
+| `/arckit.wardley.climate` | Assess 32 climatic patterns | WCLM |
+| `/arckit.wardley.gameplay` | Analyze 60+ strategic gameplay patterns | WGAM |
+
+**Recommended workflow order:**
+
+1. **Value Chain** -- Decompose domain into components ([guide](wardley-value-chain.md))
+2. **Wardley Map** -- Position components on evolution axis (this guide)
+3. **Doctrine** -- Assess organizational maturity ([guide](wardley-doctrine.md))
+4. **Climate** -- Understand external forces ([guide](wardley-climate.md))
+5. **Gameplay** -- Identify strategic plays ([guide](wardley-gameplay.md))
+6. **Strategy / Roadmap** -- Synthesise findings into actionable plans
+
+---
+
 ## Inputs
 
 | Artefact | Purpose |

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 60 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 64 AI-assisted commands for systematic, compliant project delivery following UK Government standards.">
     <meta name="keywords" content="enterprise architecture, UK government, GDS, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="60 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta property="og:description" content="64 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="60 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
+    <meta name="twitter:description" content="64 AI-assisted commands for systematic, compliant architecture governance following UK Government standards.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -312,13 +312,13 @@
                 "@type": "WebSite",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "60 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
+                "description": "64 AI-assisted commands for systematic, compliant architecture governance following UK Government standards."
             },
             {
                 "@type": "WebPage",
                 "@id": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "60 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
+                "description": "64 AI-assisted commands for systematic, compliant project delivery following UK Government standards.",
                 "isPartOf": { "@id": "https://arckit.org" }
             }
         ]
@@ -368,7 +368,7 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">60</div>
+                    <div class="app-stat-number">64</div>
                     <div class="app-stat-label">AI Commands</div>
                 </div>
                 <div class="app-stat-card">
@@ -389,7 +389,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">60 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
+            <p class="govuk-body">64 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts aligned to UK Government standards.</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -451,7 +451,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 60 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">All 64 commands produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -494,7 +494,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 60 commands across 13 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 64 commands across 13 categories with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>

--- a/docs/superpowers/plans/2026-03-13-github-issue-templates.md
+++ b/docs/superpowers/plans/2026-03-13-github-issue-templates.md
@@ -17,6 +17,7 @@
 ### Task 1: Create bug report form
 
 **Files:**
+
 - Create: `.github/ISSUE_TEMPLATE/bug-report.yml`
 
 - [ ] **Step 1: Create the bug report form**
@@ -144,6 +145,7 @@ git commit -m "feat: add bug report issue form"
 ### Task 2: Create feature request form
 
 **Files:**
+
 - Create: `.github/ISSUE_TEMPLATE/feature-request.yml`
 
 - [ ] **Step 1: Create the feature request form**
@@ -221,6 +223,7 @@ git commit -m "feat: add feature request issue form"
 ### Task 3: Create question form
 
 **Files:**
+
 - Create: `.github/ISSUE_TEMPLATE/question.yml`
 
 - [ ] **Step 1: Create the question form**
@@ -289,6 +292,7 @@ git commit -m "feat: add question issue form"
 ### Task 4: Create config to disable blank issues
 
 **Files:**
+
 - Create: `.github/ISSUE_TEMPLATE/config.yml`
 
 - [ ] **Step 1: Create the config**

--- a/docs/superpowers/plans/2026-03-16-wardley-suite-enhancement.md
+++ b/docs/superpowers/plans/2026-03-16-wardley-suite-enhancement.md
@@ -11,6 +11,7 @@
 **Spec:** `docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md`
 
 **Content Sources:**
+
 - `research/Introduction to Wardley Mapping Doctrine.md` (~283K)
 - `research/Introduction to Wardley Mapping Gameplays.md` (~484K)
 - `research/Introduction to Wardley Mapping Climatic Patterns - Kindle - v1.0.1.md` (~357K)
@@ -23,6 +24,7 @@
 ### Task 1: Register new document types in doc-types.mjs
 
 **Files:**
+
 - Modify: `arckit-claude/config/doc-types.mjs:29` (after WARD entry)
 - Modify: `arckit-claude/config/doc-types.mjs:74-77` (MULTI_INSTANCE_TYPES)
 - Modify: `arckit-claude/config/doc-types.mjs:82-93` (SUBDIR_MAP)
@@ -79,6 +81,7 @@ git commit -m "feat: register WDOC, WGAM, WCLM, WVCH document types"
 ### Task 2: Update generate-document-id.sh
 
 **Files:**
+
 - Modify: `scripts/bash/generate-document-id.sh:18-19` (comment)
 - Modify: `scripts/bash/generate-document-id.sh:85` (MULTI_INSTANCE_TYPES)
 
@@ -106,6 +109,7 @@ Update the comment on lines 18-19 to include the new types:
 - [ ] **Step 2: Test document ID generation**
 
 Run:
+
 ```bash
 bash scripts/bash/generate-document-id.sh 001 WDOC 1.0
 bash scripts/bash/generate-document-id.sh 001 WGAM 1.0 --filename --next-num /tmp
@@ -114,7 +118,8 @@ bash scripts/bash/generate-document-id.sh 001 WCLM 1.0 --filename --next-num /tm
 ```
 
 Expected:
-```
+
+```text
 ARC-001-WDOC-v1.0
 ARC-001-WGAM-001-v1.0.md
 ARC-001-WVCH-001-v1.0.md
@@ -133,6 +138,7 @@ git commit -m "feat: add WGAM, WCLM, WVCH to multi-instance types"
 ### Task 3: Extend validate-wardley-math.mjs hook
 
 **Files:**
+
 - Modify: `arckit-claude/hooks/validate-wardley-math.mjs:68` (file filter)
 
 - [ ] **Step 1: Read the current hook to find the file filter**
@@ -159,6 +165,7 @@ git commit -m "feat: extend wardley math hook to validate WVCH documents"
 ### Task 4: Fix pre-existing wardley.md hook bug
 
 **Files:**
+
 - Modify: `arckit-claude/commands/wardley.md:16` (hooks frontmatter)
 
 - [ ] **Step 1: Fix the hook command**
@@ -187,6 +194,7 @@ git commit -m "fix: correct wardley.md hook from python3 .py to node .mjs"
 ### Task 5: Fix converter regexes for dot-namespaced commands
 
 **Files:**
+
 - Modify: `scripts/converter.py:537` (colon-format regex)
 - Modify: `scripts/converter.py:542` (dot-format regex)
 - Modify: `scripts/converter.py:549` (prompts-format regex)
@@ -225,6 +233,7 @@ Each reference file is an independent task that can be parallelized. All files a
 ### Task 6: Enhance doctrine.md (120 → ~400 lines)
 
 **Files:**
+
 - Modify: `arckit-claude/skills/wardley-mapping/references/doctrine.md`
 
 **Source material**: Read `research/Introduction to Wardley Mapping Doctrine.md`
@@ -267,6 +276,7 @@ git commit -m "feat: expand doctrine reference to 40+ principles across 4 phases
 ### Task 7: Enhance gameplay-patterns.md (171 → ~600 lines)
 
 **Files:**
+
 - Modify: `arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md`
 
 **Source material**: Read `research/Introduction to Wardley Mapping Gameplays.md`
@@ -295,6 +305,7 @@ Preserve the existing build/buy/outsource decision framework. Restructure to 11 
 Each play needs: name, D&D alignment (LG/N/LE/CE), 1-2 sentence description, when to use, evolution stage applicability.
 
 Also add:
+
 - **D&D Alignment Key** — Lawful Good, Neutral, Lawful Evil, Chaotic Evil definitions
 - **Play-Position Matrix** — Table mapping (your position × market position → recommended plays)
 - **Play Compatibility** — Which plays work together vs conflict
@@ -322,6 +333,7 @@ git commit -m "feat: expand gameplay patterns to 60+ plays across 11 categories"
 ### Task 8: Enhance climatic-patterns.md (273 → ~500 lines)
 
 **Files:**
+
 - Modify: `arckit-claude/skills/wardley-mapping/references/climatic-patterns.md`
 
 **Source material**: Read `research/Introduction to Wardley Mapping Climatic Patterns - Kindle - v1.0.1.md`
@@ -345,6 +357,7 @@ Restructure into 6 categories with all 32 patterns:
 Each pattern: name, 2-3 sentence description, strategic implication, assessment question.
 
 Preserve existing assessment questions and pattern recognition template sections. Add:
+
 - **Peace/War/Wonder Cycle** — Detailed explanation with phase characteristics
 - **Pattern Interaction Map** — Which patterns reinforce or counteract each other
 - **Per-Component Assessment Template** — How to score pattern impact per component
@@ -369,6 +382,7 @@ git commit -m "feat: expand climatic patterns to 32 patterns across 6 categories
 ### Task 9: Enhance evolution-stages.md (101 → ~180 lines)
 
 **Files:**
+
 - Modify: `arckit-claude/skills/wardley-mapping/references/evolution-stages.md`
 
 **Source material**: Fundamentals chapters from all 3 books + melodic-software evolution-analysis skill patterns (documented in spec conversation).
@@ -401,6 +415,7 @@ git commit -m "feat: enhance evolution stages with transition heuristics and tal
 ### Task 10: Enhance mapping-examples.md (307 → ~450 lines)
 
 **Files:**
+
 - Modify: `arckit-claude/skills/wardley-mapping/references/mapping-examples.md`
 
 **Source material**: Gameplays book Chapter 4 (case studies), Climatic Patterns book (TechnoGadget), melodic-software value-chain skill (e-commerce/SaaS examples).
@@ -432,6 +447,7 @@ git commit -m "feat: add TechnoGadget, value chain, and case study examples"
 ### Task 11: Enhance mathematical-models.md (254 → ~300 lines)
 
 **Files:**
+
 - Modify: `arckit-claude/skills/wardley-mapping/references/mathematical-models.md`
 
 - [ ] **Step 1: Read existing file**
@@ -462,6 +478,7 @@ git commit -m "feat: add play-position scoring and climate impact weighting"
 ### Task 12: Create wardley-value-chain-template.md
 
 **Files:**
+
 - Create: `arckit-claude/templates/wardley-value-chain-template.md`
 - Create: `.arckit/templates/wardley-value-chain-template.md` (mirror)
 
@@ -501,6 +518,7 @@ git commit -m "feat: add wardley value chain template"
 ### Task 13: Create wardley-doctrine-template.md
 
 **Files:**
+
 - Create: `arckit-claude/templates/wardley-doctrine-template.md`
 - Create: `.arckit/templates/wardley-doctrine-template.md` (mirror)
 
@@ -535,6 +553,7 @@ git commit -m "feat: add wardley doctrine assessment template"
 ### Task 14: Create wardley-gameplay-template.md
 
 **Files:**
+
 - Create: `arckit-claude/templates/wardley-gameplay-template.md`
 - Create: `.arckit/templates/wardley-gameplay-template.md` (mirror)
 
@@ -567,6 +586,7 @@ git commit -m "feat: add wardley gameplay analysis template"
 ### Task 15: Create wardley-climate-template.md
 
 **Files:**
+
 - Create: `arckit-claude/templates/wardley-climate-template.md`
 - Create: `.arckit/templates/wardley-climate-template.md` (mirror)
 
@@ -607,6 +627,7 @@ git commit -m "feat: add wardley climate assessment template"
 ### Task 16: Create wardley.value-chain.md command
 
 **Files:**
+
 - Create: `arckit-claude/commands/wardley.value-chain.md`
 
 - [ ] **Step 1: Create the command file**
@@ -614,6 +635,7 @@ git commit -m "feat: add wardley climate assessment template"
 Use the existing `arckit-claude/commands/wardley.md` as the structural pattern (YAML frontmatter with description, argument-hint, handoffs, hooks; then prompt body with steps).
 
 YAML frontmatter:
+
 ```yaml
 ---
 description: Decompose user needs into value chains for Wardley Mapping
@@ -666,11 +688,13 @@ git commit -m "feat: add wardley.value-chain command for value chain decompositi
 ### Task 17: Create wardley.doctrine.md command
 
 **Files:**
+
 - Create: `arckit-claude/commands/wardley.doctrine.md`
 
 - [ ] **Step 1: Create the command file**
 
 YAML frontmatter:
+
 ```yaml
 ---
 description: Assess organizational doctrine maturity using Wardley's 4-phase framework
@@ -712,11 +736,13 @@ git commit -m "feat: add wardley.doctrine command for doctrine maturity assessme
 ### Task 18: Create wardley.gameplay.md command
 
 **Files:**
+
 - Create: `arckit-claude/commands/wardley.gameplay.md`
 
 - [ ] **Step 1: Create the command file**
 
 YAML frontmatter:
+
 ```yaml
 ---
 description: Analyze strategic play options from Wardley Maps using 60+ gameplay patterns
@@ -761,11 +787,13 @@ git commit -m "feat: add wardley.gameplay command for strategic play analysis"
 ### Task 19: Create wardley.climate.md command
 
 **Files:**
+
 - Create: `arckit-claude/commands/wardley.climate.md`
 
 - [ ] **Step 1: Create the command file**
 
 YAML frontmatter:
+
 ```yaml
 ---
 description: Assess climatic patterns affecting Wardley Map components
@@ -808,6 +836,7 @@ git commit -m "feat: add wardley.climate command for climatic pattern assessment
 ### Task 20: Update existing wardley.md handoffs
 
 **Files:**
+
 - Modify: `arckit-claude/commands/wardley.md:4-17` (frontmatter)
 
 - [ ] **Step 1: Add new handoffs to wardley.md frontmatter**
@@ -826,11 +855,13 @@ In the `handoffs:` section, add 3 new entries after the existing `research` hand
 - [ ] **Step 2: Add WVCH/WDOC/WCLM to recommended reading**
 
 In the command body where prerequisites are listed (Step 1), add to RECOMMENDED:
+
 - WVCH (Value Chain) — Extract: anchor, components, visibility, dependencies
 - WDOC (Doctrine Assessment) — Extract: doctrine scores, capability gaps
 - WCLM (Climate Assessment) — Extract: pattern impacts, predictions
 
 And to OPTIONAL:
+
 - WGAM (Gameplay Analysis) — Extract: selected plays, execution steps
 
 - [ ] **Step 3: Commit**
@@ -847,6 +878,7 @@ git commit -m "feat: add wardley suite handoffs and sibling artifact reading"
 ### Task 21: Run converter and verify output
 
 **Files:**
+
 - No new files — verification only
 
 - [ ] **Step 1: Run the converter**
@@ -911,6 +943,7 @@ git commit -m "chore: regenerate extension formats with wardley suite commands"
 ### Task 22: Create 4 new guide files
 
 **Files:**
+
 - Create: `docs/guides/wardley-value-chain.md` + mirror to `arckit-claude/guides/`
 - Create: `docs/guides/wardley-doctrine.md` + mirror to `arckit-claude/guides/`
 - Create: `docs/guides/wardley-gameplay.md` + mirror to `arckit-claude/guides/`
@@ -947,6 +980,7 @@ git commit -m "docs: add guides for wardley suite commands"
 ### Task 23: Update README.md
 
 **Files:**
+
 - Modify: `README.md`
 
 - [ ] **Step 1: Update command count**
@@ -980,6 +1014,7 @@ git commit -m "docs: add wardley suite commands to README"
 ### Task 24: Update docs/index.html
 
 **Files:**
+
 - Modify: `docs/index.html`
 
 - [ ] **Step 1: Update command count in header**
@@ -1002,6 +1037,7 @@ git commit -m "docs: add wardley suite commands to GitHub Pages index"
 ### Task 25: Update docs/DEPENDENCY-MATRIX.md
 
 **Files:**
+
 - Modify: `docs/DEPENDENCY-MATRIX.md`
 
 - [ ] **Step 1: Add 4 new commands**
@@ -1020,6 +1056,7 @@ git commit -m "docs: add wardley suite to dependency matrix"
 ### Task 26: Update docs/WORKFLOW-DIAGRAMS.md
 
 **Files:**
+
 - Modify: `docs/WORKFLOW-DIAGRAMS.md`
 
 - [ ] **Step 1: Add Wardley Suite workflow diagram**
@@ -1038,6 +1075,7 @@ git commit -m "docs: add wardley suite workflow diagram"
 ### Task 27: Update docs/README.md
 
 **Files:**
+
 - Modify: `docs/README.md`
 
 - [ ] **Step 1: Add 4 new commands to documentation index**
@@ -1056,6 +1094,7 @@ git commit -m "docs: add wardley suite to documentation index"
 ### Task 28: Update CHANGELOGs
 
 **Files:**
+
 - Modify: `CHANGELOG.md`
 - Modify: `arckit-claude/CHANGELOG.md`
 

--- a/docs/superpowers/plans/2026-03-16-wardley-suite-enhancement.md
+++ b/docs/superpowers/plans/2026-03-16-wardley-suite-enhancement.md
@@ -1,0 +1,1085 @@
+# Wardley Mapping Suite Enhancement Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Expand ArcKit's Wardley Mapping from 1 command into a composable suite of 5 commands (wardley, wardley.value-chain, wardley.doctrine, wardley.gameplay, wardley.climate) backed by enriched shared reference files distilled from 3 Wardley Mapping books.
+
+**Architecture:** Layered approach — enriched shared reference files (Layer 1) are read by focused commands (Layer 2) that produce versioned document artifacts. The existing `/arckit.wardley` orchestrates by consuming sibling artifacts when available. All commands convert to 5 AI platforms via `scripts/converter.py`.
+
+**Tech Stack:** Markdown (commands, templates, guides, references), JavaScript/MJS (doc-types, hooks), Python (converter), Bash (generate-document-id.sh)
+
+**Spec:** `docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md`
+
+**Content Sources:**
+- `research/Introduction to Wardley Mapping Doctrine.md` (~283K)
+- `research/Introduction to Wardley Mapping Gameplays.md` (~484K)
+- `research/Introduction to Wardley Mapping Climatic Patterns - Kindle - v1.0.1.md` (~357K)
+- melodic-software/claude-code-plugins wardley-mapping skill (researched in conversation, not local)
+
+---
+
+## Chunk 1: Infrastructure (doc-types, shell script, hook, converter)
+
+### Task 1: Register new document types in doc-types.mjs
+
+**Files:**
+- Modify: `arckit-claude/config/doc-types.mjs:29` (after WARD entry)
+- Modify: `arckit-claude/config/doc-types.mjs:74-77` (MULTI_INSTANCE_TYPES)
+- Modify: `arckit-claude/config/doc-types.mjs:82-93` (SUBDIR_MAP)
+
+- [ ] **Step 1: Add 4 new type codes to DOC_TYPES**
+
+In `arckit-claude/config/doc-types.mjs`, after the `'WARD'` line (line 29), add:
+
+```javascript
+  'WDOC':      { name: 'Wardley Doctrine Assessment',  category: 'Architecture' },
+  'WGAM':      { name: 'Wardley Gameplay Analysis',     category: 'Architecture' },
+  'WCLM':      { name: 'Wardley Climate Assessment',    category: 'Architecture' },
+  'WVCH':      { name: 'Wardley Value Chain',            category: 'Architecture' },
+```
+
+- [ ] **Step 2: Add multi-instance types**
+
+In the `MULTI_INSTANCE_TYPES` set (line 74-77), add `'WGAM', 'WCLM', 'WVCH'` (WDOC is single-instance, do NOT add it):
+
+```javascript
+export const MULTI_INSTANCE_TYPES = new Set([
+  'ADR', 'DIAG', 'DFD', 'WARD', 'DMC',
+  'RSCH', 'AWRS', 'AZRS', 'GCRS', 'DSCT',
+  'WGAM', 'WCLM', 'WVCH',
+]);
+```
+
+- [ ] **Step 3: Add subdirectory mappings**
+
+In the `SUBDIR_MAP` object (after line 86 `'WARD': 'wardley-maps'`), add:
+
+```javascript
+  'WDOC': 'wardley-maps',
+  'WGAM': 'wardley-maps',
+  'WCLM': 'wardley-maps',
+  'WVCH': 'wardley-maps',
+```
+
+- [ ] **Step 4: Verify the file is valid JavaScript**
+
+Run: `node -e "import('./arckit-claude/config/doc-types.mjs').then(m => console.log(Object.keys(m.DOC_TYPES).length, 'types,', m.MULTI_INSTANCE_TYPES.size, 'multi-instance,', Object.keys(m.SUBDIR_MAP).length, 'subdirs'))"`
+
+Expected: `51 types, 13 multi-instance, 14 subdirs` (was 47 types, 10 multi-instance, 10 subdirs)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add arckit-claude/config/doc-types.mjs
+git commit -m "feat: register WDOC, WGAM, WCLM, WVCH document types"
+```
+
+---
+
+### Task 2: Update generate-document-id.sh
+
+**Files:**
+- Modify: `scripts/bash/generate-document-id.sh:18-19` (comment)
+- Modify: `scripts/bash/generate-document-id.sh:85` (MULTI_INSTANCE_TYPES)
+
+- [ ] **Step 1: Add new types to MULTI_INSTANCE_TYPES**
+
+On line 85, change:
+
+```bash
+MULTI_INSTANCE_TYPES="ADR DIAG DFD WARD DMC RSCH AWRS AZRS GCRS DSCT"
+```
+
+to:
+
+```bash
+MULTI_INSTANCE_TYPES="ADR DIAG DFD WARD DMC RSCH AWRS AZRS GCRS DSCT WGAM WCLM WVCH"
+```
+
+Update the comment on lines 18-19 to include the new types:
+
+```bash
+# Multi-instance types (require --next-num for sequence numbering):
+#   ADR, DIAG, DFD, WARD, DMC, RSCH, AWRS, AZRS, GCRS, DSCT, WGAM, WCLM, WVCH
+```
+
+- [ ] **Step 2: Test document ID generation**
+
+Run:
+```bash
+bash scripts/bash/generate-document-id.sh 001 WDOC 1.0
+bash scripts/bash/generate-document-id.sh 001 WGAM 1.0 --filename --next-num /tmp
+bash scripts/bash/generate-document-id.sh 001 WVCH 1.0 --filename --next-num /tmp
+bash scripts/bash/generate-document-id.sh 001 WCLM 1.0 --filename --next-num /tmp
+```
+
+Expected:
+```
+ARC-001-WDOC-v1.0
+ARC-001-WGAM-001-v1.0.md
+ARC-001-WVCH-001-v1.0.md
+ARC-001-WCLM-001-v1.0.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/bash/generate-document-id.sh
+git commit -m "feat: add WGAM, WCLM, WVCH to multi-instance types"
+```
+
+---
+
+### Task 3: Extend validate-wardley-math.mjs hook
+
+**Files:**
+- Modify: `arckit-claude/hooks/validate-wardley-math.mjs:68` (file filter)
+
+- [ ] **Step 1: Read the current hook to find the file filter**
+
+Read `arckit-claude/hooks/validate-wardley-math.mjs` and locate the line that filters for `-WARD-` in filenames (around line 68).
+
+- [ ] **Step 2: Extend the filter to include `-WVCH-`**
+
+Change the filter condition from checking only `-WARD-` to also accepting `-WVCH-`. The exact edit depends on the current code pattern — it may be a string `.includes('-WARD-')` or a regex. Add `-WVCH-` using the same pattern (e.g., `f.includes('-WARD-') || f.includes('-WVCH-')`).
+
+- [ ] **Step 3: Verify the hook still works**
+
+Run: `node arckit-claude/hooks/validate-wardley-math.mjs` (it should exit cleanly with no errors when run outside a project context)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add arckit-claude/hooks/validate-wardley-math.mjs
+git commit -m "feat: extend wardley math hook to validate WVCH documents"
+```
+
+---
+
+### Task 4: Fix pre-existing wardley.md hook bug
+
+**Files:**
+- Modify: `arckit-claude/commands/wardley.md:16` (hooks frontmatter)
+
+- [ ] **Step 1: Fix the hook command**
+
+On line 16 of `arckit-claude/commands/wardley.md`, change:
+
+```yaml
+          command: "python3 ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.py"
+```
+
+to:
+
+```yaml
+          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.mjs"
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add arckit-claude/commands/wardley.md
+git commit -m "fix: correct wardley.md hook from python3 .py to node .mjs"
+```
+
+---
+
+### Task 5: Fix converter regexes for dot-namespaced commands
+
+**Files:**
+- Modify: `scripts/converter.py:537` (colon-format regex)
+- Modify: `scripts/converter.py:542` (dot-format regex)
+- Modify: `scripts/converter.py:549` (prompts-format regex)
+
+- [ ] **Step 1: Update all three regexes**
+
+In `scripts/converter.py`, in the `rewrite_codex_skills()` function:
+
+Line 537 — change `r"/arckit:(\w[\w-]*)"` to `r"/arckit:(\w[\w.-]*)"`
+
+Line 542 — change `r"(?<=\s)/arckit\.(\w[\w-]*)"` to `r"(?<=\s)/arckit\.(\w[\w.-]*)"`
+
+Line 549 — change `r"/prompts:arckit\.(\w[\w-]*)"` to `r"/prompts:arckit\.(\w[\w.-]*)"`
+
+- [ ] **Step 2: Verify the converter runs without errors**
+
+Run: `python scripts/converter.py`
+
+Expected: Converter completes successfully, no Python errors. Check that the output log shows the expected number of generated files.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add scripts/converter.py
+git commit -m "fix: update converter regexes to handle dot-namespaced commands"
+```
+
+---
+
+## Chunk 2: Reference File Enhancements
+
+Each reference file is an independent task that can be parallelized. All files are in `arckit-claude/skills/wardley-mapping/references/`.
+
+**Critical instruction for all reference file tasks**: Read the corresponding research book AND the existing reference file. Produce a distilled summary — NOT verbatim book content. Preserve any existing structure that works well (e.g., YAML blocks, assessment templates). The enhanced file must be self-contained and usable as a context reference for AI commands.
+
+### Task 6: Enhance doctrine.md (120 → ~400 lines)
+
+**Files:**
+- Modify: `arckit-claude/skills/wardley-mapping/references/doctrine.md`
+
+**Source material**: Read `research/Introduction to Wardley Mapping Doctrine.md`
+
+- [ ] **Step 1: Read existing file and source book**
+
+Read `arckit-claude/skills/wardley-mapping/references/doctrine.md` (current 120 lines).
+Read `research/Introduction to Wardley Mapping Doctrine.md` (full book — focus on the phase tables, category details, and implementation journeys).
+
+- [ ] **Step 2: Rewrite doctrine.md with enhanced content**
+
+Preserve the existing YAML assessment template and 1-5 scoring structure. Add:
+
+1. **Strategy Cycle** section — Purpose → Landscape → Climate → Doctrine → Leadership (from book intro)
+2. **Doctrine Phase/Category Matrix** — The canonical table (4 phases × 6 categories with all ~40 principles). Source: the book's Figure 2 table (around page 8-9 of the markdown)
+3. **Phase I: Stop Self-Harm** — Communication (common language, challenge assumptions, understand context), Development (know users, focus on needs, remove bias, appropriate methods), Operation (know details), Learning (systematic learning)
+4. **Phase II: Becoming More Context Aware** — add Leading (move fast, strategy is iterative) and Structure (small teams, distribute power, aptitude & attitude) categories
+5. **Phase III: Better for Less** — Operation (optimize flow), Learning (bias to new, do better with less, exceptional standards), Leading (commit, be owner, inspire, embrace uncertainty, be humble), Structure (seek best, purpose/mastery/autonomy)
+6. **Phase IV: Continuously Evolving** — Learning (listen to ecosystem), Leading (exploit landscape, no core), Structure (no single culture, design for constant evolution)
+7. **Implementation Journeys** — Brief per-category journey summaries (Communication Journey, Development Journey, Operation Journey, Learning Journey, Leading Journey, Structure Journey)
+8. **Assessment Template** — Keep existing 1-5 scoring but expand to cover all 40+ principles with phase grouping
+
+Target: ~400 lines, distilled summaries with the key principle names, descriptions, and phase/category placement.
+
+- [ ] **Step 3: Verify line count and structure**
+
+Run: `wc -l arckit-claude/skills/wardley-mapping/references/doctrine.md`
+
+Expected: 350-450 lines. Verify it has: Strategy Cycle, Phase/Category Matrix, Phase I-IV details, Implementation Journeys, Assessment Template.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add arckit-claude/skills/wardley-mapping/references/doctrine.md
+git commit -m "feat: expand doctrine reference to 40+ principles across 4 phases"
+```
+
+---
+
+### Task 7: Enhance gameplay-patterns.md (171 → ~600 lines)
+
+**Files:**
+- Modify: `arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md`
+
+**Source material**: Read `research/Introduction to Wardley Mapping Gameplays.md`
+
+- [ ] **Step 1: Read existing file and source book**
+
+Read `arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md` (current 171 lines).
+Read `research/Introduction to Wardley Mapping Gameplays.md` — focus on Chapter 3 (all gameplays by category) and Chapter 4 (case studies).
+
+- [ ] **Step 2: Rewrite gameplay-patterns.md with enhanced content**
+
+Preserve the existing build/buy/outsource decision framework. Restructure to 11 categories with all gameplays:
+
+1. **Category A: User Perception** (8 plays) — Education (LG), Bundling (N), Creating Artificial Needs (LE), Confusion of Choice (LE), Brand & Marketing (N), FUD (LE), Artificial Competition (CE), Lobbying (CE)
+2. **Category B: Accelerators** (5 plays) — Market Enablement (LG), Open Approaches (LG), Exploiting Network Effects (N), Co-operation (N), Industrial Policy (N)
+3. **Category C: De-accelerators** (3 plays) — Exploiting Constraint (LE), IPR (LE), Creating Constraints (CE)
+4. **Category D: Dealing with Toxicity** (4 plays) — Pig in a Poke (CE), Disposal of Liability (N), Sweat and Dump (LE), Refactoring (LG)
+5. **Category E: Market** (8 plays) — Differentiation (N), Pricing Policy (N), Buyer/Supplier Power (LE), Harvesting (LE), Standards Game (LE), Last Man Standing (LE), Signal Distortion (CE), Trading (N)
+6. **Category F: Defensive** (6 plays) — Threat Acquisition (N), Raising Barriers (N), Procrastination (N), Defensive Regulation (LE), Limitation of Competition (CE), Managing Inertia (N)
+7. **Category G: Attacking** (7 plays) — Directed Investment (LG), Experimentation (LG), Centre of Gravity (N), Undermining Barriers (N), Fool's Mate (LE), Press Release Process (LE), Playing Both Sides (N)
+8. **Category H: Ecosystem** (8 plays) — Alliances (LG), Co-creation (LG), Sensing Engines/ILC (N), Tower and Moat (N), N-sided Markets (N), Co-opting (LE), Embrace and Extend (LE), Channel Conflicts (N)
+9. **Category I: Competitor** (8 plays) — Ambush (N), Fragmentation (LE), Reinforcing Inertia (LE), Sapping (LE), Misdirection (CE), Restriction of Movement (CE), Talent Raid (CE), Circling and Probing (N)
+10. **Category J: Positional** (4 plays) — Land Grab (N), First Mover/Fast Follower (N), Aggregation (N), Weak Signal/Horizon (N)
+11. **Category K: Poison** (3 plays) — Licensing Play (LE), Insertion (CE), Designed to Fail (CE)
+
+Each play needs: name, D&D alignment (LG/N/LE/CE), 1-2 sentence description, when to use, evolution stage applicability.
+
+Also add:
+- **D&D Alignment Key** — Lawful Good, Neutral, Lawful Evil, Chaotic Evil definitions
+- **Play-Position Matrix** — Table mapping (your position × market position → recommended plays)
+- **Play Compatibility** — Which plays work together vs conflict
+- **Anti-Patterns** — Strategic mistakes to avoid
+- **Case Study Summaries** — Brief 2-3 line summaries of AWS, Netflix, Tesla, Spotify, Apple, Google Android, Ubuntu, Airbnb, Amazon Retail strategies
+- Keep existing **Build vs Buy vs Outsource** framework and **Innovation Investment** section
+
+Target: ~600 lines.
+
+- [ ] **Step 3: Verify line count and structure**
+
+Run: `wc -l arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md`
+
+Expected: 550-650 lines. Verify it has all 11 categories, D&D alignment key, play-position matrix, case studies.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add arckit-claude/skills/wardley-mapping/references/gameplay-patterns.md
+git commit -m "feat: expand gameplay patterns to 60+ plays across 11 categories"
+```
+
+---
+
+### Task 8: Enhance climatic-patterns.md (273 → ~500 lines)
+
+**Files:**
+- Modify: `arckit-claude/skills/wardley-mapping/references/climatic-patterns.md`
+
+**Source material**: Read `research/Introduction to Wardley Mapping Climatic Patterns - Kindle - v1.0.1.md`
+
+- [ ] **Step 1: Read existing file and source book**
+
+Read `arckit-claude/skills/wardley-mapping/references/climatic-patterns.md` (current 273 lines).
+Read `research/Introduction to Wardley Mapping Climatic Patterns - Kindle - v1.0.1.md` — focus on chapters IV-IX (the 6 pattern categories).
+
+- [ ] **Step 2: Rewrite climatic-patterns.md with enhanced content**
+
+Restructure into 6 categories with all 32 patterns:
+
+1. **Component Patterns** (8): Everything evolves through supply/demand competition, Rates vary by ecosystem, Characteristics change as components evolve, No choice over evolution (Red Queen), No single method fits all, Components can co-evolve, Multiple waves of diffusion with chasms, Commoditization ≠ centralization
+2. **Financial Patterns** (6): Higher-order systems create new value sources, Jevons Paradox (efficiency ≠ reduced spend), Capital flows to new value areas, Creative destruction (Schumpeter), Future value inversely proportional to certainty, Evolution increases local order and energy consumption
+3. **Speed Patterns** (5): Efficiency enables innovation (componentization), Communication evolution increases overall speed, Stability of lower-order systems increases agility, Change is not always linear (discontinuous/exponential), Product-to-utility shifts show punctuated equilibrium
+4. **Inertia Patterns** (3): Success breeds inertia, Inertia can kill an organization, Inertia increases with past model success
+5. **Competitor Patterns** (2): Competitors' actions change the game, Most competitors have poor situational awareness
+6. **Prediction Patterns** (8): P[what] vs P[when] (what is predictable, when is not), Economy has cycles (peace/war/wonder), Predictable vs unpredictable disruption, War (industrialization) causes org evolution, Cannot measure evolution over time or adoption, Less evolved = more uncertain, Not everything survives
+
+Each pattern: name, 2-3 sentence description, strategic implication, assessment question.
+
+Preserve existing assessment questions and pattern recognition template sections. Add:
+- **Peace/War/Wonder Cycle** — Detailed explanation with phase characteristics
+- **Pattern Interaction Map** — Which patterns reinforce or counteract each other
+- **Per-Component Assessment Template** — How to score pattern impact per component
+
+Target: ~500 lines.
+
+- [ ] **Step 3: Verify line count and structure**
+
+Run: `wc -l arckit-claude/skills/wardley-mapping/references/climatic-patterns.md`
+
+Expected: 450-550 lines. Verify all 6 categories with 32 patterns present.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add arckit-claude/skills/wardley-mapping/references/climatic-patterns.md
+git commit -m "feat: expand climatic patterns to 32 patterns across 6 categories"
+```
+
+---
+
+### Task 9: Enhance evolution-stages.md (101 → ~180 lines)
+
+**Files:**
+- Modify: `arckit-claude/skills/wardley-mapping/references/evolution-stages.md`
+
+**Source material**: Fundamentals chapters from all 3 books + melodic-software evolution-analysis skill patterns (documented in spec conversation).
+
+- [ ] **Step 1: Read existing file**
+
+Read `arckit-claude/skills/wardley-mapping/references/evolution-stages.md` (current 101 lines).
+
+- [ ] **Step 2: Enhance with additional content**
+
+Keep existing structure (stage characteristics, indicators table, positioning criteria, common mistakes). Add:
+
+- **Enhanced Stage Indicators** — More detailed checklists per stage from the books (ubiquity markers, certainty markers, market maturity markers, failure mode descriptions)
+- **Transition Timing Heuristics** — Weak signals for stage transitions: conference talks emerging, documentation appearing, pricing model shifts, standardization efforts, open-source alternatives appearing
+- **Pioneers/Settlers/Planners** — Expanded talent model section explaining which talent types work best at each stage, how to manage handoffs between talent types
+- **Assessment Questions per Stage** — Practical questions to validate component placement ("Can you buy this off the shelf?" → Product/Commodity; "Are there multiple competing approaches?" → Custom)
+
+Target: ~180 lines.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+wc -l arckit-claude/skills/wardley-mapping/references/evolution-stages.md
+git add arckit-claude/skills/wardley-mapping/references/evolution-stages.md
+git commit -m "feat: enhance evolution stages with transition heuristics and talent model"
+```
+
+---
+
+### Task 10: Enhance mapping-examples.md (307 → ~450 lines)
+
+**Files:**
+- Modify: `arckit-claude/skills/wardley-mapping/references/mapping-examples.md`
+
+**Source material**: Gameplays book Chapter 4 (case studies), Climatic Patterns book (TechnoGadget), melodic-software value-chain skill (e-commerce/SaaS examples).
+
+- [ ] **Step 1: Read existing file**
+
+Read `arckit-claude/skills/wardley-mapping/references/mapping-examples.md` (current 307 lines).
+
+- [ ] **Step 2: Add new examples**
+
+Keep existing 3 examples (E-Commerce, DevOps Platform, ML Product). Add:
+
+- **TechnoGadget Smart Home** example — from the Climatic Patterns book. Smart thermostat company value chain: User Need → Smart Thermostat → Mobile App → Cloud Infrastructure → Data Analytics. Include OWM syntax and component positioning.
+- **Value Chain Decomposition Example** — Step-by-step decomposition of an e-commerce user need ("Buy products online") showing anchor identification, first-level components, recursive decomposition, dependency establishment, validation. Based on melodic-software's value-chain skill patterns.
+- **Case Study Cross-References** — Brief summaries linking to gameplay patterns: AWS (ILC pattern: innovate internal infrastructure → leverage as EC2/S3 → commoditize as utility computing), Netflix (transition from DVD to streaming — attacking play + ecosystem play), Spotify (two-factor market: free users + premium subscribers + artists).
+
+Target: ~450 lines.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+wc -l arckit-claude/skills/wardley-mapping/references/mapping-examples.md
+git add arckit-claude/skills/wardley-mapping/references/mapping-examples.md
+git commit -m "feat: add TechnoGadget, value chain, and case study examples"
+```
+
+---
+
+### Task 11: Enhance mathematical-models.md (254 → ~300 lines)
+
+**Files:**
+- Modify: `arckit-claude/skills/wardley-mapping/references/mathematical-models.md`
+
+- [ ] **Step 1: Read existing file**
+
+Read `arckit-claude/skills/wardley-mapping/references/mathematical-models.md` (current 254 lines).
+
+- [ ] **Step 2: Add play-position scoring and climate impact weighting**
+
+Keep all existing content. Add:
+
+- **Play-Position Scoring** — Quantitative framework for evaluating gameplay options based on your evolution position and market position. Score = f(position_match, capability_fit, risk_tolerance). Based on melodic-software's strategic-analysis patterns.
+- **Climate Pattern Impact Weighting** — How to score the impact of each climatic pattern on each component. Impact matrix: pattern × component → impact score (1-5). Aggregate to identify most-affected components and highest-impact patterns.
+
+Target: ~300 lines.
+
+- [ ] **Step 3: Verify and commit**
+
+```bash
+wc -l arckit-claude/skills/wardley-mapping/references/mathematical-models.md
+git add arckit-claude/skills/wardley-mapping/references/mathematical-models.md
+git commit -m "feat: add play-position scoring and climate impact weighting"
+```
+
+---
+
+## Chunk 3: Templates
+
+### Task 12: Create wardley-value-chain-template.md
+
+**Files:**
+- Create: `arckit-claude/templates/wardley-value-chain-template.md`
+- Create: `.arckit/templates/wardley-value-chain-template.md` (mirror)
+
+- [ ] **Step 1: Create the template**
+
+Use the existing `arckit-claude/templates/wardley-map-template.md` as the structural pattern (Document Control table, Revision History, section structure, Generation Footer). Create `arckit-claude/templates/wardley-value-chain-template.md` with sections per the spec:
+
+- Document Control (Document ID: `ARC-[PROJECT_ID]-WVCH-[NNN]-v[VERSION]`, Document Type: `Wardley Value Chain`)
+- Revision History
+- Executive Summary
+- User Need / Anchor (`{anchor_description}` — the user need this chain serves)
+- Users and Personas table
+- Value Chain Diagram (ASCII art placeholder + OWM notation block)
+- Component Inventory table (ID, Component, Description, Depends On, Visibility score 0.0-1.0)
+- Dependency Matrix (component × component grid)
+- Critical Path Analysis
+- Validation Checklist (completeness, accuracy, usefulness — checkboxes)
+- Visibility Assessment (Y-axis positioning guide table: 0.90-1.0 direct interaction → 0.00-0.09 utilities)
+- Assumptions and Open Questions
+- Generation Footer (`/arckit.wardley.value-chain`)
+
+- [ ] **Step 2: Mirror to .arckit/templates/**
+
+```bash
+cp arckit-claude/templates/wardley-value-chain-template.md .arckit/templates/wardley-value-chain-template.md
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add arckit-claude/templates/wardley-value-chain-template.md .arckit/templates/wardley-value-chain-template.md
+git commit -m "feat: add wardley value chain template"
+```
+
+---
+
+### Task 13: Create wardley-doctrine-template.md
+
+**Files:**
+- Create: `arckit-claude/templates/wardley-doctrine-template.md`
+- Create: `.arckit/templates/wardley-doctrine-template.md` (mirror)
+
+- [ ] **Step 1: Create the template**
+
+Document Control (Document ID: `ARC-[PROJECT_ID]-WDOC-v[VERSION]`, Document Type: `Wardley Doctrine Assessment`), Revision History, then:
+
+- Executive Summary (overall maturity score, phase positioning, critical findings)
+- Strategy Cycle Context (Purpose, Landscape summary, Climate summary, Leadership context)
+- Doctrine Assessment Matrix — Large table: rows = all ~40 principles grouped by phase (I-IV), columns = Category, Principle, Score (1-5), Evidence, Improvement Action
+- Phase I Assessment (Stop Self-Harm) — detailed findings per principle
+- Phase II Assessment (Becoming More Context Aware)
+- Phase III Assessment (Better for Less)
+- Phase IV Assessment (Continuously Evolving)
+- Previous Assessment Comparison (if re-assessment: table with Principle, Previous Score, Current Score, Trend ↑↓→)
+- Critical Gaps — Top 5 gaps with phase, category, current score, target score, business impact
+- Implementation Roadmap — Immediate (0-3mo), Short-term (3-12mo), Long-term (12-24mo)
+- Recommendations
+- Traceability (links to PRIN, WARD, STKE)
+- Generation Footer (`/arckit.wardley.doctrine`)
+
+- [ ] **Step 2: Mirror and commit**
+
+```bash
+cp arckit-claude/templates/wardley-doctrine-template.md .arckit/templates/wardley-doctrine-template.md
+git add arckit-claude/templates/wardley-doctrine-template.md .arckit/templates/wardley-doctrine-template.md
+git commit -m "feat: add wardley doctrine assessment template"
+```
+
+---
+
+### Task 14: Create wardley-gameplay-template.md
+
+**Files:**
+- Create: `arckit-claude/templates/wardley-gameplay-template.md`
+- Create: `.arckit/templates/wardley-gameplay-template.md` (mirror)
+
+- [ ] **Step 1: Create the template**
+
+Document Control (Document ID: `ARC-[PROJECT_ID]-WGAM-[NNN]-v[VERSION]`, Document Type: `Wardley Gameplay Analysis`), Revision History, then:
+
+- Executive Summary
+- Map Reference (link to WARD artifact: `ARC-[PROJECT_ID]-WARD-[NNN]-v[VERSION]`)
+- Situational Assessment (Position Analysis, Capability Assessment, Market Context — based on melodic-software's play selection framework questions)
+- Play Options — 11 category sections, each with applicable plays, D&D alignment tag, applicability assessment, and recommendation (Apply/Monitor/Skip)
+- Play-Position Matrix Evaluation (your position × market → recommended plays, with scoring)
+- Play Compatibility Analysis (selected plays: do they reinforce or conflict?)
+- Selected Plays — For each selected play: Description, Prerequisites, Execution Steps (1-N), Expected Outcomes (short/long term), Risks and Mitigations, Resource Requirements, Success Criteria, Review Points
+- Risk Assessment and Anti-Patterns
+- Case Study References (which real-world examples inform the selected plays)
+- Traceability (links to WARD, WCLM, WDOC, PRIN)
+- Generation Footer (`/arckit.wardley.gameplay`)
+
+- [ ] **Step 2: Mirror and commit**
+
+```bash
+cp arckit-claude/templates/wardley-gameplay-template.md .arckit/templates/wardley-gameplay-template.md
+git add arckit-claude/templates/wardley-gameplay-template.md .arckit/templates/wardley-gameplay-template.md
+git commit -m "feat: add wardley gameplay analysis template"
+```
+
+---
+
+### Task 15: Create wardley-climate-template.md
+
+**Files:**
+- Create: `arckit-claude/templates/wardley-climate-template.md`
+- Create: `.arckit/templates/wardley-climate-template.md` (mirror)
+
+- [ ] **Step 1: Create the template**
+
+Document Control (Document ID: `ARC-[PROJECT_ID]-WCLM-[NNN]-v[VERSION]`, Document Type: `Wardley Climate Assessment`), Revision History, then:
+
+- Executive Summary
+- Map Reference (link to WARD artifact)
+- Component Inventory (extracted from WARD — table: Component, Visibility, Evolution, Stage)
+- Climate Assessment by Category:
+  - Component Patterns assessment (8 patterns × impact on this project)
+  - Financial Patterns assessment (6 patterns)
+  - Speed Patterns assessment (5 patterns)
+  - Inertia Patterns assessment (3 patterns)
+  - Competitor Patterns assessment (2 patterns)
+  - Prediction Patterns assessment (8 patterns)
+- Per-Component Impact Matrix (rows = components, columns = key patterns, cells = impact H/M/L)
+- Prediction Horizons (6-month outlook, 18-month outlook — per component: current stage, predicted stage, confidence, key signals)
+- Wave Analysis (current position in peace/war/wonder cycle, implications)
+- Inertia Assessment (per component: inertia type, severity, mitigation strategy)
+- Strategic Implications (summary of how climate affects strategy)
+- Traceability (links to WARD, REQ, RSCH)
+- Generation Footer (`/arckit.wardley.climate`)
+
+- [ ] **Step 2: Mirror and commit**
+
+```bash
+cp arckit-claude/templates/wardley-climate-template.md .arckit/templates/wardley-climate-template.md
+git add arckit-claude/templates/wardley-climate-template.md .arckit/templates/wardley-climate-template.md
+git commit -m "feat: add wardley climate assessment template"
+```
+
+---
+
+## Chunk 4: Commands
+
+### Task 16: Create wardley.value-chain.md command
+
+**Files:**
+- Create: `arckit-claude/commands/wardley.value-chain.md`
+
+- [ ] **Step 1: Create the command file**
+
+Use the existing `arckit-claude/commands/wardley.md` as the structural pattern (YAML frontmatter with description, argument-hint, handoffs, hooks; then prompt body with steps).
+
+YAML frontmatter:
+```yaml
+---
+description: Decompose user needs into value chains for Wardley Mapping
+argument-hint: "<user need or domain, e.g. 'online shopping', 'patient booking'>"
+handoffs:
+  - command: wardley
+    description: Create Wardley Map from this value chain
+  - command: wardley.doctrine
+    description: Assess organizational doctrine maturity
+    condition: "Value chain reveals organizational capability gaps"
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.mjs"
+          timeout: 10
+---
+```
+
+Prompt body structure (model on existing wardley.md patterns):
+
+1. Role description — expert in value chain decomposition using Wardley Mapping methodology
+2. User Input — `$ARGUMENTS`
+3. Step 1: Read prerequisites — MANDATORY: REQ. RECOMMENDED: STKE. OPTIONAL: PRIN. Also read existing WVCH artifacts.
+4. Step 2: Identify the Anchor (User Need) — Good vs bad anchor guidance, anchor identification questions (from melodic-software value-chain skill and books). Reference `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/evolution-stages.md` for positioning.
+5. Step 3: Decompose into Components — Recursive decomposition method, component identification checklist, stop conditions.
+6. Step 4: Establish Dependencies — Dependency types (requires, uses, enables), dependency rules, circular dependency warning.
+7. Step 5: Assess Visibility — Y-axis positioning guide (0.90-1.0 direct interaction → 0.00-0.09 utilities). Reference `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/evolution-stages.md`.
+8. Step 6: Validate the Chain — Completeness, accuracy, usefulness checklists. Common validation issues (too shallow, too deep, missing components, solution bias).
+9. Step 7: Generate Output — Read template, populate Document Control, create project path via create-project.sh, write file using Write tool. Include OWM notation for the value chain.
+10. Summary message to user with file location and next step recommendations.
+
+Include standard ArcKit patterns: Document Control auto-population, quality checklist reference (`${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md`), markdown escaping note.
+
+Target: ~350-450 lines.
+
+- [ ] **Step 2: Verify YAML frontmatter is valid**
+
+Run: `head -20 arckit-claude/commands/wardley.value-chain.md` — verify frontmatter opens and closes with `---`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add arckit-claude/commands/wardley.value-chain.md
+git commit -m "feat: add wardley.value-chain command for value chain decomposition"
+```
+
+---
+
+### Task 17: Create wardley.doctrine.md command
+
+**Files:**
+- Create: `arckit-claude/commands/wardley.doctrine.md`
+
+- [ ] **Step 1: Create the command file**
+
+YAML frontmatter:
+```yaml
+---
+description: Assess organizational doctrine maturity using Wardley's 4-phase framework
+argument-hint: "<organization or project, e.g. 'DWP Benefits Team', 'Platform Engineering'>"
+handoffs:
+  - command: wardley
+    description: Create or refine Wardley Map informed by doctrine gaps
+    condition: "Doctrine gaps affect component positioning or strategy"
+  - command: wardley.gameplay
+    description: Select gameplays that address doctrine weaknesses
+---
+```
+
+Prompt body:
+
+1. Role — expert in organizational maturity assessment using Wardley's doctrine framework
+2. User Input — `$ARGUMENTS`
+3. Step 1: Read prerequisites — MANDATORY: PRIN. RECOMMENDED: WARD, STKE. OPTIONAL: REQ. Also read existing WDOC for re-assessment comparison.
+4. Step 2: Read reference material — Read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/doctrine.md` for the full doctrine framework (40+ principles, 4 phases, 6 categories).
+5. Step 3: Gather Evidence — For each doctrine principle, assess using evidence from available artifacts, project context, and user input. Score 1-5 (1=not practiced, 2=ad-hoc, 3=developing, 4=mature, 5=cultural norm).
+6. Step 4: Analyze by Phase — Phase I through IV analysis. Emphasize: phases build sequentially — skipping foundational work undermines higher phases.
+7. Step 5: Re-assessment Comparison — If previous WDOC exists, produce comparison table (Principle, Previous Score, Current Score, Trend ↑↓→).
+8. Step 6: Identify Critical Gaps — Top 5 gaps with largest business impact. Focus on Phase I gaps first (stop self-harm before improving strategy).
+9. Step 7: Create Implementation Roadmap — Immediate (0-3mo), Short-term (3-12mo), Long-term (12-24mo) actions.
+10. Step 8: Generate Output — Read template, populate, write file.
+11. Summary message.
+
+Target: ~400-500 lines.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add arckit-claude/commands/wardley.doctrine.md
+git commit -m "feat: add wardley.doctrine command for doctrine maturity assessment"
+```
+
+---
+
+### Task 18: Create wardley.gameplay.md command
+
+**Files:**
+- Create: `arckit-claude/commands/wardley.gameplay.md`
+
+- [ ] **Step 1: Create the command file**
+
+YAML frontmatter:
+```yaml
+---
+description: Analyze strategic play options from Wardley Maps using 60+ gameplay patterns
+argument-hint: "<strategic context, e.g. 'cloud migration', 'market entry for chatbot'>"
+handoffs:
+  - command: roadmap
+    description: Create roadmap to execute selected plays
+  - command: strategy
+    description: Synthesise gameplay into architecture strategy
+  - command: wardley.climate
+    description: Validate plays against climatic patterns
+    condition: "Climate assessment not yet performed"
+---
+```
+
+Prompt body:
+
+1. Role — expert strategist in Wardley Mapping gameplays and competitive positioning
+2. User Input — `$ARGUMENTS`
+3. Step 1: Read prerequisites — MANDATORY: WARD (Wardley Map must exist). RECOMMENDED: WCLM, WDOC. OPTIONAL: RSCH, PRIN.
+4. Step 2: Read reference material — Read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/gameplay-patterns.md` for the full 60+ gameplay catalog across 11 categories with D&D alignments.
+5. Step 3: Situational Assessment — Position analysis (where are your components?), Capability assessment (what can you execute?), Market context (growing/consolidating? regulatory?). Extract from WARD artifact.
+6. Step 4: Evaluate Play Options — For each of the 11 categories, assess which plays are applicable given the current map position. Use the play-position matrix. Tag each with D&D alignment.
+7. Step 5: Check Play Compatibility — Do selected plays reinforce or conflict? Reference compatibility guidance from the reference file.
+8. Step 6: Detail Selected Plays — For each selected play: execution steps, prerequisites, expected outcomes, risks, success criteria, review points.
+9. Step 7: Anti-Pattern Check — Verify the strategy doesn't fall into common anti-patterns (playing in wrong stage, single play dependence, ignoring inertia, ecosystem hubris).
+10. Step 8: Cross-reference Case Studies — Which real-world examples (AWS, Netflix, etc.) inform the selected plays?
+11. Step 9: Generate Output — Read template, populate, write file.
+12. Summary message.
+
+Target: ~450-550 lines.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add arckit-claude/commands/wardley.gameplay.md
+git commit -m "feat: add wardley.gameplay command for strategic play analysis"
+```
+
+---
+
+### Task 19: Create wardley.climate.md command
+
+**Files:**
+- Create: `arckit-claude/commands/wardley.climate.md`
+
+- [ ] **Step 1: Create the command file**
+
+YAML frontmatter:
+```yaml
+---
+description: Assess climatic patterns affecting Wardley Map components
+argument-hint: "<domain or market, e.g. 'AI in healthcare', 'UK government digital services'>"
+handoffs:
+  - command: wardley.gameplay
+    description: Select gameplays informed by climate forces
+  - command: wardley
+    description: Update map with climate-driven evolution predictions
+    condition: "Climate analysis reveals evolution velocity changes"
+---
+```
+
+Prompt body:
+
+1. Role — expert in Wardley Mapping climatic patterns and strategic forecasting
+2. User Input — `$ARGUMENTS`
+3. Step 1: Read prerequisites — MANDATORY: WARD. RECOMMENDED: REQ, RSCH. OPTIONAL: WDOC, PRIN.
+4. Step 2: Read reference material — Read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/climatic-patterns.md` for all 32 patterns across 6 categories. Also read `${CLAUDE_PLUGIN_ROOT}/skills/wardley-mapping/references/mathematical-models.md` for impact weighting.
+5. Step 3: Extract Component Inventory — From WARD artifact, list all components with their visibility and evolution positions.
+6. Step 4: Assess Climatic Patterns — For each of the 6 categories (component, financial, speed, inertia, competitors, prediction), evaluate which patterns are actively affecting the mapped landscape. Provide evidence and strategic implications per pattern.
+7. Step 5: Per-Component Impact Matrix — For each component, score the impact of key patterns (H/M/L). Identify most-affected components.
+8. Step 6: Prediction Horizons — 6-month and 18-month forecasts per component: current stage, predicted stage, confidence level, key signals to watch.
+9. Step 7: Wave Analysis — Position the landscape in the peace/war/wonder cycle. Identify which components are in which phase and implications.
+10. Step 8: Inertia Assessment — Per component: type of inertia, severity, mitigation strategy.
+11. Step 9: Generate Output — Read template, populate, write file.
+12. Summary message.
+
+Target: ~400-500 lines.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add arckit-claude/commands/wardley.climate.md
+git commit -m "feat: add wardley.climate command for climatic pattern assessment"
+```
+
+---
+
+### Task 20: Update existing wardley.md handoffs
+
+**Files:**
+- Modify: `arckit-claude/commands/wardley.md:4-17` (frontmatter)
+
+- [ ] **Step 1: Add new handoffs to wardley.md frontmatter**
+
+In the `handoffs:` section, add 3 new entries after the existing `research` handoff:
+
+```yaml
+  - command: wardley.doctrine
+    description: Assess organizational doctrine maturity
+  - command: wardley.gameplay
+    description: Identify strategic plays from the map
+  - command: wardley.climate
+    description: Assess climatic patterns affecting components
+```
+
+- [ ] **Step 2: Add WVCH/WDOC/WCLM to recommended reading**
+
+In the command body where prerequisites are listed (Step 1), add to RECOMMENDED:
+- WVCH (Value Chain) — Extract: anchor, components, visibility, dependencies
+- WDOC (Doctrine Assessment) — Extract: doctrine scores, capability gaps
+- WCLM (Climate Assessment) — Extract: pattern impacts, predictions
+
+And to OPTIONAL:
+- WGAM (Gameplay Analysis) — Extract: selected plays, execution steps
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add arckit-claude/commands/wardley.md
+git commit -m "feat: add wardley suite handoffs and sibling artifact reading"
+```
+
+---
+
+## Chunk 5: Converter Verification
+
+### Task 21: Run converter and verify output
+
+**Files:**
+- No new files — verification only
+
+- [ ] **Step 1: Run the converter**
+
+```bash
+python scripts/converter.py
+```
+
+Expected: Converter completes without errors. Check the output log for the 4 new commands appearing in each target.
+
+- [ ] **Step 2: Verify Codex extension output**
+
+```bash
+ls arckit-codex/skills/arckit-wardley.value-chain/SKILL.md
+ls arckit-codex/skills/arckit-wardley.doctrine/SKILL.md
+ls arckit-codex/skills/arckit-wardley.gameplay/SKILL.md
+ls arckit-codex/skills/arckit-wardley.climate/SKILL.md
+```
+
+Verify all 4 skill directories exist with SKILL.md files. Check one file for correct cross-references: `grep 'arckit' arckit-codex/skills/arckit-wardley.gameplay/SKILL.md | head -5` — verify `/arckit.wardley.doctrine` was rewritten to `$arckit-wardley.doctrine` (not truncated to `$arckit-wardley`).
+
+- [ ] **Step 3: Verify Gemini extension output**
+
+```bash
+ls arckit-gemini/commands/arckit/wardley.value-chain.toml
+ls arckit-gemini/commands/arckit/wardley.doctrine.toml
+ls arckit-gemini/commands/arckit/wardley.gameplay.toml
+ls arckit-gemini/commands/arckit/wardley.climate.toml
+```
+
+If dots in TOML filenames cause issues, fix the converter to map dots to hyphens for Gemini target and re-run.
+
+- [ ] **Step 4: Verify OpenCode and Copilot output**
+
+```bash
+ls arckit-opencode/commands/arckit.wardley.value-chain.md
+ls arckit-opencode/commands/arckit.wardley.doctrine.md
+ls arckit-copilot/prompts/arckit-wardley.value-chain.prompt.md
+ls arckit-copilot/prompts/arckit-wardley.doctrine.prompt.md
+```
+
+- [ ] **Step 5: Verify reference files and templates were copied**
+
+```bash
+ls arckit-codex/references/wardley-mapping/
+ls arckit-gemini/references/wardley-mapping/
+ls arckit-codex/templates/wardley-doctrine-template.md
+ls arckit-gemini/templates/wardley-doctrine-template.md
+```
+
+- [ ] **Step 6: Commit all generated files**
+
+```bash
+git add arckit-codex/ arckit-gemini/ arckit-opencode/ arckit-copilot/ .codex/ .opencode/
+git commit -m "chore: regenerate extension formats with wardley suite commands"
+```
+
+---
+
+## Chunk 6: Documentation
+
+### Task 22: Create 4 new guide files
+
+**Files:**
+- Create: `docs/guides/wardley-value-chain.md` + mirror to `arckit-claude/guides/`
+- Create: `docs/guides/wardley-doctrine.md` + mirror to `arckit-claude/guides/`
+- Create: `docs/guides/wardley-gameplay.md` + mirror to `arckit-claude/guides/`
+- Create: `docs/guides/wardley-climate.md` + mirror to `arckit-claude/guides/`
+
+- [ ] **Step 1: Create each guide**
+
+Use `docs/guides/wardley.md` as the structural template (Guide Origin header, Inputs table, Command section, Output section, Key Concepts, Tips).
+
+Each guide should cover: when to use, prerequisites, command invocation, output artifact, key concepts from the domain, integration with other Wardley commands, tips.
+
+- [ ] **Step 2: Mirror all guides**
+
+```bash
+cp docs/guides/wardley-value-chain.md arckit-claude/guides/wardley-value-chain.md
+cp docs/guides/wardley-doctrine.md arckit-claude/guides/wardley-doctrine.md
+cp docs/guides/wardley-gameplay.md arckit-claude/guides/wardley-gameplay.md
+cp docs/guides/wardley-climate.md arckit-claude/guides/wardley-climate.md
+```
+
+- [ ] **Step 3: Update existing wardley.md guide**
+
+Add a "Wardley Mapping Suite" section to `docs/guides/wardley.md` describing the full suite, recommended workflow order (value-chain → wardley → doctrine/climate/gameplay), and links to the 4 new guides. Mirror to `arckit-claude/guides/wardley.md`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/guides/ arckit-claude/guides/
+git commit -m "docs: add guides for wardley suite commands"
+```
+
+---
+
+### Task 23: Update README.md
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update command count**
+
+Change `60` to `64` wherever the command count appears.
+
+- [ ] **Step 2: Add 4 new commands to the command table**
+
+Find the command table and add entries for the 4 new commands in the Architecture section, near the existing `wardley` entry:
+
+| Command | Description |
+|---------|-------------|
+| `wardley.value-chain` | Decompose user needs into value chains for Wardley Mapping |
+| `wardley.doctrine` | Assess organizational doctrine maturity using 4-phase framework |
+| `wardley.gameplay` | Analyze strategic play options from 60+ gameplay patterns |
+| `wardley.climate` | Assess climatic patterns affecting mapped components |
+
+- [ ] **Step 3: Add Wardley Mapping Suite description**
+
+Add a brief paragraph in the relevant section describing the Wardley suite: "The Wardley Mapping suite provides composable commands for strategic analysis. Start with `/arckit.wardley.value-chain` to decompose user needs, create maps with `/arckit.wardley`, then deepen analysis with doctrine assessment, gameplay analysis, and climate assessment."
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add README.md
+git commit -m "docs: add wardley suite commands to README"
+```
+
+---
+
+### Task 24: Update docs/index.html
+
+**Files:**
+- Modify: `docs/index.html`
+
+- [ ] **Step 1: Update command count in header**
+
+Change `60` to `64` in any header/meta text.
+
+- [ ] **Step 2: Add 4 new command entries**
+
+Add entries for the 4 new commands following the existing pattern in the HTML. Place them near the existing `wardley` entry in the Architecture category.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/index.html
+git commit -m "docs: add wardley suite commands to GitHub Pages index"
+```
+
+---
+
+### Task 25: Update docs/DEPENDENCY-MATRIX.md
+
+**Files:**
+- Modify: `docs/DEPENDENCY-MATRIX.md`
+
+- [ ] **Step 1: Add 4 new commands**
+
+Add entries for each new command showing prerequisites, outputs, and handoffs per the spec's prerequisite table and handoff declarations.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/DEPENDENCY-MATRIX.md
+git commit -m "docs: add wardley suite to dependency matrix"
+```
+
+---
+
+### Task 26: Update docs/WORKFLOW-DIAGRAMS.md
+
+**Files:**
+- Modify: `docs/WORKFLOW-DIAGRAMS.md`
+
+- [ ] **Step 1: Add Wardley Suite workflow diagram**
+
+Add the Wardley suite composition diagram from the spec (Section 4) showing: value-chain → wardley → doctrine/climate/gameplay → wardley (re-run) → roadmap/strategy.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/WORKFLOW-DIAGRAMS.md
+git commit -m "docs: add wardley suite workflow diagram"
+```
+
+---
+
+### Task 27: Update docs/README.md
+
+**Files:**
+- Modify: `docs/README.md`
+
+- [ ] **Step 1: Add 4 new commands to documentation index**
+
+Add entries for the 4 new commands in the appropriate section.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/README.md
+git commit -m "docs: add wardley suite to documentation index"
+```
+
+---
+
+### Task 28: Update CHANGELOGs
+
+**Files:**
+- Modify: `CHANGELOG.md`
+- Modify: `arckit-claude/CHANGELOG.md`
+
+- [ ] **Step 1: Add entries to both changelogs**
+
+Add under `## [Unreleased]` or the next version:
+
+```markdown
+### Added
+- `/arckit.wardley.value-chain` — Decompose user needs into value chains
+- `/arckit.wardley.doctrine` — Assess organizational doctrine maturity (4 phases, 40+ principles)
+- `/arckit.wardley.gameplay` — Analyze strategic plays from 60+ gameplay catalog with D&D alignment
+- `/arckit.wardley.climate` — Assess 32 climatic patterns across 6 categories
+- Wardley reference files enriched from 3 Wardley Mapping books (doctrine, gameplays, climatic patterns)
+- 4 new document types: WVCH, WDOC, WGAM, WCLM
+- 4 new templates and usage guides
+
+### Fixed
+- `wardley.md` hook reference corrected from `python3 .py` to `node .mjs`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CHANGELOG.md arckit-claude/CHANGELOG.md
+git commit -m "docs: update changelogs with wardley suite additions"
+```

--- a/docs/superpowers/specs/2026-03-13-github-issue-templates-design.md
+++ b/docs/superpowers/specs/2026-03-13-github-issue-templates-design.md
@@ -26,7 +26,7 @@ ArcKit's GitHub issues are frequently low-quality: vague titles, missing reprodu
 
 ## File Structure
 
-```
+```text
 .github/
 ├── ISSUE_TEMPLATE/
 │   ├── bug-report.yml

--- a/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
+++ b/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
@@ -1,0 +1,415 @@
+# Wardley Mapping Suite Enhancement Design
+
+**Date**: 2026-03-16
+**Status**: Draft
+**Author**: ArcKit Team
+
+## Summary
+
+Enhance ArcKit's Wardley Mapping capabilities from a single `/arckit.wardley` command into a composable suite of 5 commands (1 existing + 4 new), backed by massively enriched shared reference files. Content drawn from three Wardley Mapping books (Climatic Patterns, Doctrine, Gameplays) and patterns validated by the melodic-software/claude-code-plugins Wardley mapping skill.
+
+## Goals
+
+1. Expand strategic analysis depth — doctrine (15→40+ principles), gameplays (8→60+ patterns), climatic patterns (9→32 patterns)
+2. Add standalone commands for doctrine assessment, gameplay analysis, climate assessment, and value chain decomposition
+3. Maintain composability — every command works standalone but gets richer when sibling artifacts exist
+4. Support all 5 AI platforms via the converter
+5. Follow existing ArcKit patterns (templates, document control, handoffs, references)
+
+## Non-Goals
+
+- Agents for the new commands (none require heavy web research)
+- MCP server for OnlineWardleyMaps API (future opportunity)
+- Mermaid.js output format (future opportunity)
+- Breaking changes to existing `/arckit.wardley` command behavior
+
+---
+
+## Section 1: New Command Suite
+
+### Existing Command (Enhanced)
+
+- **`/arckit.wardley`** — Map creation. Stays as-is but reads enriched references and consumes outputs from new commands when available. Additional handoffs added to new sibling commands.
+
+### New Commands (4)
+
+| Command | File | Purpose | Doc Code | Multi-instance? |
+|---------|------|---------|----------|-----------------|
+| `/arckit.wardley.value-chain` | `wardley.value-chain.md` | Decompose user needs into value chains. Anchor identification, dependency tracing, visibility assessment. Pre-step to `/arckit.wardley` | `WVCH` | Yes |
+| `/arckit.wardley.doctrine` | `wardley.doctrine.md` | Assess organizational doctrine maturity across 4 phases, 6 categories, 40+ principles. Scores 1-5 per principle, produces phased improvement roadmap | `WDOC` | No (one per project) |
+| `/arckit.wardley.gameplay` | `wardley.gameplay.md` | Analyze strategic play options from 60+ gameplay catalog across 11 categories. Produces play recommendations with D&D alignment classification | `WGAM` | Yes |
+| `/arckit.wardley.climate` | `wardley.climate.md` | Assess climatic patterns affecting components — 32 patterns across 6 categories. Produces climate assessment with impact per component | `WCLM` | Yes |
+
+### Document Output Locations
+
+All artifacts saved to `projects/{id}-{name}/wardley-maps/`:
+
+- `ARC-{ID}-WVCH-{NNN}-v1.0.md` — Value Chain
+- `ARC-{ID}-WDOC-v1.0.md` — Doctrine Assessment (single instance)
+- `ARC-{ID}-WGAM-{NNN}-v1.0.md` — Gameplay Analysis
+- `ARC-{ID}-WCLM-{NNN}-v1.0.md` — Climate Assessment
+
+---
+
+## Section 2: Reference File Enhancements
+
+Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all expanded using the three research books.
+
+### doctrine.md (121 → ~400 lines)
+
+**Current**: 15 principles, checklist format, 5 categories, 1-5 scoring.
+
+**Enhanced**:
+- 40+ principles from Doctrine book
+- 4 phases: Stop Self-Harm → Context Aware → Better for Less → Continuously Evolving
+- 6 categories: Communication, Development, Operation, Learning, Leading, Structure
+- Full phase/category matrix table (the canonical Wardley doctrine table)
+- Implementation journey per category
+- Strategy Cycle framework (Purpose → Landscape → Climate → Doctrine → Leadership)
+
+**Source**: Doctrine book, chapters Phase I–IV + Implementing Doctrine.
+
+### gameplay-patterns.md (172 → ~600 lines)
+
+**Current**: 8 patterns (5 offensive, 3 defensive), basic build/buy/outsource.
+
+**Enhanced**:
+- 60+ patterns from Gameplays book
+- 11 categories: User Perception, Accelerators, De-accelerators, Dealing with Toxicity, Market, Defensive, Attacking, Ecosystem, Competitor, Positional, Poison
+- D&D alignment classification per gameplay (Lawful Good → Chaotic Evil)
+- Play-position matrix (your position × market position → recommended plays)
+- Play compatibility and conflict guidance
+- Strategic anti-patterns section
+- 9 company case studies as brief examples (AWS, Netflix, Tesla, Spotify, Apple, Google Android, Ubuntu, Airbnb, Amazon Retail)
+
+**Source**: Gameplays book, Chapter 3 (all 11 categories) + Chapter 4 (case studies).
+
+### climatic-patterns.md (274 → ~500 lines)
+
+**Current**: 9 patterns across 5 categories.
+
+**Enhanced to 32 patterns across 6 categories**:
+- **Component patterns** (8): Everything evolves, rates vary by ecosystem, characteristics change, Red Queen effect, no single method, co-evolution, multiple waves of diffusion, commoditization ≠ centralization
+- **Financial patterns** (6): Higher-order systems create value, Jevons Paradox, capital flows to new areas, creative destruction (Schumpeter), inverse value/certainty, increasing local order and energy
+- **Speed patterns** (5): Componentization effect (efficiency enables innovation), communication evolution accelerates overall evolution, stability increases agility, non-linear/discontinuous change, punctuated equilibrium
+- **Inertia patterns** (3): Success breeds inertia, inertia can kill, past success amplifies inertia
+- **Competitor patterns** (2): Actions change the game, most have poor situational awareness
+- **Prediction patterns** (8): P[what] vs P[when], peace/war/wonder cycles, predictable vs unpredictable disruption, industrialization causes org evolution, cannot measure evolution over time, less evolved = more uncertain, not everything survives
+
+**Source**: Climatic Patterns book, chapters IV–IX.
+
+### evolution-stages.md (102 → ~180 lines)
+
+**Enhanced**:
+- Detailed characteristics per stage from all 3 books
+- Enhanced indicator checklists (from melodic-software evolution-analysis skill)
+- Transition timing heuristics and weak signals
+- Expanded pioneers→settlers→planners talent model
+
+**Source**: Fundamentals chapters from all 3 books + melodic-software evolution-analysis skill.
+
+### mapping-examples.md (308 → ~450 lines)
+
+**Enhanced**:
+- 2-3 additional worked examples from books (TechnoGadget smart home, streaming service)
+- Cross-references to gameplay case studies (AWS ILC pattern, Netflix transition)
+- Worked value chain decomposition example (e-commerce and SaaS patterns from melodic-software)
+
+**Source**: Gameplays book Chapter 4 + Climatic Patterns TechnoGadget + melodic-software value-chain skill.
+
+### mathematical-models.md (255 → ~300 lines)
+
+**Enhanced**:
+- Play-position scoring from melodic-software strategic-analysis
+- Pattern impact weighting per component for climate assessment
+- Modest growth — this file is already strong
+
+**Source**: melodic-software strategic-analysis patterns.
+
+---
+
+## Section 3: Document Types, Templates & Registration
+
+### New Document Type Codes
+
+Register in `arckit-claude/config/doc-types.mjs`:
+
+| Code | Name | Category | Multi-instance? | Subdirectory |
+|------|------|----------|-----------------|--------------|
+| `WDOC` | Wardley Doctrine Assessment | Architecture | No | `wardley-maps/` |
+| `WGAM` | Wardley Gameplay Analysis | Architecture | Yes | `wardley-maps/` |
+| `WCLM` | Wardley Climate Assessment | Architecture | Yes | `wardley-maps/` |
+| `WVCH` | Wardley Value Chain | Architecture | Yes | `wardley-maps/` |
+
+Register in `scripts/bash/generate-document-id.sh`:
+- Add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES`
+
+### New Templates
+
+4 new templates in `arckit-claude/templates/` (mirrored to `.arckit/templates/`):
+
+**`wardley-doctrine-template.md`**:
+- Document Control, Executive Summary, Strategy Cycle Context
+- Doctrine Assessment Matrix (4 phases × 6 categories, 1-5 scoring per principle)
+- Phase-by-Phase Analysis (I–IV) with evidence and scores
+- Critical Gaps identification
+- Implementation Roadmap (immediate 0-3mo / short-term 3-12mo / long-term 12-24mo)
+- Recommendations, Traceability, Generation Footer
+
+**`wardley-gameplay-template.md`**:
+- Document Control, Executive Summary
+- Map Reference (link to WARD artifact)
+- Situational Assessment (position, capabilities, market context)
+- Play Options organized by 11 categories with D&D alignment
+- Play-Position Matrix evaluation
+- Play Compatibility Analysis
+- Selected Plays with execution steps, success criteria, review points
+- Risk Assessment and Anti-patterns
+- Case Study References, Traceability, Generation Footer
+
+**`wardley-climate-template.md`**:
+- Document Control, Executive Summary
+- Map Reference (link to WARD artifact)
+- Component Inventory (from WARD)
+- Climate Assessment by 6 categories (component, financial, speed, inertia, competitors, prediction)
+- Per-Component Impact Matrix (pattern × component)
+- Prediction Horizons (6-month, 18-month)
+- Wave Analysis (peace/war/wonder positioning)
+- Inertia Assessment per component
+- Strategic Implications, Traceability, Generation Footer
+
+**`wardley-value-chain-template.md`**:
+- Document Control, Executive Summary
+- User Need / Anchor definition
+- Users and Personas
+- Value Chain Diagram (ASCII + OWM notation)
+- Component Inventory with visibility scores
+- Dependency Matrix
+- Critical Path Analysis
+- Validation Checklist (completeness, accuracy, usefulness)
+- Visibility Assessment (Y-axis positioning guide)
+- Assumptions and Open Questions, Traceability, Generation Footer
+
+### Registration Checklist
+
+1. `arckit-claude/config/doc-types.mjs` — add 4 types + multi-instance set entries + subdirectory mappings
+2. `scripts/bash/generate-document-id.sh` — add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES`
+3. `arckit-claude/hooks/validate-wardley-math.py` — extend to validate new doc types if applicable
+4. Templates copied to both `arckit-claude/templates/` and `.arckit/templates/`
+
+---
+
+## Section 4: Command Composition & Handoffs
+
+### Workflow
+
+```text
+                    ┌──────────────────────┐
+                    │ wardley.value-chain   │  (pre-step)
+                    │   WVCH artifact       │
+                    └────────┬─────────────┘
+                             │ handoff
+                             ▼
+                    ┌──────────────────────┐
+                    │    wardley            │  (map creation)
+                    │   WARD artifact       │
+                    └──┬─────┬────┬────────┘
+                       │     │    │  handoffs
+              ┌────────┘     │    └────────┐
+              ▼              ▼             ▼
+    ┌────────────────┐ ┌───────────────┐ ┌────────────────┐
+    │wardley.doctrine│ │wardley.climate│ │wardley.gameplay │
+    │  WDOC artifact │ │ WCLM artifact │ │ WGAM artifact  │
+    └───────┬────────┘ └──────┬────────┘ └──────┬─────────┘
+            │                 │                  │
+            └─────────┬──────┘                   │
+                      ▼                          │
+             ┌──────────────┐                    │
+             │   wardley     │◄───────────────────┘
+             │  (re-run with │
+             │  richer context)
+             └──────┬───────┘
+                    │ existing handoffs
+             ┌──────┴──────┐
+             ▼             ▼
+        /arckit.roadmap  /arckit.strategy
+```
+
+### Handoff Declarations
+
+**`wardley.value-chain.md`** frontmatter:
+```yaml
+handoffs:
+  - command: wardley
+    description: Create Wardley Map from this value chain
+  - command: wardley.doctrine
+    description: Assess organizational doctrine maturity
+    condition: "Value chain reveals organizational capability gaps"
+```
+
+**`wardley.md`** (add to existing handoffs):
+```yaml
+handoffs:
+  - command: roadmap
+    description: Create strategic roadmap from evolution analysis
+  - command: strategy
+    description: Synthesise Wardley insights into architecture strategy
+  - command: research
+    description: Research vendors for Custom-Built components
+    condition: "Custom-Built components identified that need market research"
+  - command: wardley.doctrine
+    description: Assess organizational doctrine maturity
+  - command: wardley.gameplay
+    description: Identify strategic plays from the map
+  - command: wardley.climate
+    description: Assess climatic patterns affecting components
+```
+
+**`wardley.doctrine.md`** frontmatter:
+```yaml
+handoffs:
+  - command: wardley
+    description: Create or refine Wardley Map informed by doctrine gaps
+    condition: "Doctrine gaps affect component positioning or strategy"
+  - command: wardley.gameplay
+    description: Select gameplays that address doctrine weaknesses
+```
+
+**`wardley.gameplay.md`** frontmatter:
+```yaml
+handoffs:
+  - command: roadmap
+    description: Create roadmap to execute selected plays
+  - command: strategy
+    description: Synthesise gameplay into architecture strategy
+  - command: wardley.climate
+    description: Validate plays against climatic patterns
+    condition: "Climate assessment not yet performed"
+```
+
+**`wardley.climate.md`** frontmatter:
+```yaml
+handoffs:
+  - command: wardley.gameplay
+    description: Select gameplays informed by climate forces
+  - command: wardley
+    description: Update map with climate-driven evolution predictions
+    condition: "Climate analysis reveals evolution velocity changes"
+```
+
+### Prerequisite Reading per Command
+
+| Command | Mandatory | Recommended | Optional |
+|---------|-----------|-------------|---------|
+| `wardley.value-chain` | REQ | STKE | PRIN |
+| `wardley` (existing) | PRIN, REQ | STKE, RSCH, WVCH | WDOC, WCLM, DATA, TCOP |
+| `wardley.doctrine` | PRIN | WARD, STKE | REQ |
+| `wardley.gameplay` | WARD | WCLM, WDOC | RSCH, PRIN |
+| `wardley.climate` | WARD | REQ, RSCH | WDOC, PRIN |
+
+### Composition Principle
+
+Every command works standalone (produces useful output without siblings) but gets richer when related artifacts exist (reads them from `wardley-maps/` directory if present).
+
+---
+
+## Section 5: Converter & Multi-AI Impact
+
+### Dot-Namespaced Filenames Through the Converter
+
+The converter uses `base_name = filename.replace(".md", "")`. For `wardley.doctrine.md`:
+
+| Target | Output Filename | Invocation |
+|--------|----------------|------------|
+| Claude Code | `wardley.doctrine.md` (source) | `/arckit.wardley.doctrine` |
+| Codex CLI | `arckit.wardley.doctrine.md` | `$arckit-wardley.doctrine` |
+| Codex Extension | `skills/arckit-wardley.doctrine/SKILL.md` | Skill auto-discovery |
+| OpenCode CLI | `arckit.wardley.doctrine.md` | `/arckit.wardley.doctrine` |
+| Gemini CLI | `wardley.doctrine.toml` | `/arckit:wardley.doctrine` |
+| Copilot | `arckit-wardley.doctrine.prompt.md` | `/arckit-wardley.doctrine` |
+
+**Risk**: Dots in Gemini TOML and Copilot prompt filenames are unconventional. If these targets have issues, the converter can map dots to hyphens for those targets only (e.g., `wardley-doctrine.toml`). This is a converter-only concern — source filenames stay dot-namespaced.
+
+### Automatic Handling (No Converter Changes)
+
+- Reference file copying: `copy_extension_files()` already handles `references/`
+- Template copying: `copy_extension_files()` already handles `templates/`
+- New commands: converter processes all `.md` files in `commands/` automatically
+
+### Required Changes
+
+| Change | Scope |
+|--------|-------|
+| Gemini/Copilot dot handling | Verify; add dot→hyphen mapping if needed (small) |
+| `generate-document-id.sh` | Add new types before running converter |
+| No agent files needed | New commands don't need agents |
+
+### Agent Consideration
+
+None of the 4 new commands require agents. They read local artifacts and reference files, then produce documents. No heavy web research (>10 WebSearch/WebFetch calls). Fully portable across all 5 AI targets.
+
+---
+
+## Section 6: Documentation Updates
+
+### Files Requiring Updates
+
+| File | What Changes |
+|------|-------------|
+| `README.md` | Add 4 new commands to command table, update count 60→64, add Wardley suite description |
+| `docs/README.md` | Add 4 new commands to documentation index |
+| `docs/index.html` | Add 4 new commands to GitHub Pages searchable command reference |
+| `docs/DEPENDENCY-MATRIX.md` | Add 4 new commands with prerequisite/output dependencies |
+| `docs/WORKFLOW-DIAGRAMS.md` | Add Wardley suite workflow diagram |
+| `CHANGELOG.md` | Document new commands and reference enhancements |
+| `arckit-claude/CHANGELOG.md` | Plugin-specific changelog entry |
+
+### New Guide Files
+
+4 new usage guides in `docs/guides/` (mirrored to `arckit-claude/guides/`):
+
+| Guide | Content |
+|-------|---------|
+| `wardley-doctrine.md` | When to use, prerequisites, scoring system, example output, integration with other Wardley commands |
+| `wardley-gameplay.md` | When to use, requires WARD artifact, 11 gameplay categories, D&D alignment system, play selection example |
+| `wardley-climate.md` | When to use, 6 pattern categories overview, impact matrix reading guide, prediction horizons |
+| `wardley-value-chain.md` | When to use, anchor identification, decomposition process, feeds into `/arckit.wardley` |
+
+### Existing Guide Updates
+
+| Guide | Changes |
+|-------|---------|
+| `docs/guides/wardley.md` | Add Wardley suite overview section, recommended workflow order, links to new commands |
+
+### Count Updates
+
+| File | Change |
+|------|--------|
+| `README.md` | Command count 60→64 |
+| `docs/index.html` | Command count in header |
+
+---
+
+## Content Sources
+
+| Source | Used For |
+|--------|----------|
+| `research/Introduction to Wardley Mapping Doctrine.md` (~283K) | doctrine.md reference, wardley.doctrine command, doctrine template |
+| `research/Introduction to Wardley Mapping Gameplays.md` (~484K) | gameplay-patterns.md reference, wardley.gameplay command, gameplay template |
+| `research/Introduction to Wardley Mapping Climatic Patterns - Kindle - v1.0.1.md` (~357K) | climatic-patterns.md reference, wardley.climate command, climate template |
+| melodic-software/claude-code-plugins wardley-mapping skill | Value chain methodology, evolution-analysis indicators, strategic-plays catalog structure, play-position matrix, doctrine-advisor scoring pattern |
+
+## Implementation Order
+
+1. **Reference files** — Enrich all 6 reference files (foundation for everything else)
+2. **Doc types & templates** — Register WVCH, WDOC, WGAM, WCLM; create 4 templates
+3. **Commands** — Create 4 new command files, update existing wardley.md handoffs
+4. **Converter** — Verify dot-naming works across targets, run converter
+5. **Documentation** — README, guides, index.html, DEPENDENCY-MATRIX, WORKFLOW-DIAGRAMS, CHANGELOGs
+6. **Testing** — Run commands in a test repo, verify artifacts, check converter output
+
+## Open Questions
+
+1. Should `wardley.doctrine` support re-assessment (reading a previous WDOC and updating scores)?
+2. Should the `validate-wardley-math.py` hook extend to validate new doc types?
+3. Should reference files include the full book content verbatim or distilled summaries? (Recommendation: distilled summaries to keep token cost manageable)

--- a/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
+++ b/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
@@ -40,6 +40,32 @@ Enhance ArcKit's Wardley Mapping capabilities from a single `/arckit.wardley` co
 | `/arckit.wardley.gameplay` | `wardley.gameplay.md` | Analyze strategic play options from 60+ gameplay catalog across 11 categories. Produces play recommendations with D&D alignment classification | `WGAM` | Yes |
 | `/arckit.wardley.climate` | `wardley.climate.md` | Assess climatic patterns affecting components — 32 patterns across 6 categories. Produces climate assessment with impact per component | `WCLM` | Yes |
 
+### Argument Hints
+
+| Command | argument-hint |
+|---------|--------------|
+| `wardley.value-chain` | `"<user need or domain, e.g. 'online shopping', 'patient booking'>"` |
+| `wardley.doctrine` | `"<organization or project, e.g. 'DWP Benefits Team', 'Platform Engineering'>"` |
+| `wardley.gameplay` | `"<strategic context, e.g. 'cloud migration', 'market entry for chatbot'>"` |
+| `wardley.climate` | `"<domain or market, e.g. 'AI in healthcare', 'UK government digital services'>"` |
+
+### Hooks
+
+| Command | Stop Hook | Rationale |
+|---------|-----------|-----------|
+| `wardley.value-chain` | `validate-wardley-math.mjs` | Produces OWM syntax with component coordinates |
+| `wardley.doctrine` | None | No OWM syntax — produces scoring matrix only |
+| `wardley.gameplay` | None | No OWM syntax — produces play analysis only |
+| `wardley.climate` | None | No OWM syntax — produces pattern impact matrix only |
+
+### Template Naming Convention
+
+Command dots are replaced with hyphens for template filenames: command `wardley.doctrine` → template `wardley-doctrine-template.md`.
+
+### Re-assessment Support
+
+`wardley.doctrine` supports re-assessment: if a previous WDOC artifact exists, it reads it and presents a score comparison (previous vs current) with trend indicators. The template includes a "Previous Assessment Comparison" section.
+
 ### Document Output Locations
 
 All artifacts saved to `projects/{id}-{name}/wardley-maps/`:
@@ -55,7 +81,7 @@ All artifacts saved to `projects/{id}-{name}/wardley-maps/`:
 
 Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all expanded using the three research books.
 
-### doctrine.md (121 → ~400 lines)
+### doctrine.md (120 → ~400 lines)
 
 **Current**: 15 principles, checklist format, 5 categories, 1-5 scoring.
 
@@ -69,7 +95,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 
 **Source**: Doctrine book, chapters Phase I–IV + Implementing Doctrine.
 
-### gameplay-patterns.md (172 → ~600 lines)
+### gameplay-patterns.md (171 → ~600 lines)
 
 **Current**: 8 patterns (5 offensive, 3 defensive), basic build/buy/outsource.
 
@@ -84,7 +110,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 
 **Source**: Gameplays book, Chapter 3 (all 11 categories) + Chapter 4 (case studies).
 
-### climatic-patterns.md (274 → ~500 lines)
+### climatic-patterns.md (273 → ~500 lines)
 
 **Current**: 9 patterns across 5 categories.
 
@@ -98,7 +124,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 
 **Source**: Climatic Patterns book, chapters IV–IX.
 
-### evolution-stages.md (102 → ~180 lines)
+### evolution-stages.md (101 → ~180 lines)
 
 **Enhanced**:
 - Detailed characteristics per stage from all 3 books
@@ -108,7 +134,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 
 **Source**: Fundamentals chapters from all 3 books + melodic-software evolution-analysis skill.
 
-### mapping-examples.md (308 → ~450 lines)
+### mapping-examples.md (307 → ~450 lines)
 
 **Enhanced**:
 - 2-3 additional worked examples from books (TechnoGadget smart home, streaming service)
@@ -117,7 +143,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 
 **Source**: Gameplays book Chapter 4 + Climatic Patterns TechnoGadget + melodic-software value-chain skill.
 
-### mathematical-models.md (255 → ~300 lines)
+### mathematical-models.md (254 → ~300 lines)
 
 **Enhanced**:
 - Play-position scoring from melodic-software strategic-analysis
@@ -192,9 +218,21 @@ Register in `scripts/bash/generate-document-id.sh`:
 
 ### Registration Checklist
 
-1. `arckit-claude/config/doc-types.mjs` — add 4 types + multi-instance set entries + subdirectory mappings
+1. `arckit-claude/config/doc-types.mjs` — add 4 types to `DOC_TYPES`, add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES` set, add all 4 to `SUBDIR_MAP`:
+   ```javascript
+   'WDOC': { name: 'Wardley Doctrine Assessment',  category: 'Architecture' },
+   'WGAM': { name: 'Wardley Gameplay Analysis',     category: 'Architecture' },
+   'WCLM': { name: 'Wardley Climate Assessment',    category: 'Architecture' },
+   'WVCH': { name: 'Wardley Value Chain',            category: 'Architecture' },
+   // MULTI_INSTANCE_TYPES: add 'WGAM', 'WCLM', 'WVCH'
+   // SUBDIR_MAP:
+   'WDOC': 'wardley-maps',
+   'WGAM': 'wardley-maps',
+   'WCLM': 'wardley-maps',
+   'WVCH': 'wardley-maps',
+   ```
 2. `scripts/bash/generate-document-id.sh` — add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES`
-3. `arckit-claude/hooks/validate-wardley-math.py` — extend to validate new doc types if applicable
+3. `arckit-claude/hooks/validate-wardley-math.mjs` — extend file filter to scan `-WDOC-`, `-WGAM-`, `-WCLM-`, `-WVCH-` in addition to existing `-WARD-` pattern (required — `wardley.value-chain` produces OWM syntax)
 4. Templates copied to both `arckit-claude/templates/` and `.arckit/templates/`
 
 ---
@@ -328,21 +366,25 @@ The converter uses `base_name = filename.replace(".md", "")`. For `wardley.doctr
 | Gemini CLI | `wardley.doctrine.toml` | `/arckit:wardley.doctrine` |
 | Copilot | `arckit-wardley.doctrine.prompt.md` | `/arckit-wardley.doctrine` |
 
-**Risk**: Dots in Gemini TOML and Copilot prompt filenames are unconventional. If these targets have issues, the converter can map dots to hyphens for those targets only (e.g., `wardley-doctrine.toml`). This is a converter-only concern — source filenames stay dot-namespaced.
+**Note on dot-namespacing**: This is the first use of dots in command filenames in ArcKit. All 60 existing commands use flat names with hyphens. The following converter code paths must be validated for all 5 AI targets.
 
 ### Automatic Handling (No Converter Changes)
 
 - Reference file copying: `copy_extension_files()` already handles `references/`
 - Template copying: `copy_extension_files()` already handles `templates/`
 - New commands: converter processes all `.md` files in `commands/` automatically
+- `base_name = filename.replace(".md", "")` correctly produces `wardley.doctrine` etc.
 
-### Required Changes
+### Required Converter Changes
 
-| Change | Scope |
-|--------|-------|
-| Gemini/Copilot dot handling | Verify; add dot→hyphen mapping if needed (small) |
-| `generate-document-id.sh` | Add new types before running converter |
-| No agent files needed | New commands don't need agents |
+| Change | Scope | Detail |
+|--------|-------|--------|
+| **`rewrite_codex_skills()` regex** | **Critical** | Current regex `(?<=\s)/arckit\.(\w[\w-]*)` stops at dots — `/arckit.wardley.doctrine` would only capture `wardley`. Update character class to `\w[\w.-]*` to match dot-namespaced commands |
+| **Gemini TOML filenames** | Verify | `wardley.doctrine.toml` — verify Gemini CLI loads TOML files with dots. If not, map dots to hyphens for Gemini target only |
+| **Copilot prompt filenames** | Verify | `arckit-wardley.doctrine.prompt.md` — verify VS Code prompt discovery handles dots before `.prompt.md` |
+| **Codex skill directory names** | Verify | `skills/arckit-wardley.doctrine/SKILL.md` — verify Codex discovers skill directories with dots |
+| **Copilot `agent:` field references** | Verify | Cross-command references in `.agent.md` files if they reference dot-namespaced commands |
+| `generate-document-id.sh` | Required | Add new types before running converter |
 
 ### Agent Consideration
 
@@ -408,8 +450,8 @@ None of the 4 new commands require agents. They read local artifacts and referen
 5. **Documentation** — README, guides, index.html, DEPENDENCY-MATRIX, WORKFLOW-DIAGRAMS, CHANGELOGs
 6. **Testing** — Run commands in a test repo, verify artifacts, check converter output
 
-## Open Questions
+## Design Decisions
 
-1. Should `wardley.doctrine` support re-assessment (reading a previous WDOC and updating scores)?
-2. Should the `validate-wardley-math.py` hook extend to validate new doc types?
-3. Should reference files include the full book content verbatim or distilled summaries? (Recommendation: distilled summaries to keep token cost manageable)
+1. **Doctrine re-assessment**: Yes — `wardley.doctrine` reads existing WDOC if present and produces score comparison with trend indicators. Template includes "Previous Assessment Comparison" section.
+2. **Hook extension**: Yes — `validate-wardley-math.mjs` must extend its file filter to scan for `-WVCH-` files in addition to `-WARD-`. Other new types (WDOC, WGAM, WCLM) do not produce OWM syntax and don't need validation.
+3. **Reference file content**: Distilled summaries, not verbatim book content. Target line counts (~400, ~600, ~500 lines) keep token cost manageable while capturing all patterns, categories, and key examples. Full book text stays in `research/` for human reference.

--- a/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
+++ b/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
@@ -86,6 +86,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 **Current**: 15 principles, checklist format, 5 categories, 1-5 scoring.
 
 **Enhanced**:
+
 - 40+ principles from Doctrine book
 - 4 phases: Stop Self-Harm → Context Aware → Better for Less → Continuously Evolving
 - 6 categories: Communication, Development, Operation, Learning, Leading, Structure
@@ -100,6 +101,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 **Current**: 8 patterns (5 offensive, 3 defensive), basic build/buy/outsource.
 
 **Enhanced**:
+
 - 60+ patterns from Gameplays book
 - 11 categories: User Perception, Accelerators, De-accelerators, Dealing with Toxicity, Market, Defensive, Attacking, Ecosystem, Competitor, Positional, Poison
 - D&D alignment classification per gameplay (Lawful Good → Chaotic Evil)
@@ -115,6 +117,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 **Current**: 9 patterns across 5 categories.
 
 **Enhanced to 32 patterns across 6 categories**:
+
 - **Component patterns** (8): Everything evolves, rates vary by ecosystem, characteristics change, Red Queen effect, no single method, co-evolution, multiple waves of diffusion, commoditization ≠ centralization
 - **Financial patterns** (6): Higher-order systems create value, Jevons Paradox, capital flows to new areas, creative destruction (Schumpeter), inverse value/certainty, increasing local order and energy
 - **Speed patterns** (5): Componentization effect (efficiency enables innovation), communication evolution accelerates overall evolution, stability increases agility, non-linear/discontinuous change, punctuated equilibrium
@@ -127,6 +130,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 ### evolution-stages.md (101 → ~180 lines)
 
 **Enhanced**:
+
 - Detailed characteristics per stage from all 3 books
 - Enhanced indicator checklists (from melodic-software evolution-analysis skill)
 - Transition timing heuristics and weak signals
@@ -137,6 +141,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 ### mapping-examples.md (307 → ~450 lines)
 
 **Enhanced**:
+
 - 2-3 additional worked examples from books (TechnoGadget smart home, streaming service)
 - Cross-references to gameplay case studies (AWS ILC pattern, Netflix transition)
 - Worked value chain decomposition example (e-commerce and SaaS patterns from melodic-software)
@@ -146,6 +151,7 @@ Six existing files in `arckit-claude/skills/wardley-mapping/references/`, all ex
 ### mathematical-models.md (254 → ~300 lines)
 
 **Enhanced**:
+
 - Play-position scoring from melodic-software strategic-analysis
 - Pattern impact weighting per component for climate assessment
 - Modest growth — this file is already strong
@@ -168,6 +174,7 @@ Register in `arckit-claude/config/doc-types.mjs`:
 | `WVCH` | Wardley Value Chain | Architecture | Yes | `wardley-maps/` |
 
 Register in `scripts/bash/generate-document-id.sh`:
+
 - Add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES`
 
 ### New Templates
@@ -175,6 +182,7 @@ Register in `scripts/bash/generate-document-id.sh`:
 4 new templates in `arckit-claude/templates/` (mirrored to `.arckit/templates/`):
 
 **`wardley-doctrine-template.md`**:
+
 - Document Control, Executive Summary, Strategy Cycle Context
 - Doctrine Assessment Matrix (4 phases × 6 categories, 1-5 scoring per principle)
 - Phase-by-Phase Analysis (I–IV) with evidence and scores
@@ -183,6 +191,7 @@ Register in `scripts/bash/generate-document-id.sh`:
 - Recommendations, Traceability, Generation Footer
 
 **`wardley-gameplay-template.md`**:
+
 - Document Control, Executive Summary
 - Map Reference (link to WARD artifact)
 - Situational Assessment (position, capabilities, market context)
@@ -194,6 +203,7 @@ Register in `scripts/bash/generate-document-id.sh`:
 - Case Study References, Traceability, Generation Footer
 
 **`wardley-climate-template.md`**:
+
 - Document Control, Executive Summary
 - Map Reference (link to WARD artifact)
 - Component Inventory (from WARD)
@@ -205,6 +215,7 @@ Register in `scripts/bash/generate-document-id.sh`:
 - Strategic Implications, Traceability, Generation Footer
 
 **`wardley-value-chain-template.md`**:
+
 - Document Control, Executive Summary
 - User Need / Anchor definition
 - Users and Personas
@@ -219,6 +230,7 @@ Register in `scripts/bash/generate-document-id.sh`:
 ### Registration Checklist
 
 1. `arckit-claude/config/doc-types.mjs` — add 4 types to `DOC_TYPES`, add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES` set, add all 4 to `SUBDIR_MAP`:
+
    ```javascript
    'WDOC': { name: 'Wardley Doctrine Assessment',  category: 'Architecture' },
    'WGAM': { name: 'Wardley Gameplay Analysis',     category: 'Architecture' },
@@ -231,6 +243,7 @@ Register in `scripts/bash/generate-document-id.sh`:
    'WCLM': 'wardley-maps',
    'WVCH': 'wardley-maps',
    ```
+
 2. `scripts/bash/generate-document-id.sh` — add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES`
 3. `arckit-claude/hooks/validate-wardley-math.mjs` — extend file filter to scan `-WVCH-` in addition to existing `-WARD-` pattern (only WVCH produces OWM syntax; WDOC/WGAM/WCLM do not need validation)
 4. Templates copied to both `arckit-claude/templates/` and `.arckit/templates/`
@@ -276,6 +289,7 @@ Register in `scripts/bash/generate-document-id.sh`:
 ### Handoff Declarations
 
 **`wardley.value-chain.md`** frontmatter:
+
 ```yaml
 handoffs:
   - command: wardley
@@ -292,6 +306,7 @@ hooks:
 ```
 
 **`wardley.md`** (add new handoffs + fix pre-existing bug: hook references `python3 validate-wardley-math.py` but actual file is `validate-wardley-math.mjs` — change to `node validate-wardley-math.mjs`):
+
 ```yaml
 handoffs:
   - command: roadmap
@@ -310,6 +325,7 @@ handoffs:
 ```
 
 **`wardley.doctrine.md`** frontmatter:
+
 ```yaml
 handoffs:
   - command: wardley
@@ -320,6 +336,7 @@ handoffs:
 ```
 
 **`wardley.gameplay.md`** frontmatter:
+
 ```yaml
 handoffs:
   - command: roadmap
@@ -332,6 +349,7 @@ handoffs:
 ```
 
 **`wardley.climate.md`** frontmatter:
+
 ```yaml
 handoffs:
   - command: wardley.gameplay

--- a/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
+++ b/docs/superpowers/specs/2026-03-16-wardley-suite-enhancement-design.md
@@ -232,7 +232,7 @@ Register in `scripts/bash/generate-document-id.sh`:
    'WVCH': 'wardley-maps',
    ```
 2. `scripts/bash/generate-document-id.sh` — add `WGAM WCLM WVCH` to `MULTI_INSTANCE_TYPES`
-3. `arckit-claude/hooks/validate-wardley-math.mjs` — extend file filter to scan `-WDOC-`, `-WGAM-`, `-WCLM-`, `-WVCH-` in addition to existing `-WARD-` pattern (required — `wardley.value-chain` produces OWM syntax)
+3. `arckit-claude/hooks/validate-wardley-math.mjs` — extend file filter to scan `-WVCH-` in addition to existing `-WARD-` pattern (only WVCH produces OWM syntax; WDOC/WGAM/WCLM do not need validation)
 4. Templates copied to both `arckit-claude/templates/` and `.arckit/templates/`
 
 ---
@@ -283,9 +283,15 @@ handoffs:
   - command: wardley.doctrine
     description: Assess organizational doctrine maturity
     condition: "Value chain reveals organizational capability gaps"
+hooks:
+  Stop:
+    - hooks:
+        - type: command
+          command: "node ${CLAUDE_PLUGIN_ROOT}/hooks/validate-wardley-math.mjs"
+          timeout: 10
 ```
 
-**`wardley.md`** (add to existing handoffs):
+**`wardley.md`** (add new handoffs + fix pre-existing bug: hook references `python3 validate-wardley-math.py` but actual file is `validate-wardley-math.mjs` — change to `node validate-wardley-math.mjs`):
 ```yaml
 handoffs:
   - command: roadmap
@@ -379,7 +385,7 @@ The converter uses `base_name = filename.replace(".md", "")`. For `wardley.doctr
 
 | Change | Scope | Detail |
 |--------|-------|--------|
-| **`rewrite_codex_skills()` regex** | **Critical** | Current regex `(?<=\s)/arckit\.(\w[\w-]*)` stops at dots — `/arckit.wardley.doctrine` would only capture `wardley`. Update character class to `\w[\w.-]*` to match dot-namespaced commands |
+| **`rewrite_codex_skills()` regexes** | **Critical** | Three regexes in this function use `[\w-]*` which stops at dots. All three must update their character class to `[\w.-]*`: (1) colon-format `r"/arckit:(\w[\w-]*)"`, (2) dot-format `r"(?<=\s)/arckit\.(\w[\w-]*)"`, (3) prompts-format `r"/prompts:arckit\.(\w[\w-]*)"`. Without this fix, cross-references like `/arckit:wardley.doctrine` would only capture `wardley` |
 | **Gemini TOML filenames** | Verify | `wardley.doctrine.toml` — verify Gemini CLI loads TOML files with dots. If not, map dots to hyphens for Gemini target only |
 | **Copilot prompt filenames** | Verify | `arckit-wardley.doctrine.prompt.md` — verify VS Code prompt discovery handles dots before `.prompt.md` |
 | **Codex skill directory names** | Verify | `skills/arckit-wardley.doctrine/SKILL.md` — verify Codex discovers skill directories with dots |

--- a/scripts/bash/generate-document-id.sh
+++ b/scripts/bash/generate-document-id.sh
@@ -16,7 +16,7 @@
 #   ./generate-document-id.sh 001 ADR 1.0 --filename --next-num ./decisions → ARC-001-ADR-001-v1.0.md
 #
 # Multi-instance types (require --next-num for sequence numbering):
-#   ADR, DIAG, DFD, WARD, DMC, RSCH, AWRS, AZRS, GCRS, DSCT
+#   ADR, DIAG, DFD, WARD, DMC, RSCH, AWRS, AZRS, GCRS, DSCT, WGAM, WCLM, WVCH
 
 set -euo pipefail
 
@@ -82,7 +82,7 @@ PROJECT_ID_PADDED=$(printf "%03d" "$PROJECT_ID_CLEAN")
 
 # Multi-instance document types that require sequence numbers
 # Keep in sync with arckit-claude/config/doc-types.mjs MULTI_INSTANCE_TYPES
-MULTI_INSTANCE_TYPES="ADR DIAG DFD WARD DMC RSCH AWRS AZRS GCRS DSCT"
+MULTI_INSTANCE_TYPES="ADR DIAG DFD WARD DMC RSCH AWRS AZRS GCRS DSCT WGAM WCLM WVCH"
 
 # Check if this is a multi-instance type
 is_multi_instance() {

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -534,19 +534,19 @@ def rewrite_codex_skills(skills_dir):
             original = content
 
             # Rewrite /arckit:X -> $arckit-X (colon-prefixed plugin format)
-            content = re.sub(r"/arckit:(\w[\w-]*)", r"$arckit-\1", content)
+            content = re.sub(r"/arckit:(\w[\w.-]*)", r"$arckit-\1", content)
 
             # Rewrite /arckit.X -> $arckit-X (dot-prefixed format)
             # Only match when preceded by a space or start-of-line to avoid false matches
             content = re.sub(
-                r"(?<=\s)/arckit\.(\w[\w-]*)",
+                r"(?<=\s)/arckit\.(\w[\w.-]*)",
                 r"$arckit-\1",
                 content,
             )
 
             # Rewrite /prompts:arckit.X -> $arckit-X (old Codex prompt format)
             content = re.sub(
-                r"/prompts:arckit\.(\w[\w-]*)",
+                r"/prompts:arckit\.(\w[\w.-]*)",
                 r"$arckit-\1",
                 content,
             )

--- a/scripts/create-sdg-repo.py
+++ b/scripts/create-sdg-repo.py
@@ -500,7 +500,7 @@ This repository contains **{total_projects} UK Government technology projects** 
 
 ## ArcKit
 
-This repository is powered by [ArcKit](https://github.com/tractorjuice/arc-kit) -- an Enterprise Architecture Governance & Vendor Procurement Toolkit providing 60 slash commands for AI coding assistants.
+This repository is powered by [ArcKit](https://github.com/tractorjuice/arc-kit) -- an Enterprise Architecture Governance & Vendor Procurement Toolkit providing 64 slash commands for AI coding assistants.
 
 **Version**: {VERSION}
 """


### PR DESCRIPTION
## Summary

Expands ArcKit's Wardley Mapping from a single `/arckit.wardley` command into a composable suite of 5 commands, backed by massively enriched reference files distilled from 3 Wardley Mapping books.

- **4 new commands**: `wardley.value-chain`, `wardley.doctrine`, `wardley.gameplay`, `wardley.climate`
- **6 reference files enriched**: doctrine (120→439 lines, 40+ principles), gameplays (171→588 lines, 60+ plays), climatic patterns (273→504 lines, 32 patterns), evolution stages, mapping examples, mathematical models
- **4 new document types**: WVCH, WDOC, WGAM, WCLM — all in `wardley-maps/` subdirectory
- **4 new templates** with full Document Control standard
- **4 new usage guides** + existing wardley guide updated with suite overview
- **Composable handoffs**: every command works standalone, gets richer with siblings
- **All 5 AI platforms**: converter output regenerated (320 files, 64 per target)
- **Command count**: 60 → 64

### New Commands

| Command | Purpose | Doc Code |
|---------|---------|----------|
| `/arckit.wardley.value-chain` | Decompose user needs into value chains (pre-step to mapping) | WVCH |
| `/arckit.wardley.doctrine` | Assess organizational doctrine maturity (4 phases, 6 categories, 40+ principles) | WDOC |
| `/arckit.wardley.gameplay` | Analyze strategic plays from 60+ patterns with D&D alignment classification | WGAM |
| `/arckit.wardley.climate` | Assess 32 climatic patterns across 6 categories with prediction horizons | WCLM |

### Workflow

```
wardley.value-chain → wardley → wardley.doctrine
                               → wardley.climate
                               → wardley.gameplay
                               → roadmap / strategy
```

### Also Fixed

- Converter regexes updated for dot-namespaced commands (3 regexes in `rewrite_codex_skills()`)
- Pre-existing `wardley.md` hook bug: `python3 validate-wardley-math.py` → `node validate-wardley-math.mjs`

### Content Sources

- *Introduction to Wardley Mapping Doctrine* (~283K)
- *Introduction to Wardley Mapping Gameplays* (~484K)
- *Introduction to Wardley Mapping Climatic Patterns* (~357K)
- melodic-software/claude-code-plugins wardley-mapping skill (patterns validated)

## Test plan

- [ ] Run converter: `python scripts/converter.py` — verify 320 files, 64 per target
- [ ] Verify dot-namespaced cross-references in Codex skills
- [ ] Verify doc ID generation: `bash scripts/bash/generate-document-id.sh 001 WGAM 1.0 --filename --next-num /tmp`
- [ ] Verify hook validates WVCH: `node arckit-claude/hooks/validate-wardley-math.mjs`
- [ ] Test each new command in a test repo with the plugin enabled
- [ ] Verify all 4 new templates in `arckit-claude/templates/` and `.arckit/templates/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)