### PR TITLE
feat(hooks): graph-utils v2 — additive opts for scan-hook consolidation

### DIFF
--- a/arckit-claude/hooks/graph-utils.mjs
+++ b/arckit-claude/hooks/graph-utils.mjs
@@ -5,15 +5,37 @@
  * Used by:
  * - impact-scan.mjs (UserPromptSubmit hook for /arckit:impact)
  * - sync-guides.mjs (UserPromptSubmit hook for /arckit:pages → manifest.json)
+ *
+ * v2: Optional `opts` enrich the graph with content, full requirement records,
+ * vendors, principles, risks, and external-file listings. Defaults preserve v1
+ * behaviour exactly so existing consumers need no changes. See issue #162.
  */
 
 import { join } from 'node:path';
 import {
-  isDir, isFile, readText, listDir,
-  extractDocType,
+  isDir, isFile, readText, listDir, mtimeMs,
+  extractDocType, extractVersion,
   extractDocControlFields, extractRequirementIds,
+  extractRequirementDetails, extractPrinciples, extractRiskEntries,
 } from './hook-utils.mjs';
 import { DOC_TYPES } from '../config/doc-types.mjs';
+
+const DEFAULT_OPTS = Object.freeze({
+  withNodeMetadata: false, // version, owner, classification, vendor, subdir, controlFields, reqIds
+  withContent: false,      // full text + mtimeMs
+  withPreview: false,      // ~500-char post-control preview
+  withRequirements: false, // full requirement records per project
+  withVendors: false,      // vendor structure with reviews + verdicts
+  withPrinciples: false,   // extracted principles per project
+  withRisks: false,        // extracted risk entries per project
+  withExternals: false,    // projects/*/external/ listing
+  excludeGlobal: false,    // skip 000-global
+  projectFilter: null,     // dir name or 3-digit prefix
+});
+
+function resolveOpts(opts) {
+  return { ...DEFAULT_OPTS, ...(opts || {}) };
+}
 
 /**
  * Extract first markdown heading from content.
@@ -37,10 +59,62 @@ export function classifySeverity(docType) {
 }
 
 /**
- * Scan a single project directory for ARC documents and build graph data.
- * Mutates nodes, edges, reqIndex in-place.
+ * Build a ~500-char preview by skipping the leading doc-control table.
  */
-export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) {
+export function extractPreview(content, maxLen = 500) {
+  const lines = content.split('\n');
+  let inTable = false;
+  let pastControl = false;
+  const previewLines = [];
+
+  for (const line of lines) {
+    const trimmed = line.trim();
+
+    if (!pastControl) {
+      if (trimmed.startsWith('|') || trimmed === '' || trimmed.startsWith('#') || trimmed.startsWith('---')) {
+        if (trimmed.startsWith('|')) inTable = true;
+        else if (inTable && !trimmed.startsWith('|')) {
+          inTable = false;
+          pastControl = true;
+        }
+        continue;
+      }
+      pastControl = true;
+    }
+
+    if (pastControl && trimmed) {
+      previewLines.push(trimmed);
+    }
+
+    if (previewLines.join(' ').length >= maxLen) break;
+  }
+
+  return previewLines.join(' ').substring(0, maxLen);
+}
+
+/**
+ * Derive { subdir, vendor } from the prefix used while scanning.
+ *   ''                       → { subdir: null, vendor: null }
+ *   'decisions/'             → { subdir: 'decisions', vendor: null }
+ *   'vendors/foo/'           → { subdir: 'vendors/foo', vendor: 'foo' }
+ *   'vendors/foo/reviews/'   → { subdir: 'vendors/foo/reviews', vendor: 'foo' }
+ */
+function locationFromPrefix(prefix) {
+  if (!prefix) return { subdir: null, vendor: null };
+  const stripped = prefix.replace(/\/$/, '');
+  const vendorMatch = stripped.match(/^vendors\/([^/]+)/);
+  return { subdir: stripped, vendor: vendorMatch ? vendorMatch[1] : null };
+}
+
+/**
+ * Scan a single project directory for ARC documents and build graph data.
+ * Mutates nodes, edges, reqIndex in-place (legacy contract preserved).
+ *
+ * Optional `opts` (v2) enriches per-node fields and accumulates aggregations
+ * into the optional `aggregations` argument when provided.
+ */
+export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex, opts, aggregations) {
+  const o = resolveOpts(opts);
   const dirsToScan = [
     { dir: projectDir, prefix: '' },
     { dir: join(projectDir, 'decisions'), prefix: 'decisions/' },
@@ -65,6 +139,11 @@ export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) 
     }
   }
 
