### PR TITLE
fix: add name field to Codex agent TOML files and flatten config structure

### DIFF
--- a/arckit-codex/agents/arckit-aws-research.toml
+++ b/arckit-codex/agents/arckit-aws-research.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-aws-research.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-aws-research"
+
 developer_instructions = """
 You are an enterprise architect specialising in AWS. You research AWS services, architecture patterns, and implementation guidance for project requirements using official AWS documentation via the AWS Knowledge MCP server.
 

--- a/arckit-codex/agents/arckit-azure-research.toml
+++ b/arckit-codex/agents/arckit-azure-research.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-azure-research.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-azure-research"
+
 developer_instructions = """
 You are an enterprise architect specialising in Microsoft Azure. You research Azure services, architecture patterns, and implementation guidance for project requirements using official Microsoft documentation via the Microsoft Learn MCP server.
 

--- a/arckit-codex/agents/arckit-datascout.toml
+++ b/arckit-codex/agents/arckit-datascout.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-datascout.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-datascout"
+
 developer_instructions = """
 You are an enterprise data source discovery specialist. You systematically discover external data sources — APIs, datasets, open data portals, and commercial data providers — that can fulfil project requirements, evaluate them with weighted scoring, and produce a comprehensive discovery report.
 

--- a/arckit-codex/agents/arckit-framework.toml
+++ b/arckit-codex/agents/arckit-framework.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-framework.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-framework"
+
 developer_instructions = """
 You are an enterprise architecture framework specialist. You transform scattered architecture artifacts into structured, phased frameworks. Your role is purely one of synthesis — you do not generate new requirements, analysis, or design. You organise, summarise, and present what already exists.
 

--- a/arckit-codex/agents/arckit-gcp-research.toml
+++ b/arckit-codex/agents/arckit-gcp-research.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-gcp-research.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-gcp-research"
+
 developer_instructions = """
 You are an enterprise architect specialising in Google Cloud Platform. You research Google Cloud services, architecture patterns, and implementation guidance for project requirements using official Google documentation via the Google Developer Knowledge MCP server.
 

--- a/arckit-codex/agents/arckit-gov-code-search.toml
+++ b/arckit-codex/agents/arckit-gov-code-search.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-gov-code-search.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-gov-code-search"
+
 developer_instructions = """
 You are a government code discovery specialist. You perform semantic searches across 24,500+ UK government open-source repositories to find implementations, patterns, and approaches relevant to the user's query.
 

--- a/arckit-codex/agents/arckit-gov-landscape.toml
+++ b/arckit-codex/agents/arckit-gov-landscape.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-gov-landscape.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-gov-landscape"
+
 developer_instructions = """
 You are a government technology landscape analyst. You map what UK government organisations have built in a domain, analysing technology patterns, standards adoption, maturity levels, and collaboration opportunities across 24,500+ open-source repositories.
 

--- a/arckit-codex/agents/arckit-gov-reuse.toml
+++ b/arckit-codex/agents/arckit-gov-reuse.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-gov-reuse.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-gov-reuse"
+
 developer_instructions = """
 You are an enterprise architecture reuse specialist. You systematically search UK government open-source repositories to discover existing implementations that can be reused, adapted, or referenced, reducing build effort and promoting cross-government collaboration.
 

--- a/arckit-codex/agents/arckit-research.toml
+++ b/arckit-codex/agents/arckit-research.toml
@@ -1,6 +1,8 @@
 # Auto-generated from arckit-claude/agents/arckit-research.md
 # Do not edit — edit the source and re-run scripts/converter.py
 
