### PR TITLE
feat(hooks): warn on Claude Code below minimum version

### DIFF
--- a/arckit-claude/hooks/version-check.mjs
+++ b/arckit-claude/hooks/version-check.mjs
@@ -2,18 +2,25 @@
 /**
  * ArcKit Version Check Hook
  *
- * Fires at SessionStart. Compares the local plugin version against
- * the latest GitHub release tag for tractorjuice/arc-kit.
- * Emits a notification if a newer version is available.
+ * Fires at SessionStart. Two checks:
+ *   1. Plugin self-update — compares local plugin version against the latest
+ *      GitHub release tag for tractorjuice/arc-kit.
+ *   2. Claude Code minimum — reads `$CLAUDE_CODE_VERSION` (if set) or runs
+ *      `claude --version` via spawnSync, and warns when the client is below
+ *      MIN_CLAUDE_CODE_VERSION (features like userConfig, hook `if:`, skill
+ *      `paths:` depend on v2.1.83+/v2.1.112+). Silent on detection failure.
  *
  * Hook Type: SessionStart
  * Input (stdin): JSON with session_id, cwd, etc.
- * Output (stdout): JSON with additionalContext (only if update available)
+ * Output (stdout): JSON with additionalContext (only when a warning fires).
  */
 
+import { spawnSync } from 'node:child_process';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isFile, readText, parseHookInput } from './hook-utils.mjs';
+
+const MIN_CLAUDE_CODE_VERSION = '2.1.112';
 
 parseHookInput(); // consume stdin (required by hook protocol)
 
@@ -22,10 +29,26 @@ const pluginRoot = process.env.CLAUDE_PLUGIN_ROOT || resolve(__dirname, '..');
 const versionFile = join(pluginRoot, 'VERSION');
 const localVersion = (isFile(versionFile) && readText(versionFile)?.trim()) || null;
 
+const warnings = [];
+
+const clientVersion = detectClaudeCodeVersion();
+if (clientVersion && compareVersions(clientVersion, MIN_CLAUDE_CODE_VERSION) < 0) {
+  warnings.push(
+    `## Claude Code Version Warning\n\n` +
+    `You are running Claude Code **v${clientVersion}**. ArcKit requires **v${MIN_CLAUDE_CODE_VERSION}** or later.\n\n` +
+    `Features affected on older versions:\n` +
+    `- Plugin \`userConfig\` prompts for API keys and org defaults (needs v2.1.83)\n` +
+    `- Skill \`paths:\` globs for scoped auto-activation (needs v2.1.84)\n` +
+    `- Hook \`if:\` conditions that narrow triggering (needs v2.1.85)\n` +
+    `- Opus 4.7 \`xhigh\` effort tier and Auto mode (needs v2.1.111)\n\n` +
+    `Update with: \`claude update\``
+  );
+  process.stderr.write(`[ArcKit] Claude Code v${clientVersion} is below required v${MIN_CLAUDE_CODE_VERSION}\n`);
+}
+
 if (!localVersion) {
-  // Can't determine local version — skip silently
-  console.log(JSON.stringify({}));
-  process.exit(0);
+  // Can't determine plugin version — emit client-version warnings (if any) and exit
+  emitAndExit();
 }
 
 const REPO = 'tractorjuice/arc-kit';
@@ -44,44 +67,73 @@ try {
   });
   clearTimeout(timeout);
 
