### PR TITLE
fix(hooks): auto-allow govreposcrape MCP tools

### DIFF
--- a/arckit-claude/hooks/allow-mcp-tools.mjs
+++ b/arckit-claude/hooks/allow-mcp-tools.mjs
@@ -4,7 +4,7 @@
  *
  * Auto-approves permission requests for the read-only MCP documentation tools
  * bundled with ArcKit (AWS Knowledge, Microsoft Learn, Google Developer Knowledge,
- * DataCommons). Non-MCP tools fall through to the normal permission dialog.
+ * DataCommons, govreposcrape). Non-MCP tools fall through to the normal permission dialog.
  *
  * Hook Type: PermissionRequest
  * Input (stdin):  JSON { tool_name, ... }
@@ -20,6 +20,7 @@ const ALLOWED_PREFIXES = [
   'mcp__plugin_microsoft-docs_microsoft-learn__',
   'mcp__google-developer-knowledge__',
   'mcp__datacommons-mcp__',
+  'mcp__govreposcrape__',
 ];
 
 let raw = '';


### PR DESCRIPTION
## Summary

Adds the missing `mcp__govreposcrape__` prefix to `arckit-claude/hooks/allow-mcp-tools.mjs`. Four of the five bundled MCPs were already in the auto-allow list — `govreposcrape` was the gap. Without this fix, every run of `gov-reuse`, `gov-code-search`, and `gov-landscape` triggers a permission dialog on every tool call.

## Why this is a separate PR (not #351)

#351 bundled this fix with an investigation spike for agent `mcpServers` frontmatter scoping (issue #215 item #24). The spike concluded ABORTED — `mcpServers` frontmatter is fully inert when agents are spawned via the Task tool, which is ArcKit's invocation pattern. That investigation isn't worth merging.

Rather than carry the spike commits, version-bump-for-testing churn, and aborted design docs into main, this PR cherry-picks just the genuinely-useful 2-line fix. #351 will be closed.

## Test plan

- [x] `grep govreposcrape arckit-claude/hooks/allow-mcp-tools.mjs` → 2 matches (JSDoc + ALLOWED_PREFIXES entry)
- [x] Diff is exactly 2 insertions, 1 deletion in 1 file
- [ ] Smoke test: run `/arckit.gov-reuse` and confirm no permission dialog on govreposcrape calls

Refs #215 (item #24) — closes the side-win called out in the ABORTED spike memo.