### PR TITLE
docs(start): add Vibe Start 3-prompt super prompt

### DIFF
--- a/arckit-claude/docs/guides/start.md
+++ b/arckit-claude/docs/guides/start.md
@@ -21,6 +21,44 @@
 
 ---
 
+## Vibe Start — The 3-Prompt Super Prompt
+
+If you want to skip the decision tree and let ArcKit do the heavy lifting, this is the fastest possible path from empty repo to a fully-populated project. Three prompts, no manual orchestration:
+
+```text
+1. /arckit.init  This is a project for {one-line description of what you're building}.
+
+2. /arckit.principles
+
+3. Now create all the artifacts. Take your time. Do not stop until complete.
+```
+
+### What Happens
+
+- **Prompt 1** — `init` scaffolds the `projects/` structure and the one-line description seeds the project context.
+- **Prompt 2** — `principles` generates `ARC-000-PRIN-v1.0.md`, the prerequisite that most other commands depend on.
+- **Prompt 3** — the assistant works through the standard delivery workflow autonomously: `stakeholders` → `requirements` → `risk` → `sobc` → `adr` → `data-model` → `hld-review` → `roadmap`, etc., chaining via the `handoffs:` metadata in each command's frontmatter.
+
+### When To Use It
+
+- **Greenfield projects** where you want a complete first-pass set of artifacts to react to.
+- **Demos and proofs of concept** where speed matters more than per-command supervision.
+- **Vibe-coding sessions** where you want the assistant to keep going until everything is on disk.
+
+### When Not To Use It
+
+- **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
+- **Existing projects** with artifacts already on disk — run `/arckit.navigator` first to see what is missing rather than regenerating.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.6 or 4.7 with the `max` or `xhigh` effort levels.
+
+### Tips For Vibe Start
+
+- Add constraints to prompt 1: `/arckit.init This is a project for X. Target users are Y. Budget is Z.`
+- Use prompt 3 verbatim — the phrase "do not stop until complete" reliably suppresses early stopping. Followed by `/arckit.health` to spot anything skipped.
+- If the run stalls, resume with: `Continue from where you stopped. Do not stop until complete.`
+
+---
+
 ## `/arckit.start` — Get Oriented
 
 **Inputs**: None required. Optionally provide a focus area.

--- a/arckit-codex/docs/guides/grants.md
+++ b/arckit-codex/docs/guides/grants.md
@@ -1,0 +1,92 @@
+# UK Grants & Funding Research Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.grants` researches UK government grants, charitable funding, and accelerator programmes for the project, with eligibility scoring per programme. Runs as a research-heavy agent that produces a per-grant briefing plus reusable tech-notes.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Project scope and outcomes |
+| SOBC (`ARC-<id>-SOBC-v*.md`) | Strategic case and funding ask |
+| Architecture principles (`ARC-000-PRIN-*.md`) | Eligibility-relevant principles (open source, accessibility, etc.) |
+
+---
+
+## Command
+
+```bash
+/arckit.grants <project ID or domain>
+```
+
+Outputs:
+
+- `projects/<id>/research/ARC-<id>-GRNT-NNN-v1.0.md` — per-grant briefing, one per programme researched
+- `projects/<id>/tech-notes/<grant-slug>.md` — reusable knowledge note per programme (when 2+ substantive facts captured)
+
+---
+
+## Briefing Structure
+
+| Section | Contents |
+|---------|----------|
+| Programme Overview | Funder, scheme name, total fund, individual grant size |
+| Eligibility | Sector, organisation type, project stage, geography, IP requirements |
+| Eligibility Scoring | Project's fit against each criterion with rationale |
+| Application Process | Stages, gates, deadlines, panel / peer review model |
+| Match Funding & Co-Investment | Funder match rules, partner requirements |
+| Reporting & Compliance | Milestone reporting, audit, IP and dissemination obligations |
+| Decision | Pursue / monitor / discard with rationale |
+| External References | Programme guidance, recent awards, funder priorities |
+
+---
+
+## Funder Coverage
+
+Typical programmes researched:
+
+| Funder | Examples |
+|--------|----------|
+| UKRI | EPSRC, ESRC, MRC, NERC, Innovate UK |
+| Innovate UK | Smart Grants, KTPs, sector challenge programmes |
+| NIHR | Health and care research funding streams |
+| Wellcome | Biomedical, climate, mental health |
+| Nesta | Innovation challenges and challenge prizes |
+| Charitable trusts | Domain-specific philanthropic funding |
+| Accelerators | Government-backed and corporate accelerators |
+
+---
+
+## One-Page Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Discovery | Project scope and outcomes | `/arckit.requirements` |
+| Funding research | Programme scan + eligibility scoring | `/arckit.grants` |
+| Business case | Folding funding into Economic Case | `/arckit.sobc` |
+| Plan | Align project plan to grant milestones | `/arckit.plan` |
+| Risk | Grant-specific risks (rejection, compliance, reporting) | `/arckit.risk` |
+
+---
+
+## Review Checklist
+
+- At least one programme researched per relevant funder family.
+- Eligibility scoring shows rationale per criterion (not just a number).
+- Match-funding requirements identified for every "pursue" recommendation.
+- Reporting and IP obligations called out before "pursue" decision.
+- Pursue / monitor / discard decision recorded for every programme.
+- Funding inputs handed off to SOBC Economic Case and project plan.
+- Grant-specific risks added to the risk register.
+
+---
+
+## Key Notes
+
+- **Agent command**: Heavy WebSearch / WebFetch — runs as the `arckit-grants` autonomous agent in Claude Code; the slash command is a thin wrapper.
+- **Tech notes**: Programmes worth detailed study spawn a reusable tech-note that future projects can read without re-running the research.
+- **Plan alignment**: Grants impose milestone and reporting cadences that must be reflected in the project plan — do not skip the `/arckit.plan` handoff.
+- **Multi-instance numbering**: `GRNT-001`, `GRNT-002`, etc. — one document per programme, generated automatically.

