### PR TITLE
fix: deep autoresearch of backlog command (8.0→9.0)

### DIFF
--- a/arckit-claude/commands/backlog.md
+++ b/arckit-claude/commands/backlog.md
@@ -1535,6 +1535,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output

--- a/arckit-codex/commands/arckit.backlog.md
+++ b/arckit-codex/commands/arckit.backlog.md
@@ -1527,6 +1527,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output

--- a/arckit-codex/prompts/arckit.backlog.md
+++ b/arckit-codex/prompts/arckit.backlog.md
@@ -1527,6 +1527,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output

--- a/arckit-codex/skills/arckit-backlog/SKILL.md
+++ b/arckit-codex/skills/arckit-backlog/SKILL.md
@@ -1528,6 +1528,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output

--- a/arckit-copilot/prompts/arckit-backlog.prompt.md
+++ b/arckit-copilot/prompts/arckit-backlog.prompt.md
@@ -1529,6 +1529,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output

--- a/arckit-gemini/commands/arckit/backlog.toml
+++ b/arckit-gemini/commands/arckit/backlog.toml
@@ -1536,6 +1536,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `~/.gemini/extensions/arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output

--- a/arckit-opencode/commands/arckit.backlog.md
+++ b/arckit-opencode/commands/arckit.backlog.md
@@ -1527,6 +1527,14 @@ The footer should be populated with:
 
 ---
 
+After the backlog content, add:
+
+**Story Quality Score (INVEST)**: Validate each story against the INVEST criteria (Independent, Negotiable, Valuable, Estimable, Small, Testable). Calculate percentage of stories that pass all 6 criteria. Flag stories that fail any criterion with the specific failure. Score = passing stories / total stories × 100%.
+
+**Requirements Coverage Analysis**: Map each requirement (BR/FR/NFR/INT/DR) to the story(ies) that implement it. Calculate coverage percentage. Flag requirements with NO stories (delivery gaps) and stories with NO requirement traceability (scope creep risk).
+
+**Definition of Ready Checklist**: Include a standard Definition of Ready that each story must meet before entering a sprint: acceptance criteria defined, dependencies identified, estimated, design constraints noted, testable.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **BKLG** per-type checks pass. Fix any failures before proceeding.
 
 ### Step 14: Final Output


### PR DESCRIPTION
Deep autoresearch (2 iters, 8.0→9.0): INVEST quality score, requirements coverage analysis, Definition of Ready. Supersedes #239. 🤖 Generated with [Claude Code](https://claude.com/claude-code)