### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Bundled **Exa MCP server** (`https://mcp.exa.ai/mcp`) in the Claude Code, Gemini CLI, and OpenCode configs. Exposes `web_search_exa`, `web_fetch_exa`, and `web_search_advanced_exa` for general web search and URL-to-markdown retrieval — useful for vendor discovery, market research, regulatory/news context for business cases, and any topic not covered by the cloud-vendor docs servers. Works out of the box on the free tier; new optional `EXA_API_KEY` userConfig entry lifts free-tier rate limits.
+
 ## [4.6.13] - 2026-04-19
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 68 commands, 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 68 commands, 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape, Exa), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.112?** This version unlocks the `xhigh` effort tier on Claude Opus 4.7 (used by ArcKit's deep-research agents and synthesis commands), enables Auto mode without `--enable-auto-mode`, restores Opus 4.7 availability for Auto mode, and ships read-only bash glob patterns without permission prompts (reduces friction for ArcKit helper scripts). It also carries forward the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 
@@ -51,7 +51,7 @@ Then install from the Discover tab. Claude Code is the **primary development pla
 gemini extensions install https://github.com/tractorjuice/arckit-gemini
 ```
 
-Zero-config: all 68 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn). Updates via `gemini extensions update arckit`.
+Zero-config: all 68 commands, templates, scripts, and bundled MCP servers (AWS Knowledge, Microsoft Learn, Exa). Updates via `gemini extensions update arckit`.
 
 **GitHub Copilot** (VS Code) — install the ArcKit CLI and scaffold prompt files:
 
@@ -810,7 +810,7 @@ Claude Code is the **primary development platform** for ArcKit and provides capa
 |---------|:-----------:|:----------:|:-------:|:----------------:|
 | 68 slash commands | ✅ | ✅ | ✅ | ✅ |
 | Templates & scripts | ✅ | ✅ | ✅ | ✅ |
-| Bundled MCP servers (AWS, Azure, GCP, DataCommons, govreposcrape) | ✅ | ✅ (3 servers) | — | Manual setup |
+| Bundled MCP servers (AWS, Azure, GCP, DataCommons, govreposcrape, Exa) | ✅ | ✅ (3 servers) | — | Manual setup (OpenCode includes Exa) |
 | **Autonomous research agents** (10 agents for research, datascout, cloud research, gov code discovery, grants, framework) | ✅ | — | ✅ (10 agents) | — |
 | **SessionStart hook** (auto-detect version + projects) | ✅ | — | — | — |
 | **UserPromptSubmit hook** (project context injection on every prompt) | ✅ | — | — | — |

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -30,6 +30,12 @@
       "type": "string",
       "sensitive": true
     },
+    "EXA_API_KEY": {
+      "title": "Exa API Key",
+      "description": "Exa API key for the exa MCP server — general web search for vendor/market research (optional — leave blank to use the free tier with rate limits)",
+      "type": "string",
+      "sensitive": true
+    },
     "organisation_name": {
       "title": "Organisation Name",
       "description": "Organisation name used in generated Document Control headers (e.g. 'Acme Ltd' or 'HM Revenue & Customs')",

--- a/arckit-claude/.mcp.json
+++ b/arckit-claude/.mcp.json
@@ -25,6 +25,13 @@
     "govreposcrape": {
       "type": "http",
       "url": "https://govreposcrape-api-1060386346356.us-central1.run.app/mcp"
+    },
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${user_config.EXA_API_KEY}"
+      }
     }
   }
 }

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Bundled **Exa MCP server** (`https://mcp.exa.ai/mcp`) in `arckit-claude/.mcp.json`. Exposes `web_search_exa`, `web_fetch_exa`, and `web_search_advanced_exa` for general web search and URL-to-markdown retrieval. Works out of the box on the free tier; new `EXA_API_KEY` entry added to `userConfig` in `plugin.json` to lift rate limits when configured.
+
 ## [4.6.13] - 2026-04-19
 
 ### Fixed

--- a/arckit-codex/docs/guides/mcp-servers.md
+++ b/arckit-codex/docs/guides/mcp-servers.md
@@ -85,9 +85,9 @@ To have the plugin auto-enable for anyone who opens your repo, add `.claude/sett
 
 ## MCP Servers
 
-ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud research, plus support for optional third-party MCPs like Pinecone.
+ArcKit includes 5 bundled MCP (Model Context Protocol) servers for cloud research, general web research, and public data, plus support for optional third-party MCPs like Pinecone.
 
-> **Two servers work out of the box** (AWS Knowledge, Microsoft Learn). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**.
+> **Three servers work out of the box** (AWS Knowledge, Microsoft Learn, Exa). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**. Exa also accepts an optional `EXA_API_KEY` to lift free-tier rate limits.
 
 ---
 
@@ -97,6 +97,7 @@ ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud researc
 |------------|---------|---------|--------|
 | AWS Knowledge | Not required | `/arckit:aws-research` | Works out of the box |
 | Microsoft Learn | Not required | `/arckit:azure-research` | Works out of the box |
+| Exa | `EXA_API_KEY` (optional) | General web search for vendor/market research | Works out of the box |
 | Google Developer Knowledge | `GOOGLE_API_KEY` | `/arckit:gcp-research` | Requires setup |
 | Data Commons | `DATA_COMMONS_API_KEY` | Data statistics lookups | Requires setup |
 
@@ -121,6 +122,26 @@ Provides access to official Microsoft and Azure documentation, code samples, and
 - **Commands**: `/arckit:azure-research`
 - **Tools**: `microsoft_docs_search`, `microsoft_code_sample_search`, `microsoft_docs_fetch`
 - **Setup**: None — works immediately after plugin installation
+
+### Exa
+
+Provides general web search and URL-to-markdown retrieval for topics that the cloud-vendor docs servers don't cover: vendor discovery, market research, regulatory/news context for business cases, and ad-hoc citations. Useful alongside `/arckit:research`, `/arckit:sobc`, `/arckit:evaluate`, and the `arckit-datascout` agent.
+
+- **Type**: HTTP (remote endpoint) — `https://mcp.exa.ai/mcp`
+- **Tools**: `web_search_exa` (clean, ready-to-use search results), `web_fetch_exa` (fetch one or more URLs as markdown), `web_search_advanced_exa` (filters for domain, date range, highlights, subpage crawling)
+- **Setup**: None for the free tier — works immediately after plugin installation
+
+**Optional — lift free-tier rate limits**:
+
+1. Create a key at [dashboard.exa.ai](https://dashboard.exa.ai/api-keys)
+2. Set the environment variable:
+
+```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+export EXA_API_KEY="your-api-key-here"
+```
+
+3. Restart Claude Code
 
 ---
 
@@ -177,7 +198,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected. You may also see the Exa server work without `EXA_API_KEY` on its free tier — set the key if you hit rate limits.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 
@@ -231,6 +252,13 @@ The plugin's bundled MCP configuration (`.mcp.json`):
       "url": "https://api.datacommons.org/mcp",
       "headers": {
         "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
+    },
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
       }
     }
   }