--- a/arckit-codex/docs/guides/start.md
+++ b/arckit-codex/docs/guides/start.md
@@ -21,6 +21,44 @@
 
 ---
 
+## Vibe Start — The 3-Prompt Super Prompt
+
+If you want to skip the decision tree and let ArcKit do the heavy lifting, this is the fastest possible path from empty repo to a fully-populated project. Three prompts, no manual orchestration:
+
+```text
+1. /arckit.init  This is a project for {one-line description of what you're building}.
+
+2. /arckit.principles
+
+3. Now create all the artifacts. Take your time. Do not stop until complete.
+```
+
+### What Happens
+
+- **Prompt 1** — `init` scaffolds the `projects/` structure and the one-line description seeds the project context.
+- **Prompt 2** — `principles` generates `ARC-000-PRIN-v1.0.md`, the prerequisite that most other commands depend on.
+- **Prompt 3** — the assistant works through the standard delivery workflow autonomously: `stakeholders` → `requirements` → `risk` → `sobc` → `adr` → `data-model` → `hld-review` → `roadmap`, etc., chaining via the `handoffs:` metadata in each command's frontmatter.
+
+### When To Use It
+
+- **Greenfield projects** where you want a complete first-pass set of artifacts to react to.
+- **Demos and proofs of concept** where speed matters more than per-command supervision.
+- **Vibe-coding sessions** where you want the assistant to keep going until everything is on disk.
+
+### When Not To Use It
+
+- **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
+- **Existing projects** with artifacts already on disk — run `/arckit.navigator` first to see what is missing rather than regenerating.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.6 or 4.7 with the `max` or `xhigh` effort levels.
+
+### Tips For Vibe Start
+
+- Add constraints to prompt 1: `/arckit.init This is a project for X. Target users are Y. Budget is Z.`
+- Use prompt 3 verbatim — the phrase "do not stop until complete" reliably suppresses early stopping. Followed by `/arckit.health` to spot anything skipped.
+- If the run stalls, resume with: `Continue from where you stopped. Do not stop until complete.`
+
+---
+
 ## `/arckit.start` — Get Oriented
 
 **Inputs**: None required. Optionally provide a focus area.

