### PR TITLE
feat(pages): show HTML deck artifacts in dashboard

### DIFF
--- a/arckit-claude/commands/pages.md
+++ b/arckit-claude/commands/pages.md
@@ -154,6 +154,7 @@ projects/
 │   ├── ARC-001-AIPB-v1.0.md     # AI Playbook Assessment
 │   ├── ARC-001-ATRS-v1.0.md     # ATRS Record
 │   ├── ARC-001-PRIN-COMP-v1.0.md # Principles Compliance
+│   ├── ARC-001-DECK-v1.0.html    # Executive Deck (HTML — e.g. AntV Infographic, Reveal.js)
 │   │
 │   ├── # Multi-instance Documents (subdirectories)
 │   ├── diagrams/
@@ -256,6 +257,8 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | GLND | `ARC-*-GLND-*.md` | Government Landscape Analysis |
 | **Reporting** | | | |
 | | STORY | `ARC-*-STORY-*.md` | Project Story |
+| | PRES | `ARC-*-PRES-*.md` | Presentation (MARP) |
+| | DECK | `ARC-*-DECK-*.html` | Executive Deck (HTML) |
 | **Compliance (Community-contributed — EU)** | | | |
 | | RGPD | `ARC-*-RGPD-*.md` | GDPR Compliance Assessment |
 | | NIS2 | `ARC-*-NIS2-*.md` | NIS2 Compliance Assessment |

--- a/arckit-claude/config/doc-types.mjs
+++ b/arckit-claude/config/doc-types.mjs
@@ -13,6 +13,15 @@
  *
  * NOTE: scripts/bash/generate-document-id.sh has its own MULTI_INSTANCE_TYPES
  * list (bash, 10 entries). Keep it in sync manually — low drift risk.
+ *
+ * Schema per entry:
+ *   name:      Human-readable display name shown on the dashboard sidebar.
+ *   category:  Group used for KPI charts and the "Known artifact types" table.
+ *   extension: Optional file extension (default '.md'). Set to '.html' for
+ *              types produced as standalone HTML (e.g. AntV Infographic decks,
+ *              Reveal.js exports). The /arckit.pages scanner enforces the
+ *              extension — `ARC-001-DECK-v1.0.md` and `ARC-001-REQ-v1.0.html`
+ *              are both rejected as type/extension mismatches.
  */
 
 // All valid ArcKit document type codes with display name and category.
