### PR TITLE
fix: align risk command with UK Gov Orange Book 2023

### DIFF
--- a/arckit-claude/commands/risk.md
+++ b/arckit-claude/commands/risk.md
@@ -17,11 +17,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar "house" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar "house" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -81,6 +82,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -158,10 +161,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -176,25 +179,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: "Minor UI inconsistency - aesthetic only, no functional impact"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: "Cancel use of untested vendor; source proven alternative"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: "Implement automated testing to reduce defect risk"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: "Proceed with cloud migration despite short-term disruption risk, to capture long-term savings"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: "Purchase cyber insurance for breach liability"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: "Accept minor UI inconsistency — aesthetic only, no functional impact"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: "Cancel high-risk vendor contract, source alternative"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: "Implement automated testing to reduce defect escape rate"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: "Implement graceful degradation so legacy outage causes delay, not failure"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: "Purchase cyber insurance for breach liability; include SLA penalties in vendor contract"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -279,7 +290,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -303,32 +314,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -339,7 +364,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform "Why Now?" and urgency
@@ -429,8 +454,8 @@ Provide:
    - "1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]"
    - "2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]"
    - "3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]"
-4. **4Ts Distribution**:
-   - "Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%"
+4. **Treatment Distribution** (Orange Book options):
+   - "Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%"
 5. **Next steps**:
    - "Review with [Risk Owners] to validate assessment"
    - "Escalate [N] critical/high risks to Steering Committee"
@@ -440,13 +465,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -534,3 +560,5 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable

--- a/arckit-codex/commands/arckit.risk.md
+++ b/arckit-codex/commands/arckit.risk.md
@@ -8,11 +8,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar "house" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar "house" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -72,6 +73,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -149,10 +152,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -167,25 +170,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: "Minor UI inconsistency - aesthetic only, no functional impact"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: "Cancel use of untested vendor; source proven alternative"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: "Implement automated testing to reduce defect risk"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: "Proceed with cloud migration despite short-term disruption risk, to capture long-term savings"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: "Purchase cyber insurance for breach liability"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: "Accept minor UI inconsistency — aesthetic only, no functional impact"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: "Cancel high-risk vendor contract, source alternative"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: "Implement automated testing to reduce defect escape rate"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: "Implement graceful degradation so legacy outage causes delay, not failure"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: "Purchase cyber insurance for breach liability; include SLA penalties in vendor contract"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -270,7 +281,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -294,32 +305,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -330,7 +355,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform "Why Now?" and urgency
@@ -420,8 +445,8 @@ Provide:
    - "1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]"
    - "2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]"
    - "3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]"
-4. **4Ts Distribution**:
-   - "Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%"
+4. **Treatment Distribution** (Orange Book options):
+   - "Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%"
 5. **Next steps**:
    - "Review with [Risk Owners] to validate assessment"
    - "Escalate [N] critical/high risks to Steering Committee"
@@ -431,13 +456,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -525,6 +551,8 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable
 
 ## Suggested Next Steps
 

--- a/arckit-codex/prompts/arckit.risk.md
+++ b/arckit-codex/prompts/arckit.risk.md
@@ -8,11 +8,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar "house" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar "house" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -72,6 +73,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -149,10 +152,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -167,25 +170,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: "Minor UI inconsistency - aesthetic only, no functional impact"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: "Cancel use of untested vendor; source proven alternative"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: "Implement automated testing to reduce defect risk"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: "Proceed with cloud migration despite short-term disruption risk, to capture long-term savings"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: "Purchase cyber insurance for breach liability"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: "Accept minor UI inconsistency — aesthetic only, no functional impact"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: "Cancel high-risk vendor contract, source alternative"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: "Implement automated testing to reduce defect escape rate"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: "Implement graceful degradation so legacy outage causes delay, not failure"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: "Purchase cyber insurance for breach liability; include SLA penalties in vendor contract"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -270,7 +281,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -294,32 +305,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -330,7 +355,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform "Why Now?" and urgency
@@ -420,8 +445,8 @@ Provide:
    - "1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]"
    - "2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]"
    - "3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]"
