### PR TITLE
docs(site): wire UAE Federal Overlay into guides, articles, index

### DIFF
--- a/docs/articles.html
+++ b/docs/articles.html
@@ -312,6 +312,86 @@
 
             <div class="app-article-grid">
 
+                <!-- 2026-04-30 v4.10 launch -->
+                <article class="app-article-card">
+                    <a class="app-article-card__media" href="article-viewer.html?a=2026-04-30-uae-overlay-launch">
+                        <img src="articles/2026-04-30-uae-overlay-launch-hero.png" alt="ArcKit v4.10 UAE Federal Overlay launch — 12 commands grid">
+                    </a>
+                    <div class="app-article-card__body">
+                        <div class="app-article-card__meta">
+                            <span class="app-article-card__tag app-article-card__tag--release">Release</span>
+                            <span class="app-article-card__date">30 April 2026</span>
+                        </div>
+                        <h2 class="govuk-heading-s app-article-card__title">ArcKit v4.10: 12 UAE Federal Commands, Official Baseline</h2>
+                        <p class="app-article-card__summary">Twelve official-baseline commands covering the UAE federal regulatory and digital-government stack. The release walkthrough: PDPL, IAS, sovereign cloud residency, UAE Pass, the four Cabinet instruments, AI Charter, autonomy tier, federal procurement.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-overlay-launch" class="govuk-link app-article-card__link">Read article &rarr;</a>
+                    </div>
+                </article>
+
+                <!-- 2026-04-30 decree operationalisation -->
+                <article class="app-article-card">
+                    <a class="app-article-card__media" href="article-viewer.html?a=2026-04-30-uae-agentic-decree-arckit-v4-10">
+                        <img src="articles/2026-04-30-uae-agentic-decree-arckit-v4-10-hero.png" alt="Decree to 4 instruments to 12 commands policy stack">
+                    </a>
+                    <div class="app-article-card__body">
+                        <div class="app-article-card__meta">
+                            <span class="app-article-card__tag app-article-card__tag--technical">Essay</span>
+                            <span class="app-article-card__date">30 April 2026</span>
+                        </div>
+                        <h2 class="govuk-heading-s app-article-card__title">How ArcKit v4.10 Accelerates the UAE's Federal Agentic Decree</h2>
+                        <p class="app-article-card__summary">Policy-audience essay mapping the 23 April Cabinet decree, the four governance instruments, and the federal regulatory baseline directly onto the 12 new uae-* commands. One command per instrument; eight more for the federal baseline; two for AI governance; one for procurement.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-agentic-decree-arckit-v4-10" class="govuk-link app-article-card__link">Read article &rarr;</a>
+                    </div>
+                </article>
+
+                <!-- 2026-04-30 CAIO 90 days -->
+                <article class="app-article-card">
+                    <a class="app-article-card__media" href="article-viewer.html?a=2026-04-30-uae-caio-first-90-days">
+                        <img src="articles/2026-04-30-uae-caio-first-90-days-hero.png" alt="UAE CAIO first 90 days four-phase plan">
+                    </a>
+                    <div class="app-article-card__body">
+                        <div class="app-article-card__meta">
+                            <span class="app-article-card__tag app-article-card__tag--guide">Guide</span>
+                            <span class="app-article-card__date">30 April 2026</span>
+                        </div>
+                        <h2 class="govuk-heading-s app-article-card__title">The CAIO's First 90 Days: Delivering the UAE Cabinet Agentic AI Mandate</h2>
+                        <p class="app-article-card__summary">For UAE Chief AI Officers under the Cabinet's two-year deadline: what to produce, what timeline is achievable, what team and budget you will need, and what architecture stack the artefacts have to fit. Concrete week-one actions and a credible cadence to month twenty-four.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-caio-first-90-days" class="govuk-link app-article-card__link">Read article &rarr;</a>
+                    </div>
+                </article>
+
+                <!-- 2026-04-30 90-day playbook -->
+                <article class="app-article-card">
+                    <a class="app-article-card__media" href="article-viewer.html?a=2026-04-30-uae-agentic-decree-90-day-playbook">
+                        <img src="articles/2026-04-30-uae-agentic-decree-90-day-playbook-hero.png" alt="Conventional vs ArcKit weeks per artefact bar chart">
+                    </a>
+                    <div class="app-article-card__body">
+                        <div class="app-article-card__meta">
+                            <span class="app-article-card__tag app-article-card__tag--guide">Guide</span>
+                            <span class="app-article-card__date">30 April 2026</span>
+                        </div>
+                        <h2 class="govuk-heading-s app-article-card__title">The UAE Agentic Decree: A 90-Day ArcKit Playbook</h2>
+                        <p class="app-article-card__summary">Command-by-command, calendar-anchored playbook for the first ninety days under the UAE Cabinet's agentic decree. The acceleration ledger comparing conventional architect-weeks against ArcKit-weeks per artefact, with the working that makes the two-year deadline arithmetically possible.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-agentic-decree-90-day-playbook" class="govuk-link app-article-card__link">Read article &rarr;</a>
+                    </div>
+                </article>
+
+                <!-- 2026-04-30 drafting to judging -->
+                <article class="app-article-card">
+                    <a class="app-article-card__media" href="article-viewer.html?a=2026-04-30-toolkit-drafts-architect-judges">
+                        <img src="articles/2026-04-30-toolkit-drafts-architect-judges-hero.png" alt="Conventional vs ArcKit working day comparison — drafting collapses, judging stays constant">
+                    </a>
+                    <div class="app-article-card__body">
+                        <div class="app-article-card__meta">
+                            <span class="app-article-card__tag app-article-card__tag--technical">Essay</span>
+                            <span class="app-article-card__date">30 April 2026</span>
+                        </div>
+                        <h2 class="govuk-heading-s app-article-card__title">The Toolkit Drafts. The Architect Judges.</h2>
+                        <p class="app-article-card__summary">Why the architect's working day under agentic tooling shifts from drafting to judging, what that does to the architect-to-engineer ratio, and the two failure modes that quietly defeat the productivity case if the calibration is wrong.</p>
+                        <a href="article-viewer.html?a=2026-04-30-toolkit-drafts-architect-judges" class="govuk-link app-article-card__link">Read article &rarr;</a>
+                    </div>
+                </article>
+
                 <!-- 2026-04-28 -->
                 <article class="app-article-card">
                     <a class="app-article-card__media" href="article-viewer.html?a=2026-04-28-pricing-arckit-investor">

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -280,7 +280,7 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">91 Guides + 19 Community Overlays</span>
+            <span class="app-page-hero__stat">93 Guides + 19 Community Overlays</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
             <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 10 categories, plus 19 community-contributed EU and French public-sector overlays in dedicated sections.</p>
         </div>
