### PR TITLE
fix: enhance secure command with remediation roadmap and CAF traceability

### DIFF
--- a/arckit-claude/commands/secure.md
+++ b/arckit-claude/commands/secure.md
@@ -131,6 +131,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -182,6 +184,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory

--- a/arckit-codex/commands/arckit.secure.md
+++ b/arckit-codex/commands/arckit.secure.md
@@ -128,6 +128,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -179,6 +181,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory

--- a/arckit-codex/prompts/arckit.secure.md
+++ b/arckit-codex/prompts/arckit.secure.md
@@ -128,6 +128,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -179,6 +181,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory

--- a/arckit-codex/skills/arckit-secure/SKILL.md
+++ b/arckit-codex/skills/arckit-secure/SKILL.md
@@ -129,6 +129,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -180,6 +182,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory

--- a/arckit-copilot/prompts/arckit-secure.prompt.md
+++ b/arckit-copilot/prompts/arckit-secure.prompt.md
@@ -130,6 +130,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -181,6 +183,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory

--- a/arckit-gemini/commands/arckit/secure.toml
+++ b/arckit-gemini/commands/arckit/secure.toml
@@ -137,6 +137,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -188,6 +190,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory

--- a/arckit-opencode/commands/arckit.secure.md
+++ b/arckit-opencode/commands/arckit.secure.md
@@ -128,6 +128,8 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
+    After the CAF assessment, add a **Principles-to-CAF Traceability Matrix** showing how each Architecture Principle (P-001 through P-006) maps to specific CAF principles. For example: P-003 (Security by Design) maps to A1 (Governance), A2 (Risk Management), B2 (Identity & Access), B3 (Data Security), B4 (System Security). This shows which architecture principles provide evidence for which CAF principles, and highlights any CAF principles that have NO supporting architecture principle (gaps in security governance)
+
 10. **Assess UK Government Cyber Security Standard compliance**:
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
@@ -179,6 +181,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - High priority (1-3 months) - significant risk reduction
     - Medium priority (3-6 months) - continuous improvement
     - Include VMS enrollment and Cyber Action Plan alignment actions where applicable
+
+    After the recommendations, add a **Security Remediation Roadmap** table mapping each action to:
+    - The GDS service phase it must be completed by (Alpha/Beta/Live)
+    - The specific stakeholder owner from the RACI matrix (use actual names from STKE artifact)
+    - The CAF principle(s) it remediates
+    - Estimated effort (days) and cost where possible
+
+    Also add a **CAF Maturity Summary** — for each of the 4 CAF objectives (A-D), calculate a maturity percentage: (achieved principles + 0.5 × partially achieved) / total principles × 100%. This gives a quantitative maturity score per objective, not just pass/fail
 
 14. **Detect version**: Before generating the document ID, check if a previous version exists:
     - Look for existing `ARC-{PROJECT_ID}-SECD-v*.md` files in the project directory


### PR DESCRIPTION
## Summary

- **Autoresearch-optimised** the `/arckit:secure` command prompt over 4 iterations, improving output quality from **8.0 → 9.6** (20% improvement)
- Added three new analytical sections: Security Remediation Roadmap, CAF Maturity Summary, and Principles-to-CAF Traceability Matrix

## Changes

| Change | Before | After |
|--------|--------|-------|
| Recommendations | Prioritised lists (Critical/High/Medium) | + 25-33 item Security Remediation Roadmap with GDS phase, named owners, CAF principles, effort days, £ cost |
| CAF scoring | Binary pass/fail per principle | + CAF Maturity Summary with % per objective (e.g., A=37.5%, B=25%, C=0%, D=0%) |
| Traceability | CAF principles reference artifacts | + Principles-to-CAF Traceability Matrix mapping P-001–P-006 to CAF with gap analysis for unsupported principles |

## Autoresearch Results

```
iter 0: 8.0 baseline                                              KEEP
iter 1: 9.2 Remediation Roadmap + CAF Maturity Summary            KEEP
iter 2: 9.6 Principles-to-CAF Traceability Matrix + gap analysis  KEEP
iter 3: 9.8 Investment Summary (delta 0.2)                        DISCARD
```

3 keeps, 1 discard across 4 iterations. Converter run included — all 7 distribution formats updated.

## Test plan

- [ ] Run `/arckit:secure 001` in a test repo with STKE and PRIN artifacts
- [ ] Verify CAF Maturity Summary has percentages per objective
- [ ] Verify Security Remediation Roadmap has GDS phase, named owners, CAF principles, effort, cost
- [ ] Verify Principles-to-CAF Traceability Matrix present with gap analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)