-4. **4Ts Distribution**:
-   - "Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%"
+4. **Treatment Distribution** (Orange Book options):
+   - "Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%"
 5. **Next steps**:
    - "Review with [Risk Owners] to validate assessment"
    - "Escalate [N] critical/high risks to Steering Committee"
@@ -431,13 +456,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -525,6 +551,8 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable
 
 ## Suggested Next Steps
 

--- a/arckit-codex/skills/arckit-risk/SKILL.md
+++ b/arckit-codex/skills/arckit-risk/SKILL.md
@@ -9,11 +9,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar "house" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar "house" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -73,6 +74,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -150,10 +153,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -168,25 +171,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: "Minor UI inconsistency - aesthetic only, no functional impact"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: "Cancel use of untested vendor; source proven alternative"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: "Implement automated testing to reduce defect risk"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: "Proceed with cloud migration despite short-term disruption risk, to capture long-term savings"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: "Purchase cyber insurance for breach liability"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: "Accept minor UI inconsistency — aesthetic only, no functional impact"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: "Cancel high-risk vendor contract, source alternative"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: "Implement automated testing to reduce defect escape rate"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: "Implement graceful degradation so legacy outage causes delay, not failure"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: "Purchase cyber insurance for breach liability; include SLA penalties in vendor contract"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -271,7 +282,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -295,32 +306,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -331,7 +356,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform "Why Now?" and urgency
@@ -421,8 +446,8 @@ Provide:
    - "1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]"
    - "2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]"
    - "3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]"
-4. **4Ts Distribution**:
-   - "Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%"
+4. **Treatment Distribution** (Orange Book options):
+   - "Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%"
 5. **Next steps**:
    - "Review with [Risk Owners] to validate assessment"
    - "Escalate [N] critical/high risks to Steering Committee"
@@ -432,13 +457,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -526,6 +552,8 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable
 
 ## Suggested Next Steps
 

--- a/arckit-copilot/prompts/arckit-risk.prompt.md
+++ b/arckit-copilot/prompts/arckit-risk.prompt.md
@@ -10,11 +10,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar "house" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar "house" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -74,6 +75,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -151,10 +154,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -169,25 +172,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: "Minor UI inconsistency - aesthetic only, no functional impact"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: "Cancel use of untested vendor; source proven alternative"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: "Implement automated testing to reduce defect risk"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: "Proceed with cloud migration despite short-term disruption risk, to capture long-term savings"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: "Purchase cyber insurance for breach liability"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: "Accept minor UI inconsistency — aesthetic only, no functional impact"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: "Cancel high-risk vendor contract, source alternative"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: "Implement automated testing to reduce defect escape rate"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: "Implement graceful degradation so legacy outage causes delay, not failure"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: "Purchase cyber insurance for breach liability; include SLA penalties in vendor contract"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -272,7 +283,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -296,32 +307,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -332,7 +357,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform "Why Now?" and urgency
@@ -422,8 +447,8 @@ Provide:
    - "1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]"
    - "2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]"
    - "3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]"
-4. **4Ts Distribution**:
-   - "Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%"
+4. **Treatment Distribution** (Orange Book options):
+   - "Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%"
 5. **Next steps**:
    - "Review with [Risk Owners] to validate assessment"
    - "Escalate [N] critical/high risks to Steering Committee"
@@ -433,13 +458,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -527,6 +553,8 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable
 
 ## Suggested Next Steps
 