-  if (!res.ok) {
-    // API error (rate limit, network) — skip silently
-    console.log(JSON.stringify({}));
-    process.exit(0);
-  }
+  if (res.ok) {
+    let data;
+    try {
+      data = await res.json();
+    } catch {
+      data = null;
+    }
+    const latestTag = data?.tag_name || '';
+    const latestVersion = latestTag.replace(/^v/, '');
 
-  let data;
-  try {
-    data = await res.json();
-  } catch {
-    console.log(JSON.stringify({}));
-    process.exit(0);
-  }
-  const latestTag = data.tag_name || '';
-  const latestVersion = latestTag.replace(/^v/, '');
-
-  if (!latestVersion) {
-    console.log(JSON.stringify({}));
-    process.exit(0);
-  }
-
-  if (compareVersions(latestVersion, localVersion) > 0) {
-    const context = `## ArcKit Update Available\n\nYou are running **v${localVersion}**. The latest release is **v${latestVersion}**.\n\nTo update, restart Claude Code — the plugin marketplace will pull the latest version automatically.\n\nRelease notes: https://github.com/${REPO}/releases/tag/${latestTag}`;
-
-    process.stderr.write(`[ArcKit] Update available: v${localVersion} → v${latestVersion}\n`);
-
-    console.log(JSON.stringify({
-      hookSpecificOutput: {
-        hookEventName: 'SessionStart',
-        additionalContext: context,
-      },
-    }));
-  } else {
-    console.log(JSON.stringify({}));
+    if (latestVersion && compareVersions(latestVersion, localVersion) > 0) {
+      warnings.push(
+        `## ArcKit Update Available\n\n` +
+        `You are running **v${localVersion}**. The latest release is **v${latestVersion}**.\n\n` +
+        `To update, restart Claude Code — the plugin marketplace will pull the latest version automatically.\n\n` +
+        `Release notes: https://github.com/${REPO}/releases/tag/${latestTag}`
+      );
+      process.stderr.write(`[ArcKit] Update available: v${localVersion} → v${latestVersion}\n`);
+    }
   }
 } catch {
   // Network failure, timeout, etc. — skip silently
-  console.log(JSON.stringify({}));
+}
+
+emitAndExit();
+
+function emitAndExit() {
+  if (warnings.length === 0) {
+    console.log(JSON.stringify({}));
+  } else {
+    console.log(JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'SessionStart',
+        additionalContext: warnings.join('\n\n---\n\n'),
+      },
+    }));
+  }
+  process.exit(0);
+}
+
+/**
+ * Try to detect the running Claude Code version.
+ *
+ * Preferred: env var `CLAUDE_CODE_VERSION` if set by the harness.
+ * Fallback: invoke `claude --version` with a short timeout, arguments
+ * passed as an array (no shell interpolation). Returns null on failure.
+ */
+function detectClaudeCodeVersion() {
+  if (process.env.CLAUDE_CODE_VERSION) {
+    return parseVersion(process.env.CLAUDE_CODE_VERSION);
+  }
+  try {
+    const result = spawnSync('claude', ['--version'], {
+      encoding: 'utf8',
+      timeout: 2000,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    if (result.status !== 0) return null;
+    return parseVersion(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+function parseVersion(text) {
+  const match = /(\d+\.\d+\.\d+)/.exec(text || '');
+  return match ? match[1] : null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Extends the existing SessionStart hook at \`arckit-claude/hooks/version-check.mjs\` to also check the **Claude Code client version** against the documented minimum (v2.1.112). Pre-existing plugin self-update logic is preserved.

When the client is below v2.1.112, the hook injects an \`additionalContext\` warning listing the features users lose:

- Plugin \`userConfig\` (v2.1.83)
- Skill \`paths:\` (v2.1.84)
- Hook \`if:\` conditions (v2.1.85)
- Opus 4.7 \`xhigh\` effort tier and Auto mode (v2.1.111)

## Detection strategy

1. Read \`\$CLAUDE_CODE_VERSION\` env var if set (preferred — no subprocess).
2. Fall back to \`spawnSync('claude', ['--version'])\` with a 2s timeout. Arguments passed as an array (no shell interpolation).

Silent on detection failure: if the \`claude\` binary is unavailable, the hook returns \`{}\` and the session proceeds normally. The existing plugin self-update warning path is unchanged; both warnings combine via \`\n---\n\` when they fire together.

## Context

Per #215 comment thread: there was no check against our documented minimum Claude Code version. Users on older clients silently lost features without any diagnostic. This closes that gap.

## Test plan

Verified locally:

| Input | Output |
|---|---|
| \`CLAUDE_CODE_VERSION=2.1.100\` | Warning emitted with correct \`additionalContext\` |
| \`CLAUDE_CODE_VERSION=2.1.114\` | Silent \`{}\` |
| No env var, no \`claude\` binary | Silent \`{}\` |

- [x] Hook returns valid JSON on stdout in all three cases
- [x] Warning message lists the four feature tiers and \`claude update\` hint
- [ ] Confirm in a test repo on Claude Code v2.1.100 that the warning appears in the session context

Closes: the gap identified in #215 discussion of client-version enforcement.