### PR TITLE
docs: refresh test repo tables to v48 (public only)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -460,32 +460,53 @@ git push && git push --tags
 
 ## Test Repositories
 
-ArcKit maintains 22 test repos on GitHub (pattern: `arckit-test-project-v*`):
+ArcKit maintains 43 public test repos on GitHub (pattern: `arckit-test-project-v*`, range v0–v48). Only public repos are listed below; v0/v4/v5/v13/v15/v20 are private and v12 was retired.
 
-| Version | Name | Type | Description |
-|---------|------|------|-------------|
-| v0 | mod-chatbot | Private | MOD chatbot project |
-| v1 | m365 | Public | Microsoft 365 migration |
-| v2 | hmrc-chatbot | Public | HMRC chatbot |
-| v3 | windows11 | Public | Windows 11 deployment |
-| v4 | ipa | Private | Infrastructure Projects Authority |
-| v5 | dstl | Private | Defence Science & Technology Lab |
-| v6 | patent-system | Public | Patent system modernization |
-| v7 | nhs-appointment | Public | NHS appointment booking |
-| v8 | ons-data-platform | Public | ONS data platform |
-| v9 | cabinet-office-genai | Public | Cabinet Office GenAI |
-| v10 | training-marketplace | Public | UK Government Training Marketplace |
-| v11 | national-highways-data | Public | National Highways data architecture |
-| v12 | honky-tonks | Private | Restaurant data analytics |
-| v13 | plymouth-research | Private | Plymouth restaurant web scraping |
-| v14 | scottish-courts | Public | Scottish Courts and Tribunals Service GenAI strategy |
-| v15 | ipad-framework | Private | Investment Promotion Agency Data Framework |
-| v16 | doctors-appointment | Public | Doctors Online Appointment System |
-| v17 | fuel-prices | Public | UK Government Fuel Price Transparency Service |
-| v18 | smart-meter | Public | UK Smart Meter Data Consumer Mobile App |
-| v19 | gov-api-aggregator | Public | UK Government API Aggregator |
-| v20 | uae-moi-ipad | Private | UAE MOI IPAD Framework |
-| v21 | criminal-courts | Public | Independent Review of the Criminal Courts - Technology & AI |
+| Version | Name | Description |
+|---------|------|-------------|
+| v1 | m365 | Microsoft 365 migration |
+| v2 | hmrc-chatbot | HMRC chatbot |
+| v3 | windows11 | Windows 11 deployment |
+| v6 | patent-system | Patent system modernization |
+| v7 | nhs-appointment | NHS appointment booking |
+| v8 | ons-data-platform | ONS data platform |
+| v9 | cabinet-office-genai | Cabinet Office GenAI |
+| v10 | training-marketplace | UK Government Training Marketplace |
+| v11 | national-highways-data | National Highways data architecture |
+| v14 | scottish-courts | Scottish Courts and Tribunals Service GenAI strategy |
+| v16 | doctors-appointment | Doctors Online Appointment System |
+| v17 | fuel-prices | UK Government Fuel Price Transparency Service |
+| v18 | smart-meter | UK Smart Meter Data Consumer Mobile App |
+| v19 | gov-api-aggregator | UK Government API Aggregator |
+| v21 | criminal-courts | Independent Review of the Criminal Courts - Technology & AI |
+| v22 | genai-playbook | UK Government GenAI Playbook |
+| v23 | ccs-procurement-ai | CCS AI Procurement Intelligence Platform |
+| v24 | cabinet-office-ai | Cabinet Office Cross-Government AI Governance Framework |
+| v25 | dbt-trade-ai | DBT International Trade AI Analytics Platform |
+| v26 | dfe-education-ai | DfE AI in Education Governance & Standards |
+| v27 | defra-environment-ai | DEFRA Environmental AI & Ecological Data Platform |
+| v28 | desnz-energy-ai | DESNZ Energy Grid AI & Net Zero Modelling |
+| v29 | dhsc-health-ai | DHSC Health & Social Care AI Governance Framework |
+| v30 | dluhc-planning-ai | DLUHC Planning & Housing Data Intelligence |
+| v31 | dsit-responsible-ai | DSIT Responsible AI & Innovation Standards Framework |
+| v32 | dft-transport-ai | DfT Transport Network AI & Journey Intelligence |
+| v33 | dwp-benefits-ai | DWP Benefits Processing AI & Employment Intelligence |
+| v34 | fcdo-diplomatic-ai | FCDO Diplomatic Intelligence & Consular AI Platform |
+| v35 | gld-legal-ai | GLD Legal AI & Litigation Intelligence Platform |
+| v36 | hmlr-land-ai | HMLR Land Registration AI & Property Intelligence |
+| v37 | hmrc-tax-ai | HMRC Tax Compliance AI & Revenue Intelligence |
+| v38 | hmt-fiscal-ai | HMT Fiscal Modelling AI & Economic Intelligence |
+| v39 | home-office-borders-ai | Home Office Borders, Immigration & Security AI |
+| v40 | mod-defence-ai | MoD Defence AI Strategy & Operational Assurance |
+| v41 | moj-justice-ai | MoJ Justice System AI & Court Innovation |
+| v42 | no10-ds-policy-ai | No.10 Data Science Data-Driven Policy Intelligence Platform |
+| v43 | iai-gov-ai-products | i.AI Government AI Products & Delivery Platform |
+| v44 | australian-gov | Australian Government — Architecture Governance (non-UK proof-of-concept) |
+| v45 | nsi-rainbow | NS&I Digital Modernisation Programme (Project Rainbow) |
+| v46 | gds-local | GDS Local |
+| v46 | sdg | ArcKit SDG Mono-Repo: 17 UN SDGs, 78 UK Government technology projects |
+| v47 | dft-transforming-city-regions | DfT Transforming City Regions funding system |
+| v48 | arckit-as-a-service | ArcKit as a Service for UK Government |
 
 **Plugin-based setup (since 2026-02-07)**:
 

