### PR TITLE
feat: improve ADR command consequences quality

### DIFF
--- a/arckit-claude/commands/adr.md
+++ b/arckit-claude/commands/adr.md
@@ -202,15 +202,18 @@ Apply the user's selections: the escalation level determines the governance foru
   - Stakeholder consensus or dissenting views
   - Risk appetite alignment
 
-   **Consequences**:
+   **Consequences** (derive from project context — use actual metrics from requirements, not generic statements):
 
 - **Positive**: Benefits, capabilities enabled, compliance achieved
-  - Include measurable outcomes (metrics: baseline → target)
+  - Include measurable outcomes with project-specific metrics (e.g., "API response time: 500ms → < 200ms per NFR-P-001" not just "improved performance")
+  - Tie each benefit to a specific requirement or stakeholder goal
 - **Negative**: Accepted trade-offs, limitations, technical debt
-  - Include mitigation strategies
+  - Include mitigation strategies with owners and timelines
+  - Be explicit about what is lost or constrained — vague trade-offs are not useful
 - **Neutral**: Changes needed (training, infrastructure, process, vendors)
 - **Risks and Mitigations**: Create table with risk, likelihood, impact, mitigation, owner
   - Link to risk register (RISK-xxx)
+- **After-action review**: Schedule a review 1 month after implementation to verify assumptions and outcomes match expectations
 
    **Validation & Compliance**:
 


### PR DESCRIPTION
## Summary

Strengthens the Consequences section of the ADR command prompt to produce more actionable output:

- **Project-specific metrics** — require measurable outcomes tied to actual NFR/BR IDs (e.g., "API response time: 500ms → < 200ms per NFR-P-001") instead of generic "improved performance"
- **Requirement traceability** — tie each positive consequence to a specific requirement or stakeholder goal
- **Explicit trade-offs** — require mitigation strategies with named owners and timelines, not vague statements
- **After-action review** — schedule a review 1 month after implementation to verify assumptions

## How this was found

Used the autoresearch command prompt optimiser against the UK Gov ADR Framework and MADR v4.0 references:

| Iteration | Score | Status | Change |
|-----------|-------|--------|--------|
| 0 (baseline) | 8.6 | keep | — |
| 1 | 9.0 | keep | Strengthen consequences with project-specific metrics and after-action review |
| 2 | 9.2 | discard | Tie monitoring metrics to consequences (delta < 0.3) |

**Net: +3 lines of prompt, score 8.6 → 9.0**

## Test plan

- [ ] Run `/arckit:adr` against a test project and verify consequences reference specific NFR/BR IDs
- [ ] Verify trade-offs include named owners and timelines
- [ ] Verify after-action review is scheduled in output
- [ ] Run `python scripts/converter.py` to regenerate extension formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)