+  // Aggregations only populated when caller passes the bucket
+  const reqAccum = aggregations?.requirements;
+  const principlesAccum = aggregations?.principles;
+  const risksAccum = aggregations?.risks;
+
   for (const { dir, prefix } of dirsToScan) {
     if (!isDir(dir)) continue;
     for (const f of listDir(dir)) {
@@ -79,11 +158,15 @@ export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) 
       const fields = extractDocControlFields(content);
       const title = extractTitle(content) || fields['Document Title'] || f;
       const status = fields['Status'] || '';
+      const { subdir, vendor } = locationFromPrefix(prefix);
 
       const shortId = f.replace(/-v[\d.]+\.md$/, '');
       const fullId = f.replace(/\.md$/, '');
 
-      nodes[fullId] = {
+      const reqIdsSet = extractRequirementIds(content);
+
+      // v1 fields — always populated, identical to pre-v2 output
+      const node = {
         type: docType,
         project: projectName,
         path: `projects/${projectName}/${prefix}${f}`,
@@ -94,8 +177,27 @@ export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) 
         lastModified: fields['Last Modified'] || null,
       };
 
-      const reqIds = extractRequirementIds(content);
-      for (const reqId of reqIds) {
+      // v2 enrichments — gated to keep impact/pages output byte-stable
+      if (o.withNodeMetadata) {
+        node.version = extractVersion(f);
+        node.owner = fields['Owner'] || fields['Document Owner'] || '';
+        node.classification = fields['Classification'] || '';
+        node.vendor = vendor;
+        node.subdir = subdir;
+        node.controlFields = fields;
+        node.reqIds = Array.from(reqIdsSet);
+      }
+      if (o.withContent) {
+        node.content = content;
+        node.mtimeMs = mtimeMs(fp);
+      }
+      if (o.withPreview) {
+        node.preview = extractPreview(content);
+      }
+
+      nodes[fullId] = node;
+
+      for (const reqId of reqIdsSet) {
         if (!reqIndex[reqId]) reqIndex[reqId] = [];
         if (!reqIndex[reqId].includes(fullId)) {
           reqIndex[reqId].push(fullId);
@@ -114,26 +216,145 @@ export function scanProjectDir(projectDir, projectName, nodes, edges, reqIndex) 
           edges.push({ from: fullId, to: refShort, type: 'references' });
         }
       }
+
+      // Aggregations
+      if (reqAccum && docType === 'REQ') {
+        if (!reqAccum[projectName]) reqAccum[projectName] = [];
+        const details = extractRequirementDetails(content);
+        for (const r of details) {
+          reqAccum[projectName].push({ ...r, sourceFile: f });
+        }
+      }
+      if (principlesAccum && docType === 'PRIN') {
+        if (!principlesAccum[projectName]) principlesAccum[projectName] = [];
+        for (const p of extractPrinciples(content)) {
+          principlesAccum[projectName].push({ ...p, sourceFile: f });
+        }
+      }
+      if (risksAccum && docType === 'RISK') {
+        if (!risksAccum[projectName]) risksAccum[projectName] = [];
+        for (const r of extractRiskEntries(content)) {
+          risksAccum[projectName].push({ ...r, sourceFile: f });
+        }
+      }
     }
   }
 }
 
 /**
- * Scan all projects in the projects/ directory and build a complete dependency graph.
- * Returns { nodes, edges, reqIndex, projects }.
+ * Build a per-project vendor structure with reviews + verdicts.
  */