--- a/README.md
+++ b/README.md
@@ -1238,7 +1238,7 @@ Customize ArcKit templates without modifying defaults:
 
 ## Complete Command Reference
 
-All 67 ArcKit commands with maturity status and example outputs from public test repositories (20 test repos, v0–v19).
+All 67 ArcKit commands with maturity status and example outputs from public test repositories (43 public test repos across v0–v48).
 
 ### Status Legend
 
@@ -1267,6 +1267,35 @@ All 67 ArcKit commands with maturity status and example outputs from public test
 | v17 | [arckit-test-project-v17-fuel-prices](https://github.com/tractorjuice/arckit-test-project-v17-fuel-prices) | UK Government Fuel Price Transparency Service |
 | v18 | [arckit-test-project-v18-smart-meter](https://github.com/tractorjuice/arckit-test-project-v18-smart-meter) | UK Smart Meter Data Consumer App |
 | v19 | [arckit-test-project-v19-gov-api-aggregator](https://github.com/tractorjuice/arckit-test-project-v19-gov-api-aggregator) | UK Government API Aggregator |
+| v21 | [arckit-test-project-v21-criminal-courts](https://github.com/tractorjuice/arckit-test-project-v21-criminal-courts) | Independent Review of the Criminal Courts — Tech & AI |
+| v22 | [arckit-test-project-v22-genai-playbook](https://github.com/tractorjuice/arckit-test-project-v22-genai-playbook) | UK Government GenAI Playbook |
+| v23 | [arckit-test-project-v23-ccs-procurement-ai](https://github.com/tractorjuice/arckit-test-project-v23-ccs-procurement-ai) | CCS AI Procurement Intelligence Platform |
+| v24 | [arckit-test-project-v24-cabinet-office-ai](https://github.com/tractorjuice/arckit-test-project-v24-cabinet-office-ai) | Cabinet Office Cross-Government AI Governance |
+| v25 | [arckit-test-project-v25-dbt-trade-ai](https://github.com/tractorjuice/arckit-test-project-v25-dbt-trade-ai) | DBT International Trade AI Analytics |
+| v26 | [arckit-test-project-v26-dfe-education-ai](https://github.com/tractorjuice/arckit-test-project-v26-dfe-education-ai) | DfE AI in Education Governance & Standards |
+| v27 | [arckit-test-project-v27-defra-environment-ai](https://github.com/tractorjuice/arckit-test-project-v27-defra-environment-ai) | DEFRA Environmental AI & Ecological Data |
+| v28 | [arckit-test-project-v28-desnz-energy-ai](https://github.com/tractorjuice/arckit-test-project-v28-desnz-energy-ai) | DESNZ Energy Grid AI & Net Zero Modelling |
+| v29 | [arckit-test-project-v29-dhsc-health-ai](https://github.com/tractorjuice/arckit-test-project-v29-dhsc-health-ai) | DHSC Health & Social Care AI Governance |
+| v30 | [arckit-test-project-v30-dluhc-planning-ai](https://github.com/tractorjuice/arckit-test-project-v30-dluhc-planning-ai) | DLUHC Planning & Housing Data Intelligence |
+| v31 | [arckit-test-project-v31-dsit-responsible-ai](https://github.com/tractorjuice/arckit-test-project-v31-dsit-responsible-ai) | DSIT Responsible AI & Innovation Standards |
+| v32 | [arckit-test-project-v32-dft-transport-ai](https://github.com/tractorjuice/arckit-test-project-v32-dft-transport-ai) | DfT Transport Network AI & Journey Intelligence |
+| v33 | [arckit-test-project-v33-dwp-benefits-ai](https://github.com/tractorjuice/arckit-test-project-v33-dwp-benefits-ai) | DWP Benefits Processing AI & Employment Intelligence |
+| v34 | [arckit-test-project-v34-fcdo-diplomatic-ai](https://github.com/tractorjuice/arckit-test-project-v34-fcdo-diplomatic-ai) | FCDO Diplomatic Intelligence & Consular AI |
+| v35 | [arckit-test-project-v35-gld-legal-ai](https://github.com/tractorjuice/arckit-test-project-v35-gld-legal-ai) | GLD Legal AI & Litigation Intelligence |
+| v36 | [arckit-test-project-v36-hmlr-land-ai](https://github.com/tractorjuice/arckit-test-project-v36-hmlr-land-ai) | HMLR Land Registration AI & Property Intelligence |
+| v37 | [arckit-test-project-v37-hmrc-tax-ai](https://github.com/tractorjuice/arckit-test-project-v37-hmrc-tax-ai) | HMRC Tax Compliance AI & Revenue Intelligence |
+| v38 | [arckit-test-project-v38-hmt-fiscal-ai](https://github.com/tractorjuice/arckit-test-project-v38-hmt-fiscal-ai) | HMT Fiscal Modelling AI & Economic Intelligence |
+| v39 | [arckit-test-project-v39-home-office-borders-ai](https://github.com/tractorjuice/arckit-test-project-v39-home-office-borders-ai) | Home Office Borders, Immigration & Security AI |
+| v40 | [arckit-test-project-v40-mod-defence-ai](https://github.com/tractorjuice/arckit-test-project-v40-mod-defence-ai) | MoD Defence AI Strategy & Operational Assurance |
+| v41 | [arckit-test-project-v41-moj-justice-ai](https://github.com/tractorjuice/arckit-test-project-v41-moj-justice-ai) | MoJ Justice System AI & Court Innovation |
+| v42 | [arckit-test-project-v42-no10-ds-policy-ai](https://github.com/tractorjuice/arckit-test-project-v42-no10-ds-policy-ai) | No.10 Data Science Policy Intelligence Platform |
+| v43 | [arckit-test-project-v43-iai-gov-ai-products](https://github.com/tractorjuice/arckit-test-project-v43-iai-gov-ai-products) | i.AI Government AI Products & Delivery |
+| v44 | [arckit-test-project-v44-australian-gov](https://github.com/tractorjuice/arckit-test-project-v44-australian-gov) | Australian Government — Architecture Governance (non-UK PoC) |
+| v45 | [arckit-test-project-v45-nsi-rainbow](https://github.com/tractorjuice/arckit-test-project-v45-nsi-rainbow) | NS&I Digital Modernisation Programme (Project Rainbow) |
+| v46 | [arckit-test-project-v46-gds-local](https://github.com/tractorjuice/arckit-test-project-v46-gds-local) | GDS Local |
+| v46 | [arckit-test-project-v46-sdg](https://github.com/tractorjuice/arckit-test-project-v46-sdg) | ArcKit SDG Mono-Repo (17 UN SDGs, 78 UK Gov projects) |
+| v47 | [arckit-test-project-v47-dft-transforming-city-regions](https://github.com/tractorjuice/arckit-test-project-v47-dft-transforming-city-regions) | DfT Transforming City Regions funding system |
+| v48 | [arckit-test-project-v48-arckit-as-a-service](https://github.com/tractorjuice/arckit-test-project-v48-arckit-as-a-service) | ArcKit as a Service for UK Government |
 
 ### Foundation
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -157,7 +157,23 @@ French government (apply on top of EU baseline):
 
 ## Use cases
 
-- [Use cases](https://arckit.org/use-cases.html): New project, vendor procurement, design review, audit traceability.
+- [Use cases](https://arckit.org/use-cases.html): New project, vendor procurement, design review, audit traceability — index of 19 example projects.
+
+## Test repositories (example outputs)
+
+ArcKit maintains 43 public test repositories under the `tractorjuice` GitHub org (pattern `arckit-test-project-v{N}-{slug}`, range v0–v48). Each one is a fully AI-generated architecture project demonstrating ArcKit commands end-to-end. Selected highlights:
+
+- [v7 NHS Appointment Booking](https://github.com/tractorjuice/arckit-test-project-v7-nhs-appointment): Health digital service with NHS Spine, IG Toolkit, WCAG 2.1 AA, GDPR.
+- [v9 Cabinet Office GenAI Platform](https://github.com/tractorjuice/arckit-test-project-v9-cabinet-office-genai): Cross-government GenAI with AI Playbook, ATRS, departmental isolation.
+- [v14 Scottish Courts GenAI Strategy](https://github.com/tractorjuice/arckit-test-project-v14-scottish-courts): Justice-sector GenAI with full MLOps/FinOps/DevOps strategies.
+- [v19 UK Government API Aggregator](https://github.com/tractorjuice/arckit-test-project-v19-gov-api-aggregator): 240+ government APIs across 34+ departments, AWS & Azure research, Secure by Design.
+- [v22 GenAI Playbook](https://github.com/tractorjuice/arckit-test-project-v22-genai-playbook): Generative AI strategy, governance, risk, and implementation guidance.
+- [v44 Australian Government Architecture Governance](https://github.com/tractorjuice/arckit-test-project-v44-australian-gov): Non-UK proof-of-concept demonstrating jurisdictional reuse.
+- [v45 NS&I Project Rainbow](https://github.com/tractorjuice/arckit-test-project-v45-nsi-rainbow): Finance-sector core banking modernisation programme across 3 workstreams.
+- [v46 ArcKit SDG Mono-Repo](https://github.com/tractorjuice/arckit-test-project-v46-sdg): 17 UN SDGs covering 78 UK Government technology projects.
+- [v48 ArcKit as a Service for UK Government](https://github.com/tractorjuice/arckit-test-project-v48-arckit-as-a-service): Managed multi-tenant offering of ArcKit aligned to GDS Service Standard, TCoP, NCSC CAF, and G-Cloud — ArcKit dogfooded on its own GovTech offering.
+
+The full table (all 43 public repos) is in [CLAUDE.md](https://github.com/tractorjuice/arc-kit/blob/main/CLAUDE.md#test-repositories) and the example index in [README.md](https://github.com/tractorjuice/arc-kit/blob/main/README.md#example-repositories).
 
 ## Source code and distributions
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -22,6 +22,7 @@
     </url>
     <url>
         <loc>https://arckit.org/use-cases.html</loc>
+        <lastmod>2026-05-03</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.7</priority>
     </url>
@@ -42,6 +43,7 @@
     </url>
     <url>
         <loc>https://arckit.org/llms.txt</loc>
+        <lastmod>2026-05-03</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.5</priority>
     </url>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -308,6 +308,13 @@
                     <a href="https://tractorjuice.github.io/arckit-test-project-v3-windows11/" class="govuk-link govuk-body-s">View example outputs &rarr;</a>
                 </div>
 
+                <div class="app-use-case-card">
+                    <span class="app-use-case-card__domain app-use-case-card__domain--enterprise">Enterprise</span>
+                    <h2 class="govuk-heading-s">ArcKit as a Service for UK Gov</h2>
+                    <p class="govuk-body-s">Managed multi-tenant offering of the ArcKit governance toolkit for UK public sector — GDS Service Standard, TCoP, NCSC CAF, and G-Cloud aligned. ArcKit dogfooded on its own GovTech offering.</p>
+                    <a href="https://tractorjuice.github.io/arckit-test-project-v48-arckit-as-a-service/" class="govuk-link govuk-body-s">View example outputs &rarr;</a>
+                </div>
+
                 <!-- Digital Services -->
                 <div class="app-use-case-card">
                     <span class="app-use-case-card__domain app-use-case-card__domain--digital">Digital</span>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Example Projects - Browse AI-generated architecture documentation from 18 public test scenarios covering health, AI, cloud, digital services, and more.">
+    <meta name="description" content="ArcKit Example Projects - Browse AI-generated architecture documentation from 19 public test scenarios covering health, AI, cloud, digital services, and more.">
     <title>Example Projects - ArcKit</title>
     <meta name="keywords" content="ArcKit examples, architecture documentation examples, AI-generated architecture, UK government projects, test projects">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Example Projects - ArcKit">
-    <meta property="og:description" content="Browse 18 AI-generated architecture documentation projects across health, AI, cloud, digital services, and more.">
+    <meta property="og:description" content="Browse 19 AI-generated architecture documentation projects across health, AI, cloud, digital services, and more.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/use-cases.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Example Projects - ArcKit">
-    <meta name="twitter:description" content="Browse 18 AI-generated architecture documentation projects across health, AI, cloud, digital services, and more.">
+    <meta name="twitter:description" content="Browse 19 AI-generated architecture documentation projects across health, AI, cloud, digital services, and more.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/use-cases.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -181,7 +181,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/use-cases.html",
                 "name": "Example Projects - ArcKit",
-                "description": "18 AI-generated architecture documentation projects across health, AI, cloud, digital services, and more.",
+                "description": "19 AI-generated architecture documentation projects across health, AI, cloud, digital services, and more.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -226,7 +226,7 @@
 
     <div class="app-page-hero app-page-hero--projects">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">18 Example Projects</span>
+            <span class="app-page-hero__stat">19 Example Projects</span>
             <h1 class="app-page-hero__title">Example Projects</h1>
             <p class="app-page-hero__description">Browse AI-generated architecture documentation across health, AI, cloud, digital services, data, and more. Each project links to a live GitHub Pages site.</p>
         </div>


### PR DESCRIPTION
## Summary

- Refresh CLAUDE.md `Test Repositories` table from the stale v0–v21 (22 repos) list to the current v0–v48 set, listing **only the 43 public repos**
- Refresh README.md `Example Repositories` table to add v21–v48 (public only)
- Add the new v48-arckit-as-a-service entry created in this session via `/create-test-repo`

Per request, private repos (v0/v4/v5/v13/v15/v20) are excluded from both tables. v12 (retired) is also dropped. v46 has two public variants (gds-local, sdg) and both are listed.

Verified against live GitHub listing via `gh repo list tractorjuice` — 49 total test repos, 43 public.

## Test plan

- [x] `npx markdownlint-cli2 CLAUDE.md README.md` → 0 errors
- [x] All listed repos verified to exist and be public on GitHub
- [ ] Reviewer skim of CLAUDE.md table renders correctly
- [ ] Reviewer skim of README example table renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)