### PR TITLE
docs(site): backfill commands.html with 34 community + UAE commands

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -566,6 +566,10 @@
                     <option value="quality-compliance">Quality &amp; Compliance</option>
                     <option value="reporting">Reporting</option>
                     <option value="utility">Utility</option>
+                    <option value="uae-overlay">UAE Federal Overlay</option>
+                    <option value="eu-overlay">EU Regulatory Overlay (Community)</option>
+                    <option value="fr-overlay">French Government Overlay (Community)</option>
+                    <option value="at-overlay">Austrian Government Overlay (Community)</option>
                 </select>
             </div>
             <div>
@@ -1355,6 +1359,252 @@
                         <td>Utility</td>
                         <td class="examples">
                         </td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+
+                    <!-- UAE Federal Overlay (Official, v4.10.0) -->
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-classification</code></td>
+                        <td class="description">UAE Smart Data Classification Register — maps every dataset to Open / Shared / Confidential / Secret / Top Secret with handling rules and declassification schedule</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-pdpl</code></td>
+                        <td class="description">PDPL (Federal Decree-Law 45/2021) compliance assessment with DPIA, lawful-basis register, data-subject-rights procedure, cross-border transfer log</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-ias</code></td>
+                        <td class="description">UAE IAS Statement of Applicability against the 188 controls (60 management M1–M6 + 128 technical T1–T9), priority-tiered P1–P4</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-cloud-residency</code></td>
+                        <td class="description">Sovereign cloud residency assessment under the National Cloud Security Policy v2 — Core42 / G42, Microsoft UAE North + Central, TDRA FedNet, e&amp; Sovereign Launchpad</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-uaepass</code></td>
+                        <td class="description">UAE Pass integration design — OIDC/OAuth flow, claim mapping, Basic vs Verified profile, Service Provider onboarding pack, e-signature audit trail</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-zero-bureaucracy</code></td>
+                        <td class="description">Service catalogue review under the UAE Code for Government Services and Zero Bureaucracy — bureaucracy-elimination baseline and customer-experience KPIs</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-digital-records</code></td>
+                        <td class="description">Digital Records Plan under the UAE Government Services Digital Records Policy — source-of-truth register, retention schedule, records-as-official-source</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-data-sharing</code></td>
+                        <td class="description">Data Sharing Agreement under the UAE Government Services Data Sharing Policy — collect-once mapping, federation/API plan, PDPL lawful basis per share</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-priorities-alignment</code></td>
+                        <td class="description">National Priorities Alignment Statement under the UAE Federal Government Guide — reuse-vs-build, capability-reuse register, alignment to NIS 2031 / AI 2031 / We the UAE 2031</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-ai-charter</code></td>
+                        <td class="description">UAE Charter for the Development and Use of AI — compliance assessment against the 12 principles (human-machine ties, safety, bias mitigation, etc.)</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-ai-autonomy-tier</code></td>
+                        <td class="description">Three-tier AI autonomy posture — Tier 1 internal-productivity / Tier 2 investor-facing-with-approval / Tier 3 regulated-or-financial — with per-tier guard-rails and promotion criteria</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="uae-overlay">
+                        <td><code>/arckit.uae-procurement</code></td>
+                        <td class="description">UAE federal procurement strategy under Federal Decree-Law 11/2023 — ITT/RFP packs, MoF Digital Procurement Platform alignment, In-Country Value plan</td>
+                        <td>UAE Federal Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+
+                    <!-- EU Regulatory Overlay (Community-contributed) -->
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-rgpd</code></td>
+                        <td class="description">[COMMUNITY] GDPR (EU 2016/679) compliance assessment — Art. 6/9 lawful basis, EDPB DPIA screening, Schrems II transfer rules</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-nis2</code></td>
+                        <td class="description">[COMMUNITY] NIS2 Directive scoping (Annex I &amp; II), Article 21 minimum measures, four-stage incident reporting timeline</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-ai-act</code></td>
+                        <td class="description">[COMMUNITY] EU AI Act (2024/1689) risk classification — Article 5 prohibited, Annex III high-risk, GPAI obligations under Articles 53–55</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-dora</code></td>
+                        <td class="description">[COMMUNITY] Digital Operational Resilience Act — ICT third-party register, threat-led pen-testing, four-hour incident reporting window</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-cra</code></td>
+                        <td class="description">[COMMUNITY] EU Cyber Resilience Act — Annex I essential requirements, SBOM (SPDX/CycloneDX), CE marking</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-dsa</code></td>
+                        <td class="description">[COMMUNITY] EU Digital Services Act — intermediary / hosting / online platform / VLOP (45M+ EU MAU) classification</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="eu-overlay">
+                        <td><code>/arckit.eu-data-act</code></td>
+                        <td class="description">[COMMUNITY] EU Data Act — connected products, B2B FRAND data sharing, cloud switching obligations under Chapter VI, Article 27 transfer restrictions</td>
+                        <td>EU Regulatory Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+
+                    <!-- French Government Overlay (Community-contributed) -->
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-secnumcloud</code></td>
+                        <td class="description">[COMMUNITY] ANSSI SecNumCloud 3.2 cloud qualification — provider matrices for S3NS, Outscale, OVHcloud, Bleu, NumSpot, Cloud Temple plus FISA Section 702 residual risk</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-rgpd</code></td>
+                        <td class="description">[COMMUNITY] CNIL-specific layer over EU RGPD — Délibération 2020-091 cookies, HDS for health data, French digital consent at 15</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-ebios</code></td>
+                        <td class="description">[COMMUNITY] EBIOS Risk Manager — five-workshop ANSSI methodology, MITRE ATT&amp;CK mapping, homologation recommendation</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-anssi</code></td>
+                        <td class="description">[COMMUNITY] ANSSI Security Posture — 42-measure Guide d'hygiène informatique + cloud security recommendations</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-anssi-carto</code></td>
+                        <td class="description">[COMMUNITY] ANSSI Information System Cartography across the four reading levels: business, application, system, network</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-pssi</code></td>
+                        <td class="description">[COMMUNITY] Politique de Sécurité des Systèmes d'Information — RGS and ANSSI references, integrates with eu-nis2</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-dr</code></td>
+                        <td class="description">[COMMUNITY] Diffusion Restreinte handling under Instruction Interministérielle 901 (SGDSN/ANSSI) — marking, storage, transmission, destruction</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-marche-public</code></td>
+                        <td class="description">[COMMUNITY] French public procurement under code de la commande publique — UGAP catalogue, 40k/215k euro thresholds, sovereignty clauses</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-dinum</code></td>
+                        <td class="description">[COMMUNITY] DINUM five référentiels — RGI, RGAA, RGESN, RGS, doctrine cloud de l'État — plus FranceConnect and DSFR applicability</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-algorithme-public</code></td>
+                        <td class="description">[COMMUNITY] Public algorithm transparency notice required by Article L311-3-1 CRPA (Loi République Numérique)</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-code-reuse</code></td>
+                        <td class="description">[COMMUNITY] Build-vs-reuse decision matrix against code.gouv.fr, the SILL, and EUPL-licensed European public code repositories</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="fr-overlay">
+                        <td><code>/arckit.fr-irn</code></td>
+                        <td class="description">[COMMUNITY] Indice de Résilience Numérique — French digital resilience index assessment</td>
+                        <td>French Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+
+                    <!-- Austrian Government Overlay (Community-contributed) -->
+                    <tr data-status="experimental" data-category="at-overlay">
+                        <td><code>/arckit.at-dsgvo</code></td>
+                        <td class="description">[COMMUNITY] Austrian Datenschutzgesetz (DSG) and DSGVO compliance assessment — DSB notification, employer-context exemptions, sectoral rules</td>
+                        <td>Austrian Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="at-overlay">
+                        <td><code>/arckit.at-nisg</code></td>
+                        <td class="description">[COMMUNITY] Austrian NISG (NIS2 transposition) — sector scoping, qualified body audits, BMI reporting timelines</td>
+                        <td>Austrian Government Overlay</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
+                    </tr>
+                    <tr data-status="experimental" data-category="at-overlay">
+                        <td><code>/arckit.at-bvergg</code></td>
+                        <td class="description">[COMMUNITY] Austrian public procurement under Bundesvergabegesetz 2018 — federal/sub-federal scope, SME thresholds, e-procurement obligations</td>
+                        <td>Austrian Government Overlay</td>
+                        <td class="examples">—</td>
                         <td><span class="app-status-tag app-status-experimental">Experimental</span></td>
                     </tr>
                 </tbody>