@@ -493,6 +493,21 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-pssi" class="govuk-link">PSSI Security Policy</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Politique de Sécurité des Systèmes d'Information</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-rgpd" class="govuk-link">French GDPR / CNIL Compliance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">RGPD compliance with CNIL-specific guidance</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=fr-secnumcloud" class="govuk-link">SecNumCloud Qualification</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">SecNumCloud cloud qualification assessment</span></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- UAE Federal Overlay -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> UAE Federal Overlay
+                    <span class="app-guide-category__count">2 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Official-baseline overlay supporting UAE federal entities under the 23 April 2026 Cabinet agentic-AI decree. PDPL, IAS, sovereign cloud residency, UAE Pass, the four Cabinet instruments, AI Charter, autonomy tier, and federal procurement.</em></p>
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-overlay" class="govuk-link">UAE Federal Overlay</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">When to use the overlay, the canonical chain across the 12 commands, plugin userConfig setup, migration from the UK ladder</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-overlay-maintenance" class="govuk-link">UAE Overlay Maintenance &amp; Citation Register</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Citation register with verification dates, quarterly review cadence, known limitations, help-wanted callout for UAE domain co-maintainer</span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -524,6 +524,76 @@
             <div class="app-article-teaser-grid">
                 <article class="app-article-teaser">
                     <a class="app-article-teaser__media" href="articles.html">
