### PR TITLE
fix(extensions): propagate .guide-status.community CSS to pages-template.html

### DIFF
--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -1028,6 +1028,12 @@
             color: var(--text-inverse);
         }
 
+        .guide-status.community {
+            background: #f3f2f1;
+            color: #383f43;
+            border: 1px solid #b1b4b6;
+        }
+
         /* Mermaid Diagrams - Full Width */
         .app-markdown .mermaid {
             background: var(--bg-surface);

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -1028,6 +1028,12 @@
             color: var(--text-inverse);
         }
 
+        .guide-status.community {
+            background: #f3f2f1;
+            color: #383f43;
+            border: 1px solid #b1b4b6;
+        }
+
         /* Mermaid Diagrams - Full Width */
         .app-markdown .mermaid {
             background: var(--bg-surface);

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -1028,6 +1028,12 @@
             color: var(--text-inverse);
         }
 
+        .guide-status.community {
+            background: #f3f2f1;
+            color: #383f43;
+            border: 1px solid #b1b4b6;
+        }
+
         /* Mermaid Diagrams - Full Width */
         .app-markdown .mermaid {
             background: var(--bg-surface);

--- a/arckit-paperclip/templates/pages-template.html
+++ b/arckit-paperclip/templates/pages-template.html
@@ -1028,6 +1028,12 @@
             color: var(--text-inverse);
         }
 
+        .guide-status.community {
+            background: #f3f2f1;
+            color: #383f43;
+            border: 1px solid #b1b4b6;
+        }
+
         /* Mermaid Diagrams - Full Width */
         .app-markdown .mermaid {
             background: var(--bg-surface);


### PR DESCRIPTION
## Summary

The `.guide-status.community` CSS class added to `arckit-claude/templates/pages-template.html` in 2f3ae2e9 (sync-guides hook for 18 EU/FR community guides) was never propagated to the four extension copies. Re-runs `scripts/converter.py` to sync.

Surfaced during review of #322 — not that PR's responsibility, breaking out as a follow-up.

## Test plan

- [x] `python scripts/converter.py` → identical 6-line CSS addition in all 4 extension templates
- [x] `python -m pytest tests/ -x -q` → 1011 passed