### PR TITLE
fix: enhance stakeholders command with impact assessment and change readiness

### DIFF
--- a/arckit-claude/commands/stakeholders.md
+++ b/arckit-claude/commands/stakeholders.md
@@ -99,13 +99,20 @@ $ARGUMENTS
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks

--- a/arckit-codex/commands/arckit.stakeholders.md
+++ b/arckit-codex/commands/arckit.stakeholders.md
@@ -90,13 +90,20 @@ $ARGUMENTS
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks

--- a/arckit-codex/prompts/arckit.stakeholders.md
+++ b/arckit-codex/prompts/arckit.stakeholders.md
@@ -90,13 +90,20 @@ $ARGUMENTS
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks

--- a/arckit-codex/skills/arckit-stakeholders/SKILL.md
+++ b/arckit-codex/skills/arckit-stakeholders/SKILL.md
@@ -91,13 +91,20 @@ $ARGUMENTS
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks

--- a/arckit-copilot/prompts/arckit-stakeholders.prompt.md
+++ b/arckit-copilot/prompts/arckit-stakeholders.prompt.md
@@ -92,13 +92,20 @@ ${input:topic:Enter project name or topic}
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks

--- a/arckit-gemini/commands/arckit/stakeholders.toml
+++ b/arckit-gemini/commands/arckit/stakeholders.toml
@@ -99,13 +99,20 @@ You are helping an enterprise architect or project manager understand stakeholde
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks

--- a/arckit-opencode/commands/arckit.stakeholders.md
+++ b/arckit-opencode/commands/arckit.stakeholders.md
@@ -90,13 +90,20 @@ $ARGUMENTS
    - Identify synergies (drivers that align across stakeholders)
    - Propose resolution strategies for conflicts
 
-   **Phase 6: Engagement Plan**
+   **Phase 6: Impact and Change Readiness Assessment**
+   - For each stakeholder, assess:
+     - **Impact Score** (-3 to +3): How positively or negatively the project affects them (-3 = severely negative, +3 = strongly positive)
+     - **Change Readiness** (Low/Medium/High): How ready they are to adopt the change, based on capability, willingness, and support
+     - **Engagement Priority**: Derived from Power × |Impact| — stakeholders with high power and high impact (positive or negative) need the most engagement
+   - Create a **Change Impact Heat Map** table showing all stakeholders with their impact, readiness, and engagement priority
+
+   **Phase 7: Engagement Plan**
    - Create stakeholder-specific messaging addressing their drivers
    - Define communication frequency and channels
-   - Assess change impact and resistance risk
-   - Identify champions, fence-sitters, and resisters
+   - For each stakeholder, specify the engagement action that addresses their specific impact score and readiness level
+   - Identify champions (high impact, high readiness), fence-sitters (low impact), and resisters (negative impact, low readiness)
 
-   **Phase 7: Governance**
+   **Phase 8: Governance**
    - Define RACI matrix for key decisions
    - Document escalation path
    - Create risk register for stakeholder-related risks


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:stakeholders` (2 iterations, 8.4→9.0, 7% improvement).

## Changes
- New Phase 6: Impact and Change Readiness Assessment (impact scores, readiness, engagement priority)
- Updated Phase 7: Engagement Plan addresses specific impact/readiness per stakeholder
- Champions/fence-sitters/resisters categorization

## Test plan
- [ ] Run `/arckit:stakeholders 001` and verify Impact Assessment section present
- [ ] Verify Change Impact Heat Map table with scores per stakeholder

🤖 Generated with [Claude Code](https://claude.com/claude-code)