### PR TITLE
docs(guides): link all guides on guides.html and reconcile counts

### DIFF
--- a/docs/commands.html
+++ b/docs/commands.html
@@ -514,7 +514,7 @@
 
     <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-width-container govuk-!-margin-top-9" id="commands">
-        <h2 class="govuk-heading-l">68 ArcKit AI Commands</h2>
+        <h2 class="govuk-heading-l">70 ArcKit AI Commands</h2>
         <p class="govuk-body">Complete command reference with descriptions, example outputs, and maturity status:</p>
 
         <!-- Status Legend -->

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Command Guides - 95 usage guides (plus 22 community overlays) for enterprise architecture governance commands organized by category.">
+    <meta name="description" content="ArcKit Command Guides - 101 usage guides (plus 21 community overlays) for enterprise architecture governance commands organized by category.">
     <title>Command Guides - ArcKit</title>
     <meta name="keywords" content="ArcKit guides, architecture governance guides, command usage, workflow steps, UK government architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Guides - ArcKit">
-    <meta property="og:description" content="95 step-by-step usage guides (plus 22 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta property="og:description" content="101 step-by-step usage guides (plus 21 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/guides.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Guides - ArcKit">
-    <meta name="twitter:description" content="95 step-by-step usage guides (plus 22 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta name="twitter:description" content="101 step-by-step usage guides (plus 21 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/guides.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -235,7 +235,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/guides.html",
                 "name": "Command Guides - ArcKit",
-                "description": "95 step-by-step usage guides (plus 22 community overlays) for ArcKit enterprise architecture governance commands, organised by category.",
+                "description": "101 step-by-step usage guides (plus 21 community overlays) for ArcKit enterprise architecture governance commands, organised by category.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -280,9 +280,9 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">95 Guides + 22 Community Overlays</span>
+            <span class="app-page-hero__stat">101 Guides + 21 Community Overlays</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
-            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 10 categories, plus 22 community-contributed EU, French, and UAE public-sector overlays in dedicated sections.</p>
+            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 12 categories, plus 21 community-contributed EU, French, and UAE public-sector overlays in dedicated sections.</p>
         </div>
     </div>
 
@@ -303,7 +303,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Getting Started
-                    <span class="app-guide-category__count">9 guides</span>
+                    <span class="app-guide-category__count">10 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -311,6 +311,7 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=init" class="govuk-link">ArcKit Initialization Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Initialize ArcKit projects with arckit init</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=customize" class="govuk-link">Template Customization Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Customize templates for your organization</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=template-builder" class="govuk-link">Template Builder Guide</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">Build custom document templates</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=custom-commands" class="govuk-link">Custom Commands Authoring Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Add a new /arckit.&lt;name&gt; command across all six AI assistant formats</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=upgrading" class="govuk-link">Upgrading ArcKit</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Version upgrade instructions</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=remote-control" class="govuk-link">Remote Control Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Remote architecture governance with Claude Code</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=productivity" class="govuk-link">Architecture Productivity Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Productivity tips and workflow optimization</span></li>
@@ -364,7 +365,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Architecture
-                    <span class="app-guide-category__count">8 guides</span>
+                    <span class="app-guide-category__count">12 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -450,6 +451,26 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=atrs" class="govuk-link">Algorithmic Transparency</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">Algorithmic Transparency Recording Standard</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=mod-secure" class="govuk-link">MOD Secure by Design</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">MOD-specific Secure by Design playbook</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=jsp-936" class="govuk-link">JSP 936 AI Assurance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Defence AI assurance compliance</span></li>
+                    </ul>
+                </div>
+            </div>
+
+            <!-- UK Government Reference -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> UK Government Reference
+                    <span class="app-guide-category__count">7 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Policy and standards reference material that complements the command guides above.</em></p>
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-government/standards-map" class="govuk-link">UK Government Digital Policy &amp; Standards Map</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Map of GovS functional standards, Service Standard, TCoP, AI Playbook, security and commercial controls</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-government/technology-code-of-practice" class="govuk-link">Technology Code of Practice Reference</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Background on the 13-point TCoP that /arckit.tcop assesses against</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-government/secure-by-design" class="govuk-link">UK Government Secure by Design Reference</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">NCSC Secure by Design, Cyber Essentials and GDPR context for civilian (non-MOD) services</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-government/ai-playbook" class="govuk-link">UK Government AI Playbook Reference</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">10 principles and 6 ethical themes underpinning /arckit.ai-playbook</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-government/algorithmic-transparency" class="govuk-link">Algorithmic Transparency Recording Standard</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">Public ATRS record requirements behind /arckit.atrs</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-government/digital-marketplace" class="govuk-link">Digital Marketplace Procurement Reference</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">G-Cloud, DOS and Crown Hosting context for /arckit.sow, /arckit.evaluate and /arckit.research</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uk-mod/secure-by-design" class="govuk-link">MOD Secure by Design Reference</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">JSP 440, JSP 604, HMG SPF and DCPP obligations behind /arckit.mod-secure</span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -453,7 +453,7 @@
         <!-- 4b. Government Code Discovery -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <div class="app-feature-card" style="border-color: #00703c; border-width: 3px; padding: 2rem;">
-                <strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">New in v4.5</strong>
+                <strong class="govuk-tag govuk-tag--green govuk-!-margin-bottom-4">UK Government</strong>
                 <h2 class="govuk-heading-l">Government Code Discovery</h2>
                 <p class="govuk-body-l">Search 24,500+ UK government repositories before building from scratch. Powered by <a href="https://github.com/chrisns/govreposcrape" class="govuk-link">govreposcrape</a>, no API key required.</p>
 
@@ -744,11 +744,11 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 70 official commands plus 34 community-contributed overlays across 14 categories with examples and the full dependency matrix.</p>
+                    <p class="govuk-body-s">Browse all 70 official commands plus 34 community-contributed overlays across 13 baseline categories (and 4 community overlay categories) with examples and the full dependency matrix.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>
-                    <p class="govuk-body-s">90 usage guides covering discovery, planning, architecture, governance, compliance, and operations.</p>
+                    <p class="govuk-body-s">101 usage guides (plus 21 community overlay guides) covering discovery, planning, architecture, governance, compliance, and operations.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="roles.html" class="govuk-link">Role Guides</a></h3>
@@ -756,7 +756,7 @@
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="use-cases.html" class="govuk-link">Example Projects</a></h3>
-                    <p class="govuk-body-s">AI-generated architecture documentation from 47 public test projects spanning health, AI, cloud, and data.</p>
+                    <p class="govuk-body-s">AI-generated architecture documentation from 43 public test projects spanning health, AI, cloud, and data.</p>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Audit found that ``docs/guides.html`` was not linking every guide in ``docs/guides/`` and that the headline counts were stale.

- Add ``custom-commands`` to **Getting Started** (was missing entirely)
- Add a new **UK Government Reference** category linking the 7 guides under ``guides/uk-government/`` and ``guides/uk-mod/`` that had no entry on the page
- Fix the **Architecture** category count (header said 8, the list has 12 items)
- Reconcile hero, meta, OG/Twitter, and JSON-LD totals to **101 baseline + 21 community overlays** (was ``95 + 22``, neither of which matched the 114 links actually rendered)

After this PR, all 122 guides on disk (excluding ``guides/roles/*``, which lives on ``roles.html``) are linked from ``guides.html``, and category counts sum correctly to 122.

## Test plan

- [ ] Open ``docs/guides.html`` and confirm 13 categories render with the new section visible
- [ ] Click through the 8 newly added links (``custom-commands`` plus the 7 UK Government Reference entries) and confirm ``guide-viewer.html`` loads each one without error
- [ ] Confirm hero stat reads ``101 Guides + 21 Community Overlays`` and the page intro mentions ``12 categories``

🤖 Generated with [Claude Code](https://claude.com/claude-code)