@@ -295,6 +323,7 @@ For detailed workflows and real-world examples, see the [Architecture Productivi
 - [Microsoft Learn MCP](https://learn.microsoft.com/api/mcp) — Azure documentation server
 - [Google Developer Knowledge MCP](https://developerknowledge.googleapis.com/mcp) — Google Cloud documentation server
 - [Data Commons](https://datacommons.org) — Public statistical data
+- [Exa MCP](https://exa.ai/docs/reference/exa-mcp) — General web search and page retrieval
 - [Model Context Protocol](https://modelcontextprotocol.io/) — MCP specification
 - [Anthropic Skills](https://github.com/anthropics/skills) — Document skills (PDF, DOCX, PPTX, XLSX)
 - [Claude Plugins Directory](https://claude.com/plugins) — Browse all available plugins

--- a/arckit-copilot/docs/guides/mcp-servers.md
+++ b/arckit-copilot/docs/guides/mcp-servers.md
@@ -85,9 +85,9 @@ To have the plugin auto-enable for anyone who opens your repo, add `.claude/sett
 
 ## MCP Servers
 
-ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud research, plus support for optional third-party MCPs like Pinecone.
+ArcKit includes 5 bundled MCP (Model Context Protocol) servers for cloud research, general web research, and public data, plus support for optional third-party MCPs like Pinecone.
 
-> **Two servers work out of the box** (AWS Knowledge, Microsoft Learn). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**.
+> **Three servers work out of the box** (AWS Knowledge, Microsoft Learn, Exa). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**. Exa also accepts an optional `EXA_API_KEY` to lift free-tier rate limits.
 
 ---
 
@@ -97,6 +97,7 @@ ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud researc
 |------------|---------|---------|--------|
 | AWS Knowledge | Not required | `/arckit:aws-research` | Works out of the box |
 | Microsoft Learn | Not required | `/arckit:azure-research` | Works out of the box |
+| Exa | `EXA_API_KEY` (optional) | General web search for vendor/market research | Works out of the box |
 | Google Developer Knowledge | `GOOGLE_API_KEY` | `/arckit:gcp-research` | Requires setup |
 | Data Commons | `DATA_COMMONS_API_KEY` | Data statistics lookups | Requires setup |
 
@@ -121,6 +122,26 @@ Provides access to official Microsoft and Azure documentation, code samples, and
 - **Commands**: `/arckit:azure-research`
 - **Tools**: `microsoft_docs_search`, `microsoft_code_sample_search`, `microsoft_docs_fetch`
 - **Setup**: None — works immediately after plugin installation
+
+### Exa
+
+Provides general web search and URL-to-markdown retrieval for topics that the cloud-vendor docs servers don't cover: vendor discovery, market research, regulatory/news context for business cases, and ad-hoc citations. Useful alongside `/arckit:research`, `/arckit:sobc`, `/arckit:evaluate`, and the `arckit-datascout` agent.
+
+- **Type**: HTTP (remote endpoint) — `https://mcp.exa.ai/mcp`
+- **Tools**: `web_search_exa` (clean, ready-to-use search results), `web_fetch_exa` (fetch one or more URLs as markdown), `web_search_advanced_exa` (filters for domain, date range, highlights, subpage crawling)
+- **Setup**: None for the free tier — works immediately after plugin installation
+
+**Optional — lift free-tier rate limits**:
+
+1. Create a key at [dashboard.exa.ai](https://dashboard.exa.ai/api-keys)
+2. Set the environment variable:
+
+```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+export EXA_API_KEY="your-api-key-here"
+```
+
+3. Restart Claude Code
 
 ---
 
@@ -177,7 +198,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected. You may also see the Exa server work without `EXA_API_KEY` on its free tier — set the key if you hit rate limits.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 
@@ -231,6 +252,13 @@ The plugin's bundled MCP configuration (`.mcp.json`):
       "url": "https://api.datacommons.org/mcp",
       "headers": {
         "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
+    },
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
       }
     }
   }
@@ -295,6 +323,7 @@ For detailed workflows and real-world examples, see the [Architecture Productivi
 - [Microsoft Learn MCP](https://learn.microsoft.com/api/mcp) — Azure documentation server
 - [Google Developer Knowledge MCP](https://developerknowledge.googleapis.com/mcp) — Google Cloud documentation server
 - [Data Commons](https://datacommons.org) — Public statistical data
+- [Exa MCP](https://exa.ai/docs/reference/exa-mcp) — General web search and page retrieval
 - [Model Context Protocol](https://modelcontextprotocol.io/) — MCP specification
 - [Anthropic Skills](https://github.com/anthropics/skills) — Document skills (PDF, DOCX, PPTX, XLSX)
 - [Claude Plugins Directory](https://claude.com/plugins) — Browse all available plugins

--- a/arckit-gemini/gemini-extension.json
+++ b/arckit-gemini/gemini-extension.json
@@ -24,6 +24,12 @@
     },
     "govreposcrape": {
       "httpUrl": "https://govreposcrape-api-1060386346356.us-central1.run.app/mcp"
+    },
+    "exa": {
+      "httpUrl": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
+      }
     }
   },
   "themes": [

--- a/arckit-opencode/docs/guides/mcp-servers.md
+++ b/arckit-opencode/docs/guides/mcp-servers.md
@@ -85,9 +85,9 @@ To have the plugin auto-enable for anyone who opens your repo, add `.claude/sett
 
 ## MCP Servers
 
-ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud research, plus support for optional third-party MCPs like Pinecone.
+ArcKit includes 5 bundled MCP (Model Context Protocol) servers for cloud research, general web research, and public data, plus support for optional third-party MCPs like Pinecone.
 
-> **Two servers work out of the box** (AWS Knowledge, Microsoft Learn). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**.
+> **Three servers work out of the box** (AWS Knowledge, Microsoft Learn, Exa). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**. Exa also accepts an optional `EXA_API_KEY` to lift free-tier rate limits.
 
 ---
 
@@ -97,6 +97,7 @@ ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud researc
 |------------|---------|---------|--------|
 | AWS Knowledge | Not required | `/arckit:aws-research` | Works out of the box |
 | Microsoft Learn | Not required | `/arckit:azure-research` | Works out of the box |
+| Exa | `EXA_API_KEY` (optional) | General web search for vendor/market research | Works out of the box |
 | Google Developer Knowledge | `GOOGLE_API_KEY` | `/arckit:gcp-research` | Requires setup |
 | Data Commons | `DATA_COMMONS_API_KEY` | Data statistics lookups | Requires setup |
 
@@ -121,6 +122,26 @@ Provides access to official Microsoft and Azure documentation, code samples, and
 - **Commands**: `/arckit:azure-research`
 - **Tools**: `microsoft_docs_search`, `microsoft_code_sample_search`, `microsoft_docs_fetch`
 - **Setup**: None — works immediately after plugin installation
+
+### Exa
+
+Provides general web search and URL-to-markdown retrieval for topics that the cloud-vendor docs servers don't cover: vendor discovery, market research, regulatory/news context for business cases, and ad-hoc citations. Useful alongside `/arckit:research`, `/arckit:sobc`, `/arckit:evaluate`, and the `arckit-datascout` agent.
+
+- **Type**: HTTP (remote endpoint) — `https://mcp.exa.ai/mcp`
+- **Tools**: `web_search_exa` (clean, ready-to-use search results), `web_fetch_exa` (fetch one or more URLs as markdown), `web_search_advanced_exa` (filters for domain, date range, highlights, subpage crawling)
+- **Setup**: None for the free tier — works immediately after plugin installation
+
+**Optional — lift free-tier rate limits**:
+
+1. Create a key at [dashboard.exa.ai](https://dashboard.exa.ai/api-keys)
+2. Set the environment variable:
+
+```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+export EXA_API_KEY="your-api-key-here"
+```
+
+3. Restart Claude Code
 
 ---
 
@@ -177,7 +198,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected. You may also see the Exa server work without `EXA_API_KEY` on its free tier — set the key if you hit rate limits.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 
@@ -231,6 +252,13 @@ The plugin's bundled MCP configuration (`.mcp.json`):
       "url": "https://api.datacommons.org/mcp",
       "headers": {
         "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
+    },
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
       }
     }
   }
@@ -295,6 +323,7 @@ For detailed workflows and real-world examples, see the [Architecture Productivi
 - [Microsoft Learn MCP](https://learn.microsoft.com/api/mcp) — Azure documentation server
 - [Google Developer Knowledge MCP](https://developerknowledge.googleapis.com/mcp) — Google Cloud documentation server
 - [Data Commons](https://datacommons.org) — Public statistical data
+- [Exa MCP](https://exa.ai/docs/reference/exa-mcp) — General web search and page retrieval
 - [Model Context Protocol](https://modelcontextprotocol.io/) — MCP specification
 - [Anthropic Skills](https://github.com/anthropics/skills) — Document skills (PDF, DOCX, PPTX, XLSX)
 - [Claude Plugins Directory](https://claude.com/plugins) — Browse all available plugins

--- a/arckit-opencode/opencode.json
+++ b/arckit-opencode/opencode.json
@@ -18,6 +18,14 @@
         "X-Goog-Api-Key": "${GOOGLE_API_KEY}"
       },
       "enabled": false
+    },
+    "exa": {
+      "type": "remote",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
+      },
+      "enabled": true
     }
   }
 }

--- a/arckit-paperclip/docs/guides/mcp-servers.md
+++ b/arckit-paperclip/docs/guides/mcp-servers.md
@@ -85,9 +85,9 @@ To have the plugin auto-enable for anyone who opens your repo, add `.claude/sett
 
 ## MCP Servers
 
-ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud research, plus support for optional third-party MCPs like Pinecone.
+ArcKit includes 5 bundled MCP (Model Context Protocol) servers for cloud research, general web research, and public data, plus support for optional third-party MCPs like Pinecone.
 
-> **Two servers work out of the box** (AWS Knowledge, Microsoft Learn). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**.
+> **Three servers work out of the box** (AWS Knowledge, Microsoft Learn, Exa). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**. Exa also accepts an optional `EXA_API_KEY` to lift free-tier rate limits.
 
 ---
 
@@ -97,6 +97,7 @@ ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud researc
 |------------|---------|---------|--------|
 | AWS Knowledge | Not required | `/arckit:aws-research` | Works out of the box |
 | Microsoft Learn | Not required | `/arckit:azure-research` | Works out of the box |
+| Exa | `EXA_API_KEY` (optional) | General web search for vendor/market research | Works out of the box |
 | Google Developer Knowledge | `GOOGLE_API_KEY` | `/arckit:gcp-research` | Requires setup |
 | Data Commons | `DATA_COMMONS_API_KEY` | Data statistics lookups | Requires setup |
 
@@ -121,6 +122,26 @@ Provides access to official Microsoft and Azure documentation, code samples, and
 - **Commands**: `/arckit:azure-research`
 - **Tools**: `microsoft_docs_search`, `microsoft_code_sample_search`, `microsoft_docs_fetch`
 - **Setup**: None — works immediately after plugin installation
+
+### Exa
+
+Provides general web search and URL-to-markdown retrieval for topics that the cloud-vendor docs servers don't cover: vendor discovery, market research, regulatory/news context for business cases, and ad-hoc citations. Useful alongside `/arckit:research`, `/arckit:sobc`, `/arckit:evaluate`, and the `arckit-datascout` agent.
+
+- **Type**: HTTP (remote endpoint) — `https://mcp.exa.ai/mcp`
+- **Tools**: `web_search_exa` (clean, ready-to-use search results), `web_fetch_exa` (fetch one or more URLs as markdown), `web_search_advanced_exa` (filters for domain, date range, highlights, subpage crawling)
+- **Setup**: None for the free tier — works immediately after plugin installation
+
+**Optional — lift free-tier rate limits**:
+
+1. Create a key at [dashboard.exa.ai](https://dashboard.exa.ai/api-keys)
+2. Set the environment variable:
+
+```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+export EXA_API_KEY="your-api-key-here"
+```
+
+3. Restart Claude Code
 
 ---
 
@@ -177,7 +198,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected. You may also see the Exa server work without `EXA_API_KEY` on its free tier — set the key if you hit rate limits.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 
@@ -231,6 +252,13 @@ The plugin's bundled MCP configuration (`.mcp.json`):
       "url": "https://api.datacommons.org/mcp",
       "headers": {
         "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
+    },
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
       }
     }
   }
@@ -295,6 +323,7 @@ For detailed workflows and real-world examples, see the [Architecture Productivi
 - [Microsoft Learn MCP](https://learn.microsoft.com/api/mcp) — Azure documentation server
 - [Google Developer Knowledge MCP](https://developerknowledge.googleapis.com/mcp) — Google Cloud documentation server
 - [Data Commons](https://datacommons.org) — Public statistical data
+- [Exa MCP](https://exa.ai/docs/reference/exa-mcp) — General web search and page retrieval
 - [Model Context Protocol](https://modelcontextprotocol.io/) — MCP specification
 - [Anthropic Skills](https://github.com/anthropics/skills) — Document skills (PDF, DOCX, PPTX, XLSX)
 - [Claude Plugins Directory](https://claude.com/plugins) — Browse all available plugins

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -85,9 +85,9 @@ To have the plugin auto-enable for anyone who opens your repo, add `.claude/sett
 
 ## MCP Servers
 
-ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud research, plus support for optional third-party MCPs like Pinecone.
+ArcKit includes 5 bundled MCP (Model Context Protocol) servers for cloud research, general web research, and public data, plus support for optional third-party MCPs like Pinecone.
 
-> **Two servers work out of the box** (AWS Knowledge, Microsoft Learn). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**.
+> **Three servers work out of the box** (AWS Knowledge, Microsoft Learn, Exa). The other two require free API keys (Google Developer Knowledge, Data Commons). If you don't configure the API keys, you'll see errors in the plugin UI — **these are harmless and all other commands work normally**. Exa also accepts an optional `EXA_API_KEY` to lift free-tier rate limits.
 
 ---
 
@@ -97,6 +97,7 @@ ArcKit includes 4 bundled MCP (Model Context Protocol) servers for cloud researc
 |------------|---------|---------|--------|
 | AWS Knowledge | Not required | `/arckit:aws-research` | Works out of the box |
 | Microsoft Learn | Not required | `/arckit:azure-research` | Works out of the box |
+| Exa | `EXA_API_KEY` (optional) | General web search for vendor/market research | Works out of the box |
 | Google Developer Knowledge | `GOOGLE_API_KEY` | `/arckit:gcp-research` | Requires setup |
 | Data Commons | `DATA_COMMONS_API_KEY` | Data statistics lookups | Requires setup |
 
@@ -121,6 +122,26 @@ Provides access to official Microsoft and Azure documentation, code samples, and
 - **Commands**: `/arckit:azure-research`
 - **Tools**: `microsoft_docs_search`, `microsoft_code_sample_search`, `microsoft_docs_fetch`
 - **Setup**: None — works immediately after plugin installation
+
+### Exa
+
+Provides general web search and URL-to-markdown retrieval for topics that the cloud-vendor docs servers don't cover: vendor discovery, market research, regulatory/news context for business cases, and ad-hoc citations. Useful alongside `/arckit:research`, `/arckit:sobc`, `/arckit:evaluate`, and the `arckit-datascout` agent.
+
+- **Type**: HTTP (remote endpoint) — `https://mcp.exa.ai/mcp`
+- **Tools**: `web_search_exa` (clean, ready-to-use search results), `web_fetch_exa` (fetch one or more URLs as markdown), `web_search_advanced_exa` (filters for domain, date range, highlights, subpage crawling)
+- **Setup**: None for the free tier — works immediately after plugin installation
+
+**Optional — lift free-tier rate limits**:
+
+1. Create a key at [dashboard.exa.ai](https://dashboard.exa.ai/api-keys)
+2. Set the environment variable:
+
+```bash
+# Add to your shell profile (~/.bashrc, ~/.zshrc, etc.)
+export EXA_API_KEY="your-api-key-here"
+```
+
+3. Restart Claude Code
 
 ---
 
@@ -177,7 +198,7 @@ Invalid MCP server config for 'google-developer-knowledge': Missing environment 
 Invalid MCP server config for 'datacommons-mcp': Missing environment variables: DATA_COMMONS_API_KEY
 ```
 
-**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected.
+**These errors are harmless.** They mean you haven't configured the optional API keys. All 68 commands, 10 agents, hooks, and skills work without them. Only `/arckit:gcp-research` and Data Commons lookups are affected. You may also see the Exa server work without `EXA_API_KEY` on its free tier — set the key if you hit rate limits.
 
 **To fix**: Set the environment variables as described above and restart Claude Code.
 
@@ -231,6 +252,13 @@ The plugin's bundled MCP configuration (`.mcp.json`):
       "url": "https://api.datacommons.org/mcp",
       "headers": {
         "X-API-Key": "${DATA_COMMONS_API_KEY}"
+      }
+    },
+    "exa": {
+      "type": "http",
+      "url": "https://mcp.exa.ai/mcp",
+      "headers": {
+        "x-api-key": "${EXA_API_KEY}"
       }
     }
   }
@@ -295,6 +323,7 @@ For detailed workflows and real-world examples, see the [Architecture Productivi
 - [Microsoft Learn MCP](https://learn.microsoft.com/api/mcp) — Azure documentation server
 - [Google Developer Knowledge MCP](https://developerknowledge.googleapis.com/mcp) — Google Cloud documentation server
 - [Data Commons](https://datacommons.org) — Public statistical data
+- [Exa MCP](https://exa.ai/docs/reference/exa-mcp) — General web search and page retrieval
 - [Model Context Protocol](https://modelcontextprotocol.io/) — MCP specification
 - [Anthropic Skills](https://github.com/anthropics/skills) — Document skills (PDF, DOCX, PPTX, XLSX)
 - [Claude Plugins Directory](https://claude.com/plugins) — Browse all available plugins


### PR DESCRIPTION
## Summary

- Bundles the hosted **Exa MCP server** (`https://mcp.exa.ai/mcp`) in the Claude Code, Gemini CLI, and OpenCode configs, alongside the existing AWS Knowledge, Microsoft Learn, Google Developer Knowledge, Data Commons, and govreposcrape servers.
- Exposes three tools to ArcKit commands and agents: `web_search_exa` (clean, ready-to-use search results), `web_fetch_exa` (URL-to-markdown retrieval), `web_search_advanced_exa` (domain / date-range / highlight / subpage filters).
- Fills the gap the current bundle has for topics the cloud-vendor docs servers don't cover — vendor discovery, market research, regulatory/news context for SOBCs, and ad-hoc citations for research commands and the `arckit-datascout` agent.
- Works out of the box on Exa's free tier; new optional `EXA_API_KEY` entry in `plugin.json` `userConfig` lifts rate limits when set.

## Usage

Once installed, the three Exa tools are available to any ArcKit command/agent that consumes MCP. Examples:

- `web_search_exa(query: "UK public-sector CRM vendors 2025", num_results: 10)` — quick search for vendor/market research
- `web_fetch_exa(urls: ["https://example.com/whitepaper"])` — fetch a supplier whitepaper as markdown for citation extraction
- `web_search_advanced_exa(query: "...", include_domains: ["gov.uk"], start_published_date: "2024-01-01")` — scoped, date-filtered search for regulatory context

With the optional key:

```bash
# ~/.bashrc or ~/.zshrc
export EXA_API_KEY="your-key-from-dashboard.exa.ai"
```

Claude Code users can also set the key via the plugin's `userConfig` UI; the `.mcp.json` resolves `${user_config.EXA_API_KEY}` automatically.

## Files Changed

- `arckit-claude/.mcp.json` — register `exa` with `x-api-key` header
- `arckit-gemini/gemini-extension.json` — register `exa`
- `arckit-opencode/opencode.json` — register `exa` (`enabled: true`)
- `arckit-claude/.claude-plugin/plugin.json` — add `EXA_API_KEY` to `userConfig`
- `docs/guides/mcp-servers.md` + copies under `arckit-opencode`, `arckit-codex`, `arckit-copilot`, `arckit-paperclip` — document the server, its tools, and optional key setup
- `README.md` — list Exa in the two bundled-MCP summary lines and the "Why Claude Code?" comparison row
- `CHANGELOG.md` + `arckit-claude/CHANGELOG.md` — `[Unreleased]` entries

## Test plan

- [x] All edited JSON files parse (`python3 -m json.tool` clean on all 5)
- [x] `markdownlint-cli2` passes on all edited `.md` files (matches the repo's existing `lint-markdown.yml` workflow)
- [ ] Manual smoke test: install the plugin locally, confirm `exa` server shows up in `/plugin` and that `web_search_exa` returns results without a key
- [ ] Manual smoke test: set `EXA_API_KEY`, restart, confirm no error and that advanced features work