### PR TITLE
fix(hooks): traceability recipe missing withNodeMetadata — actual fix for #389

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/arckit:traceability` actually now reports correct coverage (#389).** Previous v4.12.2 attempt fixed regex namespace collisions but the actual bug was elsewhere: `formatTraceability` reads `node.reqIds` for every non-REQ artifact to build the coverage `refMap`, but `node.reqIds` is only assigned by `scanAllArtifacts` when the caller passes `withNodeMetadata: true`. The traceability recipe did not request that flag, so `reqIds` was always `undefined` and `refMap` always empty. Verified end-to-end against the issue's reproduction repo: coverage now reports 41 of 53 requirements (77%) with proper citation lists per requirement.
+
 ## [4.12.2] - 2026-05-01
 
 ### Fixed

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`/arckit:traceability` actually now reports correct coverage (#389).** Previous v4.12.2 attempt fixed regex namespace collisions but the actual bug was elsewhere: `formatTraceability` reads `node.reqIds` for every non-REQ artifact to build the coverage `refMap`, but `node.reqIds` is only assigned by `scanAllArtifacts` when the caller passes `withNodeMetadata: true` (`graph-utils.mjs:181-188`). The traceability recipe in `graph-inject.mjs` did not request that flag, so `reqIds` was always `undefined` and `refMap` always empty — coverage reported 0% regardless of what was in the documents. Verified end-to-end against `arckit-test-project-v20-uae-moi-ipad` project 006: coverage now reports 41 of 53 requirements (77%), with citation lists per requirement showing the actual covering artifacts (RISK, SOBC, STKE, IAS, PDPL, CLAS, RSCH, WARD, ADR, AUTI, CRES, AICH, NPRA).
+
 ## [4.12.2] - 2026-05-01
 
 ### Fixed

--- a/arckit-claude/hooks/graph-inject.mjs
+++ b/arckit-claude/hooks/graph-inject.mjs
@@ -128,6 +128,11 @@ const RECIPES = [
         excludeGlobal: true,
         withRequirements: true,
         withVendors: true,
+        // formatTraceability reads node.reqIds for every non-REQ artifact to
+        // build refMap. Without withNodeMetadata, reqIds is never assigned
+        // (graph-utils.mjs:181-188), so refMap stays empty and coverage
+        // reports 0% even when sibling artifacts genuinely cite requirements.
+        withNodeMetadata: true,
         ...(arg ? { projectFilter: arg } : {}),
       };
     },


### PR DESCRIPTION
## Summary

The real fix for #389. v4.12.1 and v4.12.2 made changes that were correct in isolation but never addressed the actual cause — apologies for shipping those without running the reporter's reproduction.

## Root cause

`formatTraceability` at `graph-inject.mjs:1209-1227` reads `node.reqIds` for every non-REQ artifact to build the coverage `refMap`. But `node.reqIds` is **only assigned** by `scanAllArtifacts` when the caller passes `withNodeMetadata: true` (gated at `graph-utils.mjs:181-188`). The traceability recipe's `opts` didn't include that flag, so `reqIds` was always `undefined` and the loop short-circuited at `if (!Array.isArray(n.reqIds) || n.reqIds.length === 0) continue;` — `refMap` stayed empty, coverage was 0%, regardless of what the documents actually contained.

## Verified end-to-end

Cloned `arckit-test-project-v20-uae-moi-ipad` and ran the actual `graph-inject.mjs` hook against project 006 (`/arckit:traceability 006` prompt simulated via stdin).

**Before this PR:** Coverage Summary | Overall | 0 | 53 | 0% |

**After this PR:** 41 of 53 requirements covered (77%), each row lists the citing artifacts, e.g.:

```
| BR-1 | Business | SHOULD | Land 50% Agentic Coverage... | Yes |
   ARC-006-AUTI, ARC-006-CLAS, ARC-006-CRES, ARC-006-IAS, ARC-006-PDPL,
   ARC-006-RISK, ARC-006-SOBC, ARC-006-STKE, ADR-001, WARD-001,
   RSCH-v1.0, RSCH-v1.1 |
```

Matches the issue reporter's manual ground truth (40-41 of 53, ~75-77%).

## Why earlier attempts didn't fix this

| Version | Change | Effect on #389 |
|---|---|---|
| 4.12.1 | Loose heading regex in `extractRequirementDetails` | Necessary (so REQ headings extract). Did not affect refMap path. |
| 4.12.2 | Loose `REQ_ID_PATTERN`, ASB `BR-N` → `BCK-N` | Both correct. But `extractRequirementIds` output is gated by `withNodeMetadata`, so this had no effect on traceability coverage. |
| 4.12.3 (this) | `withNodeMetadata: true` in traceability recipe | Actually fixes the bug. |

## Test plan

- [x] End-to-end: ran `graph-inject.mjs` against `/tmp/repro/v20` with `/arckit:traceability 006` — coverage 77%, citation lists correct.
- [x] Markdown lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)