### PR TITLE
fix: enhance atrs command with completeness score and principles traceability

### DIFF
--- a/arckit-claude/commands/atrs.md
+++ b/arckit-claude/commands/atrs.md
@@ -312,6 +312,12 @@ The footer should be populated with:
 
 Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not "to be confirmed" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`

--- a/arckit-codex/commands/arckit.atrs.md
+++ b/arckit-codex/commands/arckit.atrs.md
@@ -310,6 +310,12 @@ The footer should be populated with:
 
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not "to be confirmed" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`

--- a/arckit-codex/prompts/arckit.atrs.md
+++ b/arckit-codex/prompts/arckit.atrs.md
@@ -310,6 +310,12 @@ The footer should be populated with:
 
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not "to be confirmed" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`

--- a/arckit-codex/skills/arckit-atrs/SKILL.md
+++ b/arckit-codex/skills/arckit-atrs/SKILL.md
@@ -311,6 +311,12 @@ The footer should be populated with:
 
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not "to be confirmed" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`

--- a/arckit-copilot/prompts/arckit-atrs.prompt.md
+++ b/arckit-copilot/prompts/arckit-atrs.prompt.md
@@ -312,6 +312,12 @@ The footer should be populated with:
 
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not "to be confirmed" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`

--- a/arckit-gemini/commands/arckit/atrs.toml
+++ b/arckit-gemini/commands/arckit/atrs.toml
@@ -319,6 +319,12 @@ The footer should be populated with:
 
 Before writing the file, read `~/.gemini/extensions/arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not \"to be confirmed\" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`

--- a/arckit-opencode/commands/arckit.atrs.md
+++ b/arckit-opencode/commands/arckit.atrs.md
@@ -310,6 +310,12 @@ The footer should be populated with:
 
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **ATRS** per-type checks pass. Fix any failures before proceeding.
 
+    After the assessment, add:
+
+    **ATRS Completeness Score**: Calculate the percentage of ATRS mandatory fields that are fully populated (not "to be confirmed" or similar). Provides a trackable readiness metric.
+
+    **Architecture Principles → ATRS Traceability Matrix**: Map each principle (P-001 through P-006) to the ATRS sections it supports. Identify ATRS sections with no architecture principle coverage — these represent governance gaps.
+
 11. **Generate comprehensive ATRS record**:
 
 Output location: `projects/{project-dir}/ARC-{PROJECT_ID}-ATRS-v1.0.md`


### PR DESCRIPTION
## Summary
Autoresearch-optimised `/arckit:atrs` (2 iterations, 8.0→9.0).

## Changes
- ATRS Completeness Score for tracking mandatory field readiness
- Principles-to-ATRS Traceability Matrix with gap analysis

🤖 Generated with [Claude Code](https://claude.com/claude-code)