+                        <img src="articles/2026-04-30-uae-overlay-launch-hero.png" alt="ArcKit v4.10 UAE Federal Overlay launch">
+                    </a>
+                    <div class="app-article-teaser__body">
+                        <div class="app-article-teaser__meta">
+                            <span class="app-article-teaser__tag app-article-teaser__tag--release">Release</span>
+                            <span class="app-article-teaser__date">30 April 2026</span>
+                        </div>
+                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit v4.10: 12 UAE Federal Commands, Official Baseline</h3>
+                        <p class="app-article-teaser__summary">Twelve official-baseline commands covering PDPL, IAS, sovereign cloud residency, UAE Pass, the four Cabinet instruments, AI Charter, autonomy tier, and federal procurement.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-overlay-launch" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                    </div>
+                </article>
+                <article class="app-article-teaser">
+                    <a class="app-article-teaser__media" href="articles.html">
+                        <img src="articles/2026-04-30-uae-agentic-decree-arckit-v4-10-hero.png" alt="Decree to 4 instruments to 12 commands policy stack">
+                    </a>
+                    <div class="app-article-teaser__body">
+                        <div class="app-article-teaser__meta">
+                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
+                            <span class="app-article-teaser__date">30 April 2026</span>
+                        </div>
+                        <h3 class="govuk-heading-s app-article-teaser__title">How ArcKit v4.10 Accelerates the UAE's Federal Agentic Decree</h3>
+                        <p class="app-article-teaser__summary">Maps the 23 April Cabinet decree, the four governance instruments, and the federal regulatory baseline directly onto the 12 new uae-* commands.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-agentic-decree-arckit-v4-10" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                    </div>
+                </article>
+                <article class="app-article-teaser">
+                    <a class="app-article-teaser__media" href="articles.html">
+                        <img src="articles/2026-04-30-uae-caio-first-90-days-hero.png" alt="UAE CAIO first 90 days four-phase plan">
+                    </a>
+                    <div class="app-article-teaser__body">
+                        <div class="app-article-teaser__meta">
+                            <span class="app-article-teaser__tag app-article-teaser__tag--guide">Guide</span>
+                            <span class="app-article-teaser__date">30 April 2026</span>
+                        </div>
+                        <h3 class="govuk-heading-s app-article-teaser__title">The CAIO's First 90 Days: Delivering the UAE Cabinet Agentic AI Mandate</h3>
+                        <p class="app-article-teaser__summary">For UAE Chief AI Officers under the two-year deadline: requirements, timelines, resources, architecture, and concrete week-one actions.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-caio-first-90-days" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                    </div>
+                </article>
+                <article class="app-article-teaser">
+                    <a class="app-article-teaser__media" href="articles.html">
+                        <img src="articles/2026-04-30-uae-agentic-decree-90-day-playbook-hero.png" alt="Conventional vs ArcKit weeks per artefact bar chart">
+                    </a>
+                    <div class="app-article-teaser__body">
+                        <div class="app-article-teaser__meta">
+                            <span class="app-article-teaser__tag app-article-teaser__tag--guide">Guide</span>
+                            <span class="app-article-teaser__date">30 April 2026</span>
+                        </div>
+                        <h3 class="govuk-heading-s app-article-teaser__title">The UAE Agentic Decree: A 90-Day ArcKit Playbook</h3>
+                        <p class="app-article-teaser__summary">Command-by-command, calendar-anchored playbook for the first ninety days, with the acceleration ledger comparing conventional and ArcKit weeks per artefact.</p>
+                        <a href="article-viewer.html?a=2026-04-30-uae-agentic-decree-90-day-playbook" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                    </div>
+                </article>
+                <article class="app-article-teaser">
+                    <a class="app-article-teaser__media" href="articles.html">
+                        <img src="articles/2026-04-30-toolkit-drafts-architect-judges-hero.png" alt="Conventional vs ArcKit working day comparison">
+                    </a>
+                    <div class="app-article-teaser__body">
+                        <div class="app-article-teaser__meta">
+                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
+                            <span class="app-article-teaser__date">30 April 2026</span>
+                        </div>
+                        <h3 class="govuk-heading-s app-article-teaser__title">The Toolkit Drafts. The Architect Judges.</h3>
+                        <p class="app-article-teaser__summary">Why the architect's working day under agentic tooling shifts from drafting to judging, and what that does to the architecture-to-engineering ratio.</p>
+                        <a href="article-viewer.html?a=2026-04-30-toolkit-drafts-architect-judges" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                    </div>
+                </article>
+                <article class="app-article-teaser">
+                    <a class="app-article-teaser__media" href="articles.html">
                         <img src="articles/2026-04-28-pricing-arckit-investor-hero.png" alt="Pricing ArcKit for an investor — financial vs strategic valuation">
                     </a>
                     <div class="app-article-teaser__body">


### PR DESCRIPTION
## Summary

Backfills the public docs site with the UAE Federal Overlay coverage that Phase D of v4.10 left partial. Three pages updated.

### docs/guides.html
New "UAE Federal Overlay" section (positioned after the EU/FR community sections, before Operations) listing both new guides:
- \`uae-overlay\` — when to use, canonical chain, plugin userConfig setup, migration from UK ladder
- \`uae-overlay-maintenance\` — citation register, quarterly review cadence, known limitations, co-maintainer call

Both tagged **LIVE** rather than EXPERIMENTAL because the overlay is official-baseline. Top-of-page stat bumped from 91 to 93 guides.

### docs/articles.html
Five UAE articles dated 30 April 2026 added at the top of the grid in this order:
1. ArcKit v4.10: 12 UAE Federal Commands, Official Baseline (Release tag)
2. How ArcKit v4.10 Accelerates the UAE's Federal Agentic Decree (Essay tag)
3. The CAIO's First 90 Days (Guide tag)
4. The UAE Agentic Decree: A 90-Day ArcKit Playbook (Guide tag)
5. The Toolkit Drafts. The Architect Judges. (Essay tag)

### docs/index.html
Same five articles surfaced in the "Latest writing" teaser strip, ahead of the 28 April pricing-investor essay. Count badges in index.html (80 commands across six locations) were already updated by Phase D and were left as-is. Positioning copy ("UK Government standards") untouched.

## Out of scope (kept for a separate PR)

- \`docs/commands.html\` still has zero UAE commands AND zero EU/FR/AT community commands — pre-existing housekeeping gap that needs the master commands table extended for all 33 community + UAE entries together.

## Test plan

- [x] guides.html shows two new UAE entries with LIVE tag
- [x] articles.html lists all five UAE articles with correct hero filenames and viewer URLs
- [x] index.html "Latest writing" surfaces the five UAE articles in date order
- [x] No broken hero references (all five PNG paths exist on main after PR #370 + #371 merged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)