--- a/arckit-copilot/docs/guides/grants.md
+++ b/arckit-copilot/docs/guides/grants.md
@@ -1,0 +1,92 @@
+# UK Grants & Funding Research Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.grants` researches UK government grants, charitable funding, and accelerator programmes for the project, with eligibility scoring per programme. Runs as a research-heavy agent that produces a per-grant briefing plus reusable tech-notes.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Project scope and outcomes |
+| SOBC (`ARC-<id>-SOBC-v*.md`) | Strategic case and funding ask |
+| Architecture principles (`ARC-000-PRIN-*.md`) | Eligibility-relevant principles (open source, accessibility, etc.) |
+
+---
+
+## Command
+
+```bash
+/arckit.grants <project ID or domain>
+```
+
+Outputs:
+
+- `projects/<id>/research/ARC-<id>-GRNT-NNN-v1.0.md` — per-grant briefing, one per programme researched
+- `projects/<id>/tech-notes/<grant-slug>.md` — reusable knowledge note per programme (when 2+ substantive facts captured)
+
+---
+
+## Briefing Structure
+
+| Section | Contents |
+|---------|----------|
+| Programme Overview | Funder, scheme name, total fund, individual grant size |
+| Eligibility | Sector, organisation type, project stage, geography, IP requirements |
+| Eligibility Scoring | Project's fit against each criterion with rationale |
+| Application Process | Stages, gates, deadlines, panel / peer review model |
+| Match Funding & Co-Investment | Funder match rules, partner requirements |
+| Reporting & Compliance | Milestone reporting, audit, IP and dissemination obligations |
+| Decision | Pursue / monitor / discard with rationale |
+| External References | Programme guidance, recent awards, funder priorities |
+
+---
+
+## Funder Coverage
+
+Typical programmes researched:
+
+| Funder | Examples |
+|--------|----------|
+| UKRI | EPSRC, ESRC, MRC, NERC, Innovate UK |
+| Innovate UK | Smart Grants, KTPs, sector challenge programmes |
+| NIHR | Health and care research funding streams |
+| Wellcome | Biomedical, climate, mental health |
+| Nesta | Innovation challenges and challenge prizes |
+| Charitable trusts | Domain-specific philanthropic funding |
+| Accelerators | Government-backed and corporate accelerators |
+
+---
+
+## One-Page Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Discovery | Project scope and outcomes | `/arckit.requirements` |
+| Funding research | Programme scan + eligibility scoring | `/arckit.grants` |
+| Business case | Folding funding into Economic Case | `/arckit.sobc` |
+| Plan | Align project plan to grant milestones | `/arckit.plan` |
+| Risk | Grant-specific risks (rejection, compliance, reporting) | `/arckit.risk` |
+
+---
+
+## Review Checklist
+
+- At least one programme researched per relevant funder family.
+- Eligibility scoring shows rationale per criterion (not just a number).
+- Match-funding requirements identified for every "pursue" recommendation.
+- Reporting and IP obligations called out before "pursue" decision.
+- Pursue / monitor / discard decision recorded for every programme.
+- Funding inputs handed off to SOBC Economic Case and project plan.
+- Grant-specific risks added to the risk register.
+
+---
+
+## Key Notes
+
+- **Agent command**: Heavy WebSearch / WebFetch — runs as the `arckit-grants` autonomous agent in Claude Code; the slash command is a thin wrapper.
+- **Tech notes**: Programmes worth detailed study spawn a reusable tech-note that future projects can read without re-running the research.
+- **Plan alignment**: Grants impose milestone and reporting cadences that must be reflected in the project plan — do not skip the `/arckit.plan` handoff.
+- **Multi-instance numbering**: `GRNT-001`, `GRNT-002`, etc. — one document per programme, generated automatically.

--- a/arckit-copilot/docs/guides/start.md
+++ b/arckit-copilot/docs/guides/start.md
@@ -21,6 +21,44 @@
 
 ---
 
