### PR TITLE
docs: list all 110 guides + fix articles page font & hero colour

### DIFF
--- a/docs/articles.html
+++ b/docs/articles.html
@@ -28,6 +28,19 @@
     <link rel="stylesheet" href="heroes.css">
 
     <style>
+        /*
+         * Font Override for Non-GOV.UK Domains
+         * GDS Transport is licensed only for *.gov.uk — ArcKit is on GitHub Pages.
+         */
+        body,
+        .govuk-template,
+        .govuk-template__body {
+            font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto,
+                         Helvetica, Arial, sans-serif, "Apple Color Emoji",
+                         "Segoe UI Emoji", "Segoe UI Symbol" !important;
+        }
+        [class*="govuk-"] { font-family: inherit; }
+
         /* Nav Bar */
         .app-nav-bar {
             background: #0b0c0c;

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Command Guides - 88 usage guides for enterprise architecture governance commands organized by category.">
+    <meta name="description" content="ArcKit Command Guides - 91 usage guides (plus 19 community overlays) for enterprise architecture governance commands organized by category.">
     <title>Command Guides - ArcKit</title>
     <meta name="keywords" content="ArcKit guides, architecture governance guides, command usage, workflow steps, UK government architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Guides - ArcKit">
-    <meta property="og:description" content="88 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta property="og:description" content="91 step-by-step usage guides (plus 19 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/guides.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Guides - ArcKit">
-    <meta name="twitter:description" content="88 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta name="twitter:description" content="91 step-by-step usage guides (plus 19 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/guides.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -234,7 +234,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/guides.html",
                 "name": "Command Guides - ArcKit",
-                "description": "88 step-by-step usage guides for ArcKit enterprise architecture governance commands, organised by category.",
+                "description": "91 step-by-step usage guides (plus 19 community overlays) for ArcKit enterprise architecture governance commands, organised by category.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -279,9 +279,9 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">88 Guides</span>
+            <span class="app-page-hero__stat">91 Guides + 19 Community Overlays</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
-            <p class="app-page-hero__description">Step-by-step usage guides organised into 10 categories. Each covers prerequisites, workflow steps, and real-world examples.</p>
+            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 10 categories, plus 19 community-contributed EU and French public-sector overlays in dedicated sections.</p>
         </div>
     </div>
 
@@ -302,7 +302,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Getting Started
-                    <span class="app-guide-category__count">7 guides</span>
+                    <span class="app-guide-category__count">9 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -313,6 +313,8 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=upgrading" class="govuk-link">Upgrading ArcKit</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Version upgrade instructions</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=remote-control" class="govuk-link">Remote Control Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Remote architecture governance with Claude Code</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=productivity" class="govuk-link">Architecture Productivity Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Productivity tips and workflow optimization</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=session-memory" class="govuk-link">Session Memory Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Automated session capture across Claude Code conversations</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=testing-plugin-branches" class="govuk-link">Testing Plugin Branches</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Test an ArcKit plugin branch before merging</span></li>
                     </ul>
                 </div>
             </div>
@@ -321,7 +323,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Discovery
-                    <span class="app-guide-category__count">8 guides</span>
+                    <span class="app-guide-category__count">9 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -330,6 +332,7 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=stakeholder-analysis" class="govuk-link">Stakeholder Analysis Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Detailed stakeholder mapping and engagement strategy</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=research" class="govuk-link">Technology Research Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Technology and vendor research via web search</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=datascout" class="govuk-link">Data Source Discovery Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Data source discovery and API catalogue search</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=autoresearch" class="govuk-link">Autoresearch Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Overnight self-improving command research loops</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=gov-reuse" class="govuk-link">Government Code Reuse Assessment</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Discover reusable UK government code via govreposcrape</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=gov-code-search" class="govuk-link">Government Code Search</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Search 24,500+ UK government repositories</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=gov-landscape" class="govuk-link">Government Code Landscape Analysis</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Map UK government code landscape for a domain</span></li>
@@ -401,7 +404,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Governance
-                    <span class="app-guide-category__count">13 guides</span>
+                    <span class="app-guide-category__count">15 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -409,6 +412,8 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=risk-management" class="govuk-link">Risk Management Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Risk management strategy framework</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=traceability" class="govuk-link">Traceability Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Requirements traceability matrix</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=principles-compliance" class="govuk-link">Principles Compliance Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Check artifacts against architecture principles</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=enterprise-scale" class="govuk-link">ArcKit at Enterprise Scale</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Multi-repo, multi-application topology and governance</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=hooks" class="govuk-link">Hooks Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Plugin hooks overview and configuration</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=analyze" class="govuk-link">Project Analysis Playbook</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Comprehensive gap analysis across artifacts</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=artifact-health" class="govuk-link">Artifact Health Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Project health scanning and diagnostics</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=knowledge-compounding" class="govuk-link">Knowledge Compounding Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Reusable vendor profiles from research</span></li>
@@ -442,6 +447,51 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=atrs" class="govuk-link">Algorithmic Transparency</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">Algorithmic Transparency Recording Standard</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=mod-secure" class="govuk-link">MOD Secure by Design</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">MOD-specific Secure by Design playbook</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=jsp-936" class="govuk-link">JSP 936 AI Assurance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Defence AI assurance compliance</span></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Community overlays — EU -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> Community overlays — EU
+                    <span class="app-guide-category__count">7 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Community-contributed EU regulation overlays. Not part of the officially-maintained baseline.</em></p>
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-ai-act" class="govuk-link">EU AI Act Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">EU AI Act compliance assessment</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-cra" class="govuk-link">EU Cyber Resilience Act Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">EU CRA compliance for digital products</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-data-act" class="govuk-link">EU Data Act Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">EU Data Act compliance for connected products and services</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-dora" class="govuk-link">EU DORA Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Digital Operational Resilience Act for financial entities</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-dsa" class="govuk-link">EU Digital Services Act Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">DSA compliance for online platforms and intermediaries</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-nis2" class="govuk-link">EU NIS2 Directive Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">NIS2 cybersecurity compliance for essential and important entities</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=eu-rgpd" class="govuk-link">EU GDPR Assessment Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">GDPR compliance assessment (Règlement général sur la protection des données)</span></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- Community overlays — France -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> Community overlays — France
+                    <span class="app-guide-category__count">12 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Community-contributed French public-sector overlays. Not part of the officially-maintained baseline.</em></p>
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-algorithme-public" class="govuk-link">French Public Algorithm Transparency</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Mentions explicite des décisions administratives automatisées (art. L311-3-1 CRPA)</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-anssi" class="govuk-link">ANSSI Security Posture Assessment</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">ANSSI cybersecurity posture assessment</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-anssi-carto" class="govuk-link">ANSSI IS Cartography</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Information system cartography per ANSSI methodology</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-code-reuse" class="govuk-link">French Public Code Reuse</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Code reuse assessment for French public-sector services</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-dinum" class="govuk-link">DINUM Digital Standards</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">DINUM/beta.gouv.fr digital standards assessment</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-dr" class="govuk-link">Diffusion Restreinte Handling</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">DR-classified data handling assessment</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-ebios" class="govuk-link">EBIOS Risk Manager</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">ANSSI EBIOS Risk Manager methodology</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-irn" class="govuk-link">Indice de Résilience Numérique</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Digital resilience index assessment</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-marche-public" class="govuk-link">French Public Procurement</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Marché public procurement playbook</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-pssi" class="govuk-link">PSSI Security Policy</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Politique de Sécurité des Systèmes d'Information</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-rgpd" class="govuk-link">French GDPR / CNIL Compliance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">RGPD compliance with CNIL-specific guidance</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-secnumcloud" class="govuk-link">SecNumCloud Qualification</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">SecNumCloud cloud qualification assessment</span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/heroes.css
+++ b/docs/heroes.css
@@ -296,10 +296,10 @@
 }
 
 /* ============================================================
-   Variant: Articles  — magenta/plum, editorial diagonal stripes
+   Variant: Articles  — indigo, editorial diagonal stripes
    ============================================================ */
 .app-page-hero--articles {
-    background: linear-gradient(135deg, #912b88 0%, #4c2c92 100%);
+    background: linear-gradient(135deg, #303f9f 0%, #1a237e 100%);
 }
 
 .app-page-hero--articles::before {


### PR DESCRIPTION
## Summary

- **guides.html**: add the 24 guides that existed on disk but weren't linked. Hero stat updated to `91 Guides + 19 Community Overlays` per the baseline-vs-overlay policy.
- **articles.html**: add the system-font override so the nav menu renders like every other page (Helvetica/Arial instead of GOV.UK Frontend's serif fallback).
- **heroes.css**: `.app-page-hero--articles` → indigo (`#303f9f → #1a237e`). The previous `#912b88` start colour clashed with `.app-page-hero--roles`.

## Guides added (24)

- **Core (5)** in existing sections: `session-memory`, `testing-plugin-branches`, `enterprise-scale`, `hooks`, `autoresearch`
- **New section "Community overlays — EU" (7)**: `eu-ai-act`, `eu-cra`, `eu-data-act`, `eu-dora`, `eu-dsa`, `eu-nis2`, `eu-rgpd`
- **New section "Community overlays — France" (12)**: `fr-algorithme-public`, `fr-anssi`, `fr-anssi-carto`, `fr-code-reuse`, `fr-dinum`, `fr-dr`, `fr-ebios`, `fr-irn`, `fr-marche-public`, `fr-pssi`, `fr-rgpd`, `fr-secnumcloud`

## Test plan

- [x] `ls docs/guides/*.md` vs `grep guide=` on guides.html — 110 = 110, zero on-disk guides unlinked
- [ ] Visual check: articles page menu renders in system font; articles hero shows indigo gradient

🤖 Generated with [Claude Code](https://claude.com/claude-code)