### PR TITLE
docs: bump min Claude Code to v2.1.112 and document 1h prompt cache (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Document `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) recommendation in MCP setup and autoresearch guides for long ArcKit workflows and overnight optimisation runs (#215)
+
+### Changed
+
+- Bump minimum Claude Code version to v2.1.112 to unlock Opus 4.7 `xhigh` effort tier and Auto mode for deep-research agents and synthesis commands (#215)
+
 ## [4.6.6] - 2026-04-09
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 
 ### Installation
 
-**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.97+**):
+**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.112+**):
 
 ```text
 /plugin marketplace add tractorjuice/arc-kit
@@ -43,7 +43,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 
 Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 68 commands, 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
-> **Why v2.1.97?** This version fixes `claude plugin update` silently missing updates for git-based plugins (critical for ArcKit distribution), fixes a MCP HTTP/SSE memory leak (~50 MB/hr on reconnects, affects ArcKit's 5 bundled servers), adds proper exponential backoff for 429 retries (benefits research agents), fixes Stop/SubagentStop hooks failing on long sessions (affects session-learner), fixes subagent working directory leaks, and includes all prior v2.1.90–v2.1.94 fixes for hooks, MCP performance, and agent stability.
+> **Why v2.1.112?** This version unlocks the `xhigh` effort tier on Claude Opus 4.7 (used by ArcKit's deep-research agents and synthesis commands), enables Auto mode without `--enable-auto-mode`, restores Opus 4.7 availability for Auto mode, and ships read-only bash glob patterns without permission prompts (reduces friction for ArcKit helper scripts). It also carries forward the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 
 **Gemini CLI** — install the ArcKit extension:
 
@@ -1214,7 +1214,7 @@ Key references live in `docs/` and top-level guides:
 
 - **Python 3.11+**
 - **Git** (optional but recommended)
-- **AI Coding Agent**: [Claude Code](https://www.anthropic.com/claude-code) v2.1.97+ (via plugin), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (via extension), [OpenCode CLI](https://opencode.net/cli) (via CLI), or [OpenAI Codex CLI](https://chatgpt.com/features/codex) (via CLI)
+- **AI Coding Agent**: [Claude Code](https://www.anthropic.com/claude-code) v2.1.112+ (via plugin), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (via extension), [OpenCode CLI](https://opencode.net/cli) (via CLI), or [OpenAI Codex CLI](https://chatgpt.com/features/codex) (via CLI)
 - **uv** for package management: [Install uv](https://docs.astral.sh/uv/)
 
 ---
@@ -1273,7 +1273,7 @@ We welcome contributions! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for guid
 
 ## Tips
 
-### Continuous Governance Monitoring (Claude Code v2.1.97+)
+### Continuous Governance Monitoring
 
 Use the `/loop` command to run health checks on a recurring interval during long architecture sessions:
 

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- Document `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) recommendation in MCP setup and autoresearch guides for long ArcKit workflows and overnight optimisation runs (#215)
+
+### Changed
+
+- Bump minimum Claude Code version to v2.1.112 to unlock Opus 4.7 `xhigh` effort tier and Auto mode for deep-research agents and synthesis commands (#215)
+
 ## [4.6.6] - 2026-04-09
 
 ### Added

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -32,13 +32,13 @@ claude --plugin-dir /path/to/arc-kit/arckit-claude
 
 ## Prerequisites
 
-- **Claude Code** v2.1.97 or later (recommended minimum)
+- **Claude Code** v2.1.112 or later (recommended minimum)
 - **Bash** shell (for helper scripts)
 - For `/arckit:aws-research`: AWS Knowledge MCP server (included)
 - For `/arckit:azure-research`: Microsoft Learn MCP server (included)
 - For `/arckit:gcp-research`: Google Developer Knowledge MCP (requires `GOOGLE_API_KEY` — see [MCP Servers](#mcp-servers))
 
-> **Why v2.1.97?** This version fixes `claude plugin update` silently missing updates for git-based plugins (critical for ArcKit distribution), fixes a MCP HTTP/SSE memory leak (~50 MB/hr on reconnects, affects ArcKit's 5 bundled MCP servers), adds proper exponential backoff for 429 retries (benefits ArcKit's 10 research agents), fixes Stop/SubagentStop hooks failing on long sessions (affects session-learner), fixes subagent working directory leaks, and includes all prior v2.1.90–v2.1.94 fixes for hooks, MCP performance, and agent stability.
+> **Why v2.1.112?** This version unlocks the `xhigh` effort tier on Claude Opus 4.7 (used by ArcKit's deep-research agents and synthesis commands), enables Auto mode without `--enable-auto-mode`, restores Opus 4.7 availability for Auto mode, and ships read-only bash glob patterns without permission prompts (reduces friction for ArcKit helper scripts). It also carries forward the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 
 ## Quick Start
 

--- a/arckit-claude/docs/guides/autoresearch.md
+++ b/arckit-claude/docs/guides/autoresearch.md
@@ -204,6 +204,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 ## Tips
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
+- **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -10,8 +10,21 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.112 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
+
+### Optional: Long-session prompt cache (Claude Code v2.1.108+)
+
+Long ArcKit workflows -- requirements -> data-model -> components -> stories, or any chain that re-reads the same templates, principles, and project artifacts -- benefit from the 1-hour prompt cache TTL introduced in Claude Code v2.1.108. The default 5-minute TTL expires between commands when you pause to review output, file the next prompt, or step away.
+
+Set the env var before launching Claude:
+
+```bash
+export ENABLE_PROMPT_CACHING_1H=1
+claude
+```
+
+Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
 ### Step 1: Add the marketplace
 

--- a/arckit-codex/docs/guides/autoresearch.md
+++ b/arckit-codex/docs/guides/autoresearch.md
@@ -204,6 +204,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 ## Tips
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
+- **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -10,8 +10,21 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.112 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
+
+### Optional: Long-session prompt cache (Claude Code v2.1.108+)
+
+Long ArcKit workflows -- requirements -> data-model -> components -> stories, or any chain that re-reads the same templates, principles, and project artifacts -- benefit from the 1-hour prompt cache TTL introduced in Claude Code v2.1.108. The default 5-minute TTL expires between commands when you pause to review output, file the next prompt, or step away.
+
+Set the env var before launching Claude:
+
+```bash
+export ENABLE_PROMPT_CACHING_1H=1
+claude
+```
+
+Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
 ### Step 1: Add the marketplace
 

--- a/arckit-copilot/docs/guides/autoresearch.md
+++ b/arckit-copilot/docs/guides/autoresearch.md
@@ -204,6 +204,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 ## Tips
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
+- **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/arckit-copilot/docs/guides/mcp-servers.md
+++ b/arckit-copilot/docs/guides/mcp-servers.md
@@ -10,8 +10,21 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.112 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
+
+### Optional: Long-session prompt cache (Claude Code v2.1.108+)
+
+Long ArcKit workflows -- requirements -> data-model -> components -> stories, or any chain that re-reads the same templates, principles, and project artifacts -- benefit from the 1-hour prompt cache TTL introduced in Claude Code v2.1.108. The default 5-minute TTL expires between commands when you pause to review output, file the next prompt, or step away.
+
+Set the env var before launching Claude:
+
+```bash
+export ENABLE_PROMPT_CACHING_1H=1
+claude
+```
+
+Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
 ### Step 1: Add the marketplace
 

--- a/arckit-opencode/docs/guides/autoresearch.md
+++ b/arckit-opencode/docs/guides/autoresearch.md
@@ -204,6 +204,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 ## Tips
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
+- **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -10,8 +10,21 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.112 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
+
+### Optional: Long-session prompt cache (Claude Code v2.1.108+)
+
+Long ArcKit workflows -- requirements -> data-model -> components -> stories, or any chain that re-reads the same templates, principles, and project artifacts -- benefit from the 1-hour prompt cache TTL introduced in Claude Code v2.1.108. The default 5-minute TTL expires between commands when you pause to review output, file the next prompt, or step away.
+
+Set the env var before launching Claude:
+
+```bash
+export ENABLE_PROMPT_CACHING_1H=1
+claude
+```
+
+Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
 ### Step 1: Add the marketplace
 

--- a/arckit-paperclip/docs/guides/autoresearch.md
+++ b/arckit-paperclip/docs/guides/autoresearch.md
@@ -204,6 +204,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 ## Tips
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
+- **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/arckit-paperclip/docs/guides/mcp-servers.md
+++ b/arckit-paperclip/docs/guides/mcp-servers.md
@@ -10,8 +10,21 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.112 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
+
+### Optional: Long-session prompt cache (Claude Code v2.1.108+)
+
+Long ArcKit workflows -- requirements -> data-model -> components -> stories, or any chain that re-reads the same templates, principles, and project artifacts -- benefit from the 1-hour prompt cache TTL introduced in Claude Code v2.1.108. The default 5-minute TTL expires between commands when you pause to review output, file the next prompt, or step away.
+
+Set the env var before launching Claude:
+
+```bash
+export ENABLE_PROMPT_CACHING_1H=1
+claude
+```
+
+Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
 ### Step 1: Add the marketplace
 

--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -202,6 +202,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 ## Tips
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
+- **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -10,8 +10,21 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.97 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.112 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
+
+### Optional: Long-session prompt cache (Claude Code v2.1.108+)
+
+Long ArcKit workflows -- requirements -> data-model -> components -> stories, or any chain that re-reads the same templates, principles, and project artifacts -- benefit from the 1-hour prompt cache TTL introduced in Claude Code v2.1.108. The default 5-minute TTL expires between commands when you pause to review output, file the next prompt, or step away.
+
+Set the env var before launching Claude:
+
+```bash
+export ENABLE_PROMPT_CACHING_1H=1
+claude
+```
+
+Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
 ### Step 1: Add the marketplace
 


### PR DESCRIPTION
Implements items 14 and 16 from issue #215 changelog review:

- Bump minimum Claude Code version from v2.1.97 to v2.1.112 across READMEs
  and MCP setup guides. Unlocks the Opus 4.7 `xhigh` effort tier (used by
  ArcKit's deep-research agents and synthesis commands), Auto mode without
  `--enable-auto-mode`, and read-only bash glob patterns without permission
  prompts. Carries forward all v2.1.97 stability fixes.

- Document `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) as a
  recommended env var for long ArcKit workflows in two places:
  - autoresearch guide Tips section (overnight optimisation runs)
  - MCP setup guide as a new "Optional: Long-session prompt cache" section
    (multi-command workflows like requirements -> data-model -> components)

  The default 5-minute prompt cache TTL expires between commands once
  Claude pauses; the 1-hour TTL keeps templates, principles, and project
  context warm across the full session, reducing token cost.

Generated extensions via scripts/converter.py.

https://claude.ai/code/session_01AytX88jtxLi6UpkvaZSR3K