+## Vibe Start — The 3-Prompt Super Prompt
+
+If you want to skip the decision tree and let ArcKit do the heavy lifting, this is the fastest possible path from empty repo to a fully-populated project. Three prompts, no manual orchestration:
+
+```text
+1. /arckit.init  This is a project for {one-line description of what you're building}.
+
+2. /arckit.principles
+
+3. Now create all the artifacts. Take your time. Do not stop until complete.
+```
+
+### What Happens
+
+- **Prompt 1** — `init` scaffolds the `projects/` structure and the one-line description seeds the project context.
+- **Prompt 2** — `principles` generates `ARC-000-PRIN-v1.0.md`, the prerequisite that most other commands depend on.
+- **Prompt 3** — the assistant works through the standard delivery workflow autonomously: `stakeholders` → `requirements` → `risk` → `sobc` → `adr` → `data-model` → `hld-review` → `roadmap`, etc., chaining via the `handoffs:` metadata in each command's frontmatter.
+
+### When To Use It
+
+- **Greenfield projects** where you want a complete first-pass set of artifacts to react to.
+- **Demos and proofs of concept** where speed matters more than per-command supervision.
+- **Vibe-coding sessions** where you want the assistant to keep going until everything is on disk.
+
+### When Not To Use It
+
+- **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
+- **Existing projects** with artifacts already on disk — run `/arckit.navigator` first to see what is missing rather than regenerating.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.6 or 4.7 with the `max` or `xhigh` effort levels.
+
+### Tips For Vibe Start
+
+- Add constraints to prompt 1: `/arckit.init This is a project for X. Target users are Y. Budget is Z.`
+- Use prompt 3 verbatim — the phrase "do not stop until complete" reliably suppresses early stopping. Followed by `/arckit.health` to spot anything skipped.
+- If the run stalls, resume with: `Continue from where you stopped. Do not stop until complete.`
+
+---
+
 ## `/arckit.start` — Get Oriented
 
 **Inputs**: None required. Optionally provide a focus area.

--- a/arckit-opencode/docs/guides/grants.md
+++ b/arckit-opencode/docs/guides/grants.md
@@ -1,0 +1,92 @@
+# UK Grants & Funding Research Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.grants` researches UK government grants, charitable funding, and accelerator programmes for the project, with eligibility scoring per programme. Runs as a research-heavy agent that produces a per-grant briefing plus reusable tech-notes.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Project scope and outcomes |
+| SOBC (`ARC-<id>-SOBC-v*.md`) | Strategic case and funding ask |
+| Architecture principles (`ARC-000-PRIN-*.md`) | Eligibility-relevant principles (open source, accessibility, etc.) |
+
+---
+
+## Command
+
+```bash
+/arckit.grants <project ID or domain>
+```
+
+Outputs:
+
+- `projects/<id>/research/ARC-<id>-GRNT-NNN-v1.0.md` — per-grant briefing, one per programme researched
+- `projects/<id>/tech-notes/<grant-slug>.md` — reusable knowledge note per programme (when 2+ substantive facts captured)
+
+---
+
+## Briefing Structure
+
+| Section | Contents |
+|---------|----------|
+| Programme Overview | Funder, scheme name, total fund, individual grant size |
+| Eligibility | Sector, organisation type, project stage, geography, IP requirements |
+| Eligibility Scoring | Project's fit against each criterion with rationale |
+| Application Process | Stages, gates, deadlines, panel / peer review model |
+| Match Funding & Co-Investment | Funder match rules, partner requirements |
+| Reporting & Compliance | Milestone reporting, audit, IP and dissemination obligations |
+| Decision | Pursue / monitor / discard with rationale |
+| External References | Programme guidance, recent awards, funder priorities |
+
+---
+
+## Funder Coverage
+
+Typical programmes researched:
+
+| Funder | Examples |
+|--------|----------|
+| UKRI | EPSRC, ESRC, MRC, NERC, Innovate UK |
+| Innovate UK | Smart Grants, KTPs, sector challenge programmes |
+| NIHR | Health and care research funding streams |
+| Wellcome | Biomedical, climate, mental health |
+| Nesta | Innovation challenges and challenge prizes |
+| Charitable trusts | Domain-specific philanthropic funding |
+| Accelerators | Government-backed and corporate accelerators |
+
+---
+
+## One-Page Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Discovery | Project scope and outcomes | `/arckit.requirements` |
+| Funding research | Programme scan + eligibility scoring | `/arckit.grants` |
+| Business case | Folding funding into Economic Case | `/arckit.sobc` |
+| Plan | Align project plan to grant milestones | `/arckit.plan` |
+| Risk | Grant-specific risks (rejection, compliance, reporting) | `/arckit.risk` |
+
+---
+
+## Review Checklist
+
+- At least one programme researched per relevant funder family.
+- Eligibility scoring shows rationale per criterion (not just a number).
+- Match-funding requirements identified for every "pursue" recommendation.
+- Reporting and IP obligations called out before "pursue" decision.
+- Pursue / monitor / discard decision recorded for every programme.
+- Funding inputs handed off to SOBC Economic Case and project plan.
+- Grant-specific risks added to the risk register.
+
+---
+
+## Key Notes
+
+- **Agent command**: Heavy WebSearch / WebFetch — runs as the `arckit-grants` autonomous agent in Claude Code; the slash command is a thin wrapper.
+- **Tech notes**: Programmes worth detailed study spawn a reusable tech-note that future projects can read without re-running the research.
+- **Plan alignment**: Grants impose milestone and reporting cadences that must be reflected in the project plan — do not skip the `/arckit.plan` handoff.
+- **Multi-instance numbering**: `GRNT-001`, `GRNT-002`, etc. — one document per programme, generated automatically.