-export function scanAllArtifacts(projectsDir) {
+function scanVendors(projectDir) {
+  const vendors = [];
+  const vendorsDir = join(projectDir, 'vendors');
+  if (!isDir(vendorsDir)) return vendors;
+
+  for (const name of listDir(vendorsDir)) {
+    const vendorDir = join(vendorsDir, name);
+    if (!isDir(vendorDir)) continue;
+
+    const entry = { name, docs: [], reviews: [] };
+
+    for (const f of listDir(vendorDir)) {
+      if (!f.endsWith('.md')) continue;
+      if (!isFile(join(vendorDir, f))) continue;
+      entry.docs.push(f);
+    }
+
+    const reviewsDir = join(vendorDir, 'reviews');
+    if (isDir(reviewsDir)) {
+      for (const f of listDir(reviewsDir)) {
+        if (!f.endsWith('.md') || !isFile(join(reviewsDir, f))) continue;
+        const content = readText(join(reviewsDir, f));
+        let verdict = null;
+        if (content) {
+          if (/APPROVED\s+WITH\s+CONDITIONS/i.test(content)) verdict = 'APPROVED WITH CONDITIONS';
+          else if (/\bREJECTED\b/i.test(content)) verdict = 'REJECTED';
+          else if (/\bAPPROVED\b/i.test(content)) verdict = 'APPROVED';
+          else if (/\bPENDING\b/i.test(content)) verdict = 'PENDING';
+        }
+        entry.reviews.push({ file: f, verdict });
+      }
+    }
+
+    vendors.push(entry);
+  }
+
+  return vendors;
+}
+
+/**
+ * List files in projects/<name>/external/ with mtimes (excluding README.md).
+ */
+function scanExternals(projectDir) {
+  const externalDir = join(projectDir, 'external');
+  if (!isDir(externalDir)) return [];
+  const out = [];
+  for (const f of listDir(externalDir)) {
+    if (f === 'README.md') continue;
+    const fp = join(externalDir, f);
+    if (!isFile(fp)) continue;
+    out.push({ filename: f, path: fp, mtimeMs: mtimeMs(fp) });
+  }
+  return out;
+}
+
+/**
+ * Scan all projects in the projects/ directory and build a complete dependency graph.
+ *
+ * v1 contract preserved: with no `opts`, returns `{ nodes, edges, reqIndex, projects }`
+ * exactly as before. Optional fields (`requirements`, `vendors`, `principles`, `risks`,
+ * `externalFiles`) are added only when the corresponding flag is set.
+ */
+export function scanAllArtifacts(projectsDir, opts) {
+  const o = resolveOpts(opts);
   const nodes = {};
   const edges = [];
   const reqIndex = {};
 
-  const projectDirs = listDir(projectsDir)
+  let projectDirs = listDir(projectsDir)
     .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e));
+
+  if (o.excludeGlobal) {
+    projectDirs = projectDirs.filter(e => e !== '000-global');
+  }
+
+  if (o.projectFilter) {
+    projectDirs = projectDirs.filter(d =>
+      d === o.projectFilter || d.startsWith(o.projectFilter)
+    );
+  }
+
+  // Aggregation buckets (only built when requested)
+  const aggregations = {};
+  if (o.withRequirements) aggregations.requirements = {};
+  if (o.withPrinciples) aggregations.principles = {};
+  if (o.withRisks) aggregations.risks = {};
 
   for (const projectName of projectDirs) {
     const projectDir = join(projectsDir, projectName);
-    scanProjectDir(projectDir, projectName, nodes, edges, reqIndex);
+    scanProjectDir(projectDir, projectName, nodes, edges, reqIndex, o, aggregations);
   }
 
-  return { nodes, edges, reqIndex, projects: projectDirs };
+  const result = { nodes, edges, reqIndex, projects: projectDirs };
+
+  if (o.withRequirements) result.requirements = aggregations.requirements;
+  if (o.withPrinciples) result.principles = aggregations.principles;
+  if (o.withRisks) result.risks = aggregations.risks;
+
+  if (o.withVendors) {
+    result.vendors = {};
+    for (const projectName of projectDirs) {
+      result.vendors[projectName] = scanVendors(join(projectsDir, projectName));
+    }
+  }
+
+  if (o.withExternals) {
+    result.externalFiles = {};
+    for (const projectName of projectDirs) {
+      result.externalFiles[projectName] = scanExternals(join(projectsDir, projectName));
+    }
+  }
+
+  return result;
 }

