### PR TITLE
feat(claude): user_config defaults in command/agent prompts + governance alignment scan

### DIFF
--- a/arckit-claude/agents/arckit-aws-research.md
+++ b/arckit-claude/agents/arckit-aws-research.md
@@ -240,7 +240,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise `OFFICIAL` (UK Gov mode) or `PUBLIC` (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-azure-research.md
+++ b/arckit-claude/agents/arckit-azure-research.md
@@ -234,7 +234,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise `OFFICIAL` (UK Gov mode) or `PUBLIC` (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-datascout.md
+++ b/arckit-claude/agents/arckit-datascout.md
@@ -48,6 +48,13 @@ You are an enterprise data source discovery specialist. You systematically disco
 7. Write a comprehensive discovery document to file
 8. Return only a summary to the caller
 
+## Governance Framework Mode
+
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, keep data discovery and quality analysis but skip UK-specific obligations/references (GDS Service Standard, TCoP, NCSC CAF, Orange/Green Book).
+- If mode is `UK Gov`, keep current UK Government guidance behavior.
+
 ## Process
 
 ### Step 1: Read Available Documents
@@ -81,7 +88,7 @@ Find the project directory in `projects/` (user may specify name/number, otherwi
 - **Principles**: Data governance constraints, approved sources, compliance standards
 - **Data Model**: Entities needing external population, data quality requirements
 
-Detect if UK Government project (look for "UK Government", "Ministry of", "Department for", "NHS", "MOD").
+Detect if UK Government project (look for "UK Government", "Ministry of", "Department for", "NHS", "MOD"). Use this as a secondary signal when `${user_config.governance_framework}` is empty.
 
 ### Step 1b: Check for External Documents (optional)
 
@@ -398,7 +405,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 14
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov mode) or "PUBLIC" (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gcp-research.md
+++ b/arckit-claude/agents/arckit-gcp-research.md
@@ -235,7 +235,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise `OFFICIAL` (UK Gov mode) or `PUBLIC` (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gov-code-search.md
+++ b/arckit-claude/agents/arckit-gov-code-search.md
@@ -209,7 +209,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 11
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise `OFFICIAL` (UK Gov mode) or `PUBLIC` (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gov-landscape.md
+++ b/arckit-claude/agents/arckit-gov-landscape.md
@@ -274,7 +274,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 14
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise `OFFICIAL` (UK Gov mode) or `PUBLIC` (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gov-reuse.md
+++ b/arckit-claude/agents/arckit-gov-reuse.md
@@ -241,7 +241,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 11
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise `OFFICIAL` (UK Gov mode) or `PUBLIC` (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-research.md
+++ b/arckit-claude/agents/arckit-research.md
@@ -46,6 +46,13 @@ You are an enterprise architecture market research specialist. You conduct syste
 5. Write a comprehensive research document to file
 6. Return only a summary to the caller
 
+## Governance Framework Mode
+
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, skip UK-specific obligations/references (GDS Service Standard, TCoP, NCSC CAF, Orange/Green Book) and keep vendor/TCO/compliance analysis framework-neutral.
+- If mode is `UK Gov`, keep current UK Government guidance behavior.
+
 ## Process
 
 ### Step 1: Read Available Documents
@@ -80,7 +87,7 @@ Find the project directory in `projects/` (user may specify name/number, otherwi
 - **Stakeholders**: Priorities and success criteria for vendor evaluation
 - **Data Model**: Data storage and processing needs for technology matching
 
-Detect if UK Government project (look for "UK Government", "Ministry of", "Department for", "NHS", "MOD" in project name or requirements).
+Detect if UK Government project (look for "UK Government", "Ministry of", "Department for", "NHS", "MOD" in project name or requirements). Use this as a secondary signal when `${user_config.governance_framework}` is empty.
 
 ### Step 1b: Check for External Documents (optional)
 
@@ -252,7 +259,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov mode) or "PUBLIC" (Generic mode)
 
 Include the generation metadata footer:
 

--- a/arckit-claude/commands/adr.md
+++ b/arckit-claude/commands/adr.md
@@ -346,8 +346,8 @@ ADRs are multi-instance documents. Version detection depends on whether you are 
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/ai-playbook.md
+++ b/arckit-claude/commands/ai-playbook.md
@@ -385,8 +385,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/analyze.md
+++ b/arckit-claude/commands/analyze.md
@@ -1356,8 +1356,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/atrs.md
+++ b/arckit-claude/commands/atrs.md
@@ -16,6 +16,12 @@ $ARGUMENTS
 
 > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
 
+**Governance framework mode**:
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, keep algorithmic transparency, risk, and accountability content but remove UK-specific mandates/references (ATRS publication obligations, GDS Service Standard, TCoP, NCSC CAF, Orange/Green Book).
+- If mode is `UK Gov`, keep current ATRS behavior.
+
 1. **Understand ATRS requirements**:
    - ATRS is **MANDATORY** for all central government departments and arm's length bodies
    - Two-tier structure: Tier 1 (public summary) + Tier 2 (detailed technical)
@@ -277,8 +283,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/backlog.md
+++ b/arckit-claude/commands/backlog.md
@@ -1502,8 +1502,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/data-mesh-contract.md
+++ b/arckit-claude/commands/data-mesh-contract.md
@@ -371,8 +371,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/data-model.md
+++ b/arckit-claude/commands/data-model.md
@@ -232,12 +232,12 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-DATA-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 ### User-provided fields
 
 - `[PROJECT_NAME]` → Full project name
-- `[OWNER_NAME_AND_ROLE]` → Document owner
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
 
 ### Revision History
 

--- a/arckit-claude/commands/dfd.md
+++ b/arckit-claude/commands/dfd.md
@@ -305,8 +305,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/diagram.md
+++ b/arckit-claude/commands/diagram.md
@@ -799,8 +799,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/dld-review.md
+++ b/arckit-claude/commands/dld-review.md
@@ -199,8 +199,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/dos.md
+++ b/arckit-claude/commands/dos.md
@@ -105,8 +105,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/evaluate.md
+++ b/arckit-claude/commands/evaluate.md
@@ -130,8 +130,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/gcloud-clarify.md
+++ b/arckit-claude/commands/gcloud-clarify.md
@@ -218,8 +218,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/gcloud-search.md
+++ b/arckit-claude/commands/gcloud-search.md
@@ -102,8 +102,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/glossary.md
+++ b/arckit-claude/commands/glossary.md
@@ -189,8 +189,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` -> Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` -> Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` -> Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/hld-review.md
+++ b/arckit-claude/commands/hld-review.md
@@ -188,8 +188,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/jsp-936.md
+++ b/arckit-claude/commands/jsp-936.md
@@ -2007,12 +2007,12 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-JSP936-v[VERSION]` → Generated document ID (for filename: `ARC-{PROJECT_ID}-JSP936-v1.0.md`)
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 ### User-provided fields
 
 - `[PROJECT_NAME]` → Full project name
-- `[OWNER_NAME_AND_ROLE]` → Document owner
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
 
 ### Revision History
 

--- a/arckit-claude/commands/maturity-model.md
+++ b/arckit-claude/commands/maturity-model.md
@@ -228,8 +228,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` -> Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` -> Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` -> Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/mod-secure.md
+++ b/arckit-claude/commands/mod-secure.md
@@ -256,8 +256,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/plan.md
+++ b/arckit-claude/commands/plan.md
@@ -420,8 +420,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/presentation.md
+++ b/arckit-claude/commands/presentation.md
@@ -230,8 +230,8 @@ Before generating the document ID, check if a previous version exists:
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 **Pending fields** (leave as [PENDING] until manually updated):
 

--- a/arckit-claude/commands/principles.md
+++ b/arckit-claude/commands/principles.md
@@ -101,12 +101,12 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-PRIN-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 ### User-provided fields
 
 - `[PROJECT_NAME]` → Full project name
-- `[OWNER_NAME_AND_ROLE]` → Document owner
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
 
 ### Revision History
 

--- a/arckit-claude/commands/requirements.md
+++ b/arckit-claude/commands/requirements.md
@@ -27,6 +27,12 @@ $ARGUMENTS
 
 > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
 
+**Governance framework mode**:
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, exclude UK Government-specific references (GDS Service Standard, Technology Code of Practice, NCSC CAF, Orange/Green Book) unless the user explicitly requests them.
+- If mode is `UK Gov`, keep current UK Government guidance behavior.
+
 1. **Identify the target project**:
    - Use the **ArcKit Project Context** (above) to find the project matching the user's input (by name or number)
    - If no match, create a new project:
@@ -186,8 +192,8 @@ Before generating the document ID, check if a previous version exists:
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use `OFFICIAL` for UK Gov and `PUBLIC` for Generic
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/risk.md
+++ b/arckit-claude/commands/risk.md
@@ -391,12 +391,12 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-RISK-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 ### User-provided fields
 
 - `[PROJECT_NAME]` → Full project name
-- `[OWNER_NAME_AND_ROLE]` → Document owner
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
 
 ### Revision History
 

--- a/arckit-claude/commands/roadmap.md
+++ b/arckit-claude/commands/roadmap.md
@@ -333,8 +333,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/secure.md
+++ b/arckit-claude/commands/secure.md
@@ -19,6 +19,12 @@ $ARGUMENTS
 
 UK Government departments must follow NCSC (National Cyber Security Centre) guidance and achieve appropriate security certifications before deploying systems. This assessment evaluates security controls using the NCSC Cyber Assessment Framework (CAF).
 
+**Governance framework mode**:
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, produce a framework-neutral secure-by-design review: keep core security architecture, risk, control, and remediation analysis, but skip UK-specific obligations/references (NCSC CAF, GovAssure, GovS 007, UK Government Cyber Security Standard, Cyber Action Plan, GDS/TCoP dependencies).
+- If mode is `UK Gov`, keep current UK Government Secure by Design behavior.
+
 **Key UK Government Security References**:
 
 - NCSC Cyber Assessment Framework (CAF)
@@ -83,7 +89,10 @@ Generate a comprehensive Secure by Design assessment document by:
    - If no external docs exist but they would improve the assessment, ask: "Do you have any existing security assessments, pen test reports, or threat models? I can read PDFs and images directly. Place them in `projects/{project-dir}/external/` and re-run, or skip."
    - **Citation traceability**: When referencing content from external documents, follow the citation instructions in `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Place inline citation markers (e.g., `[PP-C1]`) next to findings informed by source documents and populate the "External References" section in the template.
 
-5. **Assess security using NCSC CAF (14 principles across 4 objectives)**:
+5. **Assess security control maturity**:
+
+   - If governance mode is `UK Gov`, use **NCSC CAF (14 principles across 4 objectives)**.
+   - If governance mode is `Generic`, use a framework-neutral control set with equivalent coverage (governance, risk management, asset management, identity/access, data protection, secure configuration, monitoring/detection, incident response/recovery).
 
    **Objective A: Managing Security Risk (4 principles)**
    - A1: Governance - SIRO appointed, security policies, oversight
@@ -132,7 +141,7 @@ Generate a comprehensive Secure by Design assessment document by:
 
 9. **Calculate overall CAF score**: X/14 principles achieved
 
-10. **Assess UK Government Cyber Security Standard compliance**:
+10. **Assess UK Government Cyber Security Standard compliance** (UK Gov mode only):
 
     **9.1 GovAssure Status** — For critical systems subject to GovAssure assurance:
     - Identify which systems are in scope for the current GovAssure cycle
@@ -158,14 +167,14 @@ Generate a comprehensive Secure by Design assessment document by:
     - Identify investment alignment and funding opportunities
     - Record gaps where the project or department does not yet meet Cyber Action Plan expectations
 
-10. **Assess Government Cyber Security Profession alignment**:
+10. **Assess Government Cyber Security Profession alignment** (UK Gov mode only):
     - Determine whether the department participates in the Government Cyber Security Profession
     - Record Certified Cyber Professional (CCP) certification status for project security roles
     - Map security roles to DDaT (Digital, Data and Technology) profession framework
     - Assess engagement with the Government Cyber Academy (learning areas, completions)
     - Identify workforce development gaps and training actions
 
-11. **Map GovS 007: Security alignment**:
+11. **Map GovS 007: Security alignment** (UK Gov mode only):
     - Complete the GovS 007 principle mapping table (9 principles → CAF sections and ArcKit artefacts)
     - For principle 5 (Security culture), reference Section 11 (Government Cyber Security Profession) in addition to CAF B6
     - For principle 8 (Continuous improvement), reference Section 9.4 (Cyber Action Plan Alignment) in addition to CAF D2
@@ -222,8 +231,8 @@ Before completing the document, populate ALL document control fields in the head
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/service-assessment.md
+++ b/arckit-claude/commands/service-assessment.md
@@ -59,6 +59,12 @@ Generate a comprehensive GDS Service Standard assessment preparation report that
 
 > **Note**: The ArcKit Project Context hook has already detected all projects, artifacts, external documents, and global policies. Use that context below — no need to scan directories manually.
 
+**Governance framework mode**:
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, run a generic service-readiness assessment instead of UK GDS-only framing: keep architecture/risk/user evidence checks but exclude mandatory references to GDS Service Standard, TCoP, NCSC CAF, Orange/Green Book.
+- If mode is `UK Gov`, keep the existing 14-point GDS assessment behavior.
+
 **Read the template** (with user override support):
 
 - **First**, check if `.arckit/templates/service-assessment-prep-template.md` exists in the project root

--- a/arckit-claude/commands/servicenow.md
+++ b/arckit-claude/commands/servicenow.md
@@ -406,12 +406,12 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-SNOW-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 ### User-provided fields
 
 - `[PROJECT_NAME]` → Full project name
-- `[OWNER_NAME_AND_ROLE]` → Document owner
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
 
 ### Revision History
 

--- a/arckit-claude/commands/sobc.md
+++ b/arckit-claude/commands/sobc.md
@@ -75,8 +75,11 @@ This command creates a **Strategic Outline Business Case (SOBC)** following HM T
    - **Citation traceability**: When referencing content from external documents, follow the citation instructions in `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Place inline citation markers (e.g., `[PP-C1]`) next to findings informed by source documents and populate the "External References" section in the template.
 
 4. **Determine project context**:
-   - If user mentions "UK Government", "public sector", "department", "ministry" → Use full Green Book format
-   - Otherwise → Use Green Book structure but adapt language for private sector
+  - Primary selector: `${user_config.governance_framework}` (`UK Gov` or `Generic`)
+  - If value is empty/unknown, infer from user/project context; default to `UK Gov`
+  - If mode is `UK Gov` → Use full Green Book behavior
+  - If mode is `Generic` → Keep core business case content but remove UK-specific sections/references (GDS Service Standard, TCoP, NCSC CAF, Orange Book, Green Book mandates)
+  - User/project context can explicitly override the default mode
    - Check stakeholder analysis for government-specific stakeholders (Minister, Permanent Secretary, Treasury, NAO)
 
 5. **Read stakeholder analysis carefully**:
@@ -254,12 +257,12 @@ Before generating the document ID, check if a previous version exists:
 - `[VERSION]` → Determined version from Step 0
 - `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
 - `[DOCUMENT_TYPE_NAME]` → "Strategic Outline Business Case (SOBC)"
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "INTERNAL" for private sector
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 - `[STATUS]` → "DRAFT" for new documents
 
-**User-specified fields** (must be confirmed with user):
+**User-specified fields** (use defaults first, then confirm if needed):
 
-- `[OWNER]` → Who owns this business case? (typically from stakeholder RACI matrix)
+- `[OWNER]` → Default to `${user_config.organisation_name}` (typically from stakeholder RACI matrix)
 - `[REVIEWED_BY]` → Who will review? (mark as "PENDING" if not yet reviewed)
 - `[APPROVED_BY]` → Who must approve? (mark as "PENDING" if not yet approved)
 
@@ -273,7 +276,7 @@ Before generating the document ID, check if a previous version exists:
 11. **Use appropriate language**:
 
 - **UK Government**: Use Green Book terminology (intervention, public value, social benefit, spending controls)
-- **Private Sector**: Adapt to commercial language (investment, shareholder value, competitive advantage)
+- **Generic**: Adapt to commercial/non-UK language (investment, organizational value, competitive advantage)
 - **Always**: Link to stakeholder analysis for credibility
 
 12. **Flag uncertainties**:
@@ -331,6 +334,8 @@ Provide:
 - Management Case: Deadline-driven, stakeholder compliance team owns
 
 ## UK Government Specific Guidance
+
+Apply this section only when governance mode is `UK Gov`. For `Generic`, skip this section and keep only core business-case analysis.
 
 **Key HM Treasury references**: The Green Book provides the 5-case model, the [Magenta Book](https://www.gov.uk/government/publications/the-magenta-book) provides evaluation design guidance (theory of change, proportionality, impact evaluation), and the [Sourcing Playbook](https://www.gov.uk/government/publications/the-sourcing-and-consultancy-playbooks) covers should-cost modelling and market assessment. See `docs/guides/codes-of-practice.md` for the full Rainbow of Books mapping.
 

--- a/arckit-claude/commands/sow.md
+++ b/arckit-claude/commands/sow.md
@@ -201,8 +201,8 @@ Before generating the document ID, check if a previous version exists:
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/stakeholders.md
+++ b/arckit-claude/commands/stakeholders.md
@@ -139,12 +139,12 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-STKE-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 ### User-provided fields
 
 - `[PROJECT_NAME]` → Full project name
-- `[OWNER_NAME_AND_ROLE]` → Document owner
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
 
 ### Revision History
 

--- a/arckit-claude/commands/strategy.md
+++ b/arckit-claude/commands/strategy.md
@@ -239,8 +239,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/tcop.md
+++ b/arckit-claude/commands/tcop.md
@@ -21,6 +21,12 @@ The Technology Code of Practice is a set of 13 criteria to help government desig
 
 **TCoP Reference**: https://www.gov.uk/guidance/the-technology-code-of-practice
 
+**Governance framework mode**:
+- Use `${user_config.governance_framework}` as the default mode selector.
+- Treat empty/unknown values as `UK Gov`.
+- If mode is `Generic`, produce a generic technology governance review (same structure and evidence depth) and skip UK-specific obligations/references (TCoP, GDS Service Standard, NCSC CAF, Orange/Green Book mandates).
+- If mode is `UK Gov`, keep current TCoP behavior.
+
 ## Your Task
 
 Generate a comprehensive TCoP review document by:
@@ -126,8 +132,8 @@ Before completing the document, populate ALL document control fields in the head
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/traceability.md
+++ b/arckit-claude/commands/traceability.md
@@ -194,8 +194,8 @@ The hook provides the existing TRAC version and a suggested next version. Use th
 **User-provided fields** (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/wardley.climate.md
+++ b/arckit-claude/commands/wardley.climate.md
@@ -381,8 +381,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.doctrine.md
+++ b/arckit-claude/commands/wardley.doctrine.md
@@ -276,8 +276,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.gameplay.md
+++ b/arckit-claude/commands/wardley.gameplay.md
@@ -386,8 +386,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.md
+++ b/arckit-claude/commands/wardley.md
@@ -415,8 +415,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.value-chain.md
+++ b/arckit-claude/commands/wardley.value-chain.md
@@ -274,8 +274,8 @@ Before completing the document, populate ALL document control fields in the head
 *User-provided fields* (extract from project metadata or user input):
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
-- `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[OWNER_NAME_AND_ROLE]` → Default to `${user_config.organisation_name}`; if unavailable, prompt user
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable use `OFFICIAL` for UK Gov mode and `PUBLIC` for Generic mode
 
 *Calculated fields*:
 

--- a/arckit-claude/hooks/governance-scan.mjs
+++ b/arckit-claude/hooks/governance-scan.mjs
@@ -1,0 +1,748 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Governance Pre-processor Hook
+ *
+ * Fires on UserPromptSubmit for /arckit:analyze commands.
+ * Pre-extracts all artifact metadata, requirements, principles, risks,
+ * cross-references, vendor data, and placeholder counts in Node.js,
+ * providing structured data via additionalContext. The command then
+ * focuses on AI reasoning (semantic analysis, detection passes, report
+ * generation) rather than I/O.
+ *
+ * Follows the same pattern as health-scan.mjs and traceability-scan.mjs.
+ *
+ * Hook Type: UserPromptSubmit (sync, not async)
+ * Input (stdin): JSON with prompt, cwd, etc.
+ * Output (stdout): JSON with additionalContext containing structured findings
+ */
+
+import { join, resolve } from 'node:path';
+import {
+  isDir, isFile, readText, listDir,
+  findRepoRoot, extractDocType, extractVersion,
+  extractDocControlFields, extractRequirementIds,
+  extractRequirementDetails, extractPrinciples, extractRiskEntries,
+  parseHookInput,
+} from './hook-utils.mjs';
+
+// ── Argument parsing ──
+
+function parseArguments(prompt) {
+  const args = { project: null, allProjects: false };
+
+  const text = prompt.replace(/^\/arckit[.:]+analyze\s*/i, '');
+
+  if (/\ball\s+projects?\b/i.test(text)) {
+    args.allProjects = true;
+    return args;
+  }
+
+  const projectMatch = text.match(/\bPROJECT\s*=\s*(\S+)/i);
+  if (projectMatch) {
+    args.project = projectMatch[1];
+    return args;
+  }
+
+  const numMatch = text.match(/\b(\d{3})\b/);
+  if (numMatch) {
+    args.project = numMatch[1];
+    return args;
+  }
+
+  return args;
+}
+
+// ── Artifact scanning ──
+
+function scanArtifacts(projectDir) {
+  const artifacts = [];
+
+  for (const f of listDir(projectDir)) {
+    const fp = join(projectDir, f);
+    if (isFile(fp) && f.startsWith('ARC-') && f.endsWith('.md')) {
+      artifacts.push({ filename: f, path: fp, subdir: null });
+    }
+  }
+
+  for (const subdir of ['decisions', 'diagrams', 'wardley-maps', 'data-contracts', 'reviews', 'research']) {
+    const subPath = join(projectDir, subdir);
+    if (!isDir(subPath)) continue;
+    for (const f of listDir(subPath)) {
+      const fp = join(subPath, f);
+      if (isFile(fp) && f.startsWith('ARC-') && f.endsWith('.md')) {
+        artifacts.push({ filename: f, path: fp, subdir });
+      }
+    }
+  }
+
+  return artifacts;
+}
+
+// ── Design document scanning (reused from traceability pattern) ──
+
+function scanDesignDocs(projectDir) {
+  const refMap = {}; // reqId -> [{ file, type, vendor }]
+
+  function addRefs(filePath, relPath, docType, vendor) {
+    const content = readText(filePath);
+    if (!content) return;
+    const ids = extractRequirementIds(content);
+    for (const id of ids) {
+      if (!refMap[id]) refMap[id] = [];
+      refMap[id].push({ file: relPath, type: docType, vendor: vendor || null });
+    }
+  }
+
+  // ADRs: decisions/ARC-*-ADR-*.md
+  const decisionsDir = join(projectDir, 'decisions');
+  if (isDir(decisionsDir)) {
+    for (const f of listDir(decisionsDir)) {
+      if (f.startsWith('ARC-') && f.endsWith('.md') && f.includes('-ADR-')) {
+        addRefs(join(decisionsDir, f), `decisions/${f}`, 'ADR', null);
+      }
+    }
+  }
+
+  // Vendor docs: vendors/{vendor}/*.md
+  const vendorsDir = join(projectDir, 'vendors');
+  if (isDir(vendorsDir)) {
+    for (const vendor of listDir(vendorsDir)) {
+      const vendorDir = join(vendorsDir, vendor);
+      if (!isDir(vendorDir)) continue;
+
+      for (const f of listDir(vendorDir)) {
+        if (!f.endsWith('.md')) continue;
+        const fp = join(vendorDir, f);
+        if (!isFile(fp)) continue;
+
+        let docType = 'Vendor Doc';
+        if (f.includes('-HLD-') || f.includes('-HLD.') || /\bhld\b/i.test(f)) docType = 'Vendor HLD';
+        else if (f.includes('-DLD-') || f.includes('-DLD.') || /\bdld\b/i.test(f)) docType = 'Vendor DLD';
+
+        addRefs(fp, `vendors/${vendor}/${f}`, docType, vendor);
+      }
+
+      // Also scan reviews subdirectory
+      const reviewsDir = join(vendorDir, 'reviews');
+      if (isDir(reviewsDir)) {
+        for (const f of listDir(reviewsDir)) {
+          if (!f.endsWith('.md')) continue;
+          const fp = join(reviewsDir, f);
+          if (!isFile(fp)) continue;
+
+          let docType = 'Review';
+          if (f.includes('-HLDR-')) docType = 'HLDR';
+          else if (f.includes('-DLDR-')) docType = 'DLDR';
+
+          addRefs(fp, `vendors/${vendor}/reviews/${f}`, docType, vendor);
+        }
+      }
+    }
+  }
+
+  // Root-level reviews: reviews/ARC-*-HLDR-*.md and reviews/ARC-*-DLDR-*.md
+  const reviewsDir = join(projectDir, 'reviews');
+  if (isDir(reviewsDir)) {
+    for (const f of listDir(reviewsDir)) {
+      if (!f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+      let docType = 'Review';
+      if (f.includes('-HLDR-')) docType = 'HLDR';
+      else if (f.includes('-DLDR-')) docType = 'DLDR';
+      addRefs(join(reviewsDir, f), `reviews/${f}`, docType, null);
+    }
+  }
+
+  // Also check root-level HLDR/DLDR files
+  for (const f of listDir(projectDir)) {
+    if (!f.startsWith('ARC-') || !f.endsWith('.md')) continue;
+    if (f.includes('-HLDR-') || f.includes('-DLDR-')) {
+      const docType = f.includes('-HLDR-') ? 'HLDR' : 'DLDR';
+      addRefs(join(projectDir, f), f, docType, null);
+    }
+  }
+
+  return refMap;
+}
+
+// ── Coverage analysis ──
+
+function computeCoverage(requirements, refMap) {
+  const coverage = {
+    total: requirements.length,
+    covered: 0,
+    orphan: [],
+    byCategory: {},
+    byPriority: {},
+  };
+
+  for (const req of requirements) {
+    const refs = refMap[req.id];
+    const isCovered = refs && refs.length > 0;
+
+    if (isCovered) {
+      coverage.covered = coverage.covered + 1;
+    } else {
+      coverage.orphan.push(req);
+    }
+
+    // By category
+    if (!coverage.byCategory[req.category]) {
+      coverage.byCategory[req.category] = { total: 0, covered: 0 };
+    }
+    coverage.byCategory[req.category].total = coverage.byCategory[req.category].total + 1;
+    if (isCovered) {
+      coverage.byCategory[req.category].covered = coverage.byCategory[req.category].covered + 1;
+    }
+
+    // By priority
+    if (!coverage.byPriority[req.priority]) {
+      coverage.byPriority[req.priority] = { total: 0, covered: 0 };
+    }
+    coverage.byPriority[req.priority].total = coverage.byPriority[req.priority].total + 1;
+    if (isCovered) {
+      coverage.byPriority[req.priority].covered = coverage.byPriority[req.priority].covered + 1;
+    }
+  }
+
+  return coverage;
+}
+
+// ── Vendor scanning ──
+
+function scanVendors(projectDir) {
+  const vendors = [];
+  const vendorsDir = join(projectDir, 'vendors');
+  if (!isDir(vendorsDir)) return vendors;
+
+  for (const vendor of listDir(vendorsDir)) {
+    const vendorDir = join(vendorsDir, vendor);
+    if (!isDir(vendorDir)) continue;
+
+    const entry = { name: vendor, docs: [], reviews: [] };
+
+    for (const f of listDir(vendorDir)) {
+      if (!f.endsWith('.md')) continue;
+      if (!isFile(join(vendorDir, f))) continue;
+      entry.docs.push(f);
+    }
+
+    // Reviews subdirectory
+    const reviewsDir = join(vendorDir, 'reviews');
+    if (isDir(reviewsDir)) {
+      for (const f of listDir(reviewsDir)) {
+        if (!f.endsWith('.md') || !isFile(join(reviewsDir, f))) continue;
+        const content = readText(join(reviewsDir, f));
+        let verdict = null;
+        if (content) {
+          if (/APPROVED\s+WITH\s+CONDITIONS/i.test(content)) verdict = 'APPROVED WITH CONDITIONS';
+          else if (/\bREJECTED\b/i.test(content)) verdict = 'REJECTED';
+          else if (/\bAPPROVED\b/i.test(content)) verdict = 'APPROVED';
+          else if (/\bPENDING\b/i.test(content)) verdict = 'PENDING';
+        }
+        entry.reviews.push({ file: f, verdict });
+      }
+    }
+
+    vendors.push(entry);
+  }
+
+  return vendors;
+}
+
+// ── Placeholder detection ──
+
+const PLACEHOLDER_RE = /\b(TODO|TBD|TBC)\b|\?\?\?|\[PENDING\]/gi;
+
+function countPlaceholders(content) {
+  const matches = content.match(PLACEHOLDER_RE);
+  return matches ? matches.length : 0;
+}
+
+// ── Percentage formatting ──
+
+function pct(covered, total) {
+  if (total === 0) return '0%';
+  return `${Math.round((covered / total) * 100)}%`;
+}
+
+// ── Main ──
+
+const data = parseHookInput();
+
+const configuredOrgName = (process.env.CLAUDE_PLUGIN_OPTION_ORGANISATION_NAME || '').trim();
+const configuredClassification = (process.env.CLAUDE_PLUGIN_OPTION_DEFAULT_CLASSIFICATION || '').trim();
+const configuredGovernanceFramework = (process.env.CLAUDE_PLUGIN_OPTION_GOVERNANCE_FRAMEWORK || '').trim();
+
+// Guard: hooks.json matcher triggers on substring "/arckit:analyze" which can
+// false-positive when another command's expanded body mentions /arckit:analyze.
+// Accept raw slash command OR the Skill-expanded body (unique description/heading).
+// No ^ anchors — Skill tool may wrap the expanded body in XML tags.
+const userPrompt = data.prompt || '';
+const isRawCommand = /^\s*\/arckit[.:]+analyze\b/i.test(userPrompt);
+const isExpandedBody = /description:\s*Perform comprehensive governance quality analysis/i.test(userPrompt)
+  || /#\s*Identify inconsistencies, gaps, ambiguities/i.test(userPrompt);
+if (!isRawCommand && !isExpandedBody) process.exit(0);
+
+// Parse arguments
+const args = parseArguments(userPrompt);
+
+// Find repo root
+const cwd = data.cwd || process.cwd();
+const repoRoot = findRepoRoot(cwd);
+if (!repoRoot) process.exit(0);
+
+const projectsDir = join(repoRoot, 'projects');
+if (!isDir(projectsDir)) process.exit(0);
+
+// Discover projects
+let projectDirs = listDir(projectsDir)
+  .filter(e => isDir(join(projectsDir, e)) && /^\d{3}-/.test(e) && e !== '000-global');
+
+// Filter to specific project if requested
+if (args.project) {
+  const match = projectDirs.find(d =>
+    d === args.project || d.startsWith(args.project)
+  );
+  if (match) {
+    projectDirs = [match];
+  } else {
+    process.exit(0);
+  }
+}
+
+// Analyze is single-project unless "all projects" specified
+if (projectDirs.length === 0) process.exit(0);
+if (projectDirs.length > 1 && !args.allProjects) {
+  // No project specified and multiple exist — let the command ask the user
+  process.exit(0);
+}
+
+// Read ArcKit version
+const pluginRoot = resolve(import.meta.url.replace('file://', ''), '..', '..');
+const arckitVersion = readText(join(pluginRoot, 'VERSION'))?.trim() || 'unknown';
+
+// Process each project (typically just one for analyze)
+const allOutput = [];
+
+for (const projectName of projectDirs) {
+  const projectDir = join(projectsDir, projectName);
+  const projectId = projectName.match(/^(\d{3})/)?.[1] || '000';
+
+  const lines = [];
+
+  // ── Phase 1: Artifact inventory ──
+
+  const artifacts = scanArtifacts(projectDir);
+  const artifactMeta = [];
+  const typeSet = new Set();
+  const placeholderCounts = [];
+
+  for (const artifact of artifacts) {
+    const content = readText(artifact.path);
+    if (!content) continue;
+
+    const docType = extractDocType(artifact.filename);
+    const version = extractVersion(artifact.filename);
+    const fields = extractDocControlFields(content);
+    const relPath = artifact.subdir ? `${artifact.subdir}/${artifact.filename}` : artifact.filename;
+
+    if (docType) typeSet.add(docType);
+
+    const placeholders = countPlaceholders(content);
+
+    artifactMeta.push({
+      filename: artifact.filename,
+      relPath,
+      docType,
+      version,
+      status: fields['Status'] || '',
+      classification: fields['Classification'] || '',
+      owner: fields['Owner'] || '',
+      createdDate: fields['Created Date'] || fields['Created'] || '',
+      lastModified: fields['Last Modified'] || fields['Modified'] || '',
+      content,
+      placeholders,
+    });
+
+    if (placeholders > 0) {
+      placeholderCounts.push({ file: relPath, count: placeholders });
+    }
+  }
+
+  // ── Phase 1b: Global artifacts (PRIN from 000-global) ──
+
+  const globalDir = join(projectsDir, '000-global');
+  const globalPrinFiles = [];
+  if (isDir(globalDir)) {
+    for (const f of listDir(globalDir)) {
+      if (f.startsWith('ARC-') && f.endsWith('.md') && f.includes('-PRIN-')) {
+        globalPrinFiles.push({ filename: f, path: join(globalDir, f) });
+      }
+    }
+  }
+
+  // ── Phase 2: Missing artifacts detection ──
+
+  const recommendedTypes = ['STKE', 'RISK', 'SOBC', 'DATA', 'TRAC'];
+  const ukGovTypes = ['TCOP', 'AIPB', 'ATRS'];
+  const modTypes = ['SECD-MOD'];
+
+  const missingRecommended = [];
+  const hasDataReqs = artifactMeta.some(a => {
+    if (a.docType !== 'REQ') return false;
+    return /\bDR-\d{3}\b/.test(a.content);
+  });
+
+  const commandMap = {
+    'STKE': '/arckit:stakeholders',
+    'RISK': '/arckit:risk',
+    'SOBC': '/arckit:sobc',
+    'DATA': '/arckit:data-model',
+    'TRAC': '/arckit:traceability',
+  };
+
+  for (const type of recommendedTypes) {
+    if (typeSet.has(type)) continue;
+    // DATA only recommended if DR-xxx requirements exist
+    if (type === 'DATA' && !hasDataReqs) continue;
+    missingRecommended.push({ type, command: commandMap[type] || '' });
+  }
+
+  const presentUkGov = ukGovTypes.filter(t => typeSet.has(t));
+  const presentMod = modTypes.filter(t => typeSet.has(t));
+
+  // ── Phase 3: Requirements inventory ──
+
+  const allRequirements = [];
+  const reqFiles = [];
+
+  for (const meta of artifactMeta) {
+    if (meta.docType !== 'REQ') continue;
+    reqFiles.push(meta.filename);
+    const reqs = extractRequirementDetails(meta.content);
+    for (const req of reqs) {
+      req.sourceFile = meta.filename;
+      allRequirements.push(req);
+    }
+  }
+
+  // Priority distribution
+  const priorityDist = { MUST: 0, SHOULD: 0, MAY: 0 };
+  for (const req of allRequirements) {
+    if (priorityDist[req.priority] !== undefined) {
+      priorityDist[req.priority] = priorityDist[req.priority] + 1;
+    }
+  }
+
+  // ── Phase 4: Principles extraction ──
+
+  const allPrinciples = [];
+  for (const pf of globalPrinFiles) {
+    const content = readText(pf.path);
+    if (!content) continue;
+    const principles = extractPrinciples(content);
+    for (const p of principles) {
+      p.sourceFile = pf.filename;
+      allPrinciples.push(p);
+    }
+  }
+
+  // ── Phase 5: Cross-reference map + coverage ──
+
+  const refMap = scanDesignDocs(projectDir);
+  const coverage = computeCoverage(allRequirements, refMap);
+
+  // ── Phase 6: Risk extraction ──
+
+  const allRisks = [];
+  for (const meta of artifactMeta) {
+    if (meta.docType !== 'RISK') continue;
+    const risks = extractRiskEntries(meta.content);
+    for (const r of risks) {
+      r.sourceFile = meta.filename;
+      allRisks.push(r);
+    }
+  }
+
+  // Severity buckets (parse inherent score for numeric comparison)
+  const riskSeverity = { 'Very High': 0, 'High': 0, 'Medium': 0, 'Low': 0, 'Very Low': 0 };
+  for (const risk of allRisks) {
+    // Try to match score like "20 (Very High)" or just "Very High"
+    const scoreMatch = risk.inherent.match(/\b(Very High|High|Medium|Low|Very Low)\b/i);
+    if (scoreMatch) {
+      const bucket = scoreMatch[1].replace(/\b\w/g, c => c.toUpperCase());
+      if (riskSeverity[bucket] !== undefined) {
+        riskSeverity[bucket] = riskSeverity[bucket] + 1;
+      }
+    }
+  }
+
+  // ── Phase 7: Vendor inventory ──
+
+  const vendors = scanVendors(projectDir);
+
+  // ── Phase 8: Build additionalContext ──
+
+  lines.push('## Governance Scan Pre-processor Complete');
+  lines.push('');
+  lines.push('**All artifact metadata, requirements, principles, risks, and cross-references pre-extracted.**');
+  lines.push('');
+
+  // Section 1: Scan Parameters
+  lines.push('### Scan Parameters');
+  lines.push(`- **Project**: ${projectName}`);
+  lines.push(`- **Project ID**: ${projectId}`);
+  lines.push(`- **ArcKit Version**: ${arckitVersion}`);
+  lines.push(`- **Artifacts scanned**: ${artifactMeta.length}`);
+  lines.push(`- **Artifact types found**: ${[...typeSet].sort().join(', ')}`);
+  lines.push(`- **REQ files**: ${reqFiles.length > 0 ? reqFiles.join(', ') : 'none'}`);
+  lines.push(`- **PRIN files (global)**: ${globalPrinFiles.length > 0 ? globalPrinFiles.map(f => f.filename).join(', ') : 'none'}`);
+  lines.push(`- **Vendors**: ${vendors.length > 0 ? vendors.map(v => v.name).join(', ') : 'none'}`);
+  lines.push('');
+
+  // Section 2: Artifact Inventory
+  lines.push('### Artifact Inventory');
+  lines.push('');
+  lines.push('| File | Doc Type | Version | Status | Classification | Owner | Last Modified |');
+  lines.push('|------|----------|---------|--------|----------------|-------|---------------|');
+  for (const meta of artifactMeta) {
+    lines.push(`| ${meta.relPath} | ${meta.docType || '?'} | ${meta.version || '?'} | ${meta.status || '\u2014'} | ${meta.classification || '\u2014'} | ${meta.owner || '\u2014'} | ${meta.lastModified || '\u2014'} |`);
+  }
+  lines.push('');
+
+  // Section 3: Missing Recommended Artifacts
+  if (missingRecommended.length > 0) {
+    lines.push('### Missing Recommended Artifacts');
+    lines.push('');
+    for (const m of missingRecommended) {
+      lines.push(`- **${m.type}**: Not found \u2014 create with \`${m.command}\``);
+    }
+    lines.push('');
+  }
+
+  // Section 4: UK Gov / MOD Artifact Presence
+  lines.push('### Compliance Artifact Presence');
+  lines.push('');
+  lines.push(`- **UK Gov (TCOP/AIPB/ATRS)**: ${presentUkGov.length > 0 ? presentUkGov.join(', ') : 'none found'}`);
+  lines.push(`- **MOD (SECD-MOD)**: ${presentMod.length > 0 ? presentMod.join(', ') : 'none found'}`);
+  lines.push('');
+
+  // Section 5: Requirements Inventory
+  if (allRequirements.length > 0) {
+    lines.push('### Requirements Inventory');
+    lines.push('');
+    lines.push('| Req ID | Category | Priority | Description | Covered |');
+    lines.push('|--------|----------|----------|-------------|---------|');
+    for (const req of allRequirements) {
+      const refs = refMap[req.id];
+      const isCovered = refs && refs.length > 0;
+      const desc = req.description.length > 80
+        ? req.description.substring(0, 77) + '...'
+        : req.description;
+      lines.push(`| ${req.id} | ${req.category} | ${req.priority} | ${desc} | ${isCovered ? 'Yes' : 'No'} |`);
+    }
+    lines.push('');
+
+    // Section 6: Priority Distribution
+    lines.push('### Priority Distribution');
+    lines.push('');
+    lines.push(`- **MUST**: ${priorityDist.MUST}`);
+    lines.push(`- **SHOULD**: ${priorityDist.SHOULD}`);
+    lines.push(`- **MAY**: ${priorityDist.MAY}`);
+    lines.push('');
+
+    // Section 7: Coverage Summary
+    lines.push('### Coverage Summary');
+    lines.push('');
+    lines.push('| Metric | Covered | Total | Pct |');
+    lines.push('|--------|---------|-------|-----|');
+    lines.push(`| Overall | ${coverage.covered} | ${coverage.total} | ${pct(coverage.covered, coverage.total)} |`);
+
+    const categoryOrder = ['Business', 'Functional', 'Non-Functional', 'Integration', 'Data'];
+    for (const cat of categoryOrder) {
+      const catData = coverage.byCategory[cat];
+      if (!catData) continue;
+      lines.push(`| ${cat} | ${catData.covered} | ${catData.total} | ${pct(catData.covered, catData.total)} |`);
+    }
+
+    const priorityOrder = ['MUST', 'SHOULD', 'MAY'];
+    for (const pri of priorityOrder) {
+      const priData = coverage.byPriority[pri];
+      if (!priData) continue;
+      lines.push(`| ${pri} priority | ${priData.covered} | ${priData.total} | ${pct(priData.covered, priData.total)} |`);
+    }
+    lines.push('');
+
+    // Section 8: Orphan Requirements
+    if (coverage.orphan.length > 0) {
+      lines.push('### Orphan Requirements (no design coverage)');
+      lines.push('');
+      for (const req of coverage.orphan) {
+        lines.push(`- **${req.id}** (${req.priority}): ${req.description}`);
+      }
+      lines.push('');
+    }
+  }
+
+  // Section 9: Principles
+  if (allPrinciples.length > 0) {
+    lines.push('### Principles');
+    lines.push('');
+    lines.push('| # | Title | Category | Statement | Gates Passed |');
+    lines.push('|---|-------|----------|-----------|--------------|');
+    for (const p of allPrinciples) {
+      const stmt = p.statement.length > 60
+        ? p.statement.substring(0, 57) + '...'
+        : p.statement;
+      const gates = p.gateCount > 0 ? `${p.gatesPassed}/${p.gateCount}` : '\u2014';
+      lines.push(`| ${p.id} | ${p.title} | ${p.category} | ${stmt} | ${gates} |`);
+    }
+    lines.push('');
+  }
+
+  // Section 10: Risks
+  if (allRisks.length > 0) {
+    lines.push('### Risks');
+    lines.push('');
+    lines.push('| Risk ID | Title | Category | Inherent | Residual | Owner | Status | Response |');
+    lines.push('|---------|-------|----------|----------|----------|-------|--------|----------|');
+    for (const r of allRisks) {
+      const title = r.title.length > 40 ? r.title.substring(0, 37) + '...' : r.title;
+      lines.push(`| ${r.id} | ${title} | ${r.category} | ${r.inherent} | ${r.residual} | ${r.owner} | ${r.status} | ${r.response} |`);
+    }
+    lines.push('');
+
+    // Severity summary
+    lines.push('**Risk Severity Summary**:');
+    for (const [bucket, count] of Object.entries(riskSeverity)) {
+      if (count > 0) lines.push(`- ${bucket}: ${count}`);
+    }
+    lines.push('');
+  }
+
+  // Section 11: Vendor Inventory
+  if (vendors.length > 0) {
+    lines.push('### Vendor Inventory');
+    lines.push('');
+    for (const v of vendors) {
+      lines.push(`#### ${v.name}`);
+      lines.push(`- **Documents**: ${v.docs.length > 0 ? v.docs.join(', ') : 'none'}`);
+      if (v.reviews.length > 0) {
+        for (const rv of v.reviews) {
+          lines.push(`- **Review**: ${rv.file} \u2014 Verdict: ${rv.verdict || 'not determined'}`);
+        }
+      }
+      lines.push('');
+    }
+  }
+
+  // Section 12: Cross-Reference Map
+  if (Object.keys(refMap).length > 0) {
+    lines.push('### Cross-Reference Map');
+    lines.push('');
+    lines.push('| Req ID | Referenced By |');
+    lines.push('|--------|---------------|');
+    for (const [reqId, refs] of Object.entries(refMap).sort()) {
+      const refList = refs.map(r => r.file).join(', ');
+      lines.push(`| ${reqId} | ${refList} |`);
+    }
+    lines.push('');
+  }
+
+  // Section 13: Placeholder Counts
+  if (placeholderCounts.length > 0) {
+    lines.push('### Placeholder Counts (TODO/TBD/TBC/???/[PENDING])');
+    lines.push('');
+    lines.push('| File | Count |');
+    lines.push('|------|-------|');
+    for (const pc of placeholderCounts.sort((a, b) => b.count - a.count)) {
+      lines.push(`| ${pc.file} | ${pc.count} |`);
+    }
+    lines.push('');
+  }
+
+  // Section 14: Document Control Fields
+  lines.push('### Document Control Fields');
+  lines.push('');
+  if (configuredOrgName || configuredClassification || configuredGovernanceFramework) {
+    lines.push('**Configured Plugin Defaults**:');
+    lines.push(`- **organisation_name**: ${configuredOrgName || '\u2014 not set \u2014'}`);
+    lines.push(`- **default_classification**: ${configuredClassification || '\u2014 not set \u2014'}`);
+    lines.push(`- **governance_framework**: ${configuredGovernanceFramework || '\u2014 not set \u2014'}`);
+    lines.push('');
+  }
+  lines.push('| File | Classification | Status | Owner |');
+  lines.push('|------|----------------|--------|-------|');
+  for (const meta of artifactMeta) {
+    lines.push(`| ${meta.relPath} | ${meta.classification || '\u2014'} | ${meta.status || '\u2014'} | ${meta.owner || '\u2014'} |`);
+  }
+  lines.push('');
+
+  if (configuredClassification || configuredOrgName) {
+    const mismatchedClassification = [];
+    const missingOrMismatchedOwner = [];
+
+    for (const meta of artifactMeta) {
+      if (configuredClassification) {
+        const actual = (meta.classification || '').trim().toUpperCase();
+        const expected = configuredClassification.toUpperCase();
+        if (!actual || actual !== expected) {
+          mismatchedClassification.push(meta.relPath);
+        }
+      }
+
+      if (configuredOrgName) {
+        const actualOwner = (meta.owner || '').trim().toLowerCase();
+        const expectedOwner = configuredOrgName.toLowerCase();
+        if (!actualOwner || !actualOwner.includes(expectedOwner)) {
+          missingOrMismatchedOwner.push(meta.relPath);
+        }
+      }
+    }
+
+    if (mismatchedClassification.length > 0 || missingOrMismatchedOwner.length > 0) {
+      lines.push('### Plugin Default Alignment Gaps');
+      lines.push('');
+      if (mismatchedClassification.length > 0) {
+        lines.push(`- **Classification differs from configured default** (${configuredClassification}): ${mismatchedClassification.join(', ')}`);
+      }
+      if (missingOrMismatchedOwner.length > 0) {
+        lines.push(`- **Owner missing or does not reference configured organisation** (${configuredOrgName}): ${missingOrMismatchedOwner.join(', ')}`);
+      }
+      lines.push('');
+    }
+  }
+
+  if (configuredGovernanceFramework) {
+    const frameworkNormalized = configuredGovernanceFramework.toLowerCase();
+    if (frameworkNormalized === 'generic' && presentUkGov.length > 0) {
+      lines.push('### Governance Framework Note');
+      lines.push('');
+      lines.push(`- Plugin is configured for Generic governance, but UK Gov artifacts are present: ${presentUkGov.join(', ')}. Verify this is intentional.`);
+      lines.push('');
+    }
+  }
+
+  // Section 15: What to do
+  lines.push('### What to do');
+  lines.push('');
+  lines.push('**Rule 1 — Hook tables are primary data.** Use them directly for all detection passes. Do NOT re-read any artifact file listed in the Artifact Inventory table.');
+  lines.push('');
+  lines.push('**Rule 2 — Targeted reads only.** When a detection pass needs evidence beyond hook tables (e.g. full principle validation criteria, TCoP per-point scores, risk appetite thresholds), use Grep for specific patterns or Read with offset/limit. NEVER read an entire artifact file.');
+  lines.push('');
+  lines.push('**Rule 3 — Skip Steps 1-2 entirely.** Go directly to Step 3 (Build Semantic Models) using the pre-extracted tables. Still read the template (Step 0) for output formatting.');
+  lines.push('');
+  lines.push('Passes A, C, K need zero file reads — hook data is sufficient. Passes B, D, E, F, G, H, I, J may need surgical Grep reads for specific evidence sections only.');
+
+  allOutput.push(lines.join('\n'));
+}
+
+const message = allOutput.join('\n\n---\n\n');
+
+const output = {
+  hookSpecificOutput: {
+    hookEventName: 'UserPromptSubmit',
+    additionalContext: message,
+  },
+};
+console.log(JSON.stringify(output));


### PR DESCRIPTION
## Summary
This PR is a scoped v2 follow-up to the previous `feat/userconfig-wiring` attempt, rebuilt from current `main` to avoid cross-PR regressions.

It keeps only the intended architecture:

- Add `user_config`-based defaulting guidance in Claude command bodies.
- Add the same defaulting guidance in Claude agent bodies.
- Add `arckit-claude/hooks/governance-scan.mjs` checks for plugin default alignment gaps (Classification / Owner).

## Included in This PR

### 1) Command Body Updates (Claude)
Command text now includes guidance to:

- Default `[CLASSIFICATION]` and `[OWNER_NAME_AND_ROLE]` from `\${user_config.*}` where available.
- Prompt the user when a default is unavailable.
- Apply Governance Framework Mode logic (UK Gov vs Generic) in body instructions.

### 2) Agent Body Updates (Claude)
Agent prompts follow the same pattern:

- Use `\${user_config.*}` defaults in prompt body logic.
- Fall back to user prompt when defaults are missing.
- Preserve governance-mode behavior in agent instructions.

### 3) Governance Scan Hook
Introduces `arckit-claude/hooks/governance-scan.mjs` behavior that:

- Reads plugin defaults from `CLAUDE_PLUGIN_OPTION_*` environment variables.
- Adds a **Plugin Default Alignment Gaps** section.
- Flags artifact-level metadata mismatches for:
  - Classification
  - Owner

## Explicitly Out of Scope

To keep this PR merge-safe and aligned with prior review feedback, the following are intentionally excluded:

- Template-level `\${user_config.*}` substitution changes.
- Bulk template rewrites across plugin trees.
- `scripts/converter.py` placeholder rewrite/copy flows.
- Any `arckit-paperclip/` script reintroductions or related regressions.
- Changes to:
  - `arckit-claude/commands/pages.md`
  - `arckit-claude/templates/pages-template.html`
  - `arckit-claude/hooks/allow-mcp-tools.mjs`
- Deletions/overwrites of recently merged guide/docs work.

## Rationale

`user_config` interpolation is reliable in command/agent body text, but not in arbitrary template file contents loaded at runtime.  
This PR therefore applies defaults only where substitution is guaranteed and avoids template-level substitution risk.

## Validation Notes

- Rebuilt from current `main` to avoid silent reverts.
- Diff intentionally constrained to:
  - Claude command bodies
  - Claude agent bodies
  - governance scan hook
- No template/converter/paperclip regression surface included.