--- a/arckit-opencode/docs/guides/start.md
+++ b/arckit-opencode/docs/guides/start.md
@@ -21,6 +21,44 @@
 
 ---
 
+## Vibe Start — The 3-Prompt Super Prompt
+
+If you want to skip the decision tree and let ArcKit do the heavy lifting, this is the fastest possible path from empty repo to a fully-populated project. Three prompts, no manual orchestration:
+
+```text
+1. /arckit.init  This is a project for {one-line description of what you're building}.
+
+2. /arckit.principles
+
+3. Now create all the artifacts. Take your time. Do not stop until complete.
+```
+
+### What Happens
+
+- **Prompt 1** — `init` scaffolds the `projects/` structure and the one-line description seeds the project context.
+- **Prompt 2** — `principles` generates `ARC-000-PRIN-v1.0.md`, the prerequisite that most other commands depend on.
+- **Prompt 3** — the assistant works through the standard delivery workflow autonomously: `stakeholders` → `requirements` → `risk` → `sobc` → `adr` → `data-model` → `hld-review` → `roadmap`, etc., chaining via the `handoffs:` metadata in each command's frontmatter.
+
+### When To Use It
+
+- **Greenfield projects** where you want a complete first-pass set of artifacts to react to.
+- **Demos and proofs of concept** where speed matters more than per-command supervision.
+- **Vibe-coding sessions** where you want the assistant to keep going until everything is on disk.
+
+### When Not To Use It
+
+- **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
+- **Existing projects** with artifacts already on disk — run `/arckit.navigator` first to see what is missing rather than regenerating.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.6 or 4.7 with the `max` or `xhigh` effort levels.
+
+### Tips For Vibe Start
+
+- Add constraints to prompt 1: `/arckit.init This is a project for X. Target users are Y. Budget is Z.`
+- Use prompt 3 verbatim — the phrase "do not stop until complete" reliably suppresses early stopping. Followed by `/arckit.health` to spot anything skipped.
+- If the run stalls, resume with: `Continue from where you stopped. Do not stop until complete.`
+
+---
+
 ## `/arckit.start` — Get Oriented
 
 **Inputs**: None required. Optionally provide a focus area.

