### PR TITLE
fix(plugin): stale-artifact monitor exits 1 in real repos

### DIFF
--- a/arckit-claude/scripts/bash/detect-stale-artifacts.sh
+++ b/arckit-claude/scripts/bash/detect-stale-artifacts.sh
@@ -15,10 +15,6 @@
 
 set -u
 
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-# shellcheck source=./common.sh
-source "$SCRIPT_DIR/common.sh" 2>/dev/null || true
-
 cwd="$(pwd)"
 if [[ ! -d "$cwd/projects" ]]; then
   exit 0
@@ -39,11 +35,14 @@ fi
 while IFS= read -r -d '' file; do
   [[ $stale_count -ge $max_report ]] && break
 
-  # Pull Document Control table fields
+  # Pull Document Control table fields. Anchor Status to a row whose label is
+  # exactly "Status" (with optional **markdown bold**) so we don't match
+  # entity-attribute tables further down the file.
   next_review="$(grep -m1 -i "Next Review Date" "$file" 2>/dev/null \
     | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"
-  status="$(grep -m1 -i "^| *Status" "$file" 2>/dev/null \
-    | sed -E 's/.*\| *(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED).*/\1/i' \
+  status="$(grep -m1 -iE '^\| *\*{0,2} *Status *\*{0,2} *\|' "$file" 2>/dev/null \
+    | grep -oiE '(DRAFT|IN_REVIEW|APPROVED|PUBLISHED|SUPERSEDED|ARCHIVED)' \
+    | head -1 \
     | tr '[:lower:]' '[:upper:]')"
   last_modified="$(grep -m1 -i "Last Modified" "$file" 2>/dev/null \
     | sed -E 's/.*\| *([0-9]{4}-[0-9]{2}-[0-9]{2}).*/\1/')"


### PR DESCRIPTION
## Summary

Two bundled fixes for `arckit-claude/scripts/bash/detect-stale-artifacts.sh`. Reported failure: `Monitor "Detect ArcKit artifacts with overdue reviews or long-unchanged drafts" script failed (exit 1)` against `tractorjuice/arckit-test-project-v2-hmrc-chatbot`.

### 1. Drop unused `source common.sh` (root cause of exit 1)

`common.sh` runs `set -euo pipefail` at top level. Sourcing it leaks `errexit + pipefail` into the monitor. Any `grep | sed | tr` pipeline whose `grep` returns no match (exit 1) then aborts the script mid-loop via the assignment `status=$(...)`. The monitor never references anything from `common.sh`, so the 3-line `SCRIPT_DIR` + source block is dead code.

### 2. Robust Document Control `Status` grep

Previous pattern `^| *Status` did not match the bolded Document Control row `| **Status** |` and instead matched the first unbolded `| status |` line further down the file — typically a row in a data-requirements entity-attribute table. The captured "status" was then a garbage string that silently disabled the DRAFT-staleness check on every artifact.

New pattern anchors to `^| *\*\*?Status\*\*? *|` and extracts the first valid status enum word from the matched line.

## Reproduction (against v2 test repo)

**Before:**
```
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/ARC-001-REQ-v1.0.md — review overdue since 2026-02-26
exit=1
```

**After:**
```
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/ARC-001-REQ-v1.0.md — review overdue since 2026-02-26
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/research/ARC-001-AWRS-v1.0.md — DRAFT unchanged since 2026-02-07
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/ARC-001-SOW-v1.0.md — DRAFT unchanged since 2026-01-26
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/ARC-001-TRAC-v1.0.md — review overdue since 2026-02-26
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/ARC-001-STKE-v1.0.md — DRAFT unchanged since 2026-02-03
[ArcKit monitor] STALE: projects/001-hmrc-chatbot/ARC-001-ATRS-v1.0.md — DRAFT unchanged since 2026-01-26
[ArcKit monitor] STALE: projects/000-global/ARC-000-PRIN-v1.0.md — DRAFT unchanged since 2026-01-26
[ArcKit monitor] Found 7 stale artifact(s). Run /arckit.health for details.
exit=0
```

The DRAFT-unchanged lines are net-new — fix #2 surfacing artifacts that were always being silently skipped.

## Test plan

- [x] Reproduce exit 1 in `arckit-test-project-v2-hmrc-chatbot` clone
- [x] Apply patch, confirm exit 0 and full artifact iteration
- [x] Confirm silent exit 0 in a non-ArcKit repo (no `projects/` dir)
- [ ] Reviewer: enable plugin in any active ArcKit project repo, confirm monitor surfaces stale artifacts at session start

🤖 Generated with [Claude Code](https://claude.com/claude-code)