### PR TITLE
fix: deep autoresearch of jsp-936 — compliance score and evidence traceability

### DIFF
--- a/arckit-claude/commands/jsp-936.md
+++ b/arckit-claude/commands/jsp-936.md
@@ -3462,6 +3462,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:

--- a/arckit-codex/commands/arckit.jsp-936.md
+++ b/arckit-codex/commands/arckit.jsp-936.md
@@ -3459,6 +3459,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:

--- a/arckit-codex/prompts/arckit.jsp-936.md
+++ b/arckit-codex/prompts/arckit.jsp-936.md
@@ -3459,6 +3459,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:

--- a/arckit-codex/skills/arckit-jsp-936/SKILL.md
+++ b/arckit-codex/skills/arckit-jsp-936/SKILL.md
@@ -3460,6 +3460,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:

--- a/arckit-copilot/prompts/arckit-jsp-936.prompt.md
+++ b/arckit-copilot/prompts/arckit-jsp-936.prompt.md
@@ -3461,6 +3461,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:

--- a/arckit-gemini/commands/arckit/jsp-936.toml
+++ b/arckit-gemini/commands/arckit/jsp-936.toml
@@ -3468,6 +3468,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `~/.gemini/extensions/arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:

--- a/arckit-opencode/commands/arckit.jsp-936.md
+++ b/arckit-opencode/commands/arckit.jsp-936.md
@@ -3459,6 +3459,14 @@ Now, **compile all documentation** into a comprehensive JSP 936 AI Assurance pac
 
 3. **Review for completeness**: Check that all JSP 936 requirements are addressed (27 requirements: 5 principles + risk classification + governance + 8 phases + approval + monitoring)
 
+After the assessment content, add:
+
+**JSP 936 Compliance Score**: Calculate as percentage of JSP 936 requirements met (across 5 principles, risk classification, governance, 8 lifecycle phases, approval, and monitoring). Score = met / 27 × 100%. Also show per-principle compliance.
+
+**Assurance Evidence Traceability Matrix**: Map each JSP 936 requirement to the evidence that satisfies it (ArcKit artifacts, test results, governance records). Flag requirements with no evidence (assurance gaps).
+
+**Remediation Roadmap**: Prioritised table mapping each gap to actions, owners, effort, and expected compliance score improvement. Include projected score after all critical gaps are resolved.
+
 Before writing the file, read `.arckit/references/quality-checklist.md` and verify all **Common Checks** plus the **JSP936** per-type checks pass. Fix any failures before proceeding.
 
 4. **Write the document** to the project directory:


### PR DESCRIPTION
Deep autoresearch: JSP 936 Compliance Score (X/27), Assurance Evidence Traceability Matrix, Remediation Roadmap with projected score. Supersedes #258. 🤖 Generated with [Claude Code](https://claude.com/claude-code)