### PR TITLE
fix: enhance service-assessment with readiness score and evidence traceability

### DIFF
--- a/arckit-claude/commands/service-assessment.md
+++ b/arckit-claude/commands/service-assessment.md
@@ -657,6 +657,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:

--- a/arckit-codex/commands/arckit.service-assessment.md
+++ b/arckit-codex/commands/arckit.service-assessment.md
@@ -654,6 +654,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:

--- a/arckit-codex/prompts/arckit.service-assessment.md
+++ b/arckit-codex/prompts/arckit.service-assessment.md
@@ -654,6 +654,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:

--- a/arckit-codex/skills/arckit-service-assessment/SKILL.md
+++ b/arckit-codex/skills/arckit-service-assessment/SKILL.md
@@ -655,6 +655,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:

--- a/arckit-copilot/prompts/arckit-service-assessment.prompt.md
+++ b/arckit-copilot/prompts/arckit-service-assessment.prompt.md
@@ -656,6 +656,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:

--- a/arckit-gemini/commands/arckit/service-assessment.toml
+++ b/arckit-gemini/commands/arckit/service-assessment.toml
@@ -663,6 +663,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:

--- a/arckit-opencode/commands/arckit.service-assessment.md
+++ b/arckit-opencode/commands/arckit.service-assessment.md
@@ -654,6 +654,10 @@ For each Service Standard point, assign a RAG rating based on evidence found:
 - **🟡 Amber (Nearly Ready)**: 10+ points Green/Amber, max 2 Red
 - **🔴 Red (Not Ready)**: More than 2 Red points or fewer than 10 Green/Amber
 
+**Readiness Score** (quantitative): Calculate as (Green × 1.0 + Amber × 0.5 + Red × 0) / 14 × 100%. This gives a single percentage score for tracking improvement over time.
+
+After the per-point assessment, add an **Evidence-to-Standard Traceability Matrix** showing which ArcKit artifacts provide evidence for which Service Standard points. This shows at a glance where evidence coverage is strong and where it's missing, and helps the team prioritise artifact creation.
+
 ### Step 6: Generate Recommendations
 
 For each gap identified, generate specific, actionable recommendations:


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:service-assessment` (2 iterations, 8.0→8.8, 10% improvement).

## Changes
- Quantitative Readiness Score: (Green×1 + Amber×0.5 + Red×0) / 14 × 100%
- Evidence-to-Standard Traceability Matrix (artifact → Service Standard point coverage)

## Test plan
- [ ] Run `/arckit:service-assessment 001 Alpha` and verify Readiness Score percentage
- [ ] Verify Evidence-to-Standard Traceability Matrix present

🤖 Generated with [Claude Code](https://claude.com/claude-code)