+name = "arckit-research"
+
 developer_instructions = """
 You are an enterprise architecture market research specialist. You conduct systematic technology and service research to identify solutions that meet project requirements, perform build vs buy analysis, and produce vendor recommendations with TCO comparisons.
 

--- a/arckit-codex/config.toml
+++ b/arckit-codex/config.toml
@@ -33,38 +33,38 @@ max_threads = 3
 max_depth = 1
 job_max_runtime_seconds = 600
 
-[agents.roles.arckit-aws-research]
+[agents.arckit-aws-research]
 description = "Use this agent when the user needs AWS-specific technology research using the AWS Knowledge MCP server to match project requirements to AWS services, architecture patterns, Well-Architected guidance, and Security Hub controls. Examples:"
 config_file = "agents/arckit-aws-research.toml"
 
-[agents.roles.arckit-azure-research]
+[agents.arckit-azure-research]
 description = "Use this agent when the user needs Azure-specific technology research using the Microsoft Learn MCP server to match project requirements to Azure services, architecture patterns, Well-Architected guidance, and Security Benchmark controls. Examples:"
 config_file = "agents/arckit-azure-research.toml"
 
-[agents.roles.arckit-datascout]
+[agents.arckit-datascout]
 description = "Use this agent when the user needs to discover external data sources — APIs, datasets, open data portals, and commercial data providers — to fulfil project requirements. This agent performs extensive web research to find real, current data sources. Examples:"
 config_file = "agents/arckit-datascout.toml"
 
-[agents.roles.arckit-framework]
+[agents.arckit-framework]
 description = "Use this agent when the user wants to transform existing project artifacts into a structured framework with phased organization, an overview document, and an executive guide. This agent reads all project artifacts and synthesises them into a coherent framework structure. Examples:"
 config_file = "agents/arckit-framework.toml"
 
-[agents.roles.arckit-gcp-research]
+[agents.arckit-gcp-research]
 description = "Use this agent when the user needs Google Cloud-specific technology research using the Google Developer Knowledge MCP server to match project requirements to Google Cloud services, architecture patterns, Architecture Framework guidance, and Security Command Center controls. Examples:"
 config_file = "agents/arckit-gcp-research.toml"
 
-[agents.roles.arckit-gov-code-search]
+[agents.arckit-gov-code-search]
 description = "Use this agent when the user wants to search UK government repositories using natural language queries. This agent provides general-purpose semantic search across 24,500+ government repos via govreposcrape. Examples:"
 config_file = "agents/arckit-gov-code-search.toml"
 
-[agents.roles.arckit-gov-landscape]
+[agents.arckit-gov-landscape]
 description = "Use this agent when the user wants to understand what UK government has built in a domain — mapping organisations, technology patterns, standards, and maturity levels. Examples:"
 config_file = "agents/arckit-gov-landscape.toml"
 
-[agents.roles.arckit-gov-reuse]
+[agents.arckit-gov-reuse]
 description = "Use this agent when the user wants to discover reusable UK government open-source code before building from scratch. This agent searches 24,500+ government repositories via govreposcrape and assesses candidates for reusability. Examples:"
 config_file = "agents/arckit-gov-reuse.toml"
 
-[agents.roles.arckit-research]
+[agents.arckit-research]
 description = "Use this agent when the user needs technology and service market research for a project, including build vs buy analysis, vendor evaluation, TCO comparison, and UK Government Digital Marketplace search. This agent performs extensive web research autonomously. Examples:"
 config_file = "agents/arckit-research.toml"

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -482,7 +482,7 @@ def generate_codex_config_toml(mcp_json_path, agents_dir, output_path):
                 first_line = desc.strip().split("\n")[0].strip()
                 toml_name = filename.replace(".md", "")
 
-                lines.append(f"[agents.roles.{name}]")
+                lines.append(f"[agents.{name}]")
                 escaped_desc = first_line.replace('"', '\\"')
                 lines.append(f'description = "{escaped_desc}"')
                 lines.append(f'config_file = "agents/{toml_name}.toml"')
@@ -510,9 +510,11 @@ def generate_agent_toml_files(agents_dir, output_dir, path_prefix=".arckit"):
         with open(agent_path, "r", encoding="utf-8") as f:
             content = f.read()
 
-        prompt = extract_agent_prompt(content)
+        frontmatter, prompt = extract_frontmatter_and_prompt(content)
         prompt = prompt.replace("${CLAUDE_PLUGIN_ROOT}", path_prefix)
         prompt_escaped = prompt.replace("\\", "\\\\").replace('"""', '\\"\\"\\"')
+
+        agent_name = frontmatter.get("name", filename.replace(".md", ""))
 
         toml_name = filename.replace(".md", ".toml")
         toml_path = os.path.join(output_dir, toml_name)
@@ -520,6 +522,8 @@ def generate_agent_toml_files(agents_dir, output_dir, path_prefix=".arckit"):
         toml_content = (
             f"# Auto-generated from arckit-claude/agents/{filename}\n"
             f"# Do not edit — edit the source and re-run scripts/converter.py\n"
+            f"\n"
+            f'name = "{agent_name}"\n'
             f"\n"
             f'developer_instructions = """\n'
             f"{prompt_escaped}\n"


### PR DESCRIPTION
## Summary
- Adds `name` field to generated Codex agent `.toml` files (required by Codex CLI)
- Flattens `[agents.roles.X]` to `[agents.X]` in `config.toml` to prevent `roles` being misinterpreted as a malformed agent role

Fixes #269