### PR TITLE
docs: track Claude Code v2.1.98-2.1.107 and bump recommended to v2.1.105

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 
 ### Installation
 
-**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.97+**):
+**Claude Code** (premier experience) — install the ArcKit plugin (**v2.1.105+ recommended**, **v2.1.97 minimum**):
 
 ```text
 /plugin marketplace add tractorjuice/arc-kit

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -32,13 +32,13 @@ claude --plugin-dir /path/to/arc-kit/arckit-claude
 
 ## Prerequisites
 
-- **Claude Code** v2.1.97 or later (recommended minimum)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum)
 - **Bash** shell (for helper scripts)
 - For `/arckit:aws-research`: AWS Knowledge MCP server (included)
 - For `/arckit:azure-research`: Microsoft Learn MCP server (included)
 - For `/arckit:gcp-research`: Google Developer Knowledge MCP (requires `GOOGLE_API_KEY` — see [MCP Servers](#mcp-servers))
 
-> **Why v2.1.97?** This version fixes `claude plugin update` silently missing updates for git-based plugins (critical for ArcKit distribution), fixes a MCP HTTP/SSE memory leak (~50 MB/hr on reconnects, affects ArcKit's 5 bundled MCP servers), adds proper exponential backoff for 429 retries (benefits ArcKit's 10 research agents), fixes Stop/SubagentStop hooks failing on long sessions (affects session-learner), fixes subagent working directory leaks, and includes all prior v2.1.90–v2.1.94 fixes for hooks, MCP performance, and agent stability.
+> **Why v2.1.105?** This version adds the `monitors` top-level manifest key (background monitors for plugins), raises the skill description cap from 250 to 1,536 characters, adds PreCompact hook blocking, fixes automatic dependency install for marketplace plugins with `package.json`/lockfile (critical for the Paperclip TypeScript plugin), fixes marketplace auto-update leaving a broken state on file locks, strips `<style>`/`<script>` tags from WebFetch (benefits research agents), and aborts stalled API streams after 5 minutes with fallback retry. **Minimum v2.1.97** is still required and fixes `claude plugin update` silently missing updates for git-based plugins, an MCP HTTP/SSE memory leak (~50 MB/hr on reconnects), proper exponential backoff for 429 retries, Stop/SubagentStop hooks failing on long sessions, and subagent working directory leaks.
 
 ## Quick Start
 

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum), or **Claude Cowork** desktop app
 - **Bash** shell (for helper scripts)
 
 ### Step 1: Add the marketplace

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum), or **Claude Cowork** desktop app
 - **Bash** shell (for helper scripts)
 
 ### Step 1: Add the marketplace

--- a/arckit-copilot/docs/guides/mcp-servers.md
+++ b/arckit-copilot/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum), or **Claude Cowork** desktop app
 - **Bash** shell (for helper scripts)
 
 ### Step 1: Add the marketplace

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum), or **Claude Cowork** desktop app
 - **Bash** shell (for helper scripts)
 
 ### Step 1: Add the marketplace

--- a/arckit-paperclip/docs/guides/mcp-servers.md
+++ b/arckit-paperclip/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum), or **Claude Cowork** desktop app
 - **Bash** shell (for helper scripts)
 
 ### Step 1: Add the marketplace

--- a/docs/book-research/06-hints-tips-and-lessons.md
+++ b/docs/book-research/06-hints-tips-and-lessons.md
@@ -113,7 +113,7 @@ Don't default to max -- it wastes tokens on simple commands and can sometimes re
 
 ArcKit checks for updates on session start. If you see an update notification, restart Claude Code to pick up the new plugin version.
 
-**Minimum Claude Code version**: v2.1.97 (as of April 2026)
+**Claude Code version**: v2.1.105 or later recommended, v2.1.97 minimum (as of April 2026)
 
 ### Project Structure
 

--- a/docs/book-research/09-claude-code-platform-evolution.md
+++ b/docs/book-research/09-claude-code-platform-evolution.md
@@ -2,9 +2,9 @@
 
 ## Tracking the Platform (Issue #215)
 
-ArcKit actively tracks Claude Code releases for capabilities that improve the plugin. Issue #215 consolidates tracking from v2.1.83 through v2.1.97.
+ArcKit actively tracks Claude Code releases for capabilities that improve the plugin. Issue #215 consolidates tracking from v2.1.83 through v2.1.107.
 
-## High-Value Capabilities Identified (14 Items)
+## High-Value Capabilities Identified (19 Items)
 
 | # | Capability | Claude Code Version | Impact on ArcKit |
 |---|-----------|-------------------|-----------------|
@@ -19,9 +19,14 @@ ArcKit actively tracks Claude Code releases for capabilities that improve the pl
 | 9 | MCP `headersHelper` env vars | v2.1.85 | Shared auth for multiple MCP servers |
 | 10 | `PermissionDenied` hook | v2.1.89 | Handle auto-mode denials with retry |
 | 11 | `defer` permission for PreToolUse | v2.1.89 | Headless/CI pause-and-resume |
-| 12 | Skill description 250-char cap | v2.1.86 | **Fixed in v4.6.1** -- trimmed all 4 skill descriptions |
+| 12 | Skill description 250-char cap | v2.1.86 | **Raised to 1,536 chars in v2.1.105** -- can restore richer descriptions |
 | 13 | `keep-coding-instructions` frontmatter | v2.1.94 | Persist static instructions across compaction |
 | 14 | `hookSpecificOutput.sessionTitle` | v2.1.94 | Session-aware learning in session-learner.mjs |
+| 15 | `monitors` top-level manifest key | v2.1.105 | Background monitors for artifact watch and stale-doc detection |
+| 16 | Skill description cap 250→1,536 | v2.1.105 | Re-evaluate 4 skill descriptions for better discoverability |
+| 17 | PreCompact hook blocking | v2.1.105 | Block compaction mid-session when critical state is still needed |
+| 18 | `Monitor` tool | v2.1.98 | Stream events from long-running background scripts (research agents, govreposcrape) |
+| 19 | `/claude-api` Managed Agents coverage | v2.1.98 | Aligns with arckit-research managed agent deployment (PR #282) |
 
 ## Platform Fixes That Affected ArcKit
 
@@ -64,12 +69,41 @@ ArcKit actively tracks Claude Code releases for capabilities that improve the pl
 - Compaction dedup of multi-MB subagent transcript files
 - Session transcript size reduced by skipping empty hook entries (benefits 18 hooks)
 
+### v2.1.98
+- Subagent MCP tool inheritance from dynamically-injected servers fixed (affects 10 agents × 5 MCP servers)
+- Compound Bash permission bypass security fix
+- `Monitor` tool added for streaming events from background scripts
+- `/claude-api` skill now covers Managed Agents alongside Claude API
+- Bash command injection in POSIX `which` fallback fixed
+
+### v2.1.101
+- Sub-agents in isolated worktrees can now Read/Edit their own worktree
+- MCP tools now available on first turn of headless/remote-trigger sessions
+- `permissions.deny` now overrides PreToolUse hook `ask` (safer default)
+- Plugin slash commands resolving to wrong plugin with duplicate `name:` fixed
+- Skills now honor `context: fork` and `agent` frontmatter fields
+- OS CA certificate store trusted by default (enterprise TLS proxies work out-of-box)
+
+### v2.1.105 (Current Recommended)
+- `monitors` top-level plugin manifest key for background monitors
+- Skill description cap raised from 250 to 1,536 characters
+- PreCompact hook can now block compaction (exit 2 or `{"decision":"block"}`)
+- Marketplace plugins with `package.json` + lockfile auto-install deps (critical for Paperclip TS plugin)
+- Marketplace auto-update no longer leaves broken state on file-lock during update
+- Stalled API streams abort after 5 min with non-streaming retry
+- WebFetch strips `<style>`/`<script>` tags (benefits research agents)
+- Stale agent worktree cleanup for squash-merged PRs
+
+### v2.1.107
+- Thinking hints shown sooner during long operations (no ArcKit impact)
+
 ## Minimum Version History
 
 | Date | Min Version | Reason |
 |------|------------|--------|
 | Pre-April 2026 | v2.1.90 | PreToolUse blocking fix, MCP performance |
 | 9 April 2026 | v2.1.97 | `claude plugin update` fix, MCP memory leak, 429 backoff |
+| 14 April 2026 | v2.1.97 (min), v2.1.105 (recommended) | Marketplace plugin deps auto-install, `monitors` manifest, skill description cap raised |
 
 ## The Relationship Between ArcKit and Claude Code
 

--- a/docs/book-research/PLAN.md
+++ b/docs/book-research/PLAN.md
@@ -217,7 +217,7 @@ Research has already been compiled from git history, memory files, changelogs, a
 | `06-hints-tips-and-lessons.md` | 5 design principles; 6 notable bugs with lessons (Orange Book 4Ts, Green Book terminology, effort trap, branch vs ref, hook async timing, slugify encoding); tips for command authors; tips for plugin users; security considerations; autoresearch workflow | Ch 5, Ch 6, Ch 11, Ch 12 |
 | `07-community-and-contributors.md` | All contributors profiled: tractorjuice (950 commits), @umag (Gemini), @DavidROliverBA (security/health), @alefbt (OpenCode), @johnfelipe (40+ issues); community impact | Ch 1, Ch 13 |
 | `08-security-architecture.md` | Full threat model (5 vectors ranked); current 3-layer defenses; identified gaps; 8 prioritized protections with effort estimates | Ch 7, Ch 8 |
-| `09-claude-code-platform-evolution.md` | Issue #215 tracking; 14 high-value capabilities; version-by-version fixes (v2.1.89-v2.1.97); minimum version history; ArcKit as platform stress-tester | Ch 6, Ch 7, Ch 12 |
+| `09-claude-code-platform-evolution.md` | Issue #215 tracking; 19 high-value capabilities; version-by-version fixes (v2.1.89-v2.1.107); minimum version history; ArcKit as platform stress-tester | Ch 6, Ch 7, Ch 12 |
 | `10-existing-articles-index.md` | 11 published articles (Medium/LinkedIn) with descriptions; hero images inventory; article adaptation notes | Ch 1, Ch 13 |
 | `11-statistics-and-numbers.md` | Every metric: 68 commands, 10 agents, 17 hooks, 5 MCP, 7 formats, 129 releases, 971 commits; growth trajectory table; autoresearch results; Wardley test suite results; MCP coverage; UK Gov coverage | All chapters, Appendices |
 

--- a/docs/book/ARCKIT-BOOK.md
+++ b/docs/book/ARCKIT-BOOK.md
@@ -166,7 +166,7 @@ ArcKit has been tested on 22 real-world projects spanning healthcare, defence, g
 
 Then enable it from the Discover tab. The plugin provides all 68 commands, 10 agents, 17 hooks, 4 skills, and 5 MCP servers. Updates are automatic.
 
-> **Minimum version**: Claude Code v2.1.97 or later is required.
+> **Recommended**: Claude Code v2.1.105 or later. **Minimum**: v2.1.97.
 
 **Gemini CLI**:
 
@@ -2364,7 +2364,7 @@ npx markdownlint-cli2 --fix "**/*.md"
 
 ### Claude Code Platform Compatibility
 
-ArcKit actively tracks Claude Code releases for capabilities that improve the plugin. Issue #215 consolidates this tracking from v2.1.83 through v2.1.97.
+ArcKit actively tracks Claude Code releases for capabilities that improve the plugin. Issue #215 consolidates this tracking from v2.1.83 through v2.1.107.
 
 **Minimum version history:**
 
@@ -2372,6 +2372,7 @@ ArcKit actively tracks Claude Code releases for capabilities that improve the pl
 |------|---------|--------|
 | Pre-April 2026 | v2.1.90 | PreToolUse blocking fix, MCP performance |
 | 9 April 2026 | v2.1.97 | Plugin update detection, MCP memory leak, 429 backoff |
+| 14 April 2026 | v2.1.97 (min), v2.1.105 (recommended) | Marketplace plugin deps auto-install, `monitors` manifest, skill description cap raised to 1,536 chars |
 
 **Key Claude Code fixes that affected ArcKit:**
 
@@ -2380,6 +2381,9 @@ ArcKit actively tracks Claude Code releases for capabilities that improve the pl
 - **v2.1.92**: Stop hook semantics fix (affects session-learner); plugin MCP stuck 'connecting' fix; Write tool 60% faster for large files
 - **v2.1.94**: `keep-coding-instructions` frontmatter for compaction persistence; fixed agents stuck after 429 with long Retry-After
 - **v2.1.97**: MCP SSE memory leak fix (~50 MB/hr); 429 exponential backoff fix; `claude plugin update` detects new commits
+- **v2.1.98**: Subagent MCP tool inheritance fix; compound Bash permission bypass security fix; `Monitor` tool for streaming background script events
+- **v2.1.101**: Sub-agents in isolated worktrees can now Read/Edit their own worktree; MCP tools available on first turn of headless sessions; `permissions.deny` overrides PreToolUse hook `ask`
+- **v2.1.105**: `monitors` top-level plugin manifest key; skill description cap raised 250→1,536 chars; PreCompact hook blocking; marketplace plugin `package.json`/lockfile auto-install (critical for Paperclip); WebFetch strips `<style>`/`<script>`
 
 ArcKit is one of the most complex Claude Code plugins in existence. Its 17 hooks, 10 agents, and 5 MCP servers push the platform's capabilities, making it both a beneficiary and a stress-tester of Claude Code features.
 
@@ -2580,7 +2584,7 @@ As of v4.6.6, ArcKit has 18 open issues on GitHub. Here are the most significant
 #### In Progress
 
 - **#282: Managed agent deployment** -- Deploy ArcKit agents as Claude Managed Agents via the Anthropic API. Prototype merged in v4.6.6. Full deployment automation still in progress
-- **#215: Claude Code v2.1.83-2.1.97 capabilities** -- 14 high-value platform features to adopt, including `userConfig` (org-level settings), `initialPrompt` (auto-starting agents), `keep-coding-instructions` (compaction resilience), and `PostCompact` hooks
+- **#215: Claude Code v2.1.83-2.1.107 capabilities** -- 19 high-value platform features to adopt, including `userConfig` (org-level settings), `initialPrompt` (auto-starting agents), `keep-coding-instructions` (compaction resilience), `PostCompact` hooks, `monitors` manifest (background monitors), and the expanded 1,536-char skill description cap
 - **#283: Citation traceability for MCP and web results** -- Currently citations only cover documents from `external/`. MCP search results and WebFetch URLs should also be cited with source URLs
 
 #### Security
@@ -3040,7 +3044,7 @@ A: Edit `.mcp.json` in the plugin root (for plugin-wide) or `.claude/settings.js
 ### Troubleshooting
 
 **Q: The plugin isn't loading or seems outdated.**
