### PR TITLE
fix(converter): skip script copies for paperclip extension

### DIFF
--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -225,6 +225,7 @@ AGENT_CONFIG = {
         "extension_dir": "arckit-paperclip",
         "copy_commands_to_extension": False,
         "copy_agents_to_extension": False,
+        "copy_scripts_to_extension": False,
         "has_context_hook": False,
         "has_sync_guides_hook": False,
     },
@@ -518,8 +519,11 @@ def copy_extension_files(plugin_dir):
         ext_dir = config.get("extension_dir")
         if not ext_dir:
             continue
+        copy_scripts = config.get("copy_scripts_to_extension", True)
         print(f"Copying to {config['name']} extension ({ext_dir})...")
         for src_rel, dst_rel in copies:
+            if not copy_scripts and src_rel.startswith("scripts/"):
+                continue
             src = os.path.join(plugin_dir, src_rel)
             dst = os.path.join(ext_dir, dst_rel)
             if os.path.isdir(src):


### PR DESCRIPTION
## Summary

- PR #353 removed `scripts/bash/` and `scripts/python/` from `arckit-paperclip/` in favor of `src/lib/arckit.ts`
- The converter's `copy_extension_files` loop kept blindly copying both directories into all extension dirs — recreating the deleted directories every time `python scripts/converter.py` ran
- Adds a `copy_scripts_to_extension` flag (defaults `True`) to `AGENT_CONFIG`, set to `False` for paperclip
- Other extensions (codex, opencode, gemini, copilot) are unaffected

## Why now

Surfaced during the v4.9.3 release flow — after running the converter, `arckit-paperclip/scripts/` reappeared with all the deleted files and had to be manually `rm -rf`'d before commit. Without this fix, every release would replay the same problem.

## Test plan

- [x] `python scripts/converter.py` no longer creates `arckit-paperclip/scripts/`
- [x] `arckit-codex/scripts/bash/` still contains all 7 bash scripts
- [x] Paperclip extension still receives templates / guides / skills / references

Refs #353