### PR TITLE
docs: add --sparse tip to plugin install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,15 @@ A comprehensive book-length guide to ArcKit — covering every subsystem (comman
 /plugin marketplace add tractorjuice/arc-kit
 ```
 
-Then install from the Discover tab. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 68 commands, 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
+Then install from the Discover tab.
+
+> **Tip: lighter marketplace clone.** The command above clones the full arc-kit monorepo (~100 MB) because it hosts five other AI-assistant distributions, 147 vendored Wardley maps, and research docs you don't need. To fetch just the plugin's directories, add the marketplace via the CLI with `--sparse`:
+>
+> ```bash
+> claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude
+> ```
+>
+> This uses `git sparse-checkout` to limit the clone to `.claude-plugin/` (the marketplace catalog) and `arckit-claude/` (the plugin itself). Works with Claude Code's documented marketplace sparse flag. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 68 commands, 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
 > **Why v2.1.112?** This version unlocks the `xhigh` effort tier on Claude Opus 4.7 (used by ArcKit's deep-research agents and synthesis commands), enables Auto mode without `--enable-auto-mode`, restores Opus 4.7 availability for Auto mode, and ships read-only bash glob patterns without permission prompts (reduces friction for ArcKit helper scripts). It also carries forward the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -379,6 +379,8 @@
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugin</h2>
                     <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
                     <p class="govuk-body govuk-!-margin-top-3">Then install from the Discover tab. The plugin provides all 68 commands, 9 autonomous research agents, 5 automation hooks, and bundled MCP servers. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-2"><strong>Lighter clone:</strong> to skip the other AI-assistant distributions in the monorepo (~100&nbsp;MB), add the marketplace from your shell with sparse-checkout:</p>
+                    <div class="app-code-block">claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude</div>
                 </div>
 
                 <div class="app-step">


### PR DESCRIPTION
## Summary

The arc-kit monorepo hosts the Claude Code plugin alongside five other AI-assistant distributions (Gemini, Codex, OpenCode, Copilot, Paperclip), 147 vendored Wardley maps (`tests/mermaid-wardley/owm-maps/`), and research docs — so a full marketplace clone runs ~100 MB, of which users need ~2 MB (`arckit-claude/` + the marketplace catalog).

Claude Code ships a documented `--sparse` flag for exactly this case. Adding the marketplace from a shell instead of in-session lets users limit the clone to only the directories they need:

```bash
claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude
```

## Changes

- `README.md` → "Quick Start / Installation" Claude Code block gains a tip explaining why the monorepo is big and offering the sparse alternative.
- `docs/getting-started.html` step 2 gets a follow-up code block labelled "Lighter clone".
- `docs/index.html` compact card is unchanged (no room for both commands in that UI).

No code changes. No plugin behaviour change. Relative-path install continues to work exactly as before — users who don't care about clone size still run `/plugin marketplace add tractorjuice/arc-kit` in-session and get everything.

## Background

We looked at four ways to reduce the clone size:

- `git-subdir` plugin source pointing at the same repo — doesn't help, the marketplace catalog still lives in arc-kit so the full clone happens first
- Split the plugin into a separate repo (`tractorjuice/arckit-claude`) — requires migrating the marketplace identifier and adding another push target to `push-extensions.sh`
- Split the marketplace catalog into its own tiny repo — same migration cost
- **Document `--sparse`** — zero code change, available today, no migration

This PR is option 4.

## Test plan

- [x] `npx markdownlint-cli2 README.md` — 0 errors
- [x] Manual review of both rendered sections