### PR TITLE
Fix: add missing title and type fields to userConfig entries

### DIFF
--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -19,21 +19,34 @@
   ],
   "userConfig": {
     "GOOGLE_API_KEY": {
+      "title": "Google API Key",
       "description": "Google API key for the google-developer-knowledge MCP server (optional — leave blank to disable)",
+      "type": "string",
       "sensitive": true
     },
     "DATA_COMMONS_API_KEY": {
+      "title": "Data Commons API Key",
       "description": "Data Commons API key for the datacommons-mcp MCP server (optional — leave blank to disable)",
+      "type": "string",
       "sensitive": true
     },
     "organisation_name": {
-      "description": "Organisation name used in generated Document Control headers (e.g. 'Acme Ltd' or 'HM Revenue & Customs')"
+      "title": "Organisation Name",
+      "description": "Organisation name used in generated Document Control headers (e.g. 'Acme Ltd' or 'HM Revenue & Customs')",
+      "type": "string",
+      "sensitive": false
     },
     "default_classification": {
-      "description": "Default document classification: PUBLIC, OFFICIAL, OFFICIAL-SENSITIVE, or SECRET"
+      "title": "Default Classification",
+      "description": "Default document classification: PUBLIC, OFFICIAL, OFFICIAL-SENSITIVE, or SECRET",
+      "type": "string",
+      "sensitive": false
     },
     "governance_framework": {
-      "description": "Default governance framework: 'UK Gov' for Service Standard/TCoP/NCSC CAF, or 'Generic' for non-government"
+      "title": "Governance Framework",
+      "description": "Default governance framework: 'UK Gov' for Service Standard/TCoP/NCSC CAF, or 'Generic' for non-government",
+      "type": "string",
+      "sensitive": false
     }
   }
 }


### PR DESCRIPTION
## Problem

Installing ArcKit fails with a manifest validation error on Claude Code 2.1.114:

## Log
Error: Failed to install: Plugin has an invalid manifest file at .claude-plugin/plugin.json.
Validation errors:
userConfig.GOOGLE_API_KEY.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"
userConfig.GOOGLE_API_KEY.title: Invalid input: expected string, received undefined
userConfig.DATA_COMMONS_API_KEY.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"
userConfig.DATA_COMMONS_API_KEY.title: Invalid input: expected string, received undefined
userConfig.organisation_name.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"
userConfig.organisation_name.title: Invalid input: expected string, received undefined
userConfig.default_classification.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"
userConfig.default_classification.title: Invalid input: expected string, received undefined
userConfig.governance_framework.type: Invalid option: expected one of "string"|"number"|"boolean"|"directory"|"file"
userConfig.governance_framework.title: Invalid input: expected string, received undefined

## Root cause

The current `userConfig` entries only define `description` (and `sensitive` for the API keys). The Claude Code manifest validator now requires both `title` (string) and `type` (one of `"string"`, `"number"`, `"boolean"`, `"directory"`, `"file"`) on every `userConfig` entry.

## Fix

Replace the `userConfig` block in `.claude-plugin/plugin.json` with:

```json
  "userConfig": {
    "GOOGLE_API_KEY": {
      "title": "Google API Key",
      "description": "Google API key for the google-developer-knowledge MCP server (optional — leave blank to disable)",
      "type": "string",
      "sensitive": true
    },
    "DATA_COMMONS_API_KEY": {
      "title": "Data Commons API Key",
      "description": "Data Commons API key for the datacommons-mcp MCP server (optional — leave blank to disable)",
      "type": "string",
      "sensitive": true
    },
    "organisation_name": {
      "title": "Organisation Name",
      "description": "Organisation name used in generated Document Control headers (e.g. 'Acme Ltd' or 'HM Revenue & Customs')",
      "type": "string",
      "sensitive": false
    },
    "default_classification": {
      "title": "Default Classification",
      "description": "Default document classification: PUBLIC, OFFICIAL, OFFICIAL-SENSITIVE, or SECRET",
      "type": "string",
      "sensitive": false
    },
    "governance_framework": {
      "title": "Governance Framework",
      "description": "Default governance framework: 'UK Gov' for Service Standard/TCoP/NCSC CAF, or 'Generic' for non-government",
      "type": "string",
      "sensitive": false
    }
  }
```

## Environment

- Claude Code: 2.1.114
- OS: Debian Bookworm AMD64
- ArcKit version: 4.6.11