### PR TITLE
feat: improve value-chain command with visibility rationale

### DIFF
--- a/arckit-claude/commands/wardley.value-chain.md
+++ b/arckit-claude/commands/wardley.value-chain.md
@@ -339,9 +339,9 @@ After generating the OWM code block, generate a Mermaid `wardley-beta` equivalen
    - Bottlenecks and single points of failure
    - Resilience gaps
 
-7. **Validation Checklist**: Completed checklist confirming chain quality
+7. **Validation Checklist**: Include the completed checklist from Step 6 as a visible section — show each check as passed/failed with evidence
 
-8. **Visibility Assessment**: Table showing how each component was scored on the Y-axis
+8. **Visibility Assessment**: Table with columns: Component, Visibility Score, Rationale. For each component, explain *why* it received that score using the assessment questions from Step 5 (e.g., "0.85 — citizen interacts directly via booking UI; failure immediately visible" not just "0.85 — high visibility")
 
 9. **Assumptions and Open Questions**: Documented assumptions made during decomposition
 


### PR DESCRIPTION
## Summary

- **Visibility Assessment** now requires per-component rationale explaining *why* each score was assigned (e.g., "0.85 — citizen interacts directly; failure immediately visible") instead of just listing scores
- **Validation Checklist** now appears as a visible section with pass/fail evidence per check instead of being implicit

## How this was found

| Iteration | Score | Status | Change |
|-----------|-------|--------|--------|
| 0 (baseline) | 8.4 | keep | — |
| 1 | 9.0 | keep | Visibility rationale + validation checklist |

**Net: 2 lines changed, score 8.4 → 9.0**

## Test plan

- [ ] Run `/arckit:wardley.value-chain` and verify Visibility Assessment table has rationale column
- [ ] Verify Validation Checklist section appears with pass/fail status and evidence
- [ ] Run `python scripts/converter.py` to regenerate extension formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)