@@ -48,6 +57,7 @@ export const DOC_TYPES = {
   'PRIN-COMP': { name: 'Principles Compliance',            category: 'Governance' },
   'CONF':      { name: 'Conformance Assessment',           category: 'Governance' },
   'PRES':      { name: 'Presentation',                     category: 'Reporting' },
+  'DECK':      { name: 'Executive Deck',                    category: 'Reporting', extension: '.html' },
   'ANAL':      { name: 'Analysis Report',                  category: 'Governance' },
   'GAPS':      { name: 'Gap Analysis',                     category: 'Governance' },
   // Compliance

--- a/arckit-claude/hooks/sync-guides.mjs
+++ b/arckit-claude/hooks/sync-guides.mjs
@@ -90,6 +90,19 @@ const DOC_TYPE_META = Object.fromEntries(
   Object.entries(DOC_TYPES).map(([code, { name, category }]) => [code, { category, title: name }])
 );
 
+// Per-type expected file extension (default '.md'). Types declaring a custom
+// extension in DOC_TYPES (e.g. 'DECK' → '.html') override the default.
+const EXT_BY_TYPE = Object.fromEntries(
+  Object.entries(DOC_TYPES).map(([code, meta]) => [code, meta.extension || '.md'])
+);
+const VALID_EXTS = new Set(Object.values(EXT_BY_TYPE));
+function hasArcExt(filename) {
+  for (const ext of VALID_EXTS) {
+    if (filename.endsWith(ext)) return true;
+  }
+  return false;
+}
+
 const GUIDE_CATEGORIES = {
   // Getting Started
   'init': 'Getting Started', 'start': 'Getting Started', 'upgrading': 'Getting Started',
@@ -179,33 +192,42 @@ const ROLE_COMMAND_COUNTS = {
 
 // ── Doc type extraction from filename ──
 
-// Match compound types first (SECD-MOD, PRIN-COMP), then simple types
+// Match compound types first (SECD-MOD, PRIN-COMP), then simple types.
+// Returns null if the file's extension does not match the type's registered
+// extension (e.g. ARC-001-DECK-v1.0.md is rejected — DECK requires .html).
 function extractDocType(filename) {
-  // ARC-001-SECD-MOD-v1.0.md → SECD-MOD
+  // ARC-001-SECD-MOD-v1.0.md  → SECD-MOD
   // ARC-001-PRIN-COMP-v1.0.md → PRIN-COMP
-  // ARC-001-REQ-v1.0.md → REQ
-  // ARC-001-ADR-001-v1.0.md → ADR
-  const m = filename.match(/^ARC-\d{3}-(.+)-v\d+(\.\d+)?\.md$/);
+  // ARC-001-REQ-v1.0.md       → REQ
+  // ARC-001-ADR-001-v1.0.md   → ADR
+  // ARC-001-DECK-v1.0.html    → DECK
+  const m = filename.match(/^ARC-\d{3}-(.+)-v\d+(\.\d+)?\.([a-z0-9]+)$/i);
   if (!m) return null;
-  let rest = m[1]; // e.g. "SECD-MOD", "REQ", "ADR-001"
+  const fileExt = `.${m[3].toLowerCase()}`;
+  if (!VALID_EXTS.has(fileExt)) return null;
+  let rest = m[1];
+
+  const matchesExt = (code) => (EXT_BY_TYPE[code] || '.md') === fileExt;
 
   // Try compound types first (longest match)
   for (const code of Object.keys(DOC_TYPE_META)) {
     if (code.includes('-') && rest.startsWith(code)) {
-      return code;
+      return matchesExt(code) ? code : null;
     }
   }
 
   // Strip trailing -NNN for multi-instance types
   rest = rest.replace(/-\d{3}$/, '');
 
-  if (DOC_TYPE_META[rest]) return rest;
-  return rest; // unknown type, return as-is
+  if (DOC_TYPE_META[rest]) return matchesExt(rest) ? rest : null;
+  // Unknown type — accept only legacy markdown files
+  return fileExt === '.md' ? rest : null;
 }
 
 function extractDocId(filename) {
-  // ARC-001-REQ-v1.0.md → ARC-001-REQ-v1.0
-  return filename.replace(/\.md$/, '');
+  // ARC-001-REQ-v1.0.md  → ARC-001-REQ-v1.0
+  // ARC-001-DECK-v1.0.html → ARC-001-DECK-v1.0
+  return filename.replace(/\.[a-z0-9]+$/i, '');
 }
 
 // ── Manifest building ──
@@ -262,22 +284,24 @@ function scanGlobalDocs(repoRoot) {
 
   if (!isDir(globalDir)) return { global, globalExternal, globalPolicies };
 
-  // Global ARC-*.md files (root level)
+  // Global ARC-* files (root level) — accepts any extension registered in DOC_TYPES
   for (const f of listDir(globalDir)) {
     const fp = join(globalDir, f);
-    if (isFile(fp) && f.startsWith('ARC-') && f.endsWith('.md')) {
+    if (isFile(fp) && f.startsWith('ARC-') && hasArcExt(f)) {
       const typeCode = extractDocType(f);
+      if (!typeCode) continue;
       const meta = DOC_TYPE_META[typeCode] || { category: 'Other', title: typeCode };
       global.push({
         path: `projects/000-global/${f}`,
         title: meta.title,
         category: meta.category,
         documentId: extractDocId(f),
+        extension: EXT_BY_TYPE[typeCode] || '.md',
       });
     }
   }
 
-  // Global ARC-*.md files in subdirectories (research/, diagrams/, decisions/, etc.)
+  // Global ARC-* files in subdirectories (research/, diagrams/, decisions/, etc.)
   const subdirSet = new Set(Object.values(SUBDIR_MAP));
   subdirSet.add('reviews');
   for (const dirName of subdirSet) {
@@ -285,15 +309,19 @@ function scanGlobalDocs(repoRoot) {
     if (!isDir(subDir)) continue;
     for (const f of listDir(subDir)) {
       const fp = join(subDir, f);
-      if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
-      const heading = extractFirstHeading(fp);
+      if (!isFile(fp) || !f.startsWith('ARC-') || !hasArcExt(f)) continue;
       const typeCode = extractDocType(f);
+      if (!typeCode) continue;
       const meta = DOC_TYPE_META[typeCode] || { category: 'Other', title: typeCode };
+      const ext = EXT_BY_TYPE[typeCode] || '.md';
+      // Only markdown artifacts have an extractable H1 heading
+      const heading = ext === '.md' ? extractFirstHeading(fp) : null;
       global.push({
         path: `projects/000-global/${dirName}/${f}`,
         title: heading || meta.title,
         category: meta.category,
         documentId: extractDocId(f),
+        extension: ext,
       });
     }
   }
@@ -360,17 +388,19 @@ function scanProject(repoRoot, projectName) {
     external: [],
   };
 
-  // Core documents in project root
+  // Core documents in project root — accepts any extension registered in DOC_TYPES
   for (const f of listDir(projectDir)) {
     const fp = join(projectDir, f);
-    if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+    if (!isFile(fp) || !f.startsWith('ARC-') || !hasArcExt(f)) continue;
     const typeCode = extractDocType(f);
+    if (!typeCode) continue;
     const meta = DOC_TYPE_META[typeCode] || { category: 'Other', title: typeCode };
     project.documents.push({
       path: `${projectPath}/${f}`,
       title: meta.title,
       category: meta.category,
       documentId: extractDocId(f),
+      extension: EXT_BY_TYPE[typeCode] || '.md',
     });
   }
 
@@ -387,15 +417,18 @@ function scanProject(repoRoot, projectName) {
     if (!isDir(subDir)) continue;
     for (const f of listDir(subDir)) {
       const fp = join(subDir, f);
-      if (!isFile(fp) || !f.startsWith('ARC-') || !f.endsWith('.md')) continue;
-      // For multi-instance types, read first heading for title
-      const heading = extractFirstHeading(fp);
+      if (!isFile(fp) || !f.startsWith('ARC-') || !hasArcExt(f)) continue;
       const typeCode = extractDocType(f);
+      if (!typeCode) continue;
       const meta = DOC_TYPE_META[typeCode] || { category: 'Other', title: typeCode };
+      const ext = EXT_BY_TYPE[typeCode] || '.md';
+      // For multi-instance markdown types, read first heading for title
+      const heading = ext === '.md' ? extractFirstHeading(fp) : null;
       project[key].push({
         path: `${projectPath}/${dirName}/${f}`,
         title: heading || meta.title,
         documentId: extractDocId(f),
+        extension: ext,
       });
     }
   }

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -478,6 +478,29 @@
             font-size: 2.25rem;
         }
 
+        /* HTML deck artifacts (e.g. ARC-001-DECK-v1.0.html) */
+        .app-deck-newtab {
+            display: inline-block;
+            margin-top: 0.75rem;
+            font-size: 0.875rem;
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .app-deck-newtab:hover {
+            text-decoration: underline;
+        }
+
+        .app-deck-frame {
+            display: block;
+            width: 100%;
+            height: 80vh;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            background: #fff;
+        }
+
         /* Loading State */
         .app-loading {
             display: flex;
@@ -1874,7 +1897,7 @@
         }
 
         function extractTitle(path) {
-            const filename = path.split('/').pop().replace('.md', '');
+            const filename = path.split('/').pop().replace(/\.(md|html)$/i, '');
             return filename
                 .replace(/-/g, ' ')
                 .replace(/\b\w/g, l => l.toUpperCase());
@@ -3988,6 +4011,14 @@
             // Hide TOC while loading
             toc.style.display = 'none';
 
+            // HTML artifacts (e.g. ARC-001-DECK-v1.0.html, AntV Infographic output) —
+            // mount in an iframe rather than parsing as markdown. Skips TOC, mermaid,
+            // PlantUML, and link-rewriting which only apply to markdown.
+            if (path.endsWith('.html')) {
+                loadHtmlArtifact(path, content);
+                return;
+            }
+
             // Show loading
             content.innerHTML = `
                 <div class="app-loading">
@@ -4122,6 +4153,42 @@
 
                 content.replaceChildren(header, notice);
             }
+        }
+
+        // Render an HTML artifact (e.g. DECK files) inside an iframe.
+        // Built with safe DOM methods — no innerHTML, no markdown parsing.
+        function loadHtmlArtifact(path, content) {
+            const title = extractTitle(path);
+            const breadcrumbText = path.split('/').slice(0, -1).join(' / ');
+            const src = getRawUrl(path);
+
+            const header = document.createElement('div');
+            header.className = 'app-doc-header';
+            const breadcrumb = document.createElement('div');
+            breadcrumb.className = 'app-doc-breadcrumb';
+            breadcrumb.textContent = breadcrumbText;
+            const titleEl = document.createElement('h1');
+            titleEl.className = 'app-doc-title';
+            titleEl.textContent = title;
+            const newTab = document.createElement('a');
+            newTab.className = 'app-deck-newtab';
+            newTab.href = src;
+            newTab.target = '_blank';
+            newTab.rel = 'noopener noreferrer';
+            newTab.textContent = 'Open in new tab ↗';
+            header.appendChild(breadcrumb);
+            header.appendChild(titleEl);
+            header.appendChild(newTab);
+
+            const frame = document.createElement('iframe');
+            frame.className = 'app-deck-frame';
+            frame.src = src;
+            frame.title = title;
+            frame.setAttribute('allowfullscreen', '');
+            frame.setAttribute('loading', 'lazy');
+
+            content.replaceChildren(header, frame);
+            document.getElementById('main-content').scrollTo(0, 0);
         }
 
         // ============================================


### PR DESCRIPTION
## Summary

- Registers a new `DECK` doc type (Reporting category) backed by `.html` so HTML decks produced by external tools (AntV Infographic, Reveal.js, etc.) have a sanctioned ArcKit filename and surface on the `/arckit.pages` dashboard.
- Adds an optional `extension` field to `DOC_TYPES` and makes the scanner extension-aware. Rejects type/extension mismatches (e.g. `ARC-001-DECK-v1.0.md` and `ARC-001-REQ-v1.0.html` are both filtered out).
- Dashboard front-end (`loadDocument`) branches on `.html` and mounts HTML artifacts in an iframe via safe DOM methods, with an "Open in new tab ↗" link in the doc header. Markdown flow is unchanged.

## What changed

- `arckit-claude/config/doc-types.mjs` — registered `DECK`; documented the new `extension` schema field
- `arckit-claude/hooks/sync-guides.mjs` — derived `EXT_BY_TYPE`/`VALID_EXTS`; generalised `extractDocType`/`extractDocId` and the four scanner file filters; manifest entries gain `extension`; H1 extraction skipped for non-markdown
- `arckit-claude/templates/pages-template.html` — new `loadHtmlArtifact()` (iframe + new-tab link, all safe DOM); `extractTitle` strips `.html` too; new `.app-deck-frame` / `.app-deck-newtab` styles
- `arckit-claude/commands/pages.md` — `DECK` row added to ASCII tree and Known Artifact Types table (also added the previously-missing `PRES` row)

## Test plan

- [x] Syntax-check on both modified `.mjs` files (`node --check`)
- [x] Unit-style test of `extractDocType` — 14/14 cases pass: `DECK.html` ✓, `DECK.md` ✗, `REQ.md` ✓, `REQ.html` ✗, compound types (`SECD-MOD`, `PRIN-COMP`), multi-instance with sequence numbers, unknown types, non-ARC files
- [x] End-to-end: synthesised a project tree with `ARC-001-DECK-v1.0.html` + `ARC-001-REQ-v1.0.md` plus the two negative cases, ran the actual `sync-guides` hook → manifest contains exactly the right entries with correct `category`/`extension`/`title` fields
- [ ] Manual: drop a sample DECK file into a test repo, run `/arckit.pages`, confirm the deck appears under Reporting in the sidebar, clicking it loads the iframe, "Open in new tab" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)