### PR TITLE
fix: publish gov repo commands and update counts

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -12,7 +12,7 @@
     {
       "name": "arckit",
       "source": "./arckit-claude",
-      "description": "64 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
+      "description": "67 slash commands for enterprise architecture artifacts, vendor procurement, and UK Government compliance",
       "version": "4.5.1",
       "author": {
         "name": "TractorJuice"

--- a/README.md
+++ b/README.md
@@ -903,7 +903,7 @@ payment-modernization/
 │   ├── agents/                            # Agent configs
 │   └── config.toml                        # MCP servers + agent roles
 ├── .github/
-│   ├── prompts/arckit-*.prompt.md         # GitHub Copilot prompt files (64 commands)
+│   ├── prompts/arckit-*.prompt.md         # GitHub Copilot prompt files (67 commands)
 │   ├── agents/arckit-*.agent.md           # GitHub Copilot custom agents (6 agents)
 │   └── copilot-instructions.md            # Repo-wide Copilot context
 └── .opencode/commands/                    # OpenCode CLI commands

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.5.1",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 64 slash commands for generating architecture artifacts",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 67 slash commands for generating architecture artifacts",
   "author": {
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin for Claude Code
 
-Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 64 slash commands for generating architecture artifacts.
+Enterprise Architecture Governance & Vendor Procurement Toolkit - a Claude Code plugin providing 67 slash commands for generating architecture artifacts.
 
 ## Installation
 

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 64 slash commands
+- **Commands**: 67 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 67 commands, 9 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-claude/docs/guides/roles/README.md
+++ b/arckit-claude/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 67 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-claude/docs/guides/roles/enterprise-architect.md
+++ b/arckit-claude/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 67 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 64 commands | Plugin mode
+Version 2.10.0 | 67 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 64 slash commands
+- **Commands**: 67 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 67 commands, 9 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-codex/docs/guides/roles/README.md
+++ b/arckit-codex/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 67 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-codex/docs/guides/roles/enterprise-architect.md
+++ b/arckit-codex/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 67 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 64 commands | Plugin mode
+Version 2.10.0 | 67 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-copilot/docs/guides/mcp-servers.md
+++ b/arckit-copilot/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 64 slash commands
+- **Commands**: 67 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 67 commands, 9 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-copilot/docs/guides/roles/README.md
+++ b/arckit-copilot/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 67 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-copilot/docs/guides/roles/enterprise-architect.md
+++ b/arckit-copilot/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 67 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-copilot/docs/guides/start.md
+++ b/arckit-copilot/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 64 commands | Plugin mode
+Version 2.10.0 | 67 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/arckit-gemini/GEMINI.md
+++ b/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 64 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is an **Enterprise Architecture Governance & Vendor Procurement Toolkit** providing 67 slash commands for generating architecture artifacts. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/arckit-gemini/README.md
+++ b/arckit-gemini/README.md
@@ -2,7 +2,7 @@
 
 **Enterprise Architecture Governance & Vendor Procurement Toolkit for Gemini CLI**
 
-ArcKit provides 64 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
+ArcKit provides 67 slash commands for generating architecture artifacts, vendor procurement documents, and UK Government compliance assessments — all from within Gemini CLI.
 
 ## Installation
 

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -1,7 +1,7 @@
 {
   "name": "arckit",
   "version": "4.5.1",
-  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 64 commands for architecture artifacts, vendor procurement, and UK Government compliance",
+  "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 67 commands for architecture artifacts, vendor procurement, and UK Government compliance",
   "contextFileName": "GEMINI.md",
   "mcpServers": {
     "aws-knowledge": {
@@ -21,6 +21,9 @@
       "headers": {
         "X-API-Key": "${DATA_COMMONS_API_KEY}"
       }
+    },
+    "govreposcrape": {
+      "httpUrl": "https://govreposcrape-api-1060386346356.us-central1.run.app/mcp"
     }
   },
   "themes": [

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 64 slash commands
+- **Commands**: 67 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 67 commands, 9 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/arckit-opencode/docs/guides/roles/README.md
+++ b/arckit-opencode/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 67 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/arckit-opencode/docs/guides/roles/enterprise-architect.md
+++ b/arckit-opencode/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 67 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 64 commands | Plugin mode
+Version 2.10.0 | 67 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/docs/README.md
+++ b/docs/README.md
@@ -241,7 +241,7 @@ See the [full index](guides/roles/README.md) for details.
 | `/arckit.maturity-model` | [maturity-model.md](guides/maturity-model.md) | ✅ Complete |
 | `/arckit.score` | [score.md](guides/score.md) | ✅ Complete |
 
-**Coverage**: 64/64 commands documented (100%)
+**Coverage**: 67/67 commands documented (100%)
 
 ---
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit AI Command Reference - 64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="description" content="ArcKit AI Command Reference - 67 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <title>AI Command Reference - ArcKit</title>
     <meta name="keywords" content="ArcKit commands, enterprise architecture commands, governance toolkit, command reference, dependency matrix, AI architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Reference - ArcKit">
-    <meta property="og:description" content="64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta property="og:description" content="67 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/commands.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Reference - ArcKit">
-    <meta name="twitter:description" content="64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
+    <meta name="twitter:description" content="67 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/commands.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -460,7 +460,7 @@
                 "@type": "WebPage",
                 "@id": "https://arckit.org/commands.html",
                 "name": "Command Reference - ArcKit",
-                "description": "64 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
+                "description": "67 AI commands for enterprise architecture governance, with sortable table, filters, and dependency matrix.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -492,10 +492,10 @@
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">
-                    <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.67-.89-3.67-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.67-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.01 8.01 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
                 </a>
                 <a href="https://discord.gg/JqgjQSnD" target="_blank" rel="noopener" class="app-icon-link" aria-label="Discord community" title="Discord community">
-                    <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M13.545 2.907a13.227 13.227 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.19 12.19 0 0 0-3.658 0 8.258 8.258 0 0 0-.412-.833.051.051 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.041.041 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032c.001.014.01.028.021.037a13.276 13.276 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019c.308-.42.582-.863.818-1.329a.05.05 0 0 0-.01-.059.051.051 0 0 0-.018-.011 8.875 8.875 0 0 1-1.248-.595.05.05 0 0 1-.02-.066.051.051 0 0 1 .015-.019c.084-.063.168-.129.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.052.052 0 0 1 .053.007c.08.066.164.132.248.195a.051.051 0 0 1-.004.085 8.254 8.254 0 0 1-1.249.594.05.05 0 0 0-.03.03.052.052 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.235 13.235 0 0 0 4.001-2.02.049.049 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.034.034 0 0 0-.02-.019Zm-8.198 7.307c-.789 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612Zm5.316 0c-.788 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612Z"/></svg>
+                    <svg width="20" height="20" viewBox="0 0 16 16" fill="currentColor"><path d="M13.545 2.907a13.227 13.227 0 0 0-3.257-1.011.05.05 0 0 0-.052.025c-.141.25-.297.577-.406.833a12.19 12.19 0 0 0-3.658 0 8.258 8.258 0 0 0-.412-.833.051.051 0 0 0-.052-.025c-1.125.194-2.22.534-3.257 1.011a.041.041 0 0 0-.021.018C.356 6.024-.213 9.047.066 12.032c.001.014.01.028.021.037a13.276 13.276 0 0 0 3.995 2.02.05.05 0 0 0 .056-.019c.308-.42.582-.863.818-1.329a.05.05 0 0 0-.01-.059.051.051 0 0 0-.018-.011 8.875 8.875 0 0 1-1.248-.595.05.05 0 0 1-.02-.066.051.051 0 0 1 .015-.019c.084-.063.168-.129.248-.195a.05.05 0 0 1 .051-.007c2.619 1.196 5.454 1.196 8.041 0a.052.052 0 0 1 .053.007c.08.066.167.132.248.195a.051.051 0 0 1-.004.085 8.254 8.254 0 0 1-1.249.594.05.05 0 0 0-.03.03.052.052 0 0 0 .003.041c.24.465.515.909.817 1.329a.05.05 0 0 0 .056.019 13.235 13.235 0 0 0 4.001-2.02.049.049 0 0 0 .021-.037c.334-3.451-.559-6.449-2.366-9.106a.034.034 0 0 0-.02-.019Zm-8.198 7.307c-.789 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.45.73 1.438 1.613 0 .888-.637 1.612-1.438 1.612Zm5.316 0c-.788 0-1.438-.724-1.438-1.612 0-.889.637-1.613 1.438-1.613.807 0 1.451.73 1.438 1.613 0 .888-.631 1.612-1.438 1.612Z"/></svg>
                 </a>
                 <button class="app-theme-toggle" onclick="toggleTheme()" aria-label="Toggle dark mode" title="Toggle theme"></button>
             </div>
@@ -504,7 +504,7 @@
 
     <div class="app-page-hero app-page-hero--commands">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">64 AI Commands</span>
+            <span class="app-page-hero__stat">67 AI Commands</span>
             <h1 class="app-page-hero__title">AI Command Reference</h1>
             <p class="app-page-hero__description">Sortable table with filters and full dependency matrix &mdash; every ArcKit command at a glance.</p>
         </div>
@@ -512,7 +512,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">64 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">67 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->
@@ -571,7 +571,7 @@
                 <input type="text" id="search-filter" placeholder="Search commands...">
             </div>
             <div class="app-command-count">
-                Showing <span id="visible-count">64</span> of 64 commands
+                Showing <span id="visible-count">67</span> of 67 commands
             </div>
         </div>
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -378,7 +378,7 @@
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 64 commands, 6 autonomous research agents, 4 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 67 commands, 9 autonomous research agents, 5 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
                 </div>
 
                 <div class="app-step">
@@ -418,7 +418,7 @@ claude</code></pre></div>
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Extension</h2>
                     <div class="app-code-block">gemini extensions install https://github.com/tractorjuice/arckit-gemini</div>
-                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 64 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Zero-config: all 67 commands, templates, scripts, and bundled MCP servers. Update with <code>gemini extensions update arckit</code>.</p>
                 </div>
 
                 <div class="app-step">
@@ -466,7 +466,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai codex</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 64 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 67 commands, templates, and scripts into your project. Use <code>--minimal</code> to skip docs and guides.</p>
                 </div>
 
                 <div class="app-step">
@@ -516,7 +516,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai opencode</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This copies all 64 commands, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This copies all 67 commands, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -562,7 +562,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai copilot</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This scaffolds 64 prompt files, 6 research agents, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This scaffolds 67 prompt files, 9 research agents, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">
@@ -624,7 +624,7 @@ arckit init my-project --ai copilot</code></pre></div>
             <div class="app-next-grid">
                 <a href="commands.html" class="app-next-card">
                     <p class="app-next-card__title">Command Reference</p>
-                    <p class="app-next-card__desc">Browse all 64 commands with filters and dependency matrix.</p>
+                    <p class="app-next-card__desc">Browse all 67 commands with filters and dependency matrix.</p>
                 </a>
                 <a href="guides.html" class="app-next-card">
                     <p class="app-next-card__title">Command Guides</p>

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -41,7 +41,7 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 64 slash commands
+- **Commands**: 67 slash commands
 - **Agents**: 6 autonomous research agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
@@ -164,7 +164,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 64 commands, 6 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 67 commands, 9 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 

--- a/docs/guides/roles/README.md
+++ b/docs/guides/roles/README.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-Which ArcKit commands should **you** use? These guides map ArcKit's 64 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
+Which ArcKit commands should **you** use? These guides map ArcKit's 67 commands to UK Government [DDaT Capability Framework](https://ddat-capability-framework.service.gov.uk/) roles, so you can focus on the commands relevant to your job.
 
 ## Architecture Roles
 

--- a/docs/guides/roles/enterprise-architect.md
+++ b/docs/guides/roles/enterprise-architect.md
@@ -7,7 +7,7 @@
 
 ## Overview
 
-The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 64 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
+The Enterprise Architect owns the architecture governance framework and is the primary ArcKit user. All 67 commands are relevant to this role — you set up principles, define the governance lifecycle, and ensure all architecture artifacts meet organisational standards.
 
 ## Primary Commands
 

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -50,7 +50,7 @@ Output: Console only (no file created). This is a navigation aid, not a governan
 
 ```text
 ArcKit — Enterprise Architecture Governance Toolkit
-Version 2.10.0 | 64 commands | Plugin mode
+Version 2.10.0 | 67 commands | Plugin mode
 
 Your AI-powered assistant for architecture governance, vendor procurement,
 and compliance — all driven by templates and traceability.

--- a/scripts/create-sdg-repo.py
+++ b/scripts/create-sdg-repo.py
@@ -500,7 +500,7 @@ This repository contains **{total_projects} UK Government technology projects** 
 
 ## ArcKit
 
-This repository is powered by [ArcKit](https://github.com/tractorjuice/arc-kit) -- an Enterprise Architecture Governance & Vendor Procurement Toolkit providing 64 slash commands for AI coding assistants.
+This repository is powered by [ArcKit](https://github.com/tractorjuice/arc-kit) -- an Enterprise Architecture Governance & Vendor Procurement Toolkit providing 67 slash commands for AI coding assistants.
 
 **Version**: {VERSION}
 """


### PR DESCRIPTION
## Summary
- Update command count from 64 to 67 across all documentation, HTML pages, plugin manifests, extension configs, and role guides
- Add govreposcrape MCP server to Gemini extension (`gemini-extension.json`)
- Update agent count (6 to 9) and hook count (4 to 5) in relevant docs
- Regenerated all extension formats via `converter.py`

Closes #200

## Test plan
- [ ] Verify plugin.json shows 67 commands
- [ ] Verify Gemini extension has govreposcrape MCP server
- [ ] Verify docs/commands.html shows 67 commands
- [ ] Verify getting-started.html shows correct counts
- [ ] Run `scripts/push-extensions.sh` after merge to publish to extension repos

🤖 Generated with [Claude Code](https://claude.com/claude-code)