### PR TITLE
fix(docs): make govuk-inset-text readable in dark mode

### DIFF
--- a/docs/theme.css
+++ b/docs/theme.css
@@ -124,6 +124,7 @@ html.dark-mode .govuk-phase-banner__text {
 
 html.dark-mode .govuk-inset-text {
     border-left-color: #555555;
+    color: #e8e8e8;
 }
 
 html.dark-mode .govuk-section-break--visible {


### PR DESCRIPTION
## Summary
- The disclaimer callout on `use-cases.html` (and 4 other pages using `govuk-inset-text`) had GOV.UK's default near-black text rendering on the dark `#1a1a1a` main-wrapper background, making it unreadable on mobile dark mode.
- Added `color: #e8e8e8;` to the existing `html.dark-mode .govuk-inset-text` rule in `docs/theme.css`. Previously only `border-left-color` was overridden.

## Test plan
- [ ] Visit https://arckit.org/use-cases.html on mobile in dark mode and confirm the disclaimer text is readable
- [ ] Spot-check `articles.html`, `contributors.html`, `commands.html`, `roles.html` for any inset-text regressions in light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)