### PR TITLE
fix(pages): mark UAE Federal Overlay sections as community-contributed

### DIFF
--- a/arckit-claude/commands/pages.md
+++ b/arckit-claude/commands/pages.md
@@ -297,21 +297,21 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | ATNISG | `ARC-*-ATNISG-*.md` | Austrian NISG (NIS2) Assessment |
 | **Procurement (Community-contributed — Austrian Government)** | | | |
 | | BVERGG | `ARC-*-BVERGG-*.md` | Austrian Public Procurement (BVergG 2018) |
-| **Compliance (UAE Federal Overlay)** | | | |
+| **Compliance (Community-contributed — UAE Federal Overlay)** | | | |
 | | PDPL | `ARC-*-PDPL-*.md` | UAE PDPL Compliance Assessment |
 | | IAS | `ARC-*-IAS-*.md` | UAE IAS Statement of Applicability |
 | | AICH | `ARC-*-AICH-*.md` | UAE AI Charter Compliance Assessment |
-| **Architecture (UAE Federal Overlay)** | | | |
+| **Architecture (Community-contributed — UAE Federal Overlay)** | | | |
 | | CRES | `ARC-*-CRES-*.md` | UAE Sovereign Cloud Residency Assessment |
 | | UPASS | `ARC-*-UPASS-*.md` | UAE Pass Integration Design |
 | | AUTI | `ARC-*-AUTI-*.md` | UAE AI Autonomy Tier Posture |
-| **Governance (UAE Federal Overlay)** | | | |
+| **Governance (Community-contributed — UAE Federal Overlay)** | | | |
 | | CLAS | `ARC-*-CLAS-*.md` | UAE Smart Data Classification Register |
 | | ZBUR | `ARC-*-ZBUR-*.md` | UAE Zero Bureaucracy Service Review |
 | | DREC | `ARC-*-DREC-*.md` | UAE Digital Records Plan |
 | | DSHR | `ARC-*-DSHR-*.md` | UAE Data Sharing Agreement |
 | | NPRA | `ARC-*-NPRA-*.md` | UAE National Priorities Alignment Statement |
-| **Procurement (UAE Federal Overlay)** | | | |
+| **Procurement (Community-contributed — UAE Federal Overlay)** | | | |
 | | FPRO | `ARC-*-FPRO-*.md` | UAE Federal Procurement Strategy |
 
 > **Single source of truth**: this table mirrors [`arckit-claude/config/doc-types.mjs`](../config/doc-types.mjs). When adding new commands, register the type code in `doc-types.mjs` first (so the hook resolves category + display name) and then add the row here so `/arckit.pages` includes the artifact in the dashboard.


### PR DESCRIPTION
## Summary

Closes the v4.10.1 cleanup gap. The reclassification PR (#375) flipped UAE from official to community across the toolkit (commands, templates, doc site, articles, CHANGELOG) but missed four section headers in \`arckit-claude/commands/pages.md\`. The pages dashboard still labelled UAE artefacts as their own first-class tier rather than aligning to the EU/FR/AT community pattern.

## Change

Four label updates in pages.md:

\`\`\`
- | **Compliance (UAE Federal Overlay)** | | | |
+ | **Compliance (Community-contributed — UAE Federal Overlay)** | | | |
\`\`\`

Same edit on the Architecture, Governance, and Procurement section headers. No type-code changes, no doc-types.mjs changes, no template changes.

## Verification

- 4 occurrences of new label string present
- Dual-registration test still passes (92 codes)
- One file changed, +4/-4

## Version

No bump. This is a label-only fix to match a registry that gets read at command-execution time; it ships immediately to anyone pulling latest plugin from main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)