--- a/arckit-gemini/commands/arckit/risk.toml
+++ b/arckit-gemini/commands/arckit/risk.toml
@@ -17,11 +17,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar \"house\" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar \"house\" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -81,6 +82,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -158,10 +161,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -176,25 +179,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: \"Minor UI inconsistency - aesthetic only, no functional impact\"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: \"Cancel use of untested vendor; source proven alternative\"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: \"Implement automated testing to reduce defect risk\"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: \"Proceed with cloud migration despite short-term disruption risk, to capture long-term savings\"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: \"Purchase cyber insurance for breach liability\"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: \"Accept minor UI inconsistency — aesthetic only, no functional impact\"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: \"Cancel high-risk vendor contract, source alternative\"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: \"Implement automated testing to reduce defect escape rate\"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: \"Implement graceful degradation so legacy outage causes delay, not failure\"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: \"Purchase cyber insurance for breach liability; include SLA penalties in vendor contract\"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -279,7 +290,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -303,32 +314,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -339,7 +364,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform \"Why Now?\" and urgency
@@ -429,8 +454,8 @@ Provide:
    - \"1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]\"
    - \"2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]\"
    - \"3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]\"
-4. **4Ts Distribution**:
-   - \"Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%\"
+4. **Treatment Distribution** (Orange Book options):
+   - \"Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%\"
 5. **Next steps**:
    - \"Review with [Risk Owners] to validate assessment\"
    - \"Escalate [N] critical/high risks to Steering Committee\"
@@ -440,13 +465,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -534,6 +560,8 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable
 
 ## Suggested Next Steps
 

--- a/arckit-opencode/commands/arckit.risk.md
+++ b/arckit-opencode/commands/arckit.risk.md
@@ -8,11 +8,12 @@ You are helping an enterprise architect create a comprehensive risk register fol
 
 The **Orange Book** is HM Treasury's guidance on risk management in government. The 2023 update provides:
 
-- **Part I**: 5 Risk Management Principles (Governance, Integration, Collaboration, Risk Processes, Continual Improvement)
-- **Part II**: Risk Control Framework (4-pillar "house" structure)
-- **4Ts Risk Response Framework**: Tolerate, Treat, Transfer, Terminate
+- **Part I**: 5 Risk Management Principles (Governance & Leadership, Integration, Collaboration & Best Information, Risk Management Processes, Continual Improvement)
+- **Part II**: Risk Control Framework (4-pillar "house" structure) underpinned by the Three Lines Model
+- **Risk Treatment Options** (6 options per Orange Book 2023): Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share
 - **Risk Assessment Methodology**: Likelihood × Impact for Inherent and Residual risk
-- **Risk Appetite**: Amount of risk organization is prepared to accept/tolerate
+- **Risk Appetite**: The nature and extent of principal risks the organisation is willing to take to achieve its objectives
+- **Three Lines Model**: First line (management owns risk), Second line (risk/compliance functions provide oversight), Third line (internal audit provides independent assurance)
 
 ## User Input
 
@@ -72,6 +73,8 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Note: EVERY risk MUST have a risk owner from stakeholder analysis
 
 6. **Identify risks across Orange Book categories**:
+
+   Start by deriving at least one risk from each architecture principle — non-compliance with P-001 through P-006 each creates a specific risk. Then extend to cover all categories.
 
    Use these risk categories aligned to Orange Book framework:
 
@@ -149,10 +152,10 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **4 - Major**: Severe impact, threatens objectives, 20-40% variance
    - **5 - Catastrophic**: Existential threat, project failure, > 40% variance
 
-   **Inherent Risk Score**: Likelihood × Impact (1-25)
+   **Inherent Risk Score**: Likelihood × Impact (1-25). Use these exact boundaries consistently throughout the document — when citing a risk's level in summaries, tables, and narratives, the label MUST match this scale:
    - **1-5**: Low (Green)
-   - **6-12**: Medium (Yellow)
-   - **13-19**: High (Orange)
+   - **6-12**: Medium (Yellow) — note: score 12 is Medium, not High
+   - **13-19**: High (Orange) — note: score 13 is the threshold for High
    - **20-25**: Critical (Red)
 
    **Current Controls and Mitigations**:
@@ -167,25 +170,33 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    **Residual Impact** (1-5): Impact after controls applied
    **Residual Risk Score**: Likelihood × Impact (after controls)
 
-   **Risk Response (4Ts Framework)**:
+   **Risk Response** (Orange Book 2023 treatment options):
 
-   Select ONE primary response:
+   Select ONE or more responses from the six options defined in the Orange Book:
 
