### PR TITLE
chore(codeowners): activate @gtonic for Austrian commands

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,8 +18,7 @@ arckit-claude/commands/fr-*.md                 @thomas-jardinet @tractorjuice
 arckit-claude/templates/fr-*-template.md       @thomas-jardinet @tractorjuice
 .arckit/templates/fr-*-template.md             @thomas-jardinet @tractorjuice
 
-# Austrian government commands — seed contribution (see #304)
-# Uncomment the @gtonic lines below once @gtonic accepts CODEOWNERS for at-* files.
-# arckit-claude/commands/at-*.md               @gtonic @tractorjuice
-# arckit-claude/templates/at-*-template.md     @gtonic @tractorjuice
-# .arckit/templates/at-*-template.md           @gtonic @tractorjuice
+# Austrian government commands — community-maintained by @gtonic (see #304, #320, #333)
+arckit-claude/commands/at-*.md                 @gtonic @tractorjuice
+arckit-claude/templates/at-*-template.md       @gtonic @tractorjuice
+.arckit/templates/at-*-template.md             @gtonic @tractorjuice


### PR DESCRIPTION
## Summary

- @gtonic has accepted the CODEOWNERS role for Austrian regulatory commands following the seed merge (#320) and verification pass (#333)
- Uncomments the three `at-*` lines in `.github/CODEOWNERS` so @gtonic is auto-requested for review on future changes to Austrian commands and templates
- Updates the section comment to reflect active maintainer status (matches the shape of the EU / French lines for @thomas-jardinet)

## Test plan

- [ ] Confirm `.github/CODEOWNERS` parses without syntax issues on GitHub (visible under repo Settings → Code owners once merged)
- [ ] On next PR touching `at-*.md`, verify @gtonic is auto-added as a reviewer

🤖 Generated with [Claude Code](https://claude.com/claude-code)