### PR TITLE
fix: deep autoresearch of diagram command — quality score and traceability

### DIFF
--- a/arckit-claude/commands/diagram.md
+++ b/arckit-claude/commands/diagram.md
@@ -1031,6 +1031,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:

--- a/arckit-codex/commands/arckit.diagram.md
+++ b/arckit-codex/commands/arckit.diagram.md
@@ -1029,6 +1029,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:

--- a/arckit-codex/prompts/arckit.diagram.md
+++ b/arckit-codex/prompts/arckit.diagram.md
@@ -1029,6 +1029,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:

--- a/arckit-codex/skills/arckit-diagram/SKILL.md
+++ b/arckit-codex/skills/arckit-diagram/SKILL.md
@@ -1030,6 +1030,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:

--- a/arckit-copilot/prompts/arckit-diagram.prompt.md
+++ b/arckit-copilot/prompts/arckit-diagram.prompt.md
@@ -1031,6 +1031,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:

--- a/arckit-gemini/commands/arckit/diagram.toml
+++ b/arckit-gemini/commands/arckit/diagram.toml
@@ -1038,6 +1038,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:

--- a/arckit-opencode/commands/arckit.diagram.md
+++ b/arckit-opencode/commands/arckit.diagram.md
@@ -1029,6 +1029,14 @@ After generating the diagram, evaluate it against the following quality criteria
 | 8 (Node placement) | Reorder declarations to place connected elements adjacent; group tightly-coupled components in a subgraph |
 | 9 (Element count) | Split diagram at natural architectural boundaries (see Step 5b) |
 
+### Diagram Quality Score
+
+Calculate: passing criteria / 9 × 100%. Include this score in the output for tracking diagram quality over iterations.
+
+### Component-to-Requirement Traceability
+
+After the quality gate, add a table mapping each diagram element (system, container, component) to the requirement(s) it addresses. Flag elements with no requirement traceability (potentially out of scope) and requirements with no diagram element (missing from the architecture).
+
 ### Iterative Review Loop
 
 **IMPORTANT:** Do not proceed to Step 6 until the quality gate passes. Follow this loop:


### PR DESCRIPTION
Deep autoresearch: Diagram Quality Score (X/9 × 100%) + Component-to-Requirement Traceability. Supersedes #240. 🤖 Generated with [Claude Code](https://claude.com/claude-code)