### PR TITLE
fix: preserve accented characters in slugify function

### DIFF
--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -113,9 +113,10 @@ check_git() {
     return 0
 }
 
-# Slugify a string (convert to kebab-case)
+# Slugify a string (convert to kebab-case, preserving accented characters)
 slugify() {
-    echo "$1" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]\+/-/g' | sed 's/^-\|-$//g'
+    local lower="${1,,}"
+    echo "$lower" | sed 's/[^[:alnum:]]\+/-/g' | sed 's/^-\|-$//g'
 }
 
 # ============================================================================


### PR DESCRIPTION
## Summary

- Fix `slugify()` in `scripts/bash/common.sh` to use locale-aware `[:alnum:]` instead of `[a-z0-9]`, preserving accented characters in project names during kebab-case conversion.

## Test plan

- [ ] Verify `slugify "Café Project"` produces `café-project` not `caf-project`

🤖 Generated with [Claude Code](https://claude.com/claude-code)