### PR TITLE
feat(pages): enrich Document Map + dashboard with graph health rollups

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -355,6 +355,35 @@
             margin-left: 4px;
         }
 
+        .app-nav-version {
+            float: right;
+            font-size: 0.7rem;
+            color: var(--text-muted);
+            font-weight: 400;
+        }
+
+        .app-nav-versioned {
+            display: flex;
+            align-items: center;
+        }
+
+        .app-nav-versioned a {
+            flex: 1;
+            min-width: 0;
+        }
+
+        .app-nav-version-select {
+            flex-shrink: 0;
+            font-size: 0.7rem;
+            color: var(--text-muted);
+            background: transparent;
+            border: 1px solid var(--border-color);
+            border-radius: 3px;
+            padding: 0 4px;
+            margin-right: 0.5rem;
+            cursor: pointer;
+        }
+
         /* Main Content - Full Width, Left Aligned */
         .app-content-wrapper {
             flex: 1;
@@ -447,6 +476,29 @@
         .app-doc-title {
             margin: 0;
             font-size: 2.25rem;
+        }
+
+        /* HTML deck artifacts (e.g. ARC-001-DECK-v1.0.html) */
+        .app-deck-newtab {
+            display: inline-block;
+            margin-top: 0.75rem;
+            font-size: 0.875rem;
+            color: var(--primary-color);
+            text-decoration: none;
+            font-weight: 600;
+        }
+
+        .app-deck-newtab:hover {
+            text-decoration: underline;
+        }
+
+        .app-deck-frame {
+            display: block;
+            width: 100%;
+            height: 80vh;
+            border: 1px solid var(--border-color);
+            border-radius: 4px;
+            background: #fff;
         }
 
         /* Loading State */
@@ -997,6 +1049,12 @@
         .guide-status.experimental {
             background: #912b88;
             color: var(--text-inverse);
+        }
+
+        .guide-status.community {
+            background: #f3f2f1;
+            color: #383f43;
+            border: 1px solid #b1b4b6;
         }
 
         /* Mermaid Diagrams - Full Width */
@@ -1580,9 +1638,28 @@
         .app-depmap-node.orphan rect {
             stroke-dasharray: 4,3;
         }
+        .app-depmap-node.stale rect {
+            stroke: #d4351c;
+            stroke-width: 2;
+        }
+        .app-depmap-node.draft rect {
+            stroke-dasharray: 6,3;
+            stroke: #f47738;
+        }
         .app-depmap-node.dimmed {
             opacity: 0.15;
         }
+        .app-depmap-health-badge {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .app-depmap-health-badge--stale { background: #fcebeb; color: #d4351c; }
+        .app-depmap-health-badge--draft { background: #fff4e5; color: #b04300; }
+        .app-depmap-health-badge--orphan { background: #f3f2f1; color: #505a5f; }
         .app-depmap-edge {
             fill: none;
             stroke-width: 1.5;
@@ -1839,7 +1916,7 @@
         }
 
         function extractTitle(path) {
-            const filename = path.split('/').pop().replace('.md', '');
+            const filename = path.split('/').pop().replace(/\.(md|html)$/i, '');
             return filename
                 .replace(/-/g, ' ')
                 .replace(/\b\w/g, l => l.toUpperCase());
@@ -2523,6 +2600,72 @@
             return '#d4351c';
         }
 
+        function renderProjectHealthPanel(manifest) {
+            const ph = manifest && manifest.projectHealth;
+            if (!ph || !Array.isArray(ph.projects) || ph.projects.length === 0) return '';
+
+            function pctColor(pct) {
+                if (pct >= 80) return '#00703c';
+                if (pct >= 50) return '#f47738';
+                return '#d4351c';
+            }
+
+            const cards = ph.projects.map(p => {
+                const compPct = p.compliance.pct;
+                const covPct = p.coverage.essentialPct;
+                const recHtml = (p.recommendations || []).slice(0, 3).map(r =>
+                    `<li><code>${escapeHtml(r.command)}</code> <span style="color:var(--text-secondary);font-size:12px">— Tier ${r.tier} ${escapeHtml(r.label)}</span></li>`
+                ).join('');
+                const noRec = (p.recommendations || []).length === 0
+                    ? '<li style="color:#00703c">All essentials present</li>'
+                    : '';
+                const flags = [];
+                if (p.health.stale > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--stale">${p.health.stale} stale</span>`);
+                if (p.health.draft > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--draft">${p.health.draft} draft</span>`);
+                if (p.health.orphan > 0) flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--orphan">${p.health.orphan} orphan</span>`);
+                const flagHtml = flags.length > 0
+                    ? flags.join(' ')
+                    : '<span style="color:#00703c;font-size:12px">&#10003; No health issues</span>';
+
+                return `
+                    <div style="border:1px solid var(--border-main);border-radius:4px;padding:1rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:0.5rem">
+                            <strong>${escapeHtml(p.project)}</strong>
+                            <span style="font-size:12px;color:var(--text-secondary)">${p.artifactCount} docs · ${p.edgeCount} refs · density ${p.density}</span>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Essential coverage</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${covPct}%;background:${pctColor(covPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${covPct}%</div>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Compliance readiness</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${compPct}%;background:${pctColor(compPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${p.compliance.presentHigh.length}/${p.compliance.total}</div>
+                        </div>
+                        <div style="margin-top:0.5rem">${flagHtml}</div>
+                        <div style="margin-top:0.75rem">
+                            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:0.25rem">Next steps</div>
+                            <ul style="margin:0;padding-left:1.25rem;font-size:13px">${recHtml}${noRec}</ul>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="app-dashboard-panel" style="margin-bottom:1.5rem">
+                    <h3>Project Health & Next Steps</h3>
+                    <p style="font-size:12px;color:var(--text-secondary);margin:0 0 0.75rem 0">
+                        Coverage = essential doc types present (Tiers 1–4). Compliance = HIGH-severity governance types present.
+                        Stale = lastModified ${ph.staleThresholdDays}+ days ago. Generated ${new Date(ph.baseline).toLocaleString()}.
+                    </p>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem">
+                        ${cards}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderVendorScores(manifest) {
             let html = '';
             const projects = (manifest.projects || []).filter(p => p.vendorScores);
@@ -2718,6 +2861,9 @@
                     </div>
                 `;
             }
+
+            // Row 3.7: Compliance & Next Steps (from manifest.projectHealth)
+            html += renderProjectHealthPanel(manifest);
 
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
@@ -3001,6 +3147,26 @@
                 legendEl.appendChild(item);
             }
 
+            // Health legend separator + entries
+            const healthLegend = [
+                { label: 'Stale', style: 'border:2px solid #d4351c;background:transparent' },
+                { label: 'Draft', style: 'border:2px dashed #f47738;background:transparent' },
+                { label: 'Orphan', style: 'border:1px dashed #505a5f;background:transparent' },
+            ];
+            const sep = document.createElement('span');
+            sep.style.cssText = 'border-left:1px solid var(--border-main);height:14px;margin:0 4px';
+            legendEl.appendChild(sep);
+            for (const h of healthLegend) {
+                const item = document.createElement('span');
+                item.className = 'app-depmap-legend-item';
+                const swatch = document.createElement('span');
+                swatch.className = 'app-depmap-legend-swatch';
+                swatch.style.cssText = h.style;
+                item.appendChild(swatch);
+                item.appendChild(document.createTextNode(' ' + h.label));
+                legendEl.appendChild(item);
+            }
+
             // Tooltip element
             const tooltip = document.createElement('div');
             tooltip.className = 'app-depmap-tooltip';
@@ -3122,14 +3288,20 @@
                     const pos = positions[id];
                     if (!pos) continue;
                     const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
+                    const h = node.health || {};
+                    const isOrphan = !connectedIds.has(id) || !!h.orphan;
 
                     const shortTitle = (node.title || '').length > 16
                         ? node.title.substring(0, 15) + '\u2026'
                         : (node.title || id);
 
+                    const classes = ['app-depmap-node'];
+                    if (isOrphan) classes.push('orphan');
+                    if (h.stale) classes.push('stale');
+                    if (h.draft) classes.push('draft');
+
                     const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.setAttribute('class', classes.join(' '));
                     g.dataset.id = id;
                     g.dataset.path = node.path;
 
@@ -3208,6 +3380,19 @@
                             tooltip.textContent = '';
                             tooltip.appendChild(ttTitle);
                             tooltip.appendChild(ttMeta);
+
+                            const ndh = nd.health || {};
+                            if (ndh.stale || ndh.draft || ndh.orphan) {
+                                const ttHealth = document.createElement('span');
+                                ttHealth.style.cssText = 'display:block;margin-top:4px;font-weight:600;color:#d4351c';
+                                const flags = [];
+                                if (ndh.stale) flags.push('Stale (' + ndh.ageDays + 'd)');
+                                if (ndh.draft) flags.push('Draft');
+                                if (ndh.orphan) flags.push('Orphan');
+                                ttHealth.textContent = '\u26a0 ' + flags.join(' \u00b7 ');
+                                tooltip.appendChild(ttHealth);
+                            }
+
                             tooltip.style.display = 'block';
                             const r = g.getBoundingClientRect();
                             tooltip.style.left = (r.right + 8) + 'px';
@@ -3706,6 +3891,93 @@
                     closeMobileSidebar();
                 });
             });
+
+            // Add change handlers for version selects
+            container.querySelectorAll('.app-nav-version-select').forEach(select => {
+                // Prevent select clicks from triggering the parent link
+                select.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                });
+
+                select.addEventListener('change', (e) => {
+                    e.stopPropagation();
+                    const newPath = select.value;
+                    // Select is a sibling of the <a>, not nested inside it
+                    const link = select.parentElement.querySelector('a[data-path]');
+                    if (link) {
+                        link.href = '#' + newPath;
+                        link.dataset.path = newPath;
+                    }
+                    window.location.hash = newPath;
+                    loadDocument(newPath);
+
+                    // Update active state
+                    container.querySelectorAll('a').forEach(a => a.classList.remove('active'));
+                    if (link) link.classList.add('active');
+
+                    closeMobileSidebar();
+                });
+            });
+        }
+
+        // ── Version display helpers ──
+
+        function extractVersion(documentId) {
+            if (!documentId) return null;
+            const m = documentId.match(/-v(\d+\.\d+)$/);
+            return m ? m[1] : null;
+        }
+
+        function baseDocId(documentId) {
+            return documentId ? documentId.replace(/-v\d+(\.\d+)?$/, '') : null;
+        }
+
+        function renderVersionedDocList(docs) {
+            // Group by base document ID
+            const groups = {};
+            const order = [];
+            docs.forEach(doc => {
+                const key = baseDocId(doc.documentId) || doc.path;
+                if (!groups[key]) {
+                    groups[key] = [];
+                    order.push(key);
+                }
+                groups[key].push(doc);
+            });
+
+            // Sort each group by version ascending (highest last = default)
+            Object.values(groups).forEach(group => {
+                group.sort((a, b) => {
+                    const va = extractVersion(a.documentId) || '0';
+                    const vb = extractVersion(b.documentId) || '0';
+                    return va.localeCompare(vb, undefined, { numeric: true });
+                });
+            });
+
+            let html = '';
+            order.forEach(key => {
+                const group = groups[key];
+                const latest = group[group.length - 1]; // highest version
+                const title = latest.title || latest.documentId || 'Untitled';
+
+                if (group.length === 1) {
+                    // Single version: static badge
+                    const ver = extractVersion(latest.documentId);
+                    const badge = ver ? ` <span class="app-nav-version">v${ver}</span>` : '';
+                    html += `<li><a href="#${latest.path}" data-path="${latest.path}">${title}${badge}</a></li>`;
+                } else {
+                    // Multiple versions: link + sibling select (select outside <a> for valid HTML)
+                    let options = '';
+                    group.forEach(doc => {
+                        const ver = extractVersion(doc.documentId) || '?';
+                        const sel = doc === latest ? ' selected' : '';
+                        options += `<option value="${doc.path}"${sel}>v${ver}</option>`;
+                    });
+                    html += `<li class="app-nav-versioned"><a href="#${latest.path}" data-path="${latest.path}">${title}</a><select class="app-nav-version-select">${options}</select></li>`;
+                }
+            });
+
+            return html;
         }
 
         function buildNavSection(title, documents, sectionId) {
@@ -3722,9 +3994,7 @@
             let listHtml = '';
             Object.keys(byCategory).forEach(category => {
                 listHtml += `<li class="app-nav-category">${category}</li>`;
-                byCategory[category].forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(byCategory[category]);
             });
 
             return `
@@ -3769,58 +4039,44 @@
 
                 Object.keys(byCategory).forEach(category => {
                     listHtml += `<li class="app-nav-category">${category}</li>`;
-                    byCategory[category].forEach(doc => {
-                        listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                    });
+                    listHtml += renderVersionedDocList(byCategory[category]);
                 });
             }
 
             // Diagrams
             if (project.diagrams && project.diagrams.length > 0) {
                 listHtml += `<li class="app-nav-category">Diagrams</li>`;
-                project.diagrams.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.diagrams);
             }
 
             // Decisions (ADRs)
             if (project.decisions && project.decisions.length > 0) {
                 listHtml += `<li class="app-nav-category">Decisions</li>`;
-                project.decisions.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.decisions);
             }
 
             // Wardley Maps
             if (project.wardleyMaps && project.wardleyMaps.length > 0) {
                 listHtml += `<li class="app-nav-category">Wardley Maps</li>`;
-                project.wardleyMaps.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.wardleyMaps);
             }
 
             // Data Contracts
             if (project.dataContracts && project.dataContracts.length > 0) {
                 listHtml += `<li class="app-nav-category">Data Contracts</li>`;
-                project.dataContracts.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.dataContracts);
             }
 
             // Research
             if (project.research && project.research.length > 0) {
                 listHtml += `<li class="app-nav-category">Research</li>`;
-                project.research.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.research);
             }
 
             // Reviews
             if (project.reviews && project.reviews.length > 0) {
                 listHtml += `<li class="app-nav-category">Reviews</li>`;
-                project.reviews.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.reviews);
             }
 
             // Vendors
@@ -3829,7 +4085,9 @@
                 project.vendors.forEach(vendor => {
                     if (vendor.documents) {
                         vendor.documents.forEach(doc => {
-                            listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${vendor.name}: ${doc.title}</a></li>`;
+                            const ver = extractVersion(doc.documentId);
+                            const badge = ver ? ` <span class="app-nav-version">v${ver}</span>` : '';
+                            listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${vendor.name}: ${doc.title}${badge}</a></li>`;
                         });
                     }
                 });
@@ -3838,17 +4096,13 @@
             // Vendor Profiles
             if (project.vendorProfiles && project.vendorProfiles.length > 0) {
                 listHtml += `<li class="app-nav-category">Vendor Profiles</li>`;
-                project.vendorProfiles.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.vendorProfiles);
             }
 
             // Tech Notes
             if (project.techNotes && project.techNotes.length > 0) {
                 listHtml += `<li class="app-nav-category">Tech Notes</li>`;
-                project.techNotes.forEach(doc => {
-                    listHtml += `<li><a href="#${doc.path}" data-path="${doc.path}">${doc.title}</a></li>`;
-                });
+                listHtml += renderVersionedDocList(project.techNotes);
             }
 
             // External Documents (mention only - not clickable)
@@ -3883,6 +4137,14 @@
 
             // Hide TOC while loading
             toc.style.display = 'none';
+
+            // HTML artifacts (e.g. ARC-001-DECK-v1.0.html, AntV Infographic output) —
+            // mount in an iframe rather than parsing as markdown. Skips TOC, mermaid,
+            // PlantUML, and link-rewriting which only apply to markdown.
+            if (path.endsWith('.html')) {
+                loadHtmlArtifact(path, content);
+                return;
+            }
 
             // Show loading
             content.innerHTML = `
@@ -4018,6 +4280,42 @@
 
                 content.replaceChildren(header, notice);
             }
+        }
+
+        // Render an HTML artifact (e.g. DECK files) inside an iframe.
+        // Built with safe DOM methods — no innerHTML, no markdown parsing.
+        function loadHtmlArtifact(path, content) {
+            const title = extractTitle(path);
+            const breadcrumbText = path.split('/').slice(0, -1).join(' / ');
+            const src = getRawUrl(path);
+
+            const header = document.createElement('div');
+            header.className = 'app-doc-header';
+            const breadcrumb = document.createElement('div');
+            breadcrumb.className = 'app-doc-breadcrumb';
+            breadcrumb.textContent = breadcrumbText;
+            const titleEl = document.createElement('h1');
+            titleEl.className = 'app-doc-title';
+            titleEl.textContent = title;
+            const newTab = document.createElement('a');
+            newTab.className = 'app-deck-newtab';
+            newTab.href = src;
+            newTab.target = '_blank';
+            newTab.rel = 'noopener noreferrer';
+            newTab.textContent = 'Open in new tab ↗';
+            header.appendChild(breadcrumb);
+            header.appendChild(titleEl);
+            header.appendChild(newTab);
+
+            const frame = document.createElement('iframe');
+            frame.className = 'app-deck-frame';
+            frame.src = src;
+            frame.title = title;
+            frame.setAttribute('allowfullscreen', '');
+            frame.setAttribute('loading', 'lazy');
+
+            content.replaceChildren(header, frame);
+            document.getElementById('main-content').scrollTo(0, 0);
         }
 
         // ============================================
