### PR TITLE
fix: enhance ai-playbook with remediation roadmap and ethics traceability

### DIFF
--- a/arckit-claude/commands/ai-playbook.md
+++ b/arckit-claude/commands/ai-playbook.md
@@ -280,11 +280,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 

--- a/arckit-codex/commands/arckit.ai-playbook.md
+++ b/arckit-codex/commands/arckit.ai-playbook.md
@@ -278,11 +278,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 

--- a/arckit-codex/prompts/arckit.ai-playbook.md
+++ b/arckit-codex/prompts/arckit.ai-playbook.md
@@ -278,11 +278,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 

--- a/arckit-codex/skills/arckit-ai-playbook/SKILL.md
+++ b/arckit-codex/skills/arckit-ai-playbook/SKILL.md
@@ -279,11 +279,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 

--- a/arckit-copilot/prompts/arckit-ai-playbook.prompt.md
+++ b/arckit-copilot/prompts/arckit-ai-playbook.prompt.md
@@ -280,11 +280,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 

--- a/arckit-gemini/commands/arckit/ai-playbook.toml
+++ b/arckit-gemini/commands/arckit/ai-playbook.toml
@@ -287,11 +287,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 

--- a/arckit-opencode/commands/arckit.ai-playbook.md
+++ b/arckit-opencode/commands/arckit.ai-playbook.md
@@ -278,11 +278,15 @@ Create detailed report with:
 - [ ] Bias Audit Report
 - [ ] User Research Report
 
-**Action Plan**:
+**Action Plan** (structured as a remediation roadmap):
 
-- High priority (before deployment)
-- Medium priority (within 3 months)
-- Low priority (continuous improvement)
+- High priority (before deployment) — with specific owner from STKE RACI, effort in days, and cost estimate
+- Medium priority (within 3 months) — same detail
+- Low priority (continuous improvement) — same detail
+
+Include a **total investment summary** and **AI Ethics Score improvement projection** showing the expected score after all high-priority actions are completed
+
+Add an **Architecture Principles → AI Ethics Traceability Matrix** mapping each principle (P-001 through P-006) to the AI ethics principles it supports. Identify AI ethics principles with no architecture principle coverage
 
 8. **Map to existing ArcKit artifacts**:
 


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:ai-playbook` (2 iterations, 8.0→9.0, 13% improvement).

## Changes
- Structured remediation roadmap with owners, costs, effort estimates
- AI Ethics Score improvement projection
- Principles-to-AI-Ethics Traceability Matrix with gap analysis

## Test plan
- [ ] Verify remediation roadmap with costs and named owners
- [ ] Verify score improvement projection
- [ ] Verify Principles-to-AI-Ethics traceability matrix

🤖 Generated with [Claude Code](https://claude.com/claude-code)