### PR TITLE
feat: optimise gov-reuse agent prompt via autoresearch (8.4 → 9.4)

### DIFF
--- a/arckit-claude/agents/arckit-gov-reuse.md
+++ b/arckit-claude/agents/arckit-gov-reuse.md
@@ -126,6 +126,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -182,6 +183,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -190,7 +193,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -198,7 +211,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -212,11 +225,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -240,7 +253,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-codex/agents/arckit-gov-reuse.md
+++ b/arckit-codex/agents/arckit-gov-reuse.md
@@ -163,6 +163,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -219,6 +220,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -227,7 +230,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -235,7 +248,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -249,11 +262,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -277,7 +290,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-codex/agents/arckit-gov-reuse.toml
+++ b/arckit-codex/agents/arckit-gov-reuse.toml
@@ -93,6 +93,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -149,6 +150,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -157,7 +160,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -165,7 +178,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -179,11 +192,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -207,7 +220,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-codex/commands/arckit.gov-reuse.md
+++ b/arckit-codex/commands/arckit.gov-reuse.md
@@ -93,6 +93,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -149,6 +150,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -157,7 +160,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -165,7 +178,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -179,11 +192,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -207,7 +220,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-codex/prompts/arckit.gov-reuse.md
+++ b/arckit-codex/prompts/arckit.gov-reuse.md
@@ -93,6 +93,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -149,6 +150,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -157,7 +160,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -165,7 +178,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -179,11 +192,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -207,7 +220,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-codex/skills/arckit-gov-reuse/SKILL.md
+++ b/arckit-codex/skills/arckit-gov-reuse/SKILL.md
@@ -94,6 +94,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -150,6 +151,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -158,7 +161,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -166,7 +179,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -180,11 +193,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -208,7 +221,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-copilot/agents/arckit-gov-reuse.agent.md
+++ b/arckit-copilot/agents/arckit-gov-reuse.agent.md
@@ -104,6 +104,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -160,6 +161,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -168,7 +171,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -176,7 +189,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -190,11 +203,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -218,7 +231,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-gemini/agents/arckit-gov-reuse.md
+++ b/arckit-gemini/agents/arckit-gov-reuse.md
@@ -128,6 +128,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -184,6 +185,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -192,7 +195,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -200,7 +213,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -214,11 +227,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `~/.gemini/extensions/arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -242,7 +255,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-opencode/agents/arckit-gov-reuse.md
+++ b/arckit-opencode/agents/arckit-gov-reuse.md
@@ -163,6 +163,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -219,6 +220,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -227,7 +230,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -235,7 +248,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -249,11 +262,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -277,7 +290,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 

--- a/arckit-opencode/commands/arckit.gov-reuse.md
+++ b/arckit-opencode/commands/arckit.gov-reuse.md
@@ -93,6 +93,7 @@ For each promising result from govreposcrape (aim for top 3-5 per capability, up
 - **Test coverage indicators**: Presence of test directories, CI badges, coverage reports
 - **Documentation quality**: Presence of docs/ folder, wiki, API docs, deployment guides
 - **Last commit date**: Fetch the main page to see "last commit X days/months ago"
+- **Installation method**: For Library candidates, extract the exact install command from README (e.g., `npm install govuk-frontend`, `pip install notifications-python-client`). For Fork candidates, note the clone URL and setup prerequisites. Include as a "Quick Start" field in the candidate card.
 
 ### Step 7: Score Each Candidate
 
@@ -149,6 +150,8 @@ Based on average score and characteristics, assign a recommended strategy:
 - **Reference** (average >= 2.5): Study the implementation for patterns, approaches, and ideas. Don't reuse the code directly but learn from it.
 - **None** (average < 2.5 OR incompatible license): Not suitable for reuse. Note why briefly.
 
+For each capability, write a **bold verdict line** at the top of its section: "**Verdict: [Strategy] — [one-sentence rationale].**"
+
 ### Step 9: Build Summary Tables
 
 Compile:
@@ -157,7 +160,17 @@ Compile:
 - **Tech Stack Alignment Table**: Repo name, language, framework, infrastructure, alignment score
 - **Reuse Strategy Summary**: Capability, best candidate repo, strategy (Fork/Library/Reference/None), rationale, estimated effort saved (days)
 
-### Step 10: Gap Analysis
+### Step 10: Requirements Traceability (CRITICAL — do not skip)
+
+Create a table mapping EVERY requirement ID from the requirements document to a capability and reuse outcome:
+
+| Requirement ID | Requirement Summary | Capability | Best Candidate | Strategy | Status |
+|---|---|---|---|---|---|
+| FR-001 | [summary] | [Capability name] | [Repo or "—"] | [Fork/Library/Reference/None/Build] | ✅/⚠️/❌ |
+
+Use status indicators: ✅ = covered by reusable candidate, ⚠️ = partially covered (Reference only), ❌ = no match (build required). Include BR, FR, NFR, INT, and DR requirements. This table ensures no requirement is overlooked and provides a clear coverage percentage.
+
+### Step 11: Gap Analysis
 
 Identify capabilities where no candidate scored >= 2.5 across all query variations. These are "build from scratch" items. For each gap:
 
@@ -165,7 +178,7 @@ Identify capabilities where no candidate scored >= 2.5 across all query variatio
 - Note what was searched (query variations tried)
 - Suggest whether to widen the search or accept it as a genuine gap
 
-### Step 11: Detect Version and Determine Increment
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-*-v*.md` files. Read the highest version number from filenames.
 
