### PR TITLE
fix: enhance dpia command with risk score and processing traceability

### DIFF
--- a/arckit-claude/commands/dpia.md
+++ b/arckit-claude/commands/dpia.md
@@ -204,6 +204,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:

--- a/arckit-codex/commands/arckit.dpia.md
+++ b/arckit-codex/commands/arckit.dpia.md
@@ -202,6 +202,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:

--- a/arckit-codex/prompts/arckit.dpia.md
+++ b/arckit-codex/prompts/arckit.dpia.md
@@ -202,6 +202,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:

--- a/arckit-codex/skills/arckit-dpia/SKILL.md
+++ b/arckit-codex/skills/arckit-dpia/SKILL.md
@@ -203,6 +203,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:

--- a/arckit-copilot/prompts/arckit-dpia.prompt.md
+++ b/arckit-copilot/prompts/arckit-dpia.prompt.md
@@ -204,6 +204,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:

--- a/arckit-gemini/commands/arckit/dpia.toml
+++ b/arckit-gemini/commands/arckit/dpia.toml
@@ -211,6 +211,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:

--- a/arckit-opencode/commands/arckit.dpia.md
+++ b/arckit-opencode/commands/arckit.dpia.md
@@ -202,6 +202,8 @@ Generate the DPIA by:
      - **Severity** (impact on individuals): Minimal, Significant, Severe
      - **Overall Risk**: Low (green), Medium (amber), High (red)
    - Link to existing risks in ARC-*-RISK-*.md if they exist
+   - After the risk assessment, calculate a **DPIA Risk Score**: (High risks × 3 + Medium × 2 + Low × 1) / (total risks × 3) × 100%. Lower is better. This provides a single trackable privacy risk metric
+   - Add a **Data Processing → Risk Traceability Matrix** showing which processing activities (from Section 3) create which privacy risks. This ensures every processing activity has been risk-assessed and no activities are missing from the risk analysis
 
 8. **Section 6: Mitigations**:
    - For each high/medium risk, propose mitigations:


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:dpia` (2 iterations, 8.0→9.0, 13% improvement).

## Changes
- DPIA Risk Score for quantitative privacy risk tracking
- Data Processing → Risk Traceability Matrix

## Test plan
- [ ] Run `/arckit:dpia 001` and verify DPIA Risk Score
- [ ] Verify Processing → Risk Traceability Matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)