--- a/tests/plugin/test_graph_utils.mjs
+++ b/tests/plugin/test_graph_utils.mjs
@@ -1,0 +1,277 @@
+#!/usr/bin/env node
+/**
+ * Smoke tests for arckit-claude/hooks/graph-utils.mjs
+ *
+ * Verifies:
+ *   1. v1 default output (no opts) is byte-stable — only the v1 keys appear on nodes.
+ *   2. Opt flags add the expected enrichments and aggregations.
+ *
+ * Run with:  node tests/plugin/test_graph_utils.mjs
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  scanAllArtifacts,
+} from '../../arckit-claude/hooks/graph-utils.mjs';
+
+// ── Fixture builder ────────────────────────────────────────────────────────
+
+function makeFixture() {
+  const root = mkdtempSync(join(tmpdir(), 'arckit-graph-'));
+  const projectsDir = join(root, 'projects');
+
+  const project = '001-fixture';
+  const projectDir = join(projectsDir, project);
+  mkdirSync(join(projectDir, 'decisions'), { recursive: true });
+  mkdirSync(join(projectDir, 'reviews'), { recursive: true });
+  mkdirSync(join(projectDir, 'vendors', 'acme', 'reviews'), { recursive: true });
+  mkdirSync(join(projectDir, 'external'), { recursive: true });
+
+  const globalDir = join(projectsDir, '000-global');
+  mkdirSync(globalDir, { recursive: true });
+
+  const docCtl = (id, type, fields = {}) => `# ${type} — ${id}
+
+| Field | Value |
+|---|---|
+| **Document ID** | ${id} |
+| **Document Type** | ${type} |
+| **Status** | ${fields.Status || 'DRAFT'} |
+| **Version** | 1.0 |
+| **Created Date** | 2026-01-01 |
+| **Last Modified** | 2026-01-15 |
+| **Owner** | ${fields.Owner || 'EA Team'} |
+| **Classification** | ${fields.Classification || 'OFFICIAL'} |
+
+## Body
+
+`;
+
+  // Requirements doc
+  writeFileSync(
+    join(projectDir, 'ARC-001-REQ-v1.0.md'),
+    docCtl('ARC-001-REQ-v1.0', 'REQ') +
+      `### BR-001: Provide ingest pipeline\n\n| Priority | MUST |\n\n` +
+      `### FR-002: Accept JSON payloads\n\n| Priority | SHOULD |\n\n` +
+      `Cross-ref to ARC-001-ADR-001.\n`
+  );
+
+  // ADR doc
+  writeFileSync(
+    join(projectDir, 'decisions', 'ARC-001-ADR-001-v1.0.md'),
+    docCtl('ARC-001-ADR-001-v1.0', 'ADR', { Status: 'Proposed' }) +
+      `## Status\n\nProposed\n\nReferences BR-001 and FR-002.\n`
+  );
+
+  // Vendor HLD
+  writeFileSync(
+    join(projectDir, 'vendors', 'acme', 'ARC-001-HLD-v1.0.md'),
+    docCtl('ARC-001-HLD-v1.0', 'HLD') + `Implements BR-001.\n`
+  );
+
+  // Vendor review
+  writeFileSync(
+    join(projectDir, 'vendors', 'acme', 'reviews', 'ARC-001-HLDR-001-v1.0.md'),
+    docCtl('ARC-001-HLDR-001-v1.0', 'HLDR') +
+      `Verdict: APPROVED WITH CONDITIONS\n`
+  );
+
+  // External file
+  writeFileSync(join(projectDir, 'external', 'spec.api.yaml'), 'openapi: 3.0\n');
+
+  // Global PRIN
+  writeFileSync(
+    join(globalDir, 'ARC-000-PRIN-v1.0.md'),
+    docCtl('ARC-000-PRIN-v1.0', 'PRIN') +
+      `## 1. Security Principles\n\n### 1. Least privilege\n\n**Principle Statement**: only grant minimum access.\n`
+  );
+
+  // RISK doc (basic)
+  writeFileSync(
+    join(projectDir, 'ARC-001-RISK-v1.0.md'),
+    docCtl('ARC-001-RISK-v1.0', 'RISK') +
+      `### R-001: Vendor lock-in\n\n| Likelihood | Medium |\n| Impact | High |\n`
+  );
+
+  return { root, projectsDir, project };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+test('v1 default output: only v1 keys appear on nodes', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir);
+
+    // Top-level keys: only v1 set
+    assert.deepEqual(
+      Object.keys(g).sort(),
+      ['edges', 'nodes', 'projects', 'reqIndex'],
+      'no v2 aggregations should appear by default'
+    );
+
+    // Each node has exactly the v1 keys, no more
+    const v1Keys = ['type', 'project', 'path', 'title', 'status', 'severity',
+                    'createdDate', 'lastModified'].sort();
+    for (const [id, node] of Object.entries(g.nodes)) {
+      assert.deepEqual(
+        Object.keys(node).sort(), v1Keys,
+        `node ${id} leaks v2 fields under default opts`
+      );
+    }
+
+    // Sanity: edges + reqIndex still populated
+    assert.ok(g.edges.length > 0, 'edges should be discovered');
+    assert.ok('BR-001' in g.reqIndex, 'reqIndex should include BR-001');
+    assert.ok(g.projects.includes('001-fixture'));
+    assert.ok(g.projects.includes('000-global'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withNodeMetadata adds version/owner/etc.', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withNodeMetadata: true });
+    const adr = g.nodes['ARC-001-ADR-001-v1.0'];
+    assert.ok(adr, 'ADR node exists');
+    assert.equal(adr.version, '1.0');
+    assert.equal(adr.owner, 'EA Team');
+    assert.equal(adr.classification, 'OFFICIAL');
+    assert.equal(adr.subdir, 'decisions');
+    assert.equal(adr.vendor, null);
+    assert.ok(Array.isArray(adr.reqIds));
+    assert.ok(adr.reqIds.includes('BR-001'));
+    assert.ok(adr.controlFields);
+
+    const hld = g.nodes['ARC-001-HLD-v1.0'];
+    assert.equal(hld.vendor, 'acme');
+    assert.equal(hld.subdir, 'vendors/acme');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withContent adds content + mtimeMs', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withContent: true });
+    const req = g.nodes['ARC-001-REQ-v1.0'];
+    assert.ok(typeof req.content === 'string');
+    assert.ok(req.content.includes('BR-001'));
+    assert.ok(typeof req.mtimeMs === 'number');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withPreview adds preview', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withPreview: true });
+    const req = g.nodes['ARC-001-REQ-v1.0'];
+    assert.ok(typeof req.preview === 'string');
+    assert.ok(req.preview.length > 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withRequirements aggregates full requirement records', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withRequirements: true });
+    assert.ok(g.requirements);
+    const reqs = g.requirements['001-fixture'];
+    assert.ok(reqs);
+    const br = reqs.find(r => r.id === 'BR-001');
+    assert.ok(br);
+    assert.equal(br.category, 'Business');
+    assert.equal(br.sourceFile, 'ARC-001-REQ-v1.0.md');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withVendors collects vendor docs + reviews + verdicts', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withVendors: true });
+    assert.ok(g.vendors);
+    const vendors = g.vendors['001-fixture'];
+    assert.equal(vendors.length, 1);
+    const acme = vendors[0];
+    assert.equal(acme.name, 'acme');
+    assert.ok(acme.docs.length > 0);
+    assert.equal(acme.reviews.length, 1);
+    assert.equal(acme.reviews[0].verdict, 'APPROVED WITH CONDITIONS');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withPrinciples aggregates from 000-global', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withPrinciples: true });
+    assert.ok(g.principles);
+    const globalPrin = g.principles['000-global'];
+    assert.ok(globalPrin);
+    assert.ok(globalPrin.length > 0);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withRisks aggregates risk entries', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withRisks: true });
+    assert.ok(g.risks);
+    // Existence is enough — exact structure depends on extractRiskEntries behaviour
+    assert.ok(g.risks['001-fixture']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('withExternals lists external/ files', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { withExternals: true });
+    assert.ok(g.externalFiles);
+    const ext = g.externalFiles['001-fixture'];
+    assert.equal(ext.length, 1);
+    assert.equal(ext[0].filename, 'spec.api.yaml');
+    assert.ok(typeof ext[0].mtimeMs === 'number');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('excludeGlobal drops 000-global', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { excludeGlobal: true });
+    assert.ok(!g.projects.includes('000-global'));
+    assert.ok(g.projects.includes('001-fixture'));
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('projectFilter restricts to one project', () => {
+  const { root, projectsDir } = makeFixture();
+  try {
+    const g = scanAllArtifacts(projectsDir, { projectFilter: '001' });
+    assert.deepEqual(g.projects, ['001-fixture']);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Step 1 of #162. Extend `graph-utils.mjs` with optional flags so the four custom-scan hooks (health, traceability, governance, search) can later migrate onto the shared graph builder. **No consumer changes** in this PR — purely additive.

## Backward compatibility

`scanAllArtifacts(projectsDir)` with no opts returns exactly the v1 shape:

- Top-level keys: `{ nodes, edges, reqIndex, projects }` only.
- Each node has only the v1 keys (`type`, `project`, `path`, `title`, `status`, `severity`, `createdDate`, `lastModified`).

This is verified by the first smoke test ("v1 default output: only v1 keys appear on nodes"). `impact-scan.mjs` and `sync-guides.mjs` keep byte-identical output.

## New opts (all default off)

| Opt | Adds |
|---|---|
| `withNodeMetadata` | `version`, `owner`, `classification`, `vendor`, `subdir`, `controlFields`, `reqIds` on each node |
| `withContent` | full `content` + `mtimeMs` on each node |
| `withPreview` | ~500-char post-control `preview` on each node |
| `withRequirements` | `graph.requirements[project] = [{id, category, priority, description, sourceFile}, …]` |
| `withVendors` | `graph.vendors[project] = [{name, docs, reviews:[{file, verdict}]}, …]` |
| `withPrinciples` | `graph.principles[project] = [{id, title, category, statement, …}]` (incl. 000-global) |
| `withRisks` | `graph.risks[project] = [{…}]` |
| `withExternals` | `graph.externalFiles[project] = [{filename, path, mtimeMs}]` |
| `excludeGlobal` | drops `000-global` |
| `projectFilter` | restricts scan to one project (matches dir name or 3-digit prefix) |

## What's intentionally not on the graph

ADR status / review verdict / unresolved conditions / placeholder counts / resolution-keyword evidence — these stay in `hook-utils.mjs` as domain extractors. Graph = inventory; hooks = reasoning.

## Tests

```
$ node --test tests/plugin/test_graph_utils.mjs
✔ v1 default output: only v1 keys appear on nodes
✔ withNodeMetadata adds version/owner/etc.
✔ withContent adds content + mtimeMs
✔ withPreview adds preview
✔ withRequirements aggregates full requirement records
✔ withVendors collects vendor docs + reviews + verdicts
✔ withPrinciples aggregates from 000-global
✔ withRisks aggregates risk entries
✔ withExternals lists external/ files
✔ excludeGlobal drops 000-global
✔ projectFilter restricts to one project
ℹ pass 11  fail 0
```

## Test plan

- [x] Smoke tests pass on Node 24
- [ ] Manually invoke `/arckit:impact` and `/arckit:pages` in a test repo and verify behaviour is unchanged
- [ ] Confirm CI (if any) is green

## Next steps (separate PRs)

Per #162 migration order:
1. ✅ This PR — additive graph-utils v2
2. `search-scan` → `graph-inject`
3. `impact-scan` → `graph-inject`
4. `traceability-scan` → `graph-inject`
5. `health-scan` → `graph-inject`
6. `governance-scan` → `graph-inject`
7. Decide `sync-guides` fate

Refs #162.

🤖 Generated with [Claude Code](https://claude.com/claude-code)