### PR TITLE
fix(wardley): handle hybrid pipeline syntax and names containing /.X

### DIFF
--- a/tests/mermaid-wardley/convert.mjs
+++ b/tests/mermaid-wardley/convert.mjs
@@ -43,7 +43,8 @@ export function findMapFiles(dir) {
       } else if (entry.isFile()) {
         const name = entry.name;
         if (name === 'LICENSE' || name === '.DS_Store' || name === 'README.md') continue;
-        if (/\.(svg|png|jpg|jpeg|gif|md|txt)$/i.test(name)) continue;
+        // Skip binaries, docs, scripts, and our own generated Mermaid output
+        if (/\.(svg|png|jpg|jpeg|gif|md|txt|mmd|mjs|js|ts|json|ya?ml)$/i.test(name)) continue;
         try {
           const content = readFileSync(full, 'utf8');
           if (content.includes('component ') || content.includes('title ')) {
@@ -69,9 +70,13 @@ export function owmToMermaid(owmContent, filename) {
   const sourcing = {};
   const compCoords = {};
   const pipelineRanges = {};
+  // Pipelines whose range declaration is followed (possibly across a blank
+  // line) by an explicit `{` block. Their children inside `{}` are
+  // authoritative; PASS 1b should not also auto-inject implicit children.
+  const pipelinesWithExplicitBlock = new Set();
 
-  for (const rawLine of lines) {
-    const trimmed = rawLine.trim();
+  for (let i = 0; i < lines.length; i++) {
+    const trimmed = lines[i].trim();
     if (trimmed.startsWith('//')) continue;
 
     const srcMatch = trimmed.match(/^(build|buy|outsource)\s+(.+)/i);
@@ -87,12 +92,25 @@ export function owmToMermaid(owmContent, filename) {
       };
     }
 
-    const pipeMatch = trimmed.match(/^pipeline\s+(.+?)\s*\[\s*([\d.]+)\s*,\s*([\d.]+)\s*\]\s*$/);
+    const pipeMatch = trimmed.match(/^pipeline\s+(.+?)\s*\[\s*([\d.]+)\s*,\s*([\d.]+)\s*\]\s*(\{?)\s*$/);
     if (pipeMatch) {
-      pipelineRanges[pipeMatch[1].trim()] = {
+      const name = pipeMatch[1].trim();
+      pipelineRanges[name] = {
         min: parseFloat(pipeMatch[2]),
         max: parseFloat(pipeMatch[3]),
       };
+      // Explicit block on same line: `pipeline X [a,b] {`
+      if (pipeMatch[4] === '{') {
+        pipelinesWithExplicitBlock.add(name);
+      } else {
+        // Look ahead for a `{` on a following line (skipping blanks/comments)
+        for (let j = i + 1; j < lines.length; j++) {
+          const t = lines[j].trim();
+          if (!t || t.startsWith('//')) continue;
+          if (t === '{' || t.startsWith('{')) pipelinesWithExplicitBlock.add(name);
+          break;
+        }
+      }
     }
   }
 
@@ -101,6 +119,10 @@ export function owmToMermaid(owmContent, filename) {
   const isPipelineChild = new Set();
 
   for (const [pipeName, range] of Object.entries(pipelineRanges)) {
+    // Pipelines with an explicit `{ ... }` block own their children directly;
+    // skip implicit vis/evo proximity detection for those.
+    if (pipelinesWithExplicitBlock.has(pipeName)) continue;
+
     const parent = compCoords[pipeName];
     if (!parent) continue;
 
@@ -171,7 +193,22 @@ export function owmToMermaid(owmContent, filename) {
       continue;
     }
 
-    if (/^pipeline\s+.+\[\s*[\d.]+\s*,\s*[\d.]+\s*\]\s*$/.test(trimmed)) {
+    // OWM `pipeline X [min, max]` with optional trailing `{`. If the pipeline
+    // has an explicit `{ ... }` block (same line or next), open a Mermaid
+    // pipeline block using the parent's name. Otherwise skip — children are
+    // injected via the implicit detection in PASS 1b.
+    const pipeRangeMatch = trimmed.match(/^pipeline\s+(.+?)\s*\[\s*[\d.]+\s*,\s*[\d.]+\s*\]\s*(\{?)\s*$/i);
+    if (pipeRangeMatch) {
+      const name = pipeRangeMatch[1].trim();
+      if (pipelinesWithExplicitBlock.has(name)) {
+        const pName = quoteName(name);
+        if (pipeRangeMatch[2] === '{') {
+          mermaidLines.push(`pipeline ${pName} {`);
+          inPipelineBlock = true;
+        } else {
+          pendingPipelineName = pName;
+        }
+      }
       continue;
     }
 
@@ -247,7 +284,10 @@ export function owmToMermaid(owmContent, filename) {
     }
 
     if (/^evolve\s+/i.test(trimmed)) {
-      const evolveMatch = trimmed.match(/^evolve\s+(.+?)\s+([\d.]+)/i);
+      // Require the position to be a properly-formed number followed by
+      // whitespace or EOL — avoids misparsing names containing ".X" (e.g.
+      // `evolve Lamp / .Net 0.72` would previously capture "." as position).
+      const evolveMatch = trimmed.match(/^evolve\s+(.+?)\s+(\d+(?:\.\d+)?)(?=\s|$)/i);
       if (evolveMatch) {
         const eName = quoteName(evolveMatch[1].trim());
         mermaidLines.push(`evolve ${eName} ${evolveMatch[2]}`);


### PR DESCRIPTION
## Summary

Two OWM → Mermaid `wardley-beta` converter fixes, taking the real-world parse rate from **144/147 → 146/147** (the remaining failure is an upstream source-data typo that can't be fixed at the converter layer). Fidelity unchanged at 100%.

Discovered while publishing the [`tractorjuice/wardley-maps-mermaid`](https://github.com/tractorjuice/wardley-maps-mermaid) mirror, where all three previously-failing maps now render cleanly.

## Fix 1 — hybrid `pipeline X [min, max] { 1-D children }` syntax

OWM supports a pipeline where the range is declared alongside an explicit `{ ... }` block with 1-D child coords, e.g.:

```
component values [0.49, 0.62]
pipeline values [0.36, 0.75]
{
component rights [0.74]
component beliefs [0.46]
}
```

The range form was already recognised, but when the block followed, the 1-D children were emitted as top-level components with invalid `[0.74]` coords, which broke `culture/gender`.

- **PASS 1** now tracks `pipelinesWithExplicitBlock` (same-line `{` or next-non-empty-line `{`).
- **PASS 1b** skips implicit proximity-based child detection for those pipelines — the explicit block wins.
- **PASS 2** opens a Mermaid `pipeline "X" {` block when the range line is followed by `{`.

## Fix 2 — tighten the `evolve` regex

Previously:

```js
/^evolve\s+(.+?)\s+([\d.]+)/
```

would misparse names containing `.X` — `evolve Lamp / .Net 0.72` captured `"."` as the position and emitted the invalid `evolve "Lamp /" .`, which broke `personal/Conversational`.

Now:

```js
/^evolve\s+(.+?)\s+(\d+(?:\.\d+)?)(?=\s|$)/
```

requires a properly-formed number followed by whitespace or EOL, so the name greedily captures `"Lamp / .Net"` before the regex locks onto `0.72`.

## Verified

```
fidelity:   100% component / anchor / link retention, |Δε| = 0 across 4905 pairs
real-maps:  144/147 → 146/147 (99.3%)
```

The remaining failure is `manufacturing/manufacturing - automation`: upstream source has `[0.55. 0.18]` (period instead of comma), which no converter can fix.

## Test plan

- [x] `npm run fidelity` — unchanged, 100% retention / |Δε| = 0
- [x] `npm run real-maps` — 146/147 (was 144/147)
- [x] `npm run validate` — all 18/18 synthetic fixtures still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)