### PR TITLE
chore(plugin): add $schema reference to plugin.json

### DIFF
--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -1,4 +1,5 @@
 {
+  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "arckit",
   "version": "4.9.2",
   "description": "Enterprise Architecture Governance & Vendor Procurement Toolkit - 68 slash commands for generating architecture artifacts",


### PR DESCRIPTION
## Summary

- Adds `"$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json"` to `arckit-claude/.claude-plugin/plugin.json`
- Enables editor autocomplete and IDE-side validation for the plugin manifest
- `claude plugin validate` accepts this field as of Claude Code **v2.1.120**

## Why

Item #38 from issue #215. Trivial cleanup, improves manifest tooling.

## Compatibility

- The plugins-reference docs explicitly state: *"Claude Code ignores this field at load time."*
- Forward-compatible — no minimum-version bump needed (floor stays v2.1.117)
- `bump-version.sh` already uses `jq '.version = $v'` which preserves the new key

## Test plan

- [x] `claude plugin validate ./arckit-claude` → ✔ Validation passed
- [x] JSON parses cleanly (`python3 -c "import json; json.load(...)"`)

Refs #215