### PR TITLE
feat(plugin): phase 2 userConfig for API keys and org defaults (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Plugin `userConfig` (Claude Code v2.1.83+) — plugin prompts at enable time for `GOOGLE_API_KEY` / `DATA_COMMONS_API_KEY` (both sensitive, stored in system keychain) plus org defaults (`organisation_name`, `default_classification`, `governance_framework`). `.mcp.json` uses `${user_config.KEY}` placeholders; the converter rewrites these to `${KEY}` shell env vars for Codex/Gemini/OpenCode/Copilot targets (#215)
+
+### Changed
+
+- Existing users enabling v4.6.8+ in Claude Code will be prompted once for MCP API keys and org defaults; existing `GOOGLE_API_KEY` / `DATA_COMMONS_API_KEY` shell env vars continue to work for non-plugin contexts (Codex / Gemini / OpenCode / Copilot).
+
 ## [4.6.7] - 2026-04-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -181,6 +181,23 @@ Plugin skills live in `arckit-claude/skills/{name}/SKILL.md` with YAML frontmatt
 
 The converter strips `paths:` for non-Claude targets (Codex skills use their own `allow_implicit_invocation` mechanism).
 
+### Plugin User Configuration
+
+Plugin-level user config is declared in `arckit-claude/.claude-plugin/plugin.json` under the `userConfig` key (v2.1.83+). Claude Code prompts the user for each field at plugin enable time. Per-field schema supports `description` (shown in the prompt) and `sensitive: true` (stores the value in the system keychain rather than plaintext `settings.json`).
+
+Current fields:
+
+- `GOOGLE_API_KEY` (sensitive) — powers the `google-developer-knowledge` MCP server
+- `DATA_COMMONS_API_KEY` (sensitive) — powers the `datacommons-mcp` MCP server
+- `organisation_name` — injected into generated Document Control headers
+- `default_classification` — default value for Document Control `Classification` field (PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE / SECRET)
+- `governance_framework` — `UK Gov` for Service Standard/TCoP/NCSC CAF or `Generic`
+
+Runtime substitution uses `${user_config.KEY}`:
+
+- **`.mcp.json`** — already wired for `GOOGLE_API_KEY` and `DATA_COMMONS_API_KEY` headers. The converter rewrites `${user_config.KEY}` → `${KEY}` for non-Claude extensions (Codex, Gemini, OpenCode, Copilot) since those platforms fall back to shell env vars.
+- **Command / agent bodies** — non-sensitive values can be referenced (e.g. `${user_config.organisation_name}` in a Document Control block). Sensitive values are never substituted into prompt content.
+
 ### Plugin Hooks
 
 Hook handlers live under `arckit-claude/hooks/` and are registered in `arckit-claude/hooks/hooks.json`. Supported hook events include `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `StopFailure`, `PermissionRequest`, plus the newer `PostCompact` (v2.1.76), `FileChanged`/`CwdChanged`/`TaskCreated` (v2.1.83–84), `PermissionDenied` (v2.1.89), and `PreCompact` blocking (v2.1.105).

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -8,5 +8,24 @@
   },
   "repository": "https://github.com/tractorjuice/arc-kit",
   "license": "MIT",
-  "mcpServers": "./.mcp.json"
+  "mcpServers": "./.mcp.json",
+  "userConfig": {
+    "GOOGLE_API_KEY": {
+      "description": "Google API key for the google-developer-knowledge MCP server (optional — leave blank to disable)",
+      "sensitive": true
+    },
+    "DATA_COMMONS_API_KEY": {
+      "description": "Data Commons API key for the datacommons-mcp MCP server (optional — leave blank to disable)",
+      "sensitive": true
+    },
+    "organisation_name": {
+      "description": "Organisation name used in generated Document Control headers (e.g. 'Acme Ltd' or 'HM Revenue & Customs')"
+    },
+    "default_classification": {
+      "description": "Default document classification: PUBLIC, OFFICIAL, OFFICIAL-SENSITIVE, or SECRET"
+    },
+    "governance_framework": {
+      "description": "Default governance framework: 'UK Gov' for Service Standard/TCoP/NCSC CAF, or 'Generic' for non-government"
+    }
+  }
 }

--- a/arckit-claude/.mcp.json
+++ b/arckit-claude/.mcp.json
@@ -12,14 +12,14 @@
       "type": "http",
       "url": "https://developerknowledge.googleapis.com/mcp",
       "headers": {
-        "X-Goog-Api-Key": "${GOOGLE_API_KEY}"
+        "X-Goog-Api-Key": "${user_config.GOOGLE_API_KEY}"
       }
     },
     "datacommons-mcp": {
       "type": "http",
       "url": "https://api.datacommons.org/mcp",
       "headers": {
-        "X-API-Key": "${DATA_COMMONS_API_KEY}"
+        "X-API-Key": "${user_config.DATA_COMMONS_API_KEY}"
       }
     },
     "govreposcrape": {

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Plugin `userConfig` (Claude Code v2.1.83+) in `plugin.json` with 5 fields: `GOOGLE_API_KEY` and `DATA_COMMONS_API_KEY` (sensitive, stored in system keychain) for MCP authentication, plus `organisation_name`, `default_classification`, and `governance_framework` for Document Control defaults. Claude Code prompts once at enable time (#215)
+
+### Changed
+
+- `arckit-claude/.mcp.json` now references `${user_config.GOOGLE_API_KEY}` and `${user_config.DATA_COMMONS_API_KEY}` instead of shell env vars. The converter rewrites these to `${KEY}` for non-Claude extensions so Codex/Gemini/OpenCode continue to read from the shell environment.
+
 ## [4.6.7] - 2026-04-18
 
 ### Added

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -20,6 +20,20 @@ CLAUDE_ONLY_AGENT_FIELDS = (
 )
 
 
+USER_CONFIG_PLACEHOLDER_RE = re.compile(r"\$\{user_config\.([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def rewrite_user_config_placeholders(value):
+    """Rewrite Claude Code `${user_config.KEY}` placeholders to plain `${KEY}`.
+
+    Non-Claude extensions (Codex, Gemini, OpenCode, Copilot) don't support
+    plugin user config and fall back to shell environment variables.
+    """
+    if not isinstance(value, str):
+        return value
+    return USER_CONFIG_PLACEHOLDER_RE.sub(r"${\1}", value)
+
+
 def build_agent_map(agents_dir):
     """Build a map from command name to agent file path and content.
 
@@ -585,10 +599,10 @@ def generate_codex_config_toml(mcp_json_path, agents_dir, output_path):
                     if key == "headers":
                         header_parts = []
                         for hk, hv in value.items():
-                            header_parts.append(f'"{hk}" = "{hv}"')
+                            header_parts.append(f'"{hk}" = "{rewrite_user_config_placeholders(hv)}"')
                         lines.append(f"headers = {{ {', '.join(header_parts)} }}")
                     else:
-                        lines.append(f'{key} = "{value}"')
+                        lines.append(f'{key} = "{rewrite_user_config_placeholders(value)}"')
                 lines.append("")
 
     # Agent roles section


### PR DESCRIPTION
## Summary

Implements the first (and largest) item of **Phase 2** of #215 — declares `userConfig` in the plugin manifest so Claude Code prompts users once at plugin enable time rather than requiring them to remember to set env vars.

Five fields declared (`arckit-claude/.claude-plugin/plugin.json`):

| Field | Sensitive | Purpose |
|---|---|---|
| `GOOGLE_API_KEY` | ✅ | `google-developer-knowledge` MCP header |
| `DATA_COMMONS_API_KEY` | ✅ | `datacommons-mcp` MCP header |
| `organisation_name` | | Document Control header injection |
| `default_classification` | | Document Control classification default |
| `governance_framework` | | `UK Gov` vs `Generic` governance profile |

**Wiring**:
- `arckit-claude/.mcp.json` now references `${user_config.GOOGLE_API_KEY}` and `${user_config.DATA_COMMONS_API_KEY}` — values are read from the system keychain at request time.
- `scripts/converter.py` adds a `rewrite_user_config_placeholders()` helper and invokes it when generating `arckit-codex/config.toml` so Codex falls back to `${GOOGLE_API_KEY}` shell env vars (verified in the diff — `arckit-codex/config.toml` line 17/22 show plain `${KEY}`). Gemini's hand-maintained `gemini-extension.json` was already on shell env vars and is unchanged.
- `CLAUDE.md` adds a "Plugin User Configuration" section documenting the schema and runtime substitution rules.

## Phase 2 status

- [x] **userConfig** — this PR
- [ ] **`initialPrompt` on 10 agents** — **deferred**. The behavior of `initialPrompt` when an agent is spawned via the Task tool with a user prompt is not documented (double-turn risk). Needs runtime verification in a test repo before adoption. Tracked in #215 checklist.
- [x] **Re-evaluate 4 skill descriptions at 1,536-char cap** — closed as "measured, no change" per the 2026-04-14 A/B test (20/20 accuracy on both short and long variants). See #215 for full test details.

## Migration note for existing users

Plugin users who previously set `GOOGLE_API_KEY` / `DATA_COMMONS_API_KEY` as shell env vars will be prompted once when they upgrade. Values then live in the system keychain. Non-plugin contexts (Codex, Gemini, OpenCode, Copilot) continue to read from shell env vars — the converter rewrites placeholders automatically.

## Test plan

- [x] `python scripts/converter.py` runs clean, generates 408 files
- [x] `plugin.json` and `.mcp.json` are valid JSON
- [x] `arckit-codex/config.toml` shows `${GOOGLE_API_KEY}` / `${DATA_COMMONS_API_KEY}` (placeholders rewritten)
- [x] Markdown lint clean on modified files
- [ ] Enable the plugin in a test repo on Claude Code v2.1.112+ and verify:
  - Claude Code prompts for the 5 userConfig fields at enable time
  - `google-developer-knowledge` MCP receives the `X-Goog-Api-Key` header populated from the keychain value
  - `datacommons-mcp` MCP receives the `X-API-Key` header populated from the keychain value
  - Non-sensitive values are accessible via `${user_config.organisation_name}` etc. in command bodies

Phase 3 (`keep-coding-instructions` on long-running commands, PostCompact / PreCompact hooks) is the next shippable unit.