### PR TITLE
docs: add @gtonic as code contributor and Austrian domain maintainer

### DIFF
--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -285,7 +285,7 @@
 
     <div class="app-page-hero app-page-hero--contributors">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">8 Contributors</span>
+            <span class="app-page-hero__stat">9 Contributors</span>
             <h1 class="app-page-hero__title">Contributors</h1>
             <p class="app-page-hero__description">Meet the community members who have shaped ArcKit through code contributions, feature requests, and bug reports. Every contribution matters.</p>
         </div>
@@ -362,6 +362,23 @@
                         <li>Templates, quality checklists, and per-format converter outputs</li>
                     </ul>
                 </div>
+
+                <div class="app-contributor-card">
+                    <div class="app-contributor-card__header">
+                        <div class="app-contributor-card__avatar">G</div>
+                        <div>
+                            <p class="app-contributor-card__name"><a href="https://github.com/gtonic">@gtonic</a></p>
+                            <span class="app-contributor-card__role app-contributor-card__role--code">Code Contributor</span>
+                            <span class="app-contributor-card__role app-contributor-card__role--feature">Domain Maintainer (AT)</span>
+                        </div>
+                    </div>
+                    <p class="govuk-body-s">Authored the original situation report that motivated a non-UK overlay and took on domain maintenance for the Austrian regulatory commands — DSG / DSGVO (Datenschutzbehörde, §§12–13 image processing, ELGA/GTelG, §96a ArbVG, age-14 consent), NISG 2024 (NIS2 transposition, GovCERT reporting, KSÖ), and BVergG 2018 public procurement (Oberschwellen/Unterschwellen, ANKÖ, Bestbieterprinzip, BVwG review). Verified and tightened citations beyond the initial seed.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>3 Austrian government &amp; regulatory commands</li>
+                        <li>Templates and quality checklist sections</li>
+                        <li>Citation verification pass across all AT commands</li>
+                    </ul>
+                </div>
             </div>
 
             <!-- Feature Requesters & Bug Reporters -->
@@ -432,7 +449,7 @@
 
             <!-- Community Summary -->
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Community Impact</h2>
-            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 4 code contributors, 2 feature requesters, and 2 bug reporters, these 8 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, and EU / French regulatory compliance coverage.</p>
+            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 5 code contributors, 2 feature requesters, and 2 bug reporters, these 9 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, and EU / French / Austrian regulatory compliance coverage.</p>
 
             <!-- Contributing CTA -->
             <div class="govuk-inset-text govuk-!-margin-top-6">


### PR DESCRIPTION
## Summary

- Adds @gtonic to `docs/contributors.html` following the Austrian overlay work in #320
- Updates hero stat (8 → 9), inserts a new contributor card after @thomas-jardinet, and refreshes the Community Impact summary to include Austrian regulatory coverage (5 code contributors, 9 total)

## Test plan

- [ ] Open `docs/contributors.html` locally and confirm the new card renders with the correct styling (Code Contributor + Domain Maintainer badges, green border)
- [ ] Confirm hero stat reads "9 Contributors"
- [ ] Confirm Community Impact paragraph reads "5 code contributors" and "9 individuals"

🤖 Generated with [Claude Code](https://claude.com/claude-code)