-A: Check your Claude Code version (minimum v2.1.97). Try `claude plugin update`. If using a branch for testing, ensure the settings use `"ref"` not `"branch"`.
+A: Check your Claude Code version (minimum v2.1.97, recommended v2.1.105). Try `claude plugin update`. If using a branch for testing, ensure the settings use `"ref"` not `"branch"`.
 
 **Q: Commands are generating truncated documents.**
 A: This usually means the Write tool path is wrong. Check that the project directory exists. Also check that the command is using the Write tool (not inline output).

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.105 or later recommended (v2.1.97 minimum), or **Claude Cowork** desktop app
 - **Bash** shell (for helper scripts)
 
 ### Step 1: Add the marketplace


### PR DESCRIPTION
## Summary
- Extends issue #215 tracking with items 15–19 (monitors manifest key, skill description cap 250→1,536, PreCompact hook blocking, Monitor tool, /claude-api Managed Agents coverage)
- Adds per-version fix notes for v2.1.98, v2.1.101, v2.1.105, v2.1.107
- Bumps recommended Claude Code version to **v2.1.105** (Paperclip plugin deps auto-install); keeps **v2.1.97** as hard minimum

## Notes
- Item #16 (skill description cap raise) was A/B tested today — current short descriptions already at ceiling (20/20 accuracy on both variants, 20/20 short-vs-long agreement). Finding recorded in auto-memory; no code change needed. The tracking-matrix entry is kept as "potential" since the capability itself is real.

## Test plan
- [ ] Version references are consistent across the 7 distribution format READMEs and docs
- [ ] `arckit-claude/README.md` "Why v2.1.105?" callout accurately summarises the release
- [ ] Book research chapter 09 item count (19) matches the enumeration

🤖 Generated with [Claude Code](https://claude.com/claude-code)