### PR TITLE
feat: optimise gov-code-search agent prompt via autoresearch (7.4 → 8.8)

### DIFF
--- a/arckit-claude/agents/arckit-gov-code-search.md
+++ b/arckit-claude/agents/arckit-gov-code-search.md
@@ -159,7 +159,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-codex/agents/arckit-gov-code-search.md
+++ b/arckit-codex/agents/arckit-gov-code-search.md
@@ -194,7 +194,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-codex/agents/arckit-gov-code-search.toml
+++ b/arckit-codex/agents/arckit-gov-code-search.toml
@@ -126,7 +126,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-codex/commands/arckit.gov-code-search.md
+++ b/arckit-codex/commands/arckit.gov-code-search.md
@@ -126,7 +126,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-codex/prompts/arckit.gov-code-search.md
+++ b/arckit-codex/prompts/arckit.gov-code-search.md
@@ -126,7 +126,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-codex/skills/arckit-gov-code-search/SKILL.md
+++ b/arckit-codex/skills/arckit-gov-code-search/SKILL.md
@@ -127,7 +127,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-copilot/agents/arckit-gov-code-search.agent.md
+++ b/arckit-copilot/agents/arckit-gov-code-search.agent.md
@@ -137,7 +137,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-gemini/agents/arckit-gov-code-search.md
+++ b/arckit-gemini/agents/arckit-gov-code-search.md
@@ -201,7 +201,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-opencode/agents/arckit-gov-code-search.md
+++ b/arckit-opencode/agents/arckit-gov-code-search.md
@@ -194,7 +194,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 

--- a/arckit-opencode/commands/arckit.gov-code-search.md
+++ b/arckit-opencode/commands/arckit.gov-code-search.md
@@ -126,7 +126,29 @@ Where multiple repos solve the same problem differently, compare:
 
 This comparison is valuable for teams choosing an implementation approach.
 
-### Step 11: Detect Version and Determine Increment
+### Step 10b: Project Relevance Mapping (if project context available)
+
+If project requirements were read in Step 1, create a table mapping the top search results back to specific project requirements:
+
+| Repository | Relevant Requirements | How It Helps | Quick Start |
+|---|---|---|---|
+| [org/repo] | [FR-001, INT-003] | [What this repo provides for those requirements] | [Install command or clone URL] |
+
+This connects abstract search results to concrete project needs and gives developers an immediate next action. Include the exact install command (npm install, pip install, git clone) for each repo where applicable.
+
+If no project context exists, skip this step.
+
+### Step 11: Search Effectiveness Assessment
+
+Evaluate the search results honestly:
+
+- **Coverage**: What percentage of the query's intent was addressed by the results? Were central government repos (alphagov, NHSDigital, govuk-one-login) found, or only local council repos?
+- **Gaps**: What specific topics returned no relevant results? For each gap, provide an alternative search strategy: direct GitHub org URL, official API documentation URL, or specific WebSearch query the user can try
+- **Index limitations**: If govreposcrape results are dominated by a narrow set of orgs or technologies, note this explicitly so the user understands the result bias
+
+This section prevents users from drawing false conclusions (e.g., "no government team has built this") when the reality is the index simply doesn't cover it.
+
+### Step 12: Detect Version and Determine Increment
 
 Use Glob to find existing `projects/{project-dir}/research/ARC-{PROJECT_ID}-GCSR-*-v*.md` files. Read the highest version number from filenames.
 


### PR DESCRIPTION
## Summary

Optimised the `/arckit.gov-code-search` agent prompt through 3 autoresearch iterations (score: 7.4 → 8.8/10):

- **Project Relevance Mapping** — when project context available, maps top results to specific requirement IDs (FR/INT/NFR) with Quick Start install/clone commands
- **Search Effectiveness Assessment** — honest evaluation of govreposcrape coverage, gaps with alternative search strategies, and index limitation notes to prevent false conclusions

## Autoresearch Results

```
commit     structural  score  status   description
2bf4119    PASS        7.4    keep     baseline
d7207ff    PASS        8.4    keep     project relevance mapping + quick-start commands
c674ec9    PASS        8.8    keep     search effectiveness assessment
5821ad8    PASS        8.6    discard  query effectiveness tracking (regression)
```

## Test plan

- [ ] Run `/arckit.gov-code-search NHS FHIR patient data` in a test repo — verify Project Relevance Mapping and Search Effectiveness Assessment appear
- [ ] Run without project context — verify Step 10b is skipped gracefully

🤖 Generated with [Claude Code](https://claude.com/claude-code)