### PR TITLE
docs(articles): add 3 May 2026 essay card

### DIFF
--- a/docs/articles.html
+++ b/docs/articles.html
@@ -312,6 +312,22 @@
 
             <div class="app-article-grid">
 
+                <!-- 2026-05-03 £24bn pattern + ArcKit -->
+                <article class="app-article-card">
+                    <a class="app-article-card__media" href="article-viewer.html?a=2026-05-03-how-open-source-saved-uk-economy-12bn">
+                        <img src="articles/2026-05-03-how-open-source-saved-uk-economy-12bn-hero.png" alt="£24bn saved twice. Now ArcKit is going to do it a third time.">
+                    </a>
+                    <div class="app-article-card__body">
+                        <div class="app-article-card__meta">
+                            <span class="app-article-card__tag app-article-card__tag--technical">Essay</span>
+                            <span class="app-article-card__date">3 May 2026</span>
+                        </div>
+                        <h2 class="govuk-heading-s app-article-card__title">I have saved the UK economy £24 billion. ArcKit is the third time.</h2>
+                        <p class="app-article-card__summary">G-Cloud saved the UK around £12bn in procurement. The UN Global Platform saved another £12bn through real-time COVID economic indicators fed to the Treasury and Bank of England. The same playbook applied to enterprise architecture is the next £12bn.</p>
+                        <a href="article-viewer.html?a=2026-05-03-how-open-source-saved-uk-economy-12bn" class="govuk-link app-article-card__link">Read article &rarr;</a>
+                    </div>
+                </article>
+
                 <!-- 2026-05-01 internal memo -->
                 <article class="app-article-card">
                     <a class="app-article-card__media" href="article-viewer.html?a=2026-05-01-consulting-internal-memo">


### PR DESCRIPTION
## Summary

- Adds an article card to \`docs/articles.html\` for the new 3 May 2026 essay "I have saved the UK economy £24 billion. ArcKit is the third time."
- Article markdown (\`docs/articles/2026-05-03-how-open-source-saved-uk-economy-12bn.md\`) and hero image are already in the repo and previously tracked.

## Test plan

- [x] Verified target article and hero image exist on disk
- [ ] After merge, confirm the card renders at https://arckit.org/articles.html and the link resolves

🤖 Generated with [Claude Code](https://claude.com/claude-code)