### PR TITLE
feat(plugin): phase 4 — stale-artifact monitor + Monitor tool guidance (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Plugin `monitors` manifest key (Claude Code v2.1.105+) with a `stale-artifact-scan` monitor that runs at session start. The monitor (`arckit-claude/scripts/bash/detect-stale-artifacts.sh`) scans `projects/` for ARC-*.md artifacts whose Document Control `Next Review Date` is overdue or whose `Status: DRAFT` is 14+ days old, emitting one notification per stale file (capped at 10). Silent in non-ArcKit repos (#215)
+- Autoresearch guide documents the built-in `Monitor` tool (v2.1.98+) for streaming overnight autoresearch progress from a second session without blocking the experiment loop (#215)
+
 ## [4.6.9] - 2026-04-18
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -198,6 +198,27 @@ Runtime substitution uses `${user_config.KEY}`:
 - **`.mcp.json`** — already wired for `GOOGLE_API_KEY` and `DATA_COMMONS_API_KEY` headers. The converter rewrites `${user_config.KEY}` → `${KEY}` for non-Claude extensions (Codex, Gemini, OpenCode, Copilot) since those platforms fall back to shell env vars.
 - **Command / agent bodies** — non-sensitive values can be referenced (e.g. `${user_config.organisation_name}` in a Document Control block). Sensitive values are never substituted into prompt content.
 
+### Plugin Monitors
+
+Background monitors declared via the `monitors` key in `arckit-claude/.claude-plugin/plugin.json` (v2.1.105+). Each entry runs as a persistent subprocess in the session's working directory; stdout lines are delivered to Claude as session notifications.
+
+Schema: `name` (unique id), `command` (shell command, supports `${CLAUDE_PLUGIN_ROOT}` and `${user_config.*}`), `description`, `when` (`always` — default, starts at session-start; or `on-skill-invoke:<skill>`).
+
+Current monitor:
+
+- `stale-artifact-scan` — runs `arckit-claude/scripts/bash/detect-stale-artifacts.sh` at session start in repos that have a `projects/` directory. Emits one line per artifact whose Document Control `Next Review Date` is overdue, or whose status is `DRAFT` and hasn't been touched in 14+ days. Exits silently in non-ArcKit repos.
+
+Monitors are Claude-only — the converter does not propagate `monitors` to Codex/Gemini/OpenCode/Copilot extension manifests (those platforms have their own notification mechanisms).
+
+### Monitor Tool (user-facing)
+
+The built-in `Monitor` tool (Claude Code v2.1.98+) tails stdout from a background Bash process and delivers each line to Claude as an in-session notification. Model-driven: the user or the model picks it up from natural language ("monitor the autoresearch log for progress"). No plugin configuration is needed.
+
+Recommended ArcKit usage:
+
+- **Long `/arckit.research` or `/arckit.datascout` runs** — redirect agent bash/shell output to a log file and ask Claude to `Monitor` the tail, so progress surfaces without blocking the main conversation.
+- **Overnight autoresearch loops** (see `docs/guides/autoresearch.md`) — tail the scoring log from a second session via `tail -F scripts/autoresearch/runs/*.log` wrapped by Monitor.
+
 ### Plugin Hooks
 
 Hook handlers live under `arckit-claude/hooks/` and are registered in `arckit-claude/hooks/hooks.json`. Supported hook events include `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `StopFailure`, `PermissionRequest`, plus the newer `PostCompact` (v2.1.76), `FileChanged`/`CwdChanged`/`TaskCreated` (v2.1.83–84), `PermissionDenied` (v2.1.89), and `PreCompact` blocking (v2.1.105).

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -9,6 +9,14 @@
   "repository": "https://github.com/tractorjuice/arc-kit",
   "license": "MIT",
   "mcpServers": "./.mcp.json",
+  "monitors": [
+    {
+      "name": "stale-artifact-scan",
+      "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/bash/detect-stale-artifacts.sh",
+      "description": "Detect ArcKit artifacts with overdue reviews or long-unchanged drafts",
+      "when": "always"
+    }
+  ],
   "userConfig": {
     "GOOGLE_API_KEY": {
       "description": "Google API key for the google-developer-knowledge MCP server (optional — leave blank to disable)",

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `monitors` key in `plugin.json` registering a `stale-artifact-scan` background monitor (Claude Code v2.1.105+). At session start, the plugin runs `scripts/bash/detect-stale-artifacts.sh` which scans `projects/` for artifacts with overdue `Next Review Date` or long-unchanged `DRAFT` status and emits one notification line per stale file. Exits silently when the cwd is not an ArcKit project (#215)
+- `scripts/bash/detect-stale-artifacts.sh` — one-shot scanner invoked by the new monitor. Caps output at 10 lines; appends a pointer to `/arckit.health` for the full list.
+
+### Changed
+
+- Autoresearch guide adds a "Watching progress without blocking the main session" paragraph recommending the built-in `Monitor` tool (v2.1.98+) for streaming overnight runs from a second session (#215).
+
 ## [4.6.9] - 2026-04-18
 
 ### Added

--- a/arckit-claude/scripts/bash/detect-stale-artifacts.sh
+++ b/arckit-claude/scripts/bash/detect-stale-artifacts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ArcKit Stale Artifact Scanner
+#
+# One-shot scan wired into the plugin's `monitors` manifest key. Fires at
+# session start (when the plugin is enabled in an ArcKit repo), emits one
+# stdout line per stale artifact, and exits.
+#
+# Stale criteria:
+#   1. Document Control "Next Review Date" is in the past
+#   2. Status is DRAFT and the file hasn't been touched in >14 days
+#
+# Output format is a single notification line per artifact, readable as
+# an additionalContext signal by Claude Code. Silent exit if the cwd is
+# not an ArcKit project (no projects/ directory).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh" 2>/dev/null || true
+
+cwd="$(pwd)"
+if [[ ! -d "$cwd/projects" ]]; then
+  exit 0
+fi
+
+today="$(date +%Y-%m-%d)"
+stale_count=0
+max_report=10
+
+# Resolve a GNU-style date threshold for draft staleness (14 days ago).
+# Falls back silently if `date -d` unsupported.
+draft_threshold=""
+if date -d "14 days ago" +%Y-%m-%d >/dev/null 2>&1; then
+  draft_threshold="$(date -d "14 days ago" +%Y-%m-%d)"
+fi
+
+# Iterate ARC-*.md files under projects/, ignoring symlinks and node_modules
+while IFS= read -r -d '' file; do
+  [[ $stale_count -ge $max_report ]] && break
+
+  # Pull Document Control table fields
+  next_review="$(grep -m1 -i "Next Review Date" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+  status="$(grep -m1 -i "^| *Status" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED).*/\1/i' \
+    | tr '[:lower:]' '[:upper:]')"
+  last_modified="$(grep -m1 -i "Last Modified" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+
+  rel="${file#$cwd/}"
+
+  # Overdue review
+  if [[ -n "$next_review" && "$next_review" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$next_review" < "$today" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — review overdue since $next_review"
+      stale_count=$((stale_count + 1))
+      continue
+    fi
+  fi
+
+  # Long-running draft
+  if [[ "$status" == "DRAFT" && -n "$draft_threshold" \
+        && -n "$last_modified" && "$last_modified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$last_modified" < "$draft_threshold" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — DRAFT unchanged since $last_modified"
+      stale_count=$((stale_count + 1))
+    fi
+  fi
+done < <(find "$cwd/projects" -type f -name "ARC-*.md" -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+if [[ $stale_count -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ $stale_count -ge $max_report ]]; then
+  echo "[ArcKit monitor] (reporting first $max_report; run /arckit.health for the full list)"
+else
+  echo "[ArcKit monitor] Found $stale_count stale artifact(s). Run /arckit.health for details."
+fi

--- a/arckit-codex/scripts/bash/detect-stale-artifacts.sh
+++ b/arckit-codex/scripts/bash/detect-stale-artifacts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ArcKit Stale Artifact Scanner
+#
+# One-shot scan wired into the plugin's `monitors` manifest key. Fires at
+# session start (when the plugin is enabled in an ArcKit repo), emits one
+# stdout line per stale artifact, and exits.
+#
+# Stale criteria:
+#   1. Document Control "Next Review Date" is in the past
+#   2. Status is DRAFT and the file hasn't been touched in >14 days
+#
+# Output format is a single notification line per artifact, readable as
+# an additionalContext signal by Claude Code. Silent exit if the cwd is
+# not an ArcKit project (no projects/ directory).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh" 2>/dev/null || true
+
+cwd="$(pwd)"
+if [[ ! -d "$cwd/projects" ]]; then
+  exit 0
+fi
+
+today="$(date +%Y-%m-%d)"
+stale_count=0
+max_report=10
+
+# Resolve a GNU-style date threshold for draft staleness (14 days ago).
+# Falls back silently if `date -d` unsupported.
+draft_threshold=""
+if date -d "14 days ago" +%Y-%m-%d >/dev/null 2>&1; then
+  draft_threshold="$(date -d "14 days ago" +%Y-%m-%d)"
+fi
+
+# Iterate ARC-*.md files under projects/, ignoring symlinks and node_modules
+while IFS= read -r -d '' file; do
+  [[ $stale_count -ge $max_report ]] && break
+
+  # Pull Document Control table fields
+  next_review="$(grep -m1 -i "Next Review Date" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+  status="$(grep -m1 -i "^| *Status" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED).*/\1/i' \
+    | tr '[:lower:]' '[:upper:]')"
+  last_modified="$(grep -m1 -i "Last Modified" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+
+  rel="${file#$cwd/}"
+
+  # Overdue review
+  if [[ -n "$next_review" && "$next_review" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$next_review" < "$today" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — review overdue since $next_review"
+      stale_count=$((stale_count + 1))
+      continue
+    fi
+  fi
+
+  # Long-running draft
+  if [[ "$status" == "DRAFT" && -n "$draft_threshold" \
+        && -n "$last_modified" && "$last_modified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$last_modified" < "$draft_threshold" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — DRAFT unchanged since $last_modified"
+      stale_count=$((stale_count + 1))
+    fi
+  fi
+done < <(find "$cwd/projects" -type f -name "ARC-*.md" -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+if [[ $stale_count -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ $stale_count -ge $max_report ]]; then
+  echo "[ArcKit monitor] (reporting first $max_report; run /arckit.health for the full list)"
+else
+  echo "[ArcKit monitor] Found $stale_count stale artifact(s). Run /arckit.health for details."
+fi

--- a/arckit-copilot/scripts/bash/detect-stale-artifacts.sh
+++ b/arckit-copilot/scripts/bash/detect-stale-artifacts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ArcKit Stale Artifact Scanner
+#
+# One-shot scan wired into the plugin's `monitors` manifest key. Fires at
+# session start (when the plugin is enabled in an ArcKit repo), emits one
+# stdout line per stale artifact, and exits.
+#
+# Stale criteria:
+#   1. Document Control "Next Review Date" is in the past
+#   2. Status is DRAFT and the file hasn't been touched in >14 days
+#
+# Output format is a single notification line per artifact, readable as
+# an additionalContext signal by Claude Code. Silent exit if the cwd is
+# not an ArcKit project (no projects/ directory).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh" 2>/dev/null || true
+
+cwd="$(pwd)"
+if [[ ! -d "$cwd/projects" ]]; then
+  exit 0
+fi
+
+today="$(date +%Y-%m-%d)"
+stale_count=0
+max_report=10
+
+# Resolve a GNU-style date threshold for draft staleness (14 days ago).
+# Falls back silently if `date -d` unsupported.
+draft_threshold=""
+if date -d "14 days ago" +%Y-%m-%d >/dev/null 2>&1; then
+  draft_threshold="$(date -d "14 days ago" +%Y-%m-%d)"
+fi
+
+# Iterate ARC-*.md files under projects/, ignoring symlinks and node_modules
+while IFS= read -r -d '' file; do
+  [[ $stale_count -ge $max_report ]] && break
+
+  # Pull Document Control table fields
+  next_review="$(grep -m1 -i "Next Review Date" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+  status="$(grep -m1 -i "^| *Status" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED).*/\1/i' \
+    | tr '[:lower:]' '[:upper:]')"
+  last_modified="$(grep -m1 -i "Last Modified" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+
+  rel="${file#$cwd/}"
+
+  # Overdue review
+  if [[ -n "$next_review" && "$next_review" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$next_review" < "$today" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — review overdue since $next_review"
+      stale_count=$((stale_count + 1))
+      continue
+    fi
+  fi
+
+  # Long-running draft
+  if [[ "$status" == "DRAFT" && -n "$draft_threshold" \
+        && -n "$last_modified" && "$last_modified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$last_modified" < "$draft_threshold" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — DRAFT unchanged since $last_modified"
+      stale_count=$((stale_count + 1))
+    fi
+  fi
+done < <(find "$cwd/projects" -type f -name "ARC-*.md" -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+if [[ $stale_count -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ $stale_count -ge $max_report ]]; then
+  echo "[ArcKit monitor] (reporting first $max_report; run /arckit.health for the full list)"
+else
+  echo "[ArcKit monitor] Found $stale_count stale artifact(s). Run /arckit.health for details."
+fi

--- a/arckit-opencode/scripts/bash/detect-stale-artifacts.sh
+++ b/arckit-opencode/scripts/bash/detect-stale-artifacts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ArcKit Stale Artifact Scanner
+#
+# One-shot scan wired into the plugin's `monitors` manifest key. Fires at
+# session start (when the plugin is enabled in an ArcKit repo), emits one
+# stdout line per stale artifact, and exits.
+#
+# Stale criteria:
+#   1. Document Control "Next Review Date" is in the past
+#   2. Status is DRAFT and the file hasn't been touched in >14 days
+#
+# Output format is a single notification line per artifact, readable as
+# an additionalContext signal by Claude Code. Silent exit if the cwd is
+# not an ArcKit project (no projects/ directory).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh" 2>/dev/null || true
+
+cwd="$(pwd)"
+if [[ ! -d "$cwd/projects" ]]; then
+  exit 0
+fi
+
+today="$(date +%Y-%m-%d)"
+stale_count=0
+max_report=10
+
+# Resolve a GNU-style date threshold for draft staleness (14 days ago).
+# Falls back silently if `date -d` unsupported.
+draft_threshold=""
+if date -d "14 days ago" +%Y-%m-%d >/dev/null 2>&1; then
+  draft_threshold="$(date -d "14 days ago" +%Y-%m-%d)"
+fi
+
+# Iterate ARC-*.md files under projects/, ignoring symlinks and node_modules
+while IFS= read -r -d '' file; do
+  [[ $stale_count -ge $max_report ]] && break
+
+  # Pull Document Control table fields
+  next_review="$(grep -m1 -i "Next Review Date" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+  status="$(grep -m1 -i "^| *Status" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED).*/\1/i' \
+    | tr '[:lower:]' '[:upper:]')"
+  last_modified="$(grep -m1 -i "Last Modified" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+
+  rel="${file#$cwd/}"
+
+  # Overdue review
+  if [[ -n "$next_review" && "$next_review" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$next_review" < "$today" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — review overdue since $next_review"
+      stale_count=$((stale_count + 1))
+      continue
+    fi
+  fi
+
+  # Long-running draft
+  if [[ "$status" == "DRAFT" && -n "$draft_threshold" \
+        && -n "$last_modified" && "$last_modified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$last_modified" < "$draft_threshold" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — DRAFT unchanged since $last_modified"
+      stale_count=$((stale_count + 1))
+    fi
+  fi
+done < <(find "$cwd/projects" -type f -name "ARC-*.md" -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+if [[ $stale_count -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ $stale_count -ge $max_report ]]; then
+  echo "[ArcKit monitor] (reporting first $max_report; run /arckit.health for the full list)"
+else
+  echo "[ArcKit monitor] Found $stale_count stale artifact(s). Run /arckit.health for details."
+fi

--- a/arckit-paperclip/scripts/bash/detect-stale-artifacts.sh
+++ b/arckit-paperclip/scripts/bash/detect-stale-artifacts.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+# ArcKit Stale Artifact Scanner
+#
+# One-shot scan wired into the plugin's `monitors` manifest key. Fires at
+# session start (when the plugin is enabled in an ArcKit repo), emits one
+# stdout line per stale artifact, and exits.
+#
+# Stale criteria:
+#   1. Document Control "Next Review Date" is in the past
+#   2. Status is DRAFT and the file hasn't been touched in >14 days
+#
+# Output format is a single notification line per artifact, readable as
+# an additionalContext signal by Claude Code. Silent exit if the cwd is
+# not an ArcKit project (no projects/ directory).
+
+set -u
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=./common.sh
+source "$SCRIPT_DIR/common.sh" 2>/dev/null || true
+
+cwd="$(pwd)"
+if [[ ! -d "$cwd/projects" ]]; then
+  exit 0
+fi
+
+today="$(date +%Y-%m-%d)"
+stale_count=0
+max_report=10
+
+# Resolve a GNU-style date threshold for draft staleness (14 days ago).
+# Falls back silently if `date -d` unsupported.
+draft_threshold=""
+if date -d "14 days ago" +%Y-%m-%d >/dev/null 2>&1; then
+  draft_threshold="$(date -d "14 days ago" +%Y-%m-%d)"
+fi
+
+# Iterate ARC-*.md files under projects/, ignoring symlinks and node_modules
+while IFS= read -r -d '' file; do
+  [[ $stale_count -ge $max_report ]] && break
+
+  # Pull Document Control table fields
+  next_review="$(grep -m1 -i "Next Review Date" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+  status="$(grep -m1 -i "^| *Status" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED).*/\1/i' \
+    | tr '[:lower:]' '[:upper:]')"
+  last_modified="$(grep -m1 -i "Last Modified" "$file" 2>/dev/null \
+    | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
+
+  rel="${file#$cwd/}"
+
+  # Overdue review
+  if [[ -n "$next_review" && "$next_review" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$next_review" < "$today" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — review overdue since $next_review"
+      stale_count=$((stale_count + 1))
+      continue
+    fi
+  fi
+
+  # Long-running draft
+  if [[ "$status" == "DRAFT" && -n "$draft_threshold" \
+        && -n "$last_modified" && "$last_modified" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
+    if [[ "$last_modified" < "$draft_threshold" ]]; then
+      echo "[ArcKit monitor] STALE: $rel — DRAFT unchanged since $last_modified"
+      stale_count=$((stale_count + 1))
+    fi
+  fi
+done < <(find "$cwd/projects" -type f -name "ARC-*.md" -not -path "*/node_modules/*" -print0 2>/dev/null)
+
+if [[ $stale_count -eq 0 ]]; then
+  exit 0
+fi
+
+if [[ $stale_count -ge $max_report ]]; then
+  echo "[ArcKit monitor] (reporting first $max_report; run /arckit.health for the full list)"
+else
+  echo "[ArcKit monitor] Found $stale_count stale artifact(s). Run /arckit.health for details."
+fi

--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -27,6 +27,16 @@ Claude will:
 
 To stop: interrupt Claude at any time. The worktree has the best prompt.
 
+### Watching progress without blocking the main session
+
+For long overnight runs, open a second Claude Code session in the worktree directory and ask it to `Monitor` the results log:
+
+```text
+Monitor scripts/autoresearch/runs/*.log and summarise each new iteration
+```
+
+The `Monitor` tool (Claude Code v2.1.98+) tails stdout from a background `tail -F` and delivers each new scoring line to Claude as a notification. You get progress updates on demand without interrupting the experiment loop in the main session. Requires Claude Code v2.1.98 or later.
+
 ---
 
 ## How It Works


### PR DESCRIPTION
## Summary

Implements two Phase 4 items from #215:

### 1. `monitors` manifest key (Claude Code v2.1.105+)

Adds a `monitors` entry to `arckit-claude/.claude-plugin/plugin.json`:

\`\`\`json
{
  "name": "stale-artifact-scan",
  "command": "bash \${CLAUDE_PLUGIN_ROOT}/scripts/bash/detect-stale-artifacts.sh",
  "description": "Detect ArcKit artifacts with overdue reviews or long-unchanged drafts",
  "when": "always"
}
\`\`\`

The scanner (\`arckit-claude/scripts/bash/detect-stale-artifacts.sh\`) runs at session start in repos that have a \`projects/\` directory. It reads Document Control fields from each ARC-*.md and reports:

- **Overdue reviews** — \`Next Review Date\` is before today
- **Stuck drafts** — \`Status: DRAFT\` and \`Last Modified\` is 14+ days old

Output is capped at 10 lines per session plus a pointer to \`/arckit.health\`. Non-ArcKit repos exit silently.

### 2. \`Monitor\` tool (Claude Code v2.1.98+) guidance

Model-driven tool; no plugin configuration needed. The autoresearch guide now documents the pattern for **overnight runs**: open a second Claude Code session, ask it to \`Monitor\` the scoring log via \`tail -F scripts/autoresearch/runs/*.log\`, and get new iteration summaries as notifications without blocking the experiment loop in the main session.

CLAUDE.md gains "Plugin Monitors" and "Monitor Tool" subsections covering both features.

## Scope limits

- Did not add \`monitors\` support to non-Claude extensions (Gemini/Codex/OpenCode/Copilot) — each has its own notification model; the scanner script is still copied by the converter and is harmless as an unused file.
- Did not modify the 10 research agents' system prompts to emit progress logs automatically. The \`Monitor\` tool is discovered by the model from natural language; pushing prompt changes for a capability the model already has would be redundant.

## Test plan

- [x] \`detect-stale-artifacts.sh\` emits expected output on a synthetic fixture with an overdue review date (verified with \`bash -x\` trace)
- [x] Scanner exits silently when no \`projects/\` directory is present
- [x] \`plugin.json\` is valid JSON
- [x] Markdown lint clean on modified docs
- [x] Converter run clean — 408 files, scanner propagated to all extension dirs
- [ ] Enable the plugin in a test repo with a stale artifact; verify \`[ArcKit monitor]\` notifications appear in the session
- [ ] Confirm the monitor does not fire in non-ArcKit repos (no noise)

## Phase 4 remaining

- \`TaskCreated\` hook for agent launch telemetry
- \`FileChanged\` / \`CwdChanged\` hooks for reactive context injection

Phase 5 (session-learner state migration to \`\${CLAUDE_PLUGIN_DATA}\`, MCP \`headersHelper\`, \`xhigh\` effort audit) remains queued.