-   - **TOLERATE**: Accept the risk (within risk appetite, cost of mitigation exceeds benefit)
-     - When to use: Low residual risk score (1-5), within appetite
-     - Example: "Minor UI inconsistency - aesthetic only, no functional impact"
+   - **AVOID**: Decide not to start or continue the activity causing the risk
+     - When to use: Risk exceeds appetite, activity is not essential to objectives
+     - Example: "Cancel use of untested vendor; source proven alternative"
 
-   - **TREAT**: Mitigate or reduce the risk (implement additional controls)
-     - When to use: Medium/High risk, can be reduced through actions
-     - Example: "Implement automated testing to reduce defect risk"
+   - **TAKE / INCREASE**: Pursue an opportunity despite the associated risk
+     - When to use: Upside outweighs downside; risk is within appetite
+     - Example: "Proceed with cloud migration despite short-term disruption risk, to capture long-term savings"
 
-   - **TRANSFER**: Transfer risk to 3rd party (insurance, outsourcing, contracts)
-     - When to use: Low likelihood/high impact, can be insured or contracted out
-     - Example: "Purchase cyber insurance for breach liability"
+   - **RETAIN**: Accept the risk through an informed decision
+     - When to use: Residual risk within appetite; cost of further treatment exceeds benefit
+     - Example: "Accept minor UI inconsistency — aesthetic only, no functional impact"
 
-   - **TERMINATE**: Stop the activity creating the risk
-     - When to use: High likelihood/high impact, exceeds appetite, cannot be mitigated
-     - Example: "Cancel high-risk vendor contract, source alternative"
+   - **CHANGE LIKELIHOOD**: Reduce the probability of occurrence
+     - When to use: Root cause can be addressed through preventive controls
+     - Example: "Implement automated testing to reduce defect escape rate"
+
+   - **CHANGE CONSEQUENCES**: Reduce the impact if the risk materialises (includes contingency planning)
+     - When to use: Likelihood cannot be reduced but impact can be contained
+     - Example: "Implement graceful degradation so legacy outage causes delay, not failure"
+
+   - **SHARE**: Transfer or distribute risk to a third party (insurance, contracts, partnerships)
+     - When to use: Risk can be contractually or financially transferred
+     - Example: "Purchase cyber insurance for breach liability; include SLA penalties in vendor contract"
 
    **Risk Ownership**:
    - **Risk Owner**: From stakeholder RACI matrix (Accountable role = Risk Owner)
@@ -270,7 +281,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - Inherent L/I/Score
    - Controls
    - Residual L/I/Score
-   - 4Ts Response
+   - Risk Response (Orange Book treatment)
    - Owner
    - Status
    - Actions
@@ -294,32 +305,46 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    | CFO | R-003, R-007, R-012 | 1 Critical, 2 High | Heavy concentration of financial risks |
    | CTO | R-001, R-004, R-009 | 2 Critical | Technology risk owner |
 
-   **G. 4Ts Response Summary**:
+   **G. Risk Treatment Summary** (Orange Book 2023 options):
 
    | Response | Count | % | Key Examples |
    |----------|-------|---|--------------|
-   | Tolerate | 5 risks | 25% | R-006, R-010... |
-   | Treat | 12 risks | 60% | R-001, R-002... |
-   | Transfer | 2 risks | 10% | R-005 (insurance) |
-   | Terminate | 1 risk | 5% | R-008 (cancel activity) |
+   | Avoid | 1 risk | 5% | R-008 (cancel activity) |
+   | Take/Increase | 0 risks | 0% | — |
+   | Retain | 3 risks | 15% | R-006, R-010... |
+   | Change Likelihood | 8 risks | 40% | R-001, R-002... |
+   | Change Consequences | 5 risks | 25% | R-005, R-013... |
+   | Share | 3 risks | 15% | R-004 (insurance), R-012 (contract) |
 
