### PR TITLE
chore(pages): bump mermaid to 11.14.0 for wardley-beta support

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -24,7 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 
     <!-- Mermaid.js for Diagrams -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
 
     <!-- SVG Pan Zoom for interactive diagrams -->
     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -24,7 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 
     <!-- Mermaid.js for Diagrams -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
 
     <!-- SVG Pan Zoom for interactive diagrams -->
     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -24,7 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 
     <!-- Mermaid.js for Diagrams -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
 
     <!-- SVG Pan Zoom for interactive diagrams -->
     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -24,7 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 
     <!-- Mermaid.js for Diagrams -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
 
     <!-- SVG Pan Zoom for interactive diagrams -->
     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -24,7 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 
     <!-- Mermaid.js for Diagrams -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
 
     <!-- SVG Pan Zoom for interactive diagrams -->
     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>

--- a/arckit-paperclip/templates/pages-template.html
+++ b/arckit-paperclip/templates/pages-template.html
@@ -24,7 +24,7 @@
     <script src="https://cdn.jsdelivr.net/npm/marked@15.0.6/marked.min.js"></script>
 
     <!-- Mermaid.js for Diagrams -->
-    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.4.1/dist/mermaid.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/mermaid@11.14.0/dist/mermaid.min.js"></script>
 
     <!-- SVG Pan Zoom for interactive diagrams -->
     <script src="https://cdn.jsdelivr.net/npm/svg-pan-zoom@3.6.2/dist/svg-pan-zoom.min.js"></script>


### PR DESCRIPTION
## Summary

- Bumps `mermaid@11.4.1` → `mermaid@11.14.0` in all six `pages-template.html` files (Claude plugin, Codex, Copilot, OpenCode, Paperclip, and the CLI-scaffolded `.arckit/templates/`)
- Mermaid 11.14.0 (released 2026-04-01) introduces the `wardley-beta` diagram type from upstream mermaid-js/mermaid#7147, which ArcKit's dual Wardley output (plugin PR #181) has been emitting since March
- With this version pin, generated `docs/index.html` pages will render Wardley maps in-browser across every distribution format

## Follow-ups (not in this PR)

- `tests/mermaid-wardley/` still pins `pkg.pr.new/mermaid@7147` — move to `^11.14.0` once the full validation suite has been re-run against the release
- After release, each test repo with a `docs/index.html` will need `/arckit:pages` re-run to pick up the bumped template

## Test plan

- [ ] Scaffold a test project, generate a Wardley artifact, run `/arckit:pages`, and confirm the resulting `docs/index.html` renders the `wardley-beta` block correctly in a browser
- [ ] Spot-check that existing diagram types (flowchart, sequence, ER) still render under 11.14.0

🤖 Generated with [Claude Code](https://claude.com/claude-code)