### PR TITLE
fix: enhance requirements command with NFR sub-prefixes, MoSCoW, and coverage matrix

### DIFF
--- a/arckit-claude/commands/requirements.md
+++ b/arckit-claude/commands/requirements.md
@@ -79,12 +79,14 @@ $ARGUMENTS
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -102,8 +104,9 @@ $ARGUMENTS
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., "Depends on: INT-001, DR-002")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -113,6 +116,7 @@ $ARGUMENTS
      - Example: "NFR-S-001 aligns with Security by Design principle (SEC-001)"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers

--- a/arckit-codex/commands/arckit.requirements.md
+++ b/arckit-codex/commands/arckit.requirements.md
@@ -67,12 +67,14 @@ $ARGUMENTS
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -90,8 +92,9 @@ $ARGUMENTS
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., "Depends on: INT-001, DR-002")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -101,6 +104,7 @@ $ARGUMENTS
      - Example: "NFR-S-001 aligns with Security by Design principle (SEC-001)"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers

--- a/arckit-codex/prompts/arckit.requirements.md
+++ b/arckit-codex/prompts/arckit.requirements.md
@@ -67,12 +67,14 @@ $ARGUMENTS
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -90,8 +92,9 @@ $ARGUMENTS
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., "Depends on: INT-001, DR-002")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -101,6 +104,7 @@ $ARGUMENTS
      - Example: "NFR-S-001 aligns with Security by Design principle (SEC-001)"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers

--- a/arckit-codex/skills/arckit-requirements/SKILL.md
+++ b/arckit-codex/skills/arckit-requirements/SKILL.md
@@ -68,12 +68,14 @@ $ARGUMENTS
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -91,8 +93,9 @@ $ARGUMENTS
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., "Depends on: INT-001, DR-002")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -102,6 +105,7 @@ $ARGUMENTS
      - Example: "NFR-S-001 aligns with Security by Design principle (SEC-001)"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers

--- a/arckit-copilot/prompts/arckit-requirements.prompt.md
+++ b/arckit-copilot/prompts/arckit-requirements.prompt.md
@@ -69,12 +69,14 @@ ${input:topic:Enter project name or topic}
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -92,8 +94,9 @@ ${input:topic:Enter project name or topic}
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., "Depends on: INT-001, DR-002")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -103,6 +106,7 @@ ${input:topic:Enter project name or topic}
      - Example: "NFR-S-001 aligns with Security by Design principle (SEC-001)"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers

--- a/arckit-gemini/commands/arckit/requirements.toml
+++ b/arckit-gemini/commands/arckit/requirements.toml
@@ -76,12 +76,14 @@ You are helping an enterprise architect define comprehensive requirements for a 
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -99,8 +101,9 @@ You are helping an enterprise architect define comprehensive requirements for a 
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., \"Depends on: INT-001, DR-002\")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -110,6 +113,7 @@ You are helping an enterprise architect define comprehensive requirements for a 
      - Example: \"NFR-S-001 aligns with Security by Design principle (SEC-001)\"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers

--- a/arckit-opencode/commands/arckit.requirements.md
+++ b/arckit-opencode/commands/arckit.requirements.md
@@ -67,12 +67,14 @@ $ARGUMENTS
    - Features and capabilities
    - User workflows
 
-   **Non-Functional Requirements (NFR-xxx)**:
-   - Performance (response time, throughput, concurrent users)
-   - Security (authentication, authorisation, encryption, compliance)
-   - Scalability (growth projections, load handling)
-   - Reliability (uptime SLA, MTBF, MTTR)
-   - Compliance (regulations, standards, certifications)
+   **Non-Functional Requirements (NFR-xxx)** — use sub-prefixes consistently:
+   - NFR-P: Performance (response time, throughput, concurrent users)
+   - NFR-SEC: Security (authentication, authorisation, encryption)
+   - NFR-S: Scalability (growth projections, load handling)
+   - NFR-A: Availability (uptime SLA, MTBF, MTTR)
+   - NFR-ACC: Accessibility (WCAG 2.2 AA, assistive technology support, screen reader compatibility) — mandatory for UK Gov public-facing services
+   - NFR-M: Maintainability (code standards, documentation, supportability)
+   - NFR-C: Compliance (regulations, standards, certifications)
 
    **Integration Requirements (INT-xxx)**:
    - Upstream/downstream systems
@@ -90,8 +92,9 @@ $ARGUMENTS
    - Unique ID (BR-001, FR-001, NFR-P-001, etc.)
    - Clear requirement statement
    - Acceptance criteria (testable)
-   - Priority (MUST/SHOULD/MAY)
-   - Rationale
+   - Priority using MoSCoW: MUST (non-negotiable), SHOULD (important but not critical), COULD (desirable if budget allows), WON'T (explicitly excluded from this release)
+   - Rationale (why this requirement exists)
+   - Dependencies (which other requirements must be met first, e.g., "Depends on: INT-001, DR-002")
 
 7. **Align with stakeholder goals and architecture principles**:
    - If stakeholder analysis exists, trace requirements back to stakeholder goals:
@@ -101,6 +104,7 @@ $ARGUMENTS
      - Example: "NFR-S-001 aligns with Security by Design principle (SEC-001)"
    - Ensure high-priority stakeholder drivers get MUST requirements
    - Document which stakeholder benefits from each requirement
+   - After generating all requirements, include a **Requirements Coverage Matrix** showing each stakeholder goal and which requirements address it. Flag any stakeholder goals with NO requirements (coverage gaps). This ensures nothing from the stakeholder analysis is missed
 
 8. **Identify and resolve conflicting requirements**:
    - Review stakeholder analysis `conflict analysis` section for known competing drivers


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:requirements` (3 iterations, 8.0→9.2, 15% improvement).

## Changes
- Explicit NFR sub-prefixes (NFR-P, NFR-SEC, NFR-S, NFR-A, NFR-ACC, NFR-M, NFR-C)
- NFR-ACC (Accessibility) mandatory for UK Gov public-facing services
- Full MoSCoW prioritization (MUST/SHOULD/COULD/WON'T)
- Requirement dependency tracking per requirement
- Requirements Coverage Matrix mapping stakeholder goals to requirements with gap analysis

## Test plan
- [ ] Run `/arckit:requirements 001` with STKE and PRIN artifacts
- [ ] Verify NFR-ACC accessibility requirements present
- [ ] Verify MoSCoW prioritization used
- [ ] Verify dependency fields on requirements
- [ ] Verify Requirements Coverage Matrix with gap analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)