### PR TITLE
fix: enhance tcop command with compliance score and principles traceability

### DIFF
--- a/arckit-claude/commands/tcop.md
+++ b/arckit-claude/commands/tcop.md
@@ -99,6 +99,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`

--- a/arckit-codex/commands/arckit.tcop.md
+++ b/arckit-codex/commands/arckit.tcop.md
@@ -96,6 +96,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`

--- a/arckit-codex/prompts/arckit.tcop.md
+++ b/arckit-codex/prompts/arckit.tcop.md
@@ -96,6 +96,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`

--- a/arckit-codex/skills/arckit-tcop/SKILL.md
+++ b/arckit-codex/skills/arckit-tcop/SKILL.md
@@ -97,6 +97,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`

--- a/arckit-copilot/prompts/arckit-tcop.prompt.md
+++ b/arckit-copilot/prompts/arckit-tcop.prompt.md
@@ -98,6 +98,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`

--- a/arckit-gemini/commands/arckit/tcop.toml
+++ b/arckit-gemini/commands/arckit/tcop.toml
@@ -105,6 +105,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `~/.gemini/extensions/arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`

--- a/arckit-opencode/commands/arckit.tcop.md
+++ b/arckit-opencode/commands/arckit.tcop.md
@@ -96,6 +96,12 @@ Generate a comprehensive TCoP review document by:
      - **Major increment** (e.g., 1.0 → 2.0): Scope materially changed — new TCoP points assessed, fundamentally different compliance posture, significant project changes
    - For v1.1+/v2.0+: Add a Revision History entry describing what changed from the previous version
 
+    After the per-point assessment, add:
+
+    **TCoP Compliance Score**: Calculate as (Compliant × 1.0 + Partially × 0.5 + Non-Compliant × 0) / 13 × 100%. This gives a single trackable percentage.
+
+    **Principles-to-TCoP Traceability Matrix**: Map each architecture principle (P-001 through P-006) to the TCoP points it supports. Highlight TCoP points with no architecture principle coverage — these need separate governance controls.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **TCOP** per-type checks pass. Fix any failures before proceeding.
 
 10. **Save the document**: Write to `projects/[project-folder]/ARC-{PROJECT_ID}-TCOP-v${VERSION}.md`


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:tcop` (2 iterations, 8.0→9.0, 13% improvement).

## Changes
- TCoP Compliance Score: (Compliant×1 + Partial×0.5 + Non×0) / 13 × 100%
- Principles-to-TCoP Traceability Matrix with gap analysis for unsupported points

## Test plan
- [ ] Run `/arckit:tcop 001` and verify Compliance Score percentage present
- [ ] Verify Principles-to-TCoP Traceability Matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)