--- a/arckit-paperclip/docs/guides/grants.md
+++ b/arckit-paperclip/docs/guides/grants.md
@@ -1,0 +1,92 @@
+# UK Grants & Funding Research Playbook
+
+> **Guide Origin**: Official | **ArcKit Version**: [VERSION]
+
+`/arckit.grants` researches UK government grants, charitable funding, and accelerator programmes for the project, with eligibility scoring per programme. Runs as a research-heavy agent that produces a per-grant briefing plus reusable tech-notes.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Project scope and outcomes |
+| SOBC (`ARC-<id>-SOBC-v*.md`) | Strategic case and funding ask |
+| Architecture principles (`ARC-000-PRIN-*.md`) | Eligibility-relevant principles (open source, accessibility, etc.) |
+
+---
+
+## Command
+
+```bash
+/arckit.grants <project ID or domain>
+```
+
+Outputs:
+
+- `projects/<id>/research/ARC-<id>-GRNT-NNN-v1.0.md` — per-grant briefing, one per programme researched
+- `projects/<id>/tech-notes/<grant-slug>.md` — reusable knowledge note per programme (when 2+ substantive facts captured)
+
+---
+
+## Briefing Structure
+
+| Section | Contents |
+|---------|----------|
+| Programme Overview | Funder, scheme name, total fund, individual grant size |
+| Eligibility | Sector, organisation type, project stage, geography, IP requirements |
+| Eligibility Scoring | Project's fit against each criterion with rationale |
+| Application Process | Stages, gates, deadlines, panel / peer review model |
+| Match Funding & Co-Investment | Funder match rules, partner requirements |
+| Reporting & Compliance | Milestone reporting, audit, IP and dissemination obligations |
+| Decision | Pursue / monitor / discard with rationale |
+| External References | Programme guidance, recent awards, funder priorities |
+
+---
+
+## Funder Coverage
+
+Typical programmes researched:
+
+| Funder | Examples |
+|--------|----------|
+| UKRI | EPSRC, ESRC, MRC, NERC, Innovate UK |
+| Innovate UK | Smart Grants, KTPs, sector challenge programmes |
+| NIHR | Health and care research funding streams |
+| Wellcome | Biomedical, climate, mental health |
+| Nesta | Innovation challenges and challenge prizes |
+| Charitable trusts | Domain-specific philanthropic funding |
+| Accelerators | Government-backed and corporate accelerators |
+
+---
+
+## One-Page Workflow
+
+| Phase | Key Activities | ArcKit Commands |
+|-------|----------------|-----------------|
+| Discovery | Project scope and outcomes | `/arckit.requirements` |
+| Funding research | Programme scan + eligibility scoring | `/arckit.grants` |
+| Business case | Folding funding into Economic Case | `/arckit.sobc` |
+| Plan | Align project plan to grant milestones | `/arckit.plan` |
+| Risk | Grant-specific risks (rejection, compliance, reporting) | `/arckit.risk` |
+
+---
+
+## Review Checklist
+
+- At least one programme researched per relevant funder family.
+- Eligibility scoring shows rationale per criterion (not just a number).
+- Match-funding requirements identified for every "pursue" recommendation.
+- Reporting and IP obligations called out before "pursue" decision.
+- Pursue / monitor / discard decision recorded for every programme.
+- Funding inputs handed off to SOBC Economic Case and project plan.
+- Grant-specific risks added to the risk register.
+
+---
+
+## Key Notes
+
+- **Agent command**: Heavy WebSearch / WebFetch — runs as the `arckit-grants` autonomous agent in Claude Code; the slash command is a thin wrapper.
+- **Tech notes**: Programmes worth detailed study spawn a reusable tech-note that future projects can read without re-running the research.
+- **Plan alignment**: Grants impose milestone and reporting cadences that must be reflected in the project plan — do not skip the `/arckit.plan` handoff.
+- **Multi-instance numbering**: `GRNT-001`, `GRNT-002`, etc. — one document per programme, generated automatically.

--- a/arckit-paperclip/docs/guides/start.md
+++ b/arckit-paperclip/docs/guides/start.md
@@ -21,6 +21,44 @@
 
 ---
 
