### PR TITLE
docs(claude.md): correct ADR/DIAG paths to show decisions/ and diagrams/ subfolders

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -261,8 +261,10 @@ project/
         ├── ARC-001-STKE-v1.0.md     # Stakeholder analysis
         ├── ARC-001-RISK-v1.0.md     # Risk register
         ├── ARC-001-SOBC-v1.0.md     # Business case
-        ├── ARC-001-ADR-001-v1.0.md  # ADRs (multi-instance)
-        ├── ARC-001-DIAG-001-v1.0.md # Diagrams (multi-instance)
+        ├── decisions/
+        │   └── ARC-001-ADR-001-v1.0.md  # ADRs (multi-instance, in decisions/ subfolder)
+        ├── diagrams/
+        │   └── ARC-001-DIAG-001-v1.0.md # Diagrams (multi-instance, in diagrams/ subfolder)
         └── vendors/
 ```
 


### PR DESCRIPTION
## Summary

The "Project Structure Created by \`arckit init\`" tree in CLAUDE.md showed ADRs and diagrams at project root, but \`/arckit:adr\` and \`/arckit:diagram\` actually write to \`decisions/\` and \`diagrams/\` subfolders. This caused at least one downstream skill author to query whether the convention was wrong.

## Evidence

- \`arckit-claude/commands/adr.md\`: \`projects/{PROJECT_ID}-{name}/decisions/ARC-{PROJECT_ID}-ADR-{NUM}-v{VERSION}.md\`
- \`arckit-claude/commands/diagram.md\`: \`projects/{project}/diagrams/ARC-{PROJECT_ID}-DIAG-{NNN}-v1.0.md\`
- Test repos with generated content confirm: v1-m365, v3-windows11, v17-fuel-prices all use \`decisions/\` and \`diagrams/\` subfolders.

## Test plan

- [x] Tree renders correctly with the two new subfolder branches
- [ ] No other docs in the repo claim the old root-level layout (spot-checked README and docs/ — none found)

🤖 Generated with [Claude Code](https://claude.com/claude-code)