### PR TITLE
docs(guides): link the 16 new guides from #381 and #385 on guides.html

### DIFF
--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Command Guides - 101 usage guides (plus 21 community overlays) for enterprise architecture governance commands organized by category.">
+    <meta name="description" content="ArcKit Command Guides - 102 usage guides (plus 36 community overlays) for enterprise architecture governance commands organized by category.">
     <title>Command Guides - ArcKit</title>
     <meta name="keywords" content="ArcKit guides, architecture governance guides, command usage, workflow steps, UK government architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Guides - ArcKit">
-    <meta property="og:description" content="101 step-by-step usage guides (plus 21 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta property="og:description" content="102 step-by-step usage guides (plus 36 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/guides.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Guides - ArcKit">
-    <meta name="twitter:description" content="101 step-by-step usage guides (plus 21 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta name="twitter:description" content="102 step-by-step usage guides (plus 36 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/guides.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -235,7 +235,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/guides.html",
                 "name": "Command Guides - ArcKit",
-                "description": "101 step-by-step usage guides (plus 21 community overlays) for ArcKit enterprise architecture governance commands, organised by category.",
+                "description": "102 step-by-step usage guides (plus 36 community overlays) for ArcKit enterprise architecture governance commands, organised by category.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -280,9 +280,9 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">101 Guides + 21 Community Overlays</span>
+            <span class="app-page-hero__stat">102 Guides + 36 Community Overlays</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
-            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 12 categories, plus 21 community-contributed EU, French, and UAE public-sector overlays in dedicated sections.</p>
+            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 12 categories, plus 36 community-contributed EU, French, Austrian, and UAE public-sector overlays in dedicated sections.</p>
         </div>
     </div>
 
@@ -325,7 +325,7 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Discovery
-                    <span class="app-guide-category__count">9 guides</span>
+                    <span class="app-guide-category__count">10 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
@@ -338,6 +338,7 @@
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=gov-reuse" class="govuk-link">Government Code Reuse Assessment</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Discover reusable UK government code via govreposcrape</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=gov-code-search" class="govuk-link">Government Code Search</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Search 24,500+ UK government repositories</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=gov-landscape" class="govuk-link">Government Code Landscape Analysis</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Map UK government code landscape for a domain</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=grants" class="govuk-link">UK Grants &amp; Funding Research Playbook</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">UK government grants, charitable funding, and accelerator programmes with eligibility scoring</span></li>
                     </ul>
                 </div>
             </div>
@@ -520,17 +521,45 @@
                 </div>
             </div>
 
+            <!-- Community overlays — Austria -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> Community overlays — Austria
+                    <span class="app-guide-category__count">3 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Community-contributed Austrian regulatory overlays. Not part of the officially-maintained baseline.</em></p>
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=at-bvergg" class="govuk-link">Austrian Federal Procurement Act (BVergG 2018)</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Bundesvergabegesetz 2018, ANKÖ publication, BVergGVS, and BVwG review</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=at-dsgvo" class="govuk-link">Austrian DSG / DSGVO Compliance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Austrian GDPR layer applied by the Datenschutzbehörde under DSG 2018</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=at-nisg" class="govuk-link">Austrian NIS Act (NISG)</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">NIS2 transposition (BGBl. I Nr. 94/2025) — entity classification and BKA / BMI reporting</span></li>
+                    </ul>
+                </div>
+            </div>
+
             <!-- UAE Federal Overlay -->
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> UAE Federal Overlay
-                    <span class="app-guide-category__count">2 guides</span>
+                    <span class="app-guide-category__count">14 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Community-contributed overlay supporting UAE federal entities under the 23 April 2026 Cabinet agentic-AI decree. PDPL, IAS, sovereign cloud residency, UAE Pass, the four Cabinet instruments, AI Charter, autonomy tier, and federal procurement. Solo-maintained by @tractorjuice; recruiting a UAE domain co-maintainer before any official-tier promotion. Output should be reviewed by qualified UAE federal compliance counsel before reliance.</em></p>
                     <ul class="app-guide-list">
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-overlay" class="govuk-link">UAE Federal Overlay</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">When to use the overlay, the canonical chain across the 12 commands, plugin userConfig setup, migration from the UK ladder</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-overlay-maintenance" class="govuk-link">UAE Overlay Maintenance &amp; Citation Register</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Citation register with verification dates, quarterly review cadence, known limitations, help-wanted callout for UAE domain co-maintainer</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-pdpl" class="govuk-link">UAE PDPL Compliance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Federal Decree-Law No. 45 of 2021 — DPIA, lawful basis, DSR, cross-border, breach playbook</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-ias" class="govuk-link">UAE Information Assurance Standard (IAS)</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Statement of Applicability against the 188 IAS controls, priority-tiered P1–P4</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-classification" class="govuk-link">UAE Smart Data Classification</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Classification register: Open / Shared / Confidential / Secret / Top Secret with handling rules</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-cloud-residency" class="govuk-link">UAE Sovereign Cloud Residency</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">National Cloud Security Policy v2 — residency, approved CSPs, exit and portability plan</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-uaepass" class="govuk-link">UAE Pass Integration</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">OIDC / OAuth integration design for federal entity service providers, with e-signature audit trail</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-ai-charter" class="govuk-link">UAE Charter for AI Compliance</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Mapping against the 12 Charter principles, bias / fairness assessment, human-in-the-loop design</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-ai-autonomy-tier" class="govuk-link">UAE AI Autonomy Tier Posture</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Three-tier autonomy posture with guard-rails, approval gates, and tier-promotion criteria</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-data-sharing" class="govuk-link">UAE Data Sharing Agreement</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">"Collect once, use securely" — federation / API plan and PDPL lawful basis per share</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-digital-records" class="govuk-link">UAE Digital Records Plan</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Source-of-truth register, retention schedule, records-as-official-source designation</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-priorities-alignment" class="govuk-link">UAE National Priorities Alignment</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Reuse-vs-build, capability-reuse register, alignment to NIS 2031 / AI 2031 / We the UAE 2031</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-procurement" class="govuk-link">UAE Federal Procurement Strategy</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Federal Decree-Law No. 11 of 2023 — DPP-aligned ITT / RFP, ICV plan, evaluation report</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=uae-zero-bureaucracy" class="govuk-link">UAE Zero Bureaucracy &amp; Code for Government Services</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Service-catalogue review, bureaucracy-elimination baseline, customer-experience KPIs</span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -748,7 +748,7 @@
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>
-                    <p class="govuk-body-s">101 usage guides (plus 21 community overlay guides) covering discovery, planning, architecture, governance, compliance, and operations.</p>
+                    <p class="govuk-body-s">102 usage guides (plus 36 community overlay guides) covering discovery, planning, architecture, governance, compliance, and operations.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="roles.html" class="govuk-link">Role Guides</a></h3>


### PR DESCRIPTION
## Summary

Follow-up to #381, #385, and #394. The 16 new guides those PRs added were not yet linked from ``guides.html``.

- ``grants`` (from #381) added to **Discovery** (count 9 → 10)
- 12 UAE per-command guides added to existing **UAE Federal Overlay** section (count 2 → 14): pdpl, ias, classification, cloud-residency, uaepass, ai-charter, ai-autonomy-tier, data-sharing, digital-records, priorities-alignment, procurement, zero-bureaucracy
- New **Community overlays — Austria** section with 3 guides: at-bvergg, at-dsgvo, at-nisg

Reconciles the total counts on hero / meta / OG / Twitter / JSON-LD (102 baseline + 36 community = 138) and updates the matching explore-card line on ``index.html``.

After this PR, all 138 guides on disk (excluding ``guides/roles/*`` which lives on ``roles.html``) are linked from ``guides.html`` and category counts sum to 138.

## Test plan

- [ ] Open ``docs/guides.html`` and confirm the new Austria section, the expanded UAE section, and the new ``grants`` row in Discovery render correctly
- [ ] Click a sample of the new links (e.g. ``grants``, ``at-bvergg``, ``uae-pdpl``) and confirm ``guide-viewer.html`` loads each one
- [ ] Confirm hero stat reads ``102 Guides + 36 Community Overlays``

🤖 Generated with [Claude Code](https://claude.com/claude-code)