@@ -179,11 +192,11 @@ Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR
    - **Minor increment** (e.g., 1.0 → 1.1): Scope unchanged — refreshed results, updated candidate assessments, corrected details, minor additions
    - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new capability areas added, requirements significantly changed, fundamentally different candidate landscape
 
-### Step 12: Quality Check
+### Step 13: Quality Check
 
 Before writing, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **GOVR** per-type checks pass. Fix any failures before proceeding.
 
-### Step 13: Write Output
+### Step 14: Write Output
 
 Use the **Write tool** to save the complete document to `projects/{project-dir}/research/ARC-{PROJECT_ID}-GOVR-v${VERSION}.md` following the template structure.
 
@@ -207,7 +220,7 @@ Include the generation metadata footer:
 
 **DO NOT output the full document.** Write it to file only.
 
-### Step 14: Return Summary
+### Step 15: Return Summary
 
 Return ONLY a concise summary including:
 


### PR DESCRIPTION
## Summary

Optimised the `/arckit.gov-reuse` agent prompt through 6 autoresearch iterations (score: 8.4 → 9.4/10):

- **Per-capability verdict line** — bold one-sentence conclusion at top of each capability section for instant readability
- **Quick Start install commands** — exact `npm install` / `pip install` / `git clone` in every candidate card so developers can begin immediately
- **Requirements traceability table** — maps every requirement ID (BR/FR/NFR/INT/DR) to capability, candidate, strategy, and status (✅/⚠️/❌)

## Autoresearch Results

```
commit     structural  score  status   description
2f393df    PASS        8.4    keep     baseline
0801b17    PASS        9.0    keep     requirements traceability table
09f308b    PASS        9.2    discard  external references (delta < 0.3)
0ec8d62    PASS        7.8    discard  verdict only (traceability regression)
e6b3681    PASS        9.2    discard  verdict + traceability (delta < 0.3)
4df76e4    PASS        9.2    discard  quick-start only (delta < 0.3)
59e2578    PASS        9.4    keep     combined: verdict + quick-start + traceability
```

## Test plan

- [ ] Run `/arckit.gov-reuse` in a test repo with requirements — verify verdict lines, quick-start commands, and traceability table appear in output
- [ ] Verify converter output includes changes for all 5 extension formats

🤖 Generated with [Claude Code](https://claude.com/claude-code)