### PR TITLE
fix(docs): readable govuk-back-link in dark mode

### DIFF
--- a/docs/theme.css
+++ b/docs/theme.css
@@ -127,6 +127,20 @@ html.dark-mode .govuk-inset-text {
     color: #e8e8e8;
 }
 
+html.dark-mode .govuk-back-link,
+html.dark-mode .govuk-back-link:link,
+html.dark-mode .govuk-back-link:visited {
+    color: #e8e8e8;
+}
+
+html.dark-mode .govuk-back-link:hover {
+    color: #ffffff;
+}
+
+html.dark-mode .govuk-back-link::before {
+    border-color: #e8e8e8;
+}
+
 html.dark-mode .govuk-section-break--visible {
     border-bottom-color: #555555;
 }


### PR DESCRIPTION
## Summary
- The \`govuk-back-link\` ("Back to ArcKit") used GOV.UK's default near-black colour, unreadable on the dark main wrapper.
- Added dark-mode overrides for link/visited/hover states plus the \`::before\` arrow border colour.

## Test plan
- [ ] Hard-refresh any sub-page (e.g. use-cases.html, articles.html) in dark mode and confirm "Back to ArcKit" is readable
- [ ] Confirm light mode is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)