### PR TITLE
fix(docs): readable warning text and contributor cards in dark mode

### DIFF
--- a/docs/theme.css
+++ b/docs/theme.css
@@ -144,6 +144,26 @@ html.dark-mode .govuk-warning-text__icon {
     color: #f0f0f0;
 }
 
+html.dark-mode .govuk-warning-text__text {
+    color: #f0f0f0;
+}
+
+html.dark-mode .app-contributor-card {
+    background: #2a2a2a;
+}
+
+html.dark-mode .app-contributor-card:hover {
+    background: #333333;
+}
+
+html.dark-mode .app-contributor-card__name a {
+    color: #f0f0f0;
+}
+
+html.dark-mode .app-contributor-card__highlights li {
+    color: #d0d0d0;
+}
+
 html.dark-mode .govuk-main-wrapper {
     background: #1a1a1a;
 }


### PR DESCRIPTION
## Summary
- \`govuk-warning-text__text\` (used on use-cases.html and getting-started.html) is a \`<strong>\` element that wasn't covered by the dark-mode color overrides in \`theme.css\` — left near-black on dark background.
- Contributor cards on contributors.html have a fixed \`#f3f2f1\` background. In dark mode the global \`html.dark-mode p, li\` rule made body text light, producing light-on-light. Cards now go dark in dark mode with matching link/highlight colours.

## Test plan
- [ ] Hard-refresh https://arckit.org/use-cases.html in dark mode and confirm the warning callout is readable
- [ ] Hard-refresh https://arckit.org/getting-started.html in dark mode and confirm any warning callouts are readable
- [ ] Hard-refresh https://arckit.org/contributors.html in dark mode and confirm card text + highlight bullets are readable
- [ ] Confirm light mode is unchanged on all three pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)