### PR TITLE
feat: improve backlog command acceptance criteria and sprint navigation

### DIFF
--- a/arckit-claude/commands/backlog.md
+++ b/arckit-claude/commands/backlog.md
@@ -319,14 +319,14 @@ Acceptance Criteria:
 - It's done when confirmation email is received
 ```
 
-**Rules for acceptance criteria**:
+**Rules for acceptance criteria** (CRITICAL — vague criteria make stories unusable):
 
 - Start with "It's done when..."
-- Make measurable and testable
-- Include success cases
-- Include key error cases
-- Reference NFRs (security, performance, compliance)
-- Typically 3-6 criteria per story
+- Every criterion MUST be testable with a specific pass/fail check — never use "works correctly", "handles errors gracefully", or "is user-friendly"
+- Include a measurable threshold where applicable (e.g., "< 2 seconds", "within 60 seconds", "> 99%")
+- Include at least one error/edge case criterion per story (e.g., "It's done when invalid email shows inline validation error")
+- Reference specific NFR IDs for quality criteria (e.g., "It's done when page loads in < 2s per NFR-P-001")
+- Typically 4-6 criteria per story
 
 #### 4.5: Estimate Story Points
 
@@ -1346,7 +1346,15 @@ Create comprehensive markdown file at `projects/{project-dir}/ARC-{PROJECT_ID}-B
 
 ## Sprint Plan
 
-{Generate all sprint plans from Step 8}
+Before the detailed sprint sections, include a sprint summary table for at-a-glance navigation:
+
+| Sprint | Theme | Points | Key Deliverables |
+|--------|-------|--------|-----------------|
+| 1 | Foundation | 20 | Auth, DB, CI/CD |
+| 2 | Core Features | 20 | Booking, notifications |
+| ... | ... | ... | ... |
+
+{Then generate all detailed sprint plans from Step 8}
 
 ---
 


### PR DESCRIPTION
## Summary

- **Strengthened acceptance criteria rules** — every criterion must be testable with a specific pass/fail check; banned vague phrases ("works correctly", "handles errors gracefully"); require measurable thresholds, error/edge case criteria, and NFR ID references
- **Added sprint summary table** — at-a-glance table (Sprint | Theme | Points | Key Deliverables) before detailed sprint plans

## How these changes were found

Used the autoresearch command prompt optimiser:

| Iteration | Score | Status | Change |
|-----------|-------|--------|--------|
| 0 (baseline) | 8.0 | keep | — |
| 1 | 8.8 | keep | Strengthen acceptance criteria rules |
| 2 | 9.0 | discard | Add sprint summary table (delta < 0.3) |

**Net: +8 lines of prompt, score 8.0 → 8.8**

The sprint summary table scored 9.0 (just below the 0.3 noise threshold) but is included as it improves navigation without adding complexity.

## Test plan

- [ ] Run `/arckit:backlog` against a test project and verify acceptance criteria use measurable thresholds
- [ ] Verify no vague criteria ("works correctly", "handles errors gracefully") in output
- [ ] Verify sprint summary table appears before detailed sprint plans
- [ ] Run `python scripts/converter.py` to regenerate extension formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)