@@ -4560,8 +4858,22 @@
                     } else {
                         loadDocument(path);
 
-                        // Mark as active
-                        const link = document.querySelector(`a[data-path="${path}"]`);
+                        // Mark as active — check both direct links and version selects
+                        let link = document.querySelector(`a[data-path="${path}"]`);
+                        if (!link) {
+                            // Path might be a non-default version — find its select option
+                            const option = document.querySelector(`.app-nav-version-select option[value="${path}"]`);
+                            if (option) {
+                                option.selected = true;
+                                const select = option.closest('select');
+                                const parentLink = select ? select.parentElement.querySelector('a[data-path]') : null;
+                                if (parentLink) {
+                                    parentLink.href = '#' + path;
+                                    parentLink.dataset.path = path;
+                                    link = parentLink;
+                                }
+                            }
+                        }
                         if (link) link.classList.add('active');
                     }
                 } else {

--- a/arckit-claude/hooks/graph-inject.mjs
+++ b/arckit-claude/hooks/graph-inject.mjs
@@ -38,6 +38,12 @@ import {
   extractRequirementIds,
 } from './hook-utils.mjs';
 import { scanAllArtifacts } from './graph-utils.mjs';
+import {
+  HIGH_SEVERITY_TYPES,
+  ESSENTIAL_TYPES,
+  CONTEXTUAL_TYPES,
+  STALE_THRESHOLD_DAYS,
+} from './graph-rollups.mjs';
 import { DOC_TYPES } from '../config/doc-types.mjs';
 
 // ── Recipe table ───────────────────────────────────────────────────────────
@@ -300,11 +306,6 @@ function formatImpact(graph, prompt) {
   return lines.join('\n');
 }
 
-// Doc types whose category yields HIGH severity in classifySeverity().
-// Used by /arckit:graph-report for "compliance readiness" scoring.
-const HIGH_SEVERITY_TYPES = ['TCOP', 'SECD', 'SECD-MOD', 'DPIA', 'SVCASS',
-  'RISK', 'TRAC', 'CONF', 'PRIN-COMP', 'AIPB', 'ATRS', 'JSP936'];
-
 function formatGraphReport(graph) {
   const workingProjects = graph.projects.filter(p => p !== '000-global');
   if (workingProjects.length === 0) return null;
@@ -435,28 +436,6 @@ function formatGraphReport(graph) {
 
   return lines.join('\n');
 }
-
-// Essential doc types per tier — used by navigator to compute coverage and
-// recommend the next command. Tiers represent rough dependency order.
-const ESSENTIAL_TYPES = [
-  { type: 'REQ',  tier: 1, command: '/arckit:requirements',  label: 'Requirements' },
-  { type: 'STKE', tier: 1, command: '/arckit:stakeholders',  label: 'Stakeholder Analysis' },
-  { type: 'RISK', tier: 1, command: '/arckit:risk',          label: 'Risk Register' },
-  { type: 'SOBC', tier: 2, command: '/arckit:sobc',          label: 'Strategic Outline Business Case' },
-  { type: 'ADR',  tier: 3, command: '/arckit:adr',           label: 'Architecture Decision Record' },
-  { type: 'HLDR', tier: 3, command: '/arckit:hld-review',    label: 'High-Level Design Review' },
-  { type: 'TRAC', tier: 4, command: '/arckit:traceability',  label: 'Traceability Matrix' },
-  { type: 'CONF', tier: 4, command: '/arckit:conformance',   label: 'Conformance Assessment' },
-];
-
-const CONTEXTUAL_TYPES = [
-  { type: 'DPIA', command: '/arckit:dpia',   trigger: 'processing personal data' },
-  { type: 'SECD', command: '/arckit:secure', trigger: 'security-sensitive system' },
-  { type: 'TCOP', command: '/arckit:tcop',   trigger: 'UK Gov Service Standard' },
-  { type: 'DATA', command: '/arckit:data-model', trigger: 'DR-* requirements present' },
-];
-
-const STALE_THRESHOLD_DAYS = 90;
 
 function formatNavigator(graph, prompt) {
   const projectArg = parseProjectArg(prompt, 'navigator');

--- a/arckit-claude/hooks/graph-rollups.mjs
+++ b/arckit-claude/hooks/graph-rollups.mjs
@@ -1,0 +1,247 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Graph Rollups — Shared health, coverage, and compliance computations
+ *
+ * Used by:
+ * - graph-inject.mjs (formatNavigator, formatGraphReport, formatHealth)
+ * - sync-guides.mjs  (manifest.projectHealth + per-node health flags for the
+ *                     dashboard Document Map and Project Health panel)
+ *
+ * Pure data — no Markdown formatting. Callers shape the output.
+ */
+
+import { DOC_TYPES } from '../config/doc-types.mjs';
+
+// ── Constants ──────────────────────────────────────────────────────────────
+
+/**
+ * Doc types whose category yields HIGH severity in classifySeverity().
+ * Used for "compliance readiness" scoring.
+ */
+export const HIGH_SEVERITY_TYPES = ['TCOP', 'SECD', 'SECD-MOD', 'DPIA', 'SVCASS',
+  'RISK', 'TRAC', 'CONF', 'PRIN-COMP', 'AIPB', 'ATRS', 'JSP936'];
+
+/**
+ * Essential doc types per tier — used by navigator to compute coverage and
+ * recommend the next command. Tiers represent rough dependency order.
+ */
+export const ESSENTIAL_TYPES = [
+  { type: 'REQ',  tier: 1, command: '/arckit:requirements',  label: 'Requirements' },
+  { type: 'STKE', tier: 1, command: '/arckit:stakeholders',  label: 'Stakeholder Analysis' },
+  { type: 'RISK', tier: 1, command: '/arckit:risk',          label: 'Risk Register' },
+  { type: 'SOBC', tier: 2, command: '/arckit:sobc',          label: 'Strategic Outline Business Case' },
+  { type: 'ADR',  tier: 3, command: '/arckit:adr',           label: 'Architecture Decision Record' },
+  { type: 'HLDR', tier: 3, command: '/arckit:hld-review',    label: 'High-Level Design Review' },
+  { type: 'TRAC', tier: 4, command: '/arckit:traceability',  label: 'Traceability Matrix' },
+  { type: 'CONF', tier: 4, command: '/arckit:conformance',   label: 'Conformance Assessment' },
+];
+
+export const CONTEXTUAL_TYPES = [
+  { type: 'DPIA', command: '/arckit:dpia',       trigger: 'processing personal data' },
+  { type: 'SECD', command: '/arckit:secure',     trigger: 'security-sensitive system' },
+  { type: 'TCOP', command: '/arckit:tcop',       trigger: 'UK Gov Service Standard' },
+  { type: 'DATA', command: '/arckit:data-model', trigger: 'DR-* requirements present' },
+];
+
+/** Days since lastModified before a node is flagged stale. */
+export const STALE_THRESHOLD_DAYS = 90;
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+function safeParseDate(s) {
+  if (!s) return null;
+  const d = new Date(s);
+  return isNaN(d.getTime()) ? null : d;
+}
+
+function daysBetween(date, baseline) {
+  return Math.floor((baseline.getTime() - date.getTime()) / (1000 * 60 * 60 * 24));
+}
+
+function shortIdOf(fullId) {
+  return fullId.replace(/-v[\d.]+$/, '');
+}
+
+function fullIdFromPath(path) {
+  return path.split('/').pop().replace(/\.md$/, '');
+}
+
+// ── Per-node health ────────────────────────────────────────────────────────
+
+/**
+ * Compute health flags for every node in the graph and attach them as
+ * `node.health = { stale, draft, orphan, ageDays }`.
+ *
+ * Mutates graph.nodes in place. Returns the graph for chaining.
+ *
+ * `stale` = lastModified (or createdDate) older than STALE_THRESHOLD_DAYS
+ * `draft` = status matches /draft/i
+ * `orphan` = no incoming or outgoing edges within the project's id-space
+ */
+export function tagNodeHealth(graph, baseline = new Date()) {
+  if (!graph || !graph.nodes) return graph;
+
+  // Build per-project full-id sets so orphan detection is project-scoped.
+  const projectIds = {};
+  for (const [fullId, node] of Object.entries(graph.nodes)) {
+    if (!projectIds[node.project]) projectIds[node.project] = new Set();
+    projectIds[node.project].add(fullId);
+  }
+
+  // Build connected sets per project from edges.
+  const connectedByProject = {};
+  for (const projectName of Object.keys(projectIds)) {
+    connectedByProject[projectName] = new Set();
+  }
+  for (const e of graph.edges || []) {
+    const fromNode = graph.nodes[e.from];
+    if (!fromNode) continue;
+    const proj = fromNode.project;
+    const set = connectedByProject[proj];
+    if (!set) continue;
+    set.add(e.from);
+    // Edge `to` is short-id; connect any matching full-id in the same project.
+    for (const fullId of projectIds[proj]) {
+      if (fullId === e.to || shortIdOf(fullId) === e.to) {
+        set.add(fullId);
+      }
+    }
+  }
+
+  for (const [fullId, node] of Object.entries(graph.nodes)) {
+    const dateStr = node.lastModified || node.createdDate;
+    const d = safeParseDate(dateStr);
+    const ageDays = d ? daysBetween(d, baseline) : null;
+    const stale = ageDays != null && ageDays >= STALE_THRESHOLD_DAYS;
+    const draft = /draft/i.test(node.status || '');
+    const connected = connectedByProject[node.project];
+    const orphan = !!connected && !connected.has(fullId);
+
+    node.health = { stale, draft, orphan, ageDays };
+  }
+
+  return graph;
+}
+
+// ── Per-project rollup ─────────────────────────────────────────────────────
+
+/**
+ * Compute a per-project rollup with coverage, compliance, density, and
+ * recommended next commands. Mirrors the formulas used in graph-inject.mjs
+ * formatNavigator + formatGraphReport but returns structured data.
+ *
+ * @param {string} projectName  e.g. '001-foo'
+ * @param {object} graph        from scanAllArtifacts (must include nodes, edges)
+ * @param {Date}   baseline     reference "now" for stale calculations
+ * @returns {object}            project rollup
+ */
+export function computeProjectRollup(projectName, graph, baseline = new Date()) {
+  const projectNodes = Object.values(graph.nodes).filter(n => n.project === projectName);
+  const projectFullIds = new Set(projectNodes.map(n => fullIdFromPath(n.path)));
+
+  // Edges originating in this project
+  const projectEdges = (graph.edges || []).filter(e => projectFullIds.has(e.from));
+  const density = projectNodes.length === 0
+    ? 0
+    : projectEdges.length / projectNodes.length;
+
+  // Type set
+  const presentTypes = new Set(projectNodes.map(n => n.type).filter(Boolean));
+
+  // Essential coverage (Tier 1–4 doc types)
+  const essentialPresent = ESSENTIAL_TYPES.filter(e => presentTypes.has(e.type));
+  const essentialMissing = ESSENTIAL_TYPES.filter(e => !presentTypes.has(e.type));
+  const essentialPct = ESSENTIAL_TYPES.length === 0
+    ? 0
+    : Math.round((essentialPresent.length / ESSENTIAL_TYPES.length) * 100);
+
+  // Contextual artifact suggestions (only flag those NOT present)
+  const contextualMissing = CONTEXTUAL_TYPES.filter(c => !presentTypes.has(c.type));
+
+  // Compliance readiness (HIGH-severity types)
+  const presentHigh = HIGH_SEVERITY_TYPES.filter(t => presentTypes.has(t));
+  const missingHigh = HIGH_SEVERITY_TYPES.filter(t => !presentTypes.has(t));
+  const compliancePct = HIGH_SEVERITY_TYPES.length === 0
+    ? 0
+    : Math.round((presentHigh.length / HIGH_SEVERITY_TYPES.length) * 100);
+
+  // Coverage by category — counts vs total possible types per category
+  const presentByCategory = {};
+  for (const t of presentTypes) {
+    const info = DOC_TYPES[t];
+    if (!info) continue;
+    if (!presentByCategory[info.category]) presentByCategory[info.category] = 0;
+    presentByCategory[info.category]++;
+  }
+
+  // Health rollup (count nodes already tagged via tagNodeHealth)
+  const tagged = projectNodes.every(n => n.health !== undefined);
+  const staleCount = tagged ? projectNodes.filter(n => n.health.stale).length : 0;
+  const draftCount = tagged ? projectNodes.filter(n => n.health.draft).length : 0;
+  const orphanCount = tagged ? projectNodes.filter(n => n.health.orphan).length : 0;
+
+  // Global principles presence
+  const hasGlobalPrin = Object.values(graph.nodes).some(
+    n => n.project === '000-global' && n.type === 'PRIN'
+  );
+
+  // Recommended next commands — missing essentials in tier order, capped at 3
+  const recommendations = essentialMissing
+    .slice()
+    .sort((a, b) => a.tier - b.tier)
+    .slice(0, 3)
+    .map(e => ({
+      command: e.command,
+      label: e.label,
+      type: e.type,
+      tier: e.tier,
+      reason: `Tier ${e.tier} essential missing`,
+    }));
+
+  return {
+    project: projectName,
+    projectId: projectName.match(/^(\d{3})/)?.[1] || '',
+    artifactCount: projectNodes.length,
+    edgeCount: projectEdges.length,
+    density: Number(density.toFixed(2)),
+    coverage: {
+      essentialPresent: essentialPresent.map(e => e.type),
+      essentialMissing: essentialMissing.map(e => ({
+        type: e.type,
+        command: e.command,
+        label: e.label,
+        tier: e.tier,
+      })),
+      essentialPct,
+      presentTypes: [...presentTypes].sort(),
+      presentByCategory,
+    },
+    compliance: {
+      presentHigh,
+      missingHigh,
+      pct: compliancePct,
+      total: HIGH_SEVERITY_TYPES.length,
+    },
+    health: { stale: staleCount, draft: draftCount, orphan: orphanCount },
+    contextualSuggestions: contextualMissing.map(c => ({
+      command: c.command,
+      type: c.type,
+      trigger: c.trigger,
+    })),
+    hasGlobalPrin,
+    recommendations,
+  };
+}
+
+/**
+ * Compute rollups for every working project in the graph (excludes 000-global).
+ *
+ * @param {object} graph     from scanAllArtifacts
+ * @param {Date}   baseline  reference "now"
+ * @returns {object[]}       array of per-project rollups, sorted by project name
+ */
+export function computeAllProjectRollups(graph, baseline = new Date()) {
+  if (!graph || !graph.projects) return [];
+  const working = graph.projects.filter(p => p !== '000-global').sort();
+  return working.map(p => computeProjectRollup(p, graph, baseline));
+}

--- a/arckit-claude/hooks/sync-guides.mjs
+++ b/arckit-claude/hooks/sync-guides.mjs
@@ -28,6 +28,13 @@ import {
   findRepoRoot, parseHookInput,
 } from './hook-utils.mjs';
 import { scanAllArtifacts } from './graph-utils.mjs';
+import {
+  tagNodeHealth,
+  computeAllProjectRollups,
+  HIGH_SEVERITY_TYPES,
+  ESSENTIAL_TYPES,
+  STALE_THRESHOLD_DAYS,
+} from './graph-rollups.mjs';
 
 function walkMdFiles(baseDir, currentDir = baseDir) {
   const results = [];
@@ -593,6 +600,28 @@ function buildLlmsTxt(manifest, repoInfo, version) {
   lines.push('- [Manifest](./manifest.json): Machine-readable JSON index of every artifact, guide, and project in this repository.');
   lines.push('');
 
+  // Project status — coverage / compliance / top recommendation per project,
+  // sourced from manifest.projectHealth (computed by graph-rollups.mjs).
+  // Lets external agents fetch llms.txt and answer "where is this repo at"
+  // without scraping the dashboard.
+  if (manifest.projectHealth && Array.isArray(manifest.projectHealth.projects)
+      && manifest.projectHealth.projects.length > 0) {
+    lines.push('## Project status');
+    lines.push('');
+    for (const p of manifest.projectHealth.projects) {
+      const flags = [];
+      if (p.health.draft > 0)  flags.push(`${p.health.draft} drafts`);
+      if (p.health.stale > 0)  flags.push(`${p.health.stale} stale`);
+      if (p.health.orphan > 0) flags.push(`${p.health.orphan} orphans`);
+      const flagsText = flags.length > 0 ? ` · ${flags.join(', ')}` : '';
+      const next = (p.recommendations && p.recommendations[0])
+        ? p.recommendations[0].command
+        : 'all essentials present';
+      lines.push(`- ${p.project}: ${p.coverage.essentialPct}% essential coverage · ${p.compliance.pct}% compliance readiness${flagsText} · next: ${next}`);
+    }
+    lines.push('');
+  }
+
   // Global artifacts
   if (manifest.global && manifest.global.length > 0) {
     lines.push('## Global artifacts');
@@ -744,13 +773,31 @@ function buildManifest(repoRoot, repoInfo, guideTitles) {
   if (globalPolicies.length > 0) manifest.globalPolicies = globalPolicies;
   manifest.projects = projects;
 
-  // Dependency graph for dashboard visualization
+  // Dependency graph for dashboard visualization.
+  // Pass richer opts so the graph carries enough metadata for the dashboard
+  // to render health flags, coverage, and compliance rollups without a
+  // separate scan. tagNodeHealth() then stamps stale/draft/orphan flags on
+  // each node, and computeAllProjectRollups() builds the per-project
+  // summary that the new "Project Health" panel renders.
   if (isDir(projectsDir)) {
-    const graph = scanAllArtifacts(projectsDir);
+    const graph = scanAllArtifacts(projectsDir, {
+      withNodeMetadata: true,
+    });
     if (Object.keys(graph.nodes).length > 0) {
+      const baseline = new Date();
+      tagNodeHealth(graph, baseline);
       manifest.dependencyGraph = {
         nodes: graph.nodes,
         edges: graph.edges,
+      };
+      manifest.projectHealth = {
+        baseline: baseline.toISOString(),
+        staleThresholdDays: STALE_THRESHOLD_DAYS,
+        essentialTypes: ESSENTIAL_TYPES.map(e => ({
+          type: e.type, tier: e.tier, command: e.command, label: e.label,
+        })),
+        highSeverityTypes: HIGH_SEVERITY_TYPES,
+        projects: computeAllProjectRollups(graph, baseline),
       };
     }
   }

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -1638,9 +1638,28 @@
         .app-depmap-node.orphan rect {
             stroke-dasharray: 4,3;
         }
+        .app-depmap-node.stale rect {
+            stroke: #d4351c;
+            stroke-width: 2;
+        }
+        .app-depmap-node.draft rect {
+            stroke-dasharray: 6,3;
+            stroke: #f47738;
+        }
         .app-depmap-node.dimmed {
             opacity: 0.15;
         }
+        .app-depmap-health-badge {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .app-depmap-health-badge--stale { background: #fcebeb; color: #d4351c; }
+        .app-depmap-health-badge--draft { background: #fff4e5; color: #b04300; }
+        .app-depmap-health-badge--orphan { background: #f3f2f1; color: #505a5f; }
         .app-depmap-edge {
             fill: none;
             stroke-width: 1.5;
@@ -2581,6 +2600,72 @@
             return '#d4351c';
         }
 
+        function renderProjectHealthPanel(manifest) {
+            const ph = manifest && manifest.projectHealth;
+            if (!ph || !Array.isArray(ph.projects) || ph.projects.length === 0) return '';
+
+            function pctColor(pct) {
+                if (pct >= 80) return '#00703c';
+                if (pct >= 50) return '#f47738';
+                return '#d4351c';
+            }
+
+            const cards = ph.projects.map(p => {
+                const compPct = p.compliance.pct;
+                const covPct = p.coverage.essentialPct;
+                const recHtml = (p.recommendations || []).slice(0, 3).map(r =>
+                    `<li><code>${escapeHtml(r.command)}</code> <span style="color:var(--text-secondary);font-size:12px">— Tier ${r.tier} ${escapeHtml(r.label)}</span></li>`
+                ).join('');
+                const noRec = (p.recommendations || []).length === 0
+                    ? '<li style="color:#00703c">All essentials present</li>'
+                    : '';
+                const flags = [];
+                if (p.health.stale > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--stale">${p.health.stale} stale</span>`);
+                if (p.health.draft > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--draft">${p.health.draft} draft</span>`);
+                if (p.health.orphan > 0) flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--orphan">${p.health.orphan} orphan</span>`);
+                const flagHtml = flags.length > 0
+                    ? flags.join(' ')
+                    : '<span style="color:#00703c;font-size:12px">&#10003; No health issues</span>';
+
+                return `
+                    <div style="border:1px solid var(--border-main);border-radius:4px;padding:1rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:0.5rem">
+                            <strong>${escapeHtml(p.project)}</strong>
+                            <span style="font-size:12px;color:var(--text-secondary)">${p.artifactCount} docs · ${p.edgeCount} refs · density ${p.density}</span>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Essential coverage</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${covPct}%;background:${pctColor(covPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${covPct}%</div>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Compliance readiness</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${compPct}%;background:${pctColor(compPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${p.compliance.presentHigh.length}/${p.compliance.total}</div>
+                        </div>
+                        <div style="margin-top:0.5rem">${flagHtml}</div>
+                        <div style="margin-top:0.75rem">
+                            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:0.25rem">Next steps</div>
+                            <ul style="margin:0;padding-left:1.25rem;font-size:13px">${recHtml}${noRec}</ul>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="app-dashboard-panel" style="margin-bottom:1.5rem">
+                    <h3>Project Health & Next Steps</h3>
+                    <p style="font-size:12px;color:var(--text-secondary);margin:0 0 0.75rem 0">
+                        Coverage = essential doc types present (Tiers 1–4). Compliance = HIGH-severity governance types present.
+                        Stale = lastModified ${ph.staleThresholdDays}+ days ago. Generated ${new Date(ph.baseline).toLocaleString()}.
+                    </p>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem">
+                        ${cards}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderVendorScores(manifest) {
             let html = '';
             const projects = (manifest.projects || []).filter(p => p.vendorScores);
@@ -2776,6 +2861,9 @@
                     </div>
                 `;
             }
+
+            // Row 3.7: Compliance & Next Steps (from manifest.projectHealth)
+            html += renderProjectHealthPanel(manifest);
 
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
@@ -3059,6 +3147,26 @@
                 legendEl.appendChild(item);
             }
 
+            // Health legend separator + entries
+            const healthLegend = [
+                { label: 'Stale', style: 'border:2px solid #d4351c;background:transparent' },
+                { label: 'Draft', style: 'border:2px dashed #f47738;background:transparent' },
+                { label: 'Orphan', style: 'border:1px dashed #505a5f;background:transparent' },
+            ];
+            const sep = document.createElement('span');
+            sep.style.cssText = 'border-left:1px solid var(--border-main);height:14px;margin:0 4px';
+            legendEl.appendChild(sep);
+            for (const h of healthLegend) {
+                const item = document.createElement('span');
+                item.className = 'app-depmap-legend-item';
+                const swatch = document.createElement('span');
+                swatch.className = 'app-depmap-legend-swatch';
+                swatch.style.cssText = h.style;
+                item.appendChild(swatch);
+                item.appendChild(document.createTextNode(' ' + h.label));
+                legendEl.appendChild(item);
+            }
+
             // Tooltip element
             const tooltip = document.createElement('div');
             tooltip.className = 'app-depmap-tooltip';
@@ -3180,14 +3288,20 @@
                     const pos = positions[id];
                     if (!pos) continue;
                     const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
+                    const h = node.health || {};
+                    const isOrphan = !connectedIds.has(id) || !!h.orphan;
 
                     const shortTitle = (node.title || '').length > 16
                         ? node.title.substring(0, 15) + '\u2026'
                         : (node.title || id);
 
+                    const classes = ['app-depmap-node'];
+                    if (isOrphan) classes.push('orphan');
+                    if (h.stale) classes.push('stale');
+                    if (h.draft) classes.push('draft');
+
                     const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.setAttribute('class', classes.join(' '));
                     g.dataset.id = id;
                     g.dataset.path = node.path;
 
@@ -3266,6 +3380,19 @@
                             tooltip.textContent = '';
                             tooltip.appendChild(ttTitle);
                             tooltip.appendChild(ttMeta);
+
+                            const ndh = nd.health || {};
+                            if (ndh.stale || ndh.draft || ndh.orphan) {
+                                const ttHealth = document.createElement('span');
+                                ttHealth.style.cssText = 'display:block;margin-top:4px;font-weight:600;color:#d4351c';
+                                const flags = [];
+                                if (ndh.stale) flags.push('Stale (' + ndh.ageDays + 'd)');
+                                if (ndh.draft) flags.push('Draft');
+                                if (ndh.orphan) flags.push('Orphan');
+                                ttHealth.textContent = '\u26a0 ' + flags.join(' \u00b7 ');
+                                tooltip.appendChild(ttHealth);
+                            }
+
                             tooltip.style.display = 'block';
                             const r = g.getBoundingClientRect();
                             tooltip.style.left = (r.right + 8) + 'px';

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -1638,9 +1638,28 @@
         .app-depmap-node.orphan rect {
             stroke-dasharray: 4,3;
         }
+        .app-depmap-node.stale rect {
+            stroke: #d4351c;
+            stroke-width: 2;
+        }
+        .app-depmap-node.draft rect {
+            stroke-dasharray: 6,3;
+            stroke: #f47738;
+        }
         .app-depmap-node.dimmed {
             opacity: 0.15;
         }
+        .app-depmap-health-badge {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .app-depmap-health-badge--stale { background: #fcebeb; color: #d4351c; }
+        .app-depmap-health-badge--draft { background: #fff4e5; color: #b04300; }
+        .app-depmap-health-badge--orphan { background: #f3f2f1; color: #505a5f; }
         .app-depmap-edge {
             fill: none;
             stroke-width: 1.5;
@@ -2581,6 +2600,72 @@
             return '#d4351c';
         }
 
+        function renderProjectHealthPanel(manifest) {
+            const ph = manifest && manifest.projectHealth;
+            if (!ph || !Array.isArray(ph.projects) || ph.projects.length === 0) return '';
+
+            function pctColor(pct) {
+                if (pct >= 80) return '#00703c';
+                if (pct >= 50) return '#f47738';
+                return '#d4351c';
+            }
+
+            const cards = ph.projects.map(p => {
+                const compPct = p.compliance.pct;
+                const covPct = p.coverage.essentialPct;
+                const recHtml = (p.recommendations || []).slice(0, 3).map(r =>
+                    `<li><code>${escapeHtml(r.command)}</code> <span style="color:var(--text-secondary);font-size:12px">— Tier ${r.tier} ${escapeHtml(r.label)}</span></li>`
+                ).join('');
+                const noRec = (p.recommendations || []).length === 0
+                    ? '<li style="color:#00703c">All essentials present</li>'
+                    : '';
+                const flags = [];
+                if (p.health.stale > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--stale">${p.health.stale} stale</span>`);
+                if (p.health.draft > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--draft">${p.health.draft} draft</span>`);
+                if (p.health.orphan > 0) flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--orphan">${p.health.orphan} orphan</span>`);
+                const flagHtml = flags.length > 0
+                    ? flags.join(' ')
+                    : '<span style="color:#00703c;font-size:12px">&#10003; No health issues</span>';
+
+                return `
+                    <div style="border:1px solid var(--border-main);border-radius:4px;padding:1rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:0.5rem">
+                            <strong>${escapeHtml(p.project)}</strong>
+                            <span style="font-size:12px;color:var(--text-secondary)">${p.artifactCount} docs · ${p.edgeCount} refs · density ${p.density}</span>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Essential coverage</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${covPct}%;background:${pctColor(covPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${covPct}%</div>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Compliance readiness</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${compPct}%;background:${pctColor(compPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${p.compliance.presentHigh.length}/${p.compliance.total}</div>
+                        </div>
+                        <div style="margin-top:0.5rem">${flagHtml}</div>
+                        <div style="margin-top:0.75rem">
+                            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:0.25rem">Next steps</div>
+                            <ul style="margin:0;padding-left:1.25rem;font-size:13px">${recHtml}${noRec}</ul>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="app-dashboard-panel" style="margin-bottom:1.5rem">
+                    <h3>Project Health & Next Steps</h3>
+                    <p style="font-size:12px;color:var(--text-secondary);margin:0 0 0.75rem 0">
+                        Coverage = essential doc types present (Tiers 1–4). Compliance = HIGH-severity governance types present.
+                        Stale = lastModified ${ph.staleThresholdDays}+ days ago. Generated ${new Date(ph.baseline).toLocaleString()}.
+                    </p>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem">
+                        ${cards}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderVendorScores(manifest) {
             let html = '';
             const projects = (manifest.projects || []).filter(p => p.vendorScores);
@@ -2776,6 +2861,9 @@
                     </div>
                 `;
             }
+
+            // Row 3.7: Compliance & Next Steps (from manifest.projectHealth)
+            html += renderProjectHealthPanel(manifest);
 
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
@@ -3059,6 +3147,26 @@
                 legendEl.appendChild(item);
             }
 
+            // Health legend separator + entries
+            const healthLegend = [
+                { label: 'Stale', style: 'border:2px solid #d4351c;background:transparent' },
+                { label: 'Draft', style: 'border:2px dashed #f47738;background:transparent' },
+                { label: 'Orphan', style: 'border:1px dashed #505a5f;background:transparent' },
+            ];
+            const sep = document.createElement('span');
+            sep.style.cssText = 'border-left:1px solid var(--border-main);height:14px;margin:0 4px';
+            legendEl.appendChild(sep);
+            for (const h of healthLegend) {
+                const item = document.createElement('span');
+                item.className = 'app-depmap-legend-item';
+                const swatch = document.createElement('span');
+                swatch.className = 'app-depmap-legend-swatch';
+                swatch.style.cssText = h.style;
+                item.appendChild(swatch);
+                item.appendChild(document.createTextNode(' ' + h.label));
+                legendEl.appendChild(item);
+            }
+
             // Tooltip element
             const tooltip = document.createElement('div');
             tooltip.className = 'app-depmap-tooltip';
@@ -3180,14 +3288,20 @@
                     const pos = positions[id];
                     if (!pos) continue;
                     const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
+                    const h = node.health || {};
+                    const isOrphan = !connectedIds.has(id) || !!h.orphan;
 
                     const shortTitle = (node.title || '').length > 16
                         ? node.title.substring(0, 15) + '\u2026'
                         : (node.title || id);
 
+                    const classes = ['app-depmap-node'];
+                    if (isOrphan) classes.push('orphan');
+                    if (h.stale) classes.push('stale');
+                    if (h.draft) classes.push('draft');
+
                     const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.setAttribute('class', classes.join(' '));
                     g.dataset.id = id;
                     g.dataset.path = node.path;
 
@@ -3266,6 +3380,19 @@
                             tooltip.textContent = '';
                             tooltip.appendChild(ttTitle);
                             tooltip.appendChild(ttMeta);
+
+                            const ndh = nd.health || {};
+                            if (ndh.stale || ndh.draft || ndh.orphan) {
+                                const ttHealth = document.createElement('span');
+                                ttHealth.style.cssText = 'display:block;margin-top:4px;font-weight:600;color:#d4351c';
+                                const flags = [];
+                                if (ndh.stale) flags.push('Stale (' + ndh.ageDays + 'd)');
+                                if (ndh.draft) flags.push('Draft');
+                                if (ndh.orphan) flags.push('Orphan');
+                                ttHealth.textContent = '\u26a0 ' + flags.join(' \u00b7 ');
+                                tooltip.appendChild(ttHealth);
+                            }
+
                             tooltip.style.display = 'block';
                             const r = g.getBoundingClientRect();
                             tooltip.style.left = (r.right + 8) + 'px';

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -1638,9 +1638,28 @@
         .app-depmap-node.orphan rect {
             stroke-dasharray: 4,3;
         }
+        .app-depmap-node.stale rect {
+            stroke: #d4351c;
+            stroke-width: 2;
+        }
+        .app-depmap-node.draft rect {
+            stroke-dasharray: 6,3;
+            stroke: #f47738;
+        }
         .app-depmap-node.dimmed {
             opacity: 0.15;
         }
+        .app-depmap-health-badge {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .app-depmap-health-badge--stale { background: #fcebeb; color: #d4351c; }
+        .app-depmap-health-badge--draft { background: #fff4e5; color: #b04300; }
+        .app-depmap-health-badge--orphan { background: #f3f2f1; color: #505a5f; }
         .app-depmap-edge {
             fill: none;
             stroke-width: 1.5;
@@ -2581,6 +2600,72 @@
             return '#d4351c';
         }
 
+        function renderProjectHealthPanel(manifest) {
+            const ph = manifest && manifest.projectHealth;
+            if (!ph || !Array.isArray(ph.projects) || ph.projects.length === 0) return '';
+
+            function pctColor(pct) {
+                if (pct >= 80) return '#00703c';
+                if (pct >= 50) return '#f47738';
+                return '#d4351c';
+            }
+
+            const cards = ph.projects.map(p => {
+                const compPct = p.compliance.pct;
+                const covPct = p.coverage.essentialPct;
+                const recHtml = (p.recommendations || []).slice(0, 3).map(r =>
+                    `<li><code>${escapeHtml(r.command)}</code> <span style="color:var(--text-secondary);font-size:12px">— Tier ${r.tier} ${escapeHtml(r.label)}</span></li>`
+                ).join('');
+                const noRec = (p.recommendations || []).length === 0
+                    ? '<li style="color:#00703c">All essentials present</li>'
+                    : '';
+                const flags = [];
+                if (p.health.stale > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--stale">${p.health.stale} stale</span>`);
+                if (p.health.draft > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--draft">${p.health.draft} draft</span>`);
+                if (p.health.orphan > 0) flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--orphan">${p.health.orphan} orphan</span>`);
+                const flagHtml = flags.length > 0
+                    ? flags.join(' ')
+                    : '<span style="color:#00703c;font-size:12px">&#10003; No health issues</span>';
+
+                return `
+                    <div style="border:1px solid var(--border-main);border-radius:4px;padding:1rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:0.5rem">
+                            <strong>${escapeHtml(p.project)}</strong>
+                            <span style="font-size:12px;color:var(--text-secondary)">${p.artifactCount} docs · ${p.edgeCount} refs · density ${p.density}</span>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Essential coverage</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${covPct}%;background:${pctColor(covPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${covPct}%</div>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Compliance readiness</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${compPct}%;background:${pctColor(compPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${p.compliance.presentHigh.length}/${p.compliance.total}</div>
+                        </div>
+                        <div style="margin-top:0.5rem">${flagHtml}</div>
+                        <div style="margin-top:0.75rem">
+                            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:0.25rem">Next steps</div>
+                            <ul style="margin:0;padding-left:1.25rem;font-size:13px">${recHtml}${noRec}</ul>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="app-dashboard-panel" style="margin-bottom:1.5rem">
+                    <h3>Project Health & Next Steps</h3>
+                    <p style="font-size:12px;color:var(--text-secondary);margin:0 0 0.75rem 0">
+                        Coverage = essential doc types present (Tiers 1–4). Compliance = HIGH-severity governance types present.
+                        Stale = lastModified ${ph.staleThresholdDays}+ days ago. Generated ${new Date(ph.baseline).toLocaleString()}.
+                    </p>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem">
+                        ${cards}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderVendorScores(manifest) {
             let html = '';
             const projects = (manifest.projects || []).filter(p => p.vendorScores);
@@ -2776,6 +2861,9 @@
                     </div>
                 `;
             }
+
+            // Row 3.7: Compliance & Next Steps (from manifest.projectHealth)
+            html += renderProjectHealthPanel(manifest);
 
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
@@ -3059,6 +3147,26 @@
                 legendEl.appendChild(item);
             }
 
+            // Health legend separator + entries
+            const healthLegend = [
+                { label: 'Stale', style: 'border:2px solid #d4351c;background:transparent' },
+                { label: 'Draft', style: 'border:2px dashed #f47738;background:transparent' },
+                { label: 'Orphan', style: 'border:1px dashed #505a5f;background:transparent' },
+            ];
+            const sep = document.createElement('span');
+            sep.style.cssText = 'border-left:1px solid var(--border-main);height:14px;margin:0 4px';
+            legendEl.appendChild(sep);
+            for (const h of healthLegend) {
+                const item = document.createElement('span');
+                item.className = 'app-depmap-legend-item';
+                const swatch = document.createElement('span');
+                swatch.className = 'app-depmap-legend-swatch';
+                swatch.style.cssText = h.style;
+                item.appendChild(swatch);
+                item.appendChild(document.createTextNode(' ' + h.label));
+                legendEl.appendChild(item);
+            }
+
             // Tooltip element
             const tooltip = document.createElement('div');
             tooltip.className = 'app-depmap-tooltip';
@@ -3180,14 +3288,20 @@
                     const pos = positions[id];
                     if (!pos) continue;
                     const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
+                    const h = node.health || {};
+                    const isOrphan = !connectedIds.has(id) || !!h.orphan;
 
                     const shortTitle = (node.title || '').length > 16
                         ? node.title.substring(0, 15) + '\u2026'
                         : (node.title || id);
 
+                    const classes = ['app-depmap-node'];
+                    if (isOrphan) classes.push('orphan');
+                    if (h.stale) classes.push('stale');
+                    if (h.draft) classes.push('draft');
+
                     const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.setAttribute('class', classes.join(' '));
                     g.dataset.id = id;
                     g.dataset.path = node.path;
 
@@ -3266,6 +3380,19 @@
                             tooltip.textContent = '';
                             tooltip.appendChild(ttTitle);
                             tooltip.appendChild(ttMeta);
+
+                            const ndh = nd.health || {};
+                            if (ndh.stale || ndh.draft || ndh.orphan) {
+                                const ttHealth = document.createElement('span');
+                                ttHealth.style.cssText = 'display:block;margin-top:4px;font-weight:600;color:#d4351c';
+                                const flags = [];
+                                if (ndh.stale) flags.push('Stale (' + ndh.ageDays + 'd)');
+                                if (ndh.draft) flags.push('Draft');
+                                if (ndh.orphan) flags.push('Orphan');
+                                ttHealth.textContent = '\u26a0 ' + flags.join(' \u00b7 ');
+                                tooltip.appendChild(ttHealth);
+                            }
+
                             tooltip.style.display = 'block';
                             const r = g.getBoundingClientRect();
                             tooltip.style.left = (r.right + 8) + 'px';

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -1638,9 +1638,28 @@
         .app-depmap-node.orphan rect {
             stroke-dasharray: 4,3;
         }
+        .app-depmap-node.stale rect {
+            stroke: #d4351c;
+            stroke-width: 2;
+        }
+        .app-depmap-node.draft rect {
+            stroke-dasharray: 6,3;
+            stroke: #f47738;
+        }
         .app-depmap-node.dimmed {
             opacity: 0.15;
         }
+        .app-depmap-health-badge {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .app-depmap-health-badge--stale { background: #fcebeb; color: #d4351c; }
+        .app-depmap-health-badge--draft { background: #fff4e5; color: #b04300; }
+        .app-depmap-health-badge--orphan { background: #f3f2f1; color: #505a5f; }
         .app-depmap-edge {
             fill: none;
             stroke-width: 1.5;
@@ -2581,6 +2600,72 @@
             return '#d4351c';
         }
 
+        function renderProjectHealthPanel(manifest) {
+            const ph = manifest && manifest.projectHealth;
+            if (!ph || !Array.isArray(ph.projects) || ph.projects.length === 0) return '';
+
+            function pctColor(pct) {
+                if (pct >= 80) return '#00703c';
+                if (pct >= 50) return '#f47738';
+                return '#d4351c';
+            }
+
+            const cards = ph.projects.map(p => {
+                const compPct = p.compliance.pct;
+                const covPct = p.coverage.essentialPct;
+                const recHtml = (p.recommendations || []).slice(0, 3).map(r =>
+                    `<li><code>${escapeHtml(r.command)}</code> <span style="color:var(--text-secondary);font-size:12px">— Tier ${r.tier} ${escapeHtml(r.label)}</span></li>`
+                ).join('');
+                const noRec = (p.recommendations || []).length === 0
+                    ? '<li style="color:#00703c">All essentials present</li>'
+                    : '';
+                const flags = [];
+                if (p.health.stale > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--stale">${p.health.stale} stale</span>`);
+                if (p.health.draft > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--draft">${p.health.draft} draft</span>`);
+                if (p.health.orphan > 0) flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--orphan">${p.health.orphan} orphan</span>`);
+                const flagHtml = flags.length > 0
+                    ? flags.join(' ')
+                    : '<span style="color:#00703c;font-size:12px">&#10003; No health issues</span>';
+
+                return `
+                    <div style="border:1px solid var(--border-main);border-radius:4px;padding:1rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:0.5rem">
+                            <strong>${escapeHtml(p.project)}</strong>
+                            <span style="font-size:12px;color:var(--text-secondary)">${p.artifactCount} docs · ${p.edgeCount} refs · density ${p.density}</span>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Essential coverage</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${covPct}%;background:${pctColor(covPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${covPct}%</div>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Compliance readiness</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${compPct}%;background:${pctColor(compPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${p.compliance.presentHigh.length}/${p.compliance.total}</div>
+                        </div>
+                        <div style="margin-top:0.5rem">${flagHtml}</div>
+                        <div style="margin-top:0.75rem">
+                            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:0.25rem">Next steps</div>
+                            <ul style="margin:0;padding-left:1.25rem;font-size:13px">${recHtml}${noRec}</ul>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="app-dashboard-panel" style="margin-bottom:1.5rem">
+                    <h3>Project Health & Next Steps</h3>
+                    <p style="font-size:12px;color:var(--text-secondary);margin:0 0 0.75rem 0">
+                        Coverage = essential doc types present (Tiers 1–4). Compliance = HIGH-severity governance types present.
+                        Stale = lastModified ${ph.staleThresholdDays}+ days ago. Generated ${new Date(ph.baseline).toLocaleString()}.
+                    </p>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem">
+                        ${cards}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderVendorScores(manifest) {
             let html = '';
             const projects = (manifest.projects || []).filter(p => p.vendorScores);
@@ -2776,6 +2861,9 @@
                     </div>
                 `;
             }
+
+            // Row 3.7: Compliance & Next Steps (from manifest.projectHealth)
+            html += renderProjectHealthPanel(manifest);
 
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
@@ -3059,6 +3147,26 @@
                 legendEl.appendChild(item);
             }
 
+            // Health legend separator + entries
+            const healthLegend = [
+                { label: 'Stale', style: 'border:2px solid #d4351c;background:transparent' },
+                { label: 'Draft', style: 'border:2px dashed #f47738;background:transparent' },
+                { label: 'Orphan', style: 'border:1px dashed #505a5f;background:transparent' },
+            ];
+            const sep = document.createElement('span');
+            sep.style.cssText = 'border-left:1px solid var(--border-main);height:14px;margin:0 4px';
+            legendEl.appendChild(sep);
+            for (const h of healthLegend) {
+                const item = document.createElement('span');
+                item.className = 'app-depmap-legend-item';
+                const swatch = document.createElement('span');
+                swatch.className = 'app-depmap-legend-swatch';
+                swatch.style.cssText = h.style;
+                item.appendChild(swatch);
+                item.appendChild(document.createTextNode(' ' + h.label));
+                legendEl.appendChild(item);
+            }
+
             // Tooltip element
             const tooltip = document.createElement('div');
             tooltip.className = 'app-depmap-tooltip';
@@ -3180,14 +3288,20 @@
                     const pos = positions[id];
                     if (!pos) continue;
                     const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
+                    const h = node.health || {};
+                    const isOrphan = !connectedIds.has(id) || !!h.orphan;
 
                     const shortTitle = (node.title || '').length > 16
                         ? node.title.substring(0, 15) + '\u2026'
                         : (node.title || id);
 
+                    const classes = ['app-depmap-node'];
+                    if (isOrphan) classes.push('orphan');
+                    if (h.stale) classes.push('stale');
+                    if (h.draft) classes.push('draft');
+
                     const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.setAttribute('class', classes.join(' '));
                     g.dataset.id = id;
                     g.dataset.path = node.path;
 
@@ -3266,6 +3380,19 @@
                             tooltip.textContent = '';
                             tooltip.appendChild(ttTitle);
                             tooltip.appendChild(ttMeta);
+
+                            const ndh = nd.health || {};
+                            if (ndh.stale || ndh.draft || ndh.orphan) {
+                                const ttHealth = document.createElement('span');
+                                ttHealth.style.cssText = 'display:block;margin-top:4px;font-weight:600;color:#d4351c';
+                                const flags = [];
+                                if (ndh.stale) flags.push('Stale (' + ndh.ageDays + 'd)');
+                                if (ndh.draft) flags.push('Draft');
+                                if (ndh.orphan) flags.push('Orphan');
+                                ttHealth.textContent = '\u26a0 ' + flags.join(' \u00b7 ');
+                                tooltip.appendChild(ttHealth);
+                            }
+
                             tooltip.style.display = 'block';
                             const r = g.getBoundingClientRect();
                             tooltip.style.left = (r.right + 8) + 'px';

--- a/arckit-paperclip/templates/pages-template.html
+++ b/arckit-paperclip/templates/pages-template.html
@@ -1638,9 +1638,28 @@
         .app-depmap-node.orphan rect {
             stroke-dasharray: 4,3;
         }
+        .app-depmap-node.stale rect {
+            stroke: #d4351c;
+            stroke-width: 2;
+        }
+        .app-depmap-node.draft rect {
+            stroke-dasharray: 6,3;
+            stroke: #f47738;
+        }
         .app-depmap-node.dimmed {
             opacity: 0.15;
         }
+        .app-depmap-health-badge {
+            display: inline-block;
+            margin-left: 4px;
+            padding: 1px 6px;
+            border-radius: 8px;
+            font-size: 11px;
+            font-weight: 600;
+        }
+        .app-depmap-health-badge--stale { background: #fcebeb; color: #d4351c; }
+        .app-depmap-health-badge--draft { background: #fff4e5; color: #b04300; }
+        .app-depmap-health-badge--orphan { background: #f3f2f1; color: #505a5f; }
         .app-depmap-edge {
             fill: none;
             stroke-width: 1.5;
@@ -2581,6 +2600,72 @@
             return '#d4351c';
         }
 
+        function renderProjectHealthPanel(manifest) {
+            const ph = manifest && manifest.projectHealth;
+            if (!ph || !Array.isArray(ph.projects) || ph.projects.length === 0) return '';
+
+            function pctColor(pct) {
+                if (pct >= 80) return '#00703c';
+                if (pct >= 50) return '#f47738';
+                return '#d4351c';
+            }
+
+            const cards = ph.projects.map(p => {
+                const compPct = p.compliance.pct;
+                const covPct = p.coverage.essentialPct;
+                const recHtml = (p.recommendations || []).slice(0, 3).map(r =>
+                    `<li><code>${escapeHtml(r.command)}</code> <span style="color:var(--text-secondary);font-size:12px">— Tier ${r.tier} ${escapeHtml(r.label)}</span></li>`
+                ).join('');
+                const noRec = (p.recommendations || []).length === 0
+                    ? '<li style="color:#00703c">All essentials present</li>'
+                    : '';
+                const flags = [];
+                if (p.health.stale > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--stale">${p.health.stale} stale</span>`);
+                if (p.health.draft > 0)  flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--draft">${p.health.draft} draft</span>`);
+                if (p.health.orphan > 0) flags.push(`<span class="app-depmap-health-badge app-depmap-health-badge--orphan">${p.health.orphan} orphan</span>`);
+                const flagHtml = flags.length > 0
+                    ? flags.join(' ')
+                    : '<span style="color:#00703c;font-size:12px">&#10003; No health issues</span>';
+
+                return `
+                    <div style="border:1px solid var(--border-main);border-radius:4px;padding:1rem;background:var(--bg-surface)">
+                        <div style="display:flex;justify-content:space-between;align-items:baseline;gap:1rem;margin-bottom:0.5rem">
+                            <strong>${escapeHtml(p.project)}</strong>
+                            <span style="font-size:12px;color:var(--text-secondary)">${p.artifactCount} docs · ${p.edgeCount} refs · density ${p.density}</span>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Essential coverage</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${covPct}%;background:${pctColor(covPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${covPct}%</div>
+                        </div>
+                        <div class="app-dashboard-bar-row" style="margin:0.25rem 0">
+                            <div class="app-dashboard-bar-label" style="font-size:12px">Compliance readiness</div>
+                            <div class="app-dashboard-bar-track"><div class="app-dashboard-bar-fill" style="width:${compPct}%;background:${pctColor(compPct)}"></div></div>
+                            <div class="app-dashboard-bar-value">${p.compliance.presentHigh.length}/${p.compliance.total}</div>
+                        </div>
+                        <div style="margin-top:0.5rem">${flagHtml}</div>
+                        <div style="margin-top:0.75rem">
+                            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);text-transform:uppercase;letter-spacing:0.5px;margin-bottom:0.25rem">Next steps</div>
+                            <ul style="margin:0;padding-left:1.25rem;font-size:13px">${recHtml}${noRec}</ul>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
+            return `
+                <div class="app-dashboard-panel" style="margin-bottom:1.5rem">
+                    <h3>Project Health & Next Steps</h3>
+                    <p style="font-size:12px;color:var(--text-secondary);margin:0 0 0.75rem 0">
+                        Coverage = essential doc types present (Tiers 1–4). Compliance = HIGH-severity governance types present.
+                        Stale = lastModified ${ph.staleThresholdDays}+ days ago. Generated ${new Date(ph.baseline).toLocaleString()}.
+                    </p>
+                    <div style="display:grid;grid-template-columns:repeat(auto-fit,minmax(320px,1fr));gap:1rem">
+                        ${cards}
+                    </div>
+                </div>
+            `;
+        }
+
         function renderVendorScores(manifest) {
             let html = '';
             const projects = (manifest.projects || []).filter(p => p.vendorScores);
@@ -2776,6 +2861,9 @@
                     </div>
                 `;
             }
+
+            // Row 3.7: Compliance & Next Steps (from manifest.projectHealth)
+            html += renderProjectHealthPanel(manifest);
 
             // Row 3.5: Vendor Scores
             html += renderVendorScores(manifest);
@@ -3059,6 +3147,26 @@
                 legendEl.appendChild(item);
             }
 
+            // Health legend separator + entries
+            const healthLegend = [
+                { label: 'Stale', style: 'border:2px solid #d4351c;background:transparent' },
+                { label: 'Draft', style: 'border:2px dashed #f47738;background:transparent' },
+                { label: 'Orphan', style: 'border:1px dashed #505a5f;background:transparent' },
+            ];
+            const sep = document.createElement('span');
+            sep.style.cssText = 'border-left:1px solid var(--border-main);height:14px;margin:0 4px';
+            legendEl.appendChild(sep);
+            for (const h of healthLegend) {
+                const item = document.createElement('span');
+                item.className = 'app-depmap-legend-item';
+                const swatch = document.createElement('span');
+                swatch.className = 'app-depmap-legend-swatch';
+                swatch.style.cssText = h.style;
+                item.appendChild(swatch);
+                item.appendChild(document.createTextNode(' ' + h.label));
+                legendEl.appendChild(item);
+            }
+
             // Tooltip element
             const tooltip = document.createElement('div');
             tooltip.className = 'app-depmap-tooltip';
@@ -3180,14 +3288,20 @@
                     const pos = positions[id];
                     if (!pos) continue;
                     const color = CATEGORY_COLORS[TYPE_CATEGORIES[node.type] || 'Other'] || CATEGORY_COLORS.Other;
-                    const isOrphan = !connectedIds.has(id);
+                    const h = node.health || {};
+                    const isOrphan = !connectedIds.has(id) || !!h.orphan;
 
                     const shortTitle = (node.title || '').length > 16
                         ? node.title.substring(0, 15) + '\u2026'
                         : (node.title || id);
 
+                    const classes = ['app-depmap-node'];
+                    if (isOrphan) classes.push('orphan');
+                    if (h.stale) classes.push('stale');
+                    if (h.draft) classes.push('draft');
+
                     const g = document.createElementNS(NS, 'g');
-                    g.setAttribute('class', 'app-depmap-node' + (isOrphan ? ' orphan' : ''));
+                    g.setAttribute('class', classes.join(' '));
                     g.dataset.id = id;
                     g.dataset.path = node.path;
 
@@ -3266,6 +3380,19 @@
                             tooltip.textContent = '';
                             tooltip.appendChild(ttTitle);
                             tooltip.appendChild(ttMeta);
+
+                            const ndh = nd.health || {};
+                            if (ndh.stale || ndh.draft || ndh.orphan) {
+                                const ttHealth = document.createElement('span');
+                                ttHealth.style.cssText = 'display:block;margin-top:4px;font-weight:600;color:#d4351c';
+                                const flags = [];
+                                if (ndh.stale) flags.push('Stale (' + ndh.ageDays + 'd)');
+                                if (ndh.draft) flags.push('Draft');
+                                if (ndh.orphan) flags.push('Orphan');
+                                ttHealth.textContent = '\u26a0 ' + flags.join(' \u00b7 ');
+                                tooltip.appendChild(ttHealth);
+                            }
+
                             tooltip.style.display = 'block';
                             const r = g.getBoundingClientRect();
                             tooltip.style.left = (r.right + 8) + 'px';


### PR DESCRIPTION
## Summary

Wires the new graph-inject pipeline (#162) into the `/arckit:pages` dashboard so the Document Map visualises the same health/coverage/compliance signals that `/arckit:navigator` and `/arckit:graph-report` already compute. All data is sourced from a single shared rollup module — no duplicate scans.

### Data layer

- **New `arckit-claude/hooks/graph-rollups.mjs`** — single source of truth for `HIGH_SEVERITY_TYPES`, `ESSENTIAL_TYPES`, `CONTEXTUAL_TYPES`, `STALE_THRESHOLD_DAYS`, plus `tagNodeHealth()` and `computeAllProjectRollups()`. Pure data, no Markdown.
- **`graph-inject.mjs`** — refactored to import constants from the new module. No behaviour change.
- **`sync-guides.mjs`** — passes `{withNodeMetadata: true}` to `scanAllArtifacts`, tags each node with `health: { stale, draft, orphan, ageDays }`, and emits `manifest.projectHealth` with per-project rollups (coverage, compliance, density, top-3 recommendations, health counters).

### Dashboard layer (`pages-template.html`, propagated to all 6 distributions)

- **Document Map node tinting** — stale=red border, draft=amber dashed, orphan=existing dashed.
- **Legend** extended with three health swatches.
- **Tooltip** extended with a health row (e.g. `⚠ Stale (151d) · Draft`).
- **New "Project Health & Next Steps" dashboard panel** — one card per project showing essential-coverage and compliance-readiness gauges, health badges, and top-3 recommended commands.

### llms.txt (opt-in)

- New `## Project status` section — one line per project listing coverage %, compliance %, draft/stale/orphan counts, and the top recommended next command. Gives external agents a "where is this repo at" signal without scraping the dashboard. No new computation; reuses `manifest.projectHealth` already in memory.

### Sync

- `python scripts/converter.py` propagated the template to all 5 generated extension dirs (codex/copilot/opencode/paperclip/gemini).
- `.arckit/templates/pages-template.html` (CLI fallback) synced manually — was 10 days behind the plugin source.

## Test plan

- [x] `node --check` clean on `graph-rollups.mjs`, `graph-inject.mjs`, `sync-guides.mjs`
- [x] Inline `<script>` blocks in `pages-template.html` parse as ESM (extracted + `node --check`)
- [x] End-to-end run against a 38-artifact test repo: hook exits 0, manifest grows ~80 KB → ~127 KB, dashboard HTML parses, llms.txt gains 4 lines
- [x] All 7 `pages-template.html` copies in sync (`md5sum` identical)
- [ ] Visual check of the Document Map + Project Health panel in a real browser after merge
- [ ] Verify behaviour on a multi-project test repo (rollup cards render side-by-side)

## Notes

- **Manifest size** grows ~60% for typical projects because dependency-graph nodes now carry the v2 metadata (version/owner/classification/reqIds). Acceptable for the dashboard value; can be revisited if it becomes a problem on very large repos.
- **Non-Claude distributions** (Codex/Copilot/etc) ship the new template but don't run the hook — `manifest.projectHealth` will be absent and the panel renders nothing (`renderProjectHealthPanel` returns `''`). No regression. Wiring those distributions into the rollup is a separate piece of work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)