### PR TITLE
feat(commands): Phase 3 item 1 — keep-coding-instructions on 5 long-running commands (#215)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `keep-coding-instructions: true` on 5 long-running commands (`requirements`, `research`, `sobc`, `datascout`, `framework`) — persists the command's instructions across `/compact` so Claude Code doesn't drop the template and traceability rules mid-run. Requires Claude Code v2.1.94+; the converter already strips the field for non-Claude extensions (Phase 1 work, now activated) (#215)
+
 ## [4.6.10] - 2026-04-18
 
 ### Added

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `keep-coding-instructions: true` (Claude Code v2.1.94+) on `requirements`, `research`, `sobc`, `datascout`, and `framework` commands. These long-running commands now keep their template and traceability instructions in context across `/compact`, preventing Claude from "forgetting" Document Control structure, requirement ID conventions, and citation patterns mid-run (#215)
+
 ## [4.6.10] - 2026-04-18
 
 ### Added

--- a/arckit-claude/commands/datascout.md
+++ b/arckit-claude/commands/datascout.md
@@ -3,6 +3,7 @@ description: Discover external data sources (APIs, datasets, open data portals) 
 argument-hint: "<data need, e.g. 'real-time traffic data UK', 'company financials'>"
 tags: [data, api, open-data, datasets, data-sources, discovery, uk-gov, data-integration]
 effort: max
+keep-coding-instructions: true
 handoffs:
   - command: data-model
     description: Add discovered sources to data model

--- a/arckit-claude/commands/framework.md
+++ b/arckit-claude/commands/framework.md
@@ -2,6 +2,7 @@
 description: Transform existing project artifacts into a structured, phased framework with overview and executive guide
 argument-hint: "<project ID or name, e.g. '001', 'data governance framework'>"
 effort: max
+keep-coding-instructions: true
 handoffs:
   - command: glossary
     description: Generate glossary of framework terminology

--- a/arckit-claude/commands/requirements.md
+++ b/arckit-claude/commands/requirements.md
@@ -2,6 +2,7 @@
 description: Create comprehensive business and technical requirements
 argument-hint: "<project ID or feature, e.g. '001', 'authentication module'>"
 effort: max
+keep-coding-instructions: true
 handoffs:
   - command: data-model
     description: Create data model from data requirements

--- a/arckit-claude/commands/research.md
+++ b/arckit-claude/commands/research.md
@@ -3,6 +3,7 @@ description: Research technology, services, and products to meet requirements wi
 argument-hint: "<topic, e.g. 'CRM platforms for charity', 'API management tools'>"
 tags: [research, build-vs-buy, vendor, procurement, digital-marketplace, tco, saas, open-source]
 effort: max
+keep-coding-instructions: true
 handoffs:
   - command: wardley
     description: Create Wardley Map from research evolution positioning

--- a/arckit-claude/commands/sobc.md
+++ b/arckit-claude/commands/sobc.md
@@ -2,6 +2,7 @@
 description: Create Strategic Outline Business Case (SOBC) using UK Government Green Book 5-case model
 argument-hint: "<project ID or initiative, e.g. '001', 'cloud migration programme'>"
 effort: max
+keep-coding-instructions: true
 handoffs:
   - command: requirements
     description: Define detailed requirements after SOBC approval


### PR DESCRIPTION
## Summary

Ships **Phase 3 item 1** from #215. Adds `keep-coding-instructions: true` (Claude Code v2.1.94+) to the frontmatter of the 5 commands that run long enough for \`/compact\` to drop their template and traceability instructions mid-run:

- \`requirements\`
- \`research\`
- \`sobc\`
- \`datascout\`
- \`framework\`

Behaviour: when these commands invoke and later get compacted, Claude Code preserves the command body's instructions across the compaction boundary. Previously, long \`/arckit.requirements\` runs on complex projects would lose the Document Control table structure and requirement ID conventions (BR/FR/NFR/INT/DR) and start freestyling sections.

## No converter change needed

Phase 1 (#297) already added \`keep-coding-instructions\` to the \`CLAUDE_ONLY_COMMAND_FIELDS\` strip list, so Codex / Gemini / OpenCode / Copilot / Paperclip outputs are unaffected — verified by \`grep -l keep-coding arckit-codex/prompts/*.md ...\` returning no matches post-converter-run.

## Phase 3 remaining

Items 2 (PostCompact re-injection) and 3 (PreCompact blocking) are **deferred**. \`keep-coding-instructions\` covers the biggest pain — static template/rules preservation — with zero code. The deferred items address dynamic state (active project ID, mid-flight workflow markers) which needs a marker-file convention that no command currently writes.

## Test plan

- [x] 5 target commands carry \`keep-coding-instructions: true\` (verified by \`grep -c\`)
- [x] No leaks to \`arckit-codex/prompts\`, \`arckit-opencode/commands\`, \`arckit-gemini/commands\`, \`arckit-copilot/prompts\`, \`.codex/prompts\`, \`.opencode/commands\` after \`python scripts/converter.py\`
- [x] Markdown lint clean on modified CHANGELOGs
- [ ] Run \`/arckit.requirements\` on a large synthetic project in a test repo with v2.1.112+, trigger \`/compact\` mid-run, verify the command continues with intact Document Control structure

Closes: Phase 3 item 1 in #215.