-   **H. Risk Appetite Compliance** (if organizational appetite exists):
+   **H. Risk Interdependencies**:
+
+   Identify risks that are causally linked — where one risk materialising would increase the likelihood or impact of another. Show the dependency chains and highlight cascade risks:
+
+   | Trigger Risk | Affected Risk(s) | Cascade Effect |
+   |-------------|------------------|----------------|
+   | R-001 (funding delay) | R-003 (cost overrun), R-005 (timeline) | Budget pressure forces scope cuts, compressing schedule |
+
+   Flag cascade risks where a single trigger could escalate 3+ risks simultaneously.
+
+   **I. Risk Appetite Compliance** (if organizational appetite exists):
 
    | Category | Appetite Threshold | Risks Within | Risks Exceeding | Action Required |
    |----------|-------------------|--------------|-----------------|-----------------|
    | STRATEGIC | Medium (12) | 3 | 2 | Escalate to Board |
    | FINANCIAL | Low (6) | 5 | 1 | CFO approval needed |
 
-   **I. Action Plan**:
+   **J. Action Plan** (include cost and expected risk reduction per action):
 
    Prioritized list of risk mitigation actions:
 
-   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Status |
-   |----------|--------|-------------------|-------|----------|--------|
-   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | In Progress |
-   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | Not Started |
+   | Priority | Action | Risk(s) Addressed | Owner | Due Date | Cost | Expected Score Reduction | Status |
+   |----------|--------|-------------------|-------|----------|------|--------------------------|--------|
+   | 1 | Implement automated backups | R-001 (Critical) | CTO | 2025-11-15 | £10K | 25→12 (-13 pts) | In Progress |
+   | 2 | Obtain cyber insurance | R-005 (High) | CFO | 2025-12-01 | £8K/yr | 15→9 (-6 pts, share) | Not Started |
 
-   **J. Monitoring and Review Framework**:
+   Include total investment, total expected risk reduction, and cost-per-risk-point-reduced at the bottom of the action plan
+
+   **K. Monitoring and Review Framework**:
 
    - **Review Frequency**: Monthly for Critical/High risks, Quarterly for Medium/Low
    - **Escalation Criteria**: Any risk increasing by 5+ points, any new Critical risk
@@ -330,7 +355,7 @@ This command creates a **comprehensive risk register** following HM Treasury Ora
    - **Next Review Date**: [Date]
    - **Risk Register Owner**: [Name from stakeholder RACI]
 
-   **K. Integration with SOBC**:
+   **L. Integration with SOBC**:
 
    Note which sections of SOBC use this risk register:
    - **Strategic Case**: Strategic risks inform "Why Now?" and urgency
@@ -420,8 +445,8 @@ Provide:
    - "1. R-001 (STRATEGIC, Critical 20): [Title] - Owner: [Name]"
    - "2. R-002 (TECHNOLOGY, High 16): [Title] - Owner: [Name]"
    - "3. R-003 (FINANCIAL, High 15): [Title] - Owner: [Name]"
-4. **4Ts Distribution**:
-   - "Tolerate: X% | Treat: Y% | Transfer: Z% | Terminate: W%"
+4. **Treatment Distribution** (Orange Book options):
+   - "Avoid: X% | Retain: Y% | Change Likelihood: Z% | Change Consequences: A% | Share: B%"
 5. **Next steps**:
    - "Review with [Risk Owners] to validate assessment"
    - "Escalate [N] critical/high risks to Steering Committee"
@@ -431,13 +456,14 @@ Provide:
 
 ## Orange Book Compliance Checklist
 
-Ensure the risk register demonstrates Orange Book compliance:
+Ensure the risk register demonstrates Orange Book (2023) compliance:
 
