### PR TITLE
feat: require project-specific execution steps in gameplay analysis

### DIFF
--- a/arckit-claude/commands/wardley.gameplay.md
+++ b/arckit-claude/commands/wardley.gameplay.md
@@ -278,11 +278,11 @@ For each detailed play:
 - [Prerequisite 2]
 - [Prerequisite 3 if needed]
 
-**Execution Steps**:
+**Execution Steps** (each step must name a specific component, stakeholder, or requirement — never generic):
 
-1. [Specific, actionable first step — who does what]
-2. [Second step]
-3. [Third step]
+1. [Who (STK-xxx) does what to which component/artifact, by when]
+2. [Second step with specific deliverable]
+3. [Third step referencing requirement or principle]
 4. [Continuing steps as needed]
 
 **Expected Outcomes**:


### PR DESCRIPTION
## Summary

Each gameplay execution step must name a specific component, stakeholder (STK-xxx), or requirement — never generic steps like "who does what" without specifying which component/artifact and by when.

## How this was found

| Iteration | Score | Status | Change |
|-----------|-------|--------|--------|
| 0 (baseline) | 8.8 | keep | — |
| 1 | 9.0 | keep | Project-specific execution steps |

**Net: 4 lines changed, score 8.8 → 9.0**

## Test plan

- [ ] Run `/arckit:wardley.gameplay` and verify execution steps name specific STK-xxx, components, and timelines
- [ ] Verify no generic steps without component/stakeholder references
- [ ] Run `python scripts/converter.py` to regenerate extension formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)