### PR DESCRIPTION
## Summary

Closes the pre-existing housekeeping gap noted in PR #373. The master commands table at \`docs/commands.html\` had zero entries for any of the 22 community-contributed commands (7 EU + 12 FR + 3 AT) or the 12 new UAE Federal Overlay commands. All 34 now appear with descriptions, categories, and appropriate status tags.

## Changes

### Filter dropdown (4 new options)

- UAE Federal Overlay
- EU Regulatory Overlay (Community)
- French Government Overlay (Community)
- Austrian Government Overlay (Community)

### 34 new table rows

- **12 UAE rows** (data-category=\"uae-overlay\", **Live** status — official baseline). All twelve uae-* commands with one-line descriptions taken from the command frontmatter.
- **7 EU rows** (data-category=\"eu-overlay\", **Experimental** status, [COMMUNITY] prefix). RGPD, NIS2, AI Act, DORA, CRA, DSA, Data Act.
- **12 FR rows** (data-category=\"fr-overlay\", **Experimental** status, [COMMUNITY] prefix). SecNumCloud, RGPD/CNIL, EBIOS, ANSSI, ANSSI-Carto, PSSI, DR, Marché Public, DINUM, Algorithme Public, Code Reuse, IRN.
- **3 AT rows** (data-category=\"at-overlay\", **Experimental** status, [COMMUNITY] prefix). DSGVO, NISG, BVergG.

Examples column set to em-dash for all 34 — UAE test repos (v15-ipad, v20-uae-moi-ipad) are private; EU/FR/AT community commands have no public test artefacts to link.

## Verification

- 12 UAE + 7 EU + 12 FR + 3 AT = 34 rows present (\`grep -c\` per category)
- HTML still parses with the standard library parser
- No changes to existing 80 baseline rows; pure additive change

🤖 Generated with [Claude Code](https://claude.com/claude-code)