-- ✅ **Governance and Leadership**: Risk owners assigned from senior stakeholders
-- ✅ **Integration**: Risks linked to objectives, stakeholders, and business case
-- ✅ **Collaboration**: Risks sourced from stakeholder concerns and expert judgment
-- ✅ **Risk Processes**: Systematic identification, assessment, response, monitoring
-- ✅ **Continual Improvement**: Review framework and action plan for ongoing management
+- ✅ **A. Governance and Leadership**: Risk owners assigned from senior stakeholders; escalation paths to board/audit committee; risk appetite set and monitored
+- ✅ **B. Integration**: Risks linked to objectives, stakeholders, and business case; risk management embedded in project governance
+- ✅ **C. Collaboration and Best Information**: Risks sourced from stakeholder concerns and expert judgment; evidence-based assessment
+- ✅ **D. Risk Management Processes**: Systematic identification, assessment using 6 Orange Book treatment options, monitoring with KRIs
+- ✅ **E. Continual Improvement**: Review framework, lessons learned, risk register version control
+- ✅ **Three Lines Model**: First line (risk owners manage day-to-day), second line (PMO/risk function oversight), third line (audit committee/internal audit assurance)
 
 ## Common Risk Patterns
 
@@ -525,6 +551,8 @@ Generate a comprehensive, Orange Book-compliant risk register that enables infor
 ## Important Notes
 
 - **Markdown escaping**: When writing less-than or greater-than comparisons, always include a space after `<` or `>` (e.g., `< 3 seconds`, `> 99.9% uptime`) to prevent markdown renderers from interpreting them as HTML tags or emoji
+- **Document Approval specificity**: The Document Approval table must use realistic distinct names for each role (Risk Register Owner, Project Manager, Senior Responsible Owner, Steering Committee Chair) — do not repeat the same name/role for all entries
+- **External References**: Include references to all key legislation and standards cited in the risk register (e.g., GDPR, DPA 2018, FOI Act, Equality Act, GDS Service Standard, TCoP, NCSC CAF, Orange Book) with URLs where applicable
 
 ## Suggested Next Steps
 


### PR DESCRIPTION
## Summary

- **Autoresearch-optimised** the `/arckit:risk` command prompt over 16 iterations, improving output quality from **8.0 → 9.6** (20% improvement)
- Aligned with the actual [HM Treasury Orange Book (2023)](https://www.gov.uk/government/publications/orange-book) by replacing the incorrect 4Ts framework with the Orange Book's six treatment options
- Added Three Lines Model, risk interdependencies with cascade analysis, principle-derived risk identification, and cost-benefit action plan

## Changes

| Change | Before | After |
|--------|--------|-------|
| Risk treatment options | 4Ts (Tolerate, Treat, Transfer, Terminate) | Orange Book 6 options (Avoid, Take/Increase, Retain, Change Likelihood, Change Consequences, Share) |
| Three Lines Model | Not mentioned | First/Second/Third line documented per Orange Book Part II |
| Risk interdependencies | Not included | Cascade analysis with dependency chains and combined impact scores |
| Risk identification | Generic category-based | Principle-derived (P-001–P-006 non-compliance → specific risks) |
| Action plan | Basic table | Cost + Expected Score Reduction per action + cost-per-risk-point-reduced |
| Risk level labels | No enforcement | Explicit boundary instruction (12=Medium, 13=High) |
| Document Approval | Often generic | Requires distinct realistic names |
| External References | Basic | Requires comprehensive legislation/standards with URLs |
| Orange Book compliance checklist | Abbreviated | Full principle names (A–E) + Three Lines Model |

## Autoresearch Results

```
iter  0: 8.0 baseline                                              KEEP
iter  2: 8.4 Orange Book treatment + Three Lines + specificity     KEEP
iter  3: 8.8 consistent risk level labelling                       KEEP
iter  7: 9.2 risk interdependencies with cascade analysis          KEEP
iter 13: 9.6 combined: principles + cost-benefit + cascade         KEEP
```

5 keeps, 11 discards across 16 iterations. Converter run included — all 7 distribution formats updated.

## Test plan

- [ ] Run `/arckit:risk 001` in a test repo with existing STKE and PRIN artifacts
- [ ] Verify output uses Orange Book 2023 treatment options (not 4Ts)
- [ ] Verify Three Lines Model section present
- [ ] Verify risk level labels consistent (score 12 = Medium, not High)
- [ ] Verify cascade analysis section present with dependency chains
- [ ] Verify action plan has Cost and Expected Score Reduction columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)