+## Vibe Start — The 3-Prompt Super Prompt
+
+If you want to skip the decision tree and let ArcKit do the heavy lifting, this is the fastest possible path from empty repo to a fully-populated project. Three prompts, no manual orchestration:
+
+```text
+1. /arckit.init  This is a project for {one-line description of what you're building}.
+
+2. /arckit.principles
+
+3. Now create all the artifacts. Take your time. Do not stop until complete.
+```
+
+### What Happens
+
+- **Prompt 1** — `init` scaffolds the `projects/` structure and the one-line description seeds the project context.
+- **Prompt 2** — `principles` generates `ARC-000-PRIN-v1.0.md`, the prerequisite that most other commands depend on.
+- **Prompt 3** — the assistant works through the standard delivery workflow autonomously: `stakeholders` → `requirements` → `risk` → `sobc` → `adr` → `data-model` → `hld-review` → `roadmap`, etc., chaining via the `handoffs:` metadata in each command's frontmatter.
+
+### When To Use It
+
+- **Greenfield projects** where you want a complete first-pass set of artifacts to react to.
+- **Demos and proofs of concept** where speed matters more than per-command supervision.
+- **Vibe-coding sessions** where you want the assistant to keep going until everything is on disk.
+
+### When Not To Use It
+
+- **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
+- **Existing projects** with artifacts already on disk — run `/arckit.navigator` first to see what is missing rather than regenerating.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.6 or 4.7 with the `max` or `xhigh` effort levels.
+
+### Tips For Vibe Start
+
+- Add constraints to prompt 1: `/arckit.init This is a project for X. Target users are Y. Budget is Z.`
+- Use prompt 3 verbatim — the phrase "do not stop until complete" reliably suppresses early stopping. Followed by `/arckit.health` to spot anything skipped.
+- If the run stalls, resume with: `Continue from where you stopped. Do not stop until complete.`
+
+---
+
 ## `/arckit.start` — Get Oriented
 
 **Inputs**: None required. Optionally provide a focus area.

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -21,6 +21,44 @@
 
 ---
 
+## Vibe Start — The 3-Prompt Super Prompt
+
+If you want to skip the decision tree and let ArcKit do the heavy lifting, this is the fastest possible path from empty repo to a fully-populated project. Three prompts, no manual orchestration:
+
+```text
+1. /arckit.init  This is a project for {one-line description of what you're building}.
+
+2. /arckit.principles
+
+3. Now create all the artifacts. Take your time. Do not stop until complete.
+```
+
+### What Happens
+
+- **Prompt 1** — `init` scaffolds the `projects/` structure and the one-line description seeds the project context.
+- **Prompt 2** — `principles` generates `ARC-000-PRIN-v1.0.md`, the prerequisite that most other commands depend on.
+- **Prompt 3** — the assistant works through the standard delivery workflow autonomously: `stakeholders` → `requirements` → `risk` → `sobc` → `adr` → `data-model` → `hld-review` → `roadmap`, etc., chaining via the `handoffs:` metadata in each command's frontmatter.
+
+### When To Use It
+
+- **Greenfield projects** where you want a complete first-pass set of artifacts to react to.
+- **Demos and proofs of concept** where speed matters more than per-command supervision.
+- **Vibe-coding sessions** where you want the assistant to keep going until everything is on disk.
+
+### When Not To Use It
+
+- **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
+- **Existing projects** with artifacts already on disk — run `/arckit.navigator` first to see what is missing rather than regenerating.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.6 or 4.7 with the `max` or `xhigh` effort levels.
+
+### Tips For Vibe Start
+
+- Add constraints to prompt 1: `/arckit.init This is a project for X. Target users are Y. Budget is Z.`
+- Use prompt 3 verbatim — the phrase "do not stop until complete" reliably suppresses early stopping. Followed by `/arckit.health` to spot anything skipped.
+- If the run stalls, resume with: `Continue from where you stopped. Do not stop until complete.`
+
+---
+
 ## `/arckit.start` — Get Oriented
 
 **Inputs**: None required. Optionally provide a focus area.


### PR DESCRIPTION
## Summary
- Adds a **Vibe Start** section to `docs/guides/start.md` documenting the 3-prompt fast path: `/arckit.init "This is a project for X"` → `/arckit.principles` → "Now create all the artifacts. Take your time. Do not stop until complete."
- Covers when to use it (greenfield, demos, vibe-coding), when not to (regulated work, existing projects, token-constrained sessions), and tips for keeping the chain running.
- Propagates pre-existing `docs/guides/grants.md` to extension copies as a side-effect of running `scripts/converter.py`.

## Test plan
- [x] Lint clean: `npx markdownlint-cli2 docs/guides/start.md`
- [x] Verified Vibe Start section present in all 6 extension copies (claude, opencode, paperclip, copilot, gemini, codex)

🤖 Generated with [Claude Code](https://claude.com/claude-code)