### PR TITLE
fix: trim skill descriptions to fit 250-char context cap

### DIFF
--- a/arckit-claude/skills/architecture-workflow/SKILL.md
+++ b/arckit-claude/skills/architecture-workflow/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: architecture-workflow
-description: "This skill should be used when the user asks how to start an architecture project, which ArcKit commands to run and in what order, what workflow path to follow, how to onboard a project, or what comes next after a command. Common triggers: getting started with ArcKit, recommend a workflow, new project setup, guide me through, command sequence, next steps, arckit start."
+description: "This skill should be used when the user asks how to start an architecture project, which ArcKit commands to run and in what order, what workflow to follow, getting started, new project setup, guide me through, or what comes next."
 ---
 
 # Architecture Workflow

--- a/arckit-claude/skills/mermaid-syntax/SKILL.md
+++ b/arckit-claude/skills/mermaid-syntax/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: mermaid-syntax
-description: "This skill should be used when the user asks about Mermaid diagram syntax, how to write a specific Mermaid diagram type (flowchart, sequence, class, state, ER, Gantt, pie, mindmap, timeline, git graph, quadrant, C4, sankey, XY chart, block, packet, kanban, architecture, radar, treemap, user journey, ZenUML), Mermaid node shapes, edge labels, styling, configuration, theming, layout options, or troubleshooting Mermaid rendering errors and syntax gotchas."
+description: "This skill should be used when the user asks about Mermaid diagram syntax, how to write flowchart, sequence, class, state, ER, Gantt, C4, mindmap, timeline, or other diagram types, node shapes, styling, theming, or rendering errors."
 ---
 
 # Mermaid Syntax Reference

--- a/arckit-claude/skills/plantuml-syntax/SKILL.md
+++ b/arckit-claude/skills/plantuml-syntax/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: plantuml-syntax
-description: "This skill should be used when the user asks about PlantUML syntax for any diagram type including C4-PlantUML, sequence, class, activity, state, ER, component, deployment, or use case diagrams. Also applies when troubleshooting PlantUML rendering errors, fixing layout conflicts between Rel_Down and Lay_Right, styling with skinparams or themes, or asking about C4 directional relationships and tier-based layout patterns."
+description: "This skill should be used when the user asks about PlantUML syntax for C4-PlantUML, sequence, class, activity, state, ER, component, deployment, or use case diagrams, rendering errors, layout conflicts, skinparams, or themes."
 ---
 
 # PlantUML Syntax Reference

--- a/arckit-claude/skills/wardley-mapping/SKILL.md
+++ b/arckit-claude/skills/wardley-mapping/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: wardley-mapping
-description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, situational awareness, technology evolution, competitive landscape, creating maps, value chain decomposition, gameplay patterns, doctrine assessment, doctrine maturity, climatic patterns, climate assessment, build vs. buy decisions, inertia analysis, D&D alignment of strategies, peace/war/wonder cycles, play-position matrix, pioneers/settlers/planners, or quantitative evolution scoring including differentiation pressure, commodity leverage, weak signal detection, and readiness scores."
+description: "This skill should be used when the user asks about Wardley Mapping, evolution stages, strategic positioning, creating maps, value chain decomposition, gameplay patterns, doctrine assessment, climatic patterns, build vs. buy, or inertia analysis."
 ---
 
 # Wardley Mapping


### PR DESCRIPTION
## Summary

- Trim all 4 skill descriptions to under 250 characters to comply with the Claude Code v2.1.86 context cap
- Front-loads the most important trigger keywords; drops niche terms covered by the skill body once loaded

| Skill | Before | After |
|-------|--------|-------|
| architecture-workflow | 370 chars | 229 chars |
| mermaid-syntax | 460 chars | 232 chars |
| plantuml-syntax | 430 chars | 225 chars |
| wardley-mapping | 560 chars | 245 chars |

Closes #215 (skill description item)

## Test plan

- [ ] Verify skills still trigger on expected user queries (e.g. "how do I start a project", "mermaid flowchart syntax", "wardley map")
- [ ] Confirm no regressions in `/skills` menu display

🤖 Generated with [Claude Code](https://claude.com/claude-code)