### PR TITLE
docs: sitemap, llms.txt, and getting-started for v4.13.0

### DIFF
--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -597,7 +597,7 @@ arckit init my-project --ai copilot</code></pre></div>
                     <h2 class="govuk-notification-banner__title" id="vibe-start-title">Fast path</h2>
                 </div>
                 <div class="govuk-notification-banner__content">
-                    <h3 class="govuk-notification-banner__heading">Vibe Start — the 3-prompt super prompt</h3>
+                    <h3 class="govuk-notification-banner__heading">Vibe Start &mdash; the 3-prompt super prompt</h3>
                     <p class="govuk-body">Skip the decision tree. Three prompts take you from empty repo to a fully-populated project. ArcKit chains commands via the <code>handoffs:</code> metadata in each command's frontmatter.</p>
                     <div class="app-code-block">/arckit.init  This is a project for {one-line description of what you're building}.</div>
                     <div class="app-code-block govuk-!-margin-top-2">/arckit.principles</div>
@@ -605,6 +605,25 @@ arckit init my-project --ai copilot</code></pre></div>
                     <p class="govuk-body govuk-!-margin-top-3"><strong>When to use it:</strong> greenfield projects, demos, proofs of concept, vibe-coding sessions where you want a complete first-pass set of artifacts to react to.</p>
                     <p class="govuk-body"><strong>When not to use it:</strong> heavily regulated work (Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off; existing projects with artifacts already on disk (run <code>/arckit.navigator</code> first); token-constrained sessions.</p>
                     <p class="govuk-body govuk-!-margin-bottom-0"><strong>If the run stalls:</strong> resume with <em>"Continue from where you stopped. Do not stop until complete."</em> Then run <code>/arckit.health</code> to spot anything skipped. Full guide: <a href="guide-viewer.html?guide=start" class="govuk-link">Getting Started with ArcKit</a>.</p>
+                </div>
+            </div>
+
+            <!-- The GDS Harness -->
+            <div class="govuk-notification-banner govuk-!-margin-top-4" role="region" aria-labelledby="gds-harness-title">
+                <div class="govuk-notification-banner__header">
+                    <h2 class="govuk-notification-banner__title" id="gds-harness-title">Faster path (Claude Code only)</h2>
+                </div>
+                <div class="govuk-notification-banner__content">
+                    <h3 class="govuk-notification-banner__heading">The GDS Harness &mdash; <code>/arckit:build</code></h3>
+                    <p class="govuk-body">New in v4.13.0. Run one command and the whole architecture builds itself: requirements, stakeholder analysis, ADRs, risk register, business case, designs, Secure-by-Design assessment, DPIA, diagrams, traceability matrix, plus the post-build health check. Reads a YAML recipe, dispatches subagents in parallel waves, commits each wave atomically.</p>
+                    <div class="app-code-block">/arckit:build 001 --plan</div>
+                    <div class="app-code-block govuk-!-margin-top-2">/arckit:build 001</div>
+                    <div class="app-code-block govuk-!-margin-top-2">/arckit:build 002 --recipe uk-mod-sovereign</div>
+                    <div class="app-code-block govuk-!-margin-top-2">/arckit:build 003 --recipe uae-federal-ai</div>
+                    <p class="govuk-body govuk-!-margin-top-3"><strong>Three built-in recipes:</strong> <code>uk-saas</code> (31 targets, UK civilian SaaS), <code>uk-mod-sovereign</code> (32 targets, MOD / air-gapped with JSP 936 and MOD Secure by Design), and <code>uae-federal-ai</code> (47 targets, UAE Cabinet agentic AI decree compliance with all 12 UAE community commands plus an integrated research wave).</p>
+                    <p class="govuk-body"><strong>Customize:</strong> copy a recipe to <code>.arckit/recipes/{name}.yaml</code> and edit. The harness reads project overrides first, falling back to the plugin defaults &mdash; your customisations survive plugin updates.</p>
+                    <p class="govuk-body"><strong>Resumable:</strong> state persists to <code>projects/{P}/.arckit/state.json</code>. If a wave fails, fix the underlying issue and run <code>/arckit:build 001 --resume</code> to pick up exactly where it stopped.</p>
+                    <p class="govuk-body govuk-!-margin-bottom-0"><strong>When to use it:</strong> end-to-end governance builds where you want a full template-driven artefact set committed in atomic, reviewable waves. Full guide: <a href="guide-viewer.html?guide=build" class="govuk-link">Build Harness Guide</a>.</p>
                 </div>
             </div>
 

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -1,6 +1,6 @@
 # ArcKit
 
-> ArcKit is an Enterprise Architecture Governance & Vendor Procurement toolkit that provides 68 AI-assisted slash commands for Claude Code, Gemini CLI, GitHub Copilot, Codex CLI, and OpenCode CLI, plus 18 community-contributed EU and French regulatory commands. It transforms architecture governance from scattered documents into a systematic, template-driven workflow covering requirements, stakeholders, risk, business cases, architecture (C4, Wardley, ADRs), research, vendor procurement (G-Cloud/DOS), UK Government compliance (GDS, TCoP, Secure by Design, NCSC CAF, Orange/Green Book), EU regulations (GDPR, NIS2, AI Act, DORA, CRA, DSA, Data Act), French government compliance (SecNumCloud, ANSSI, EBIOS, CNIL, DINUM, PSSI), DevOps/MLOps/FinOps, and traceability.
+> ArcKit is an Enterprise Architecture Governance & Vendor Procurement toolkit that provides 71 AI-assisted slash commands for Claude Code, Gemini CLI, GitHub Copilot, Codex CLI, and OpenCode CLI, plus 34 community-contributed EU, French, Austrian, and UAE regulatory commands. It transforms architecture governance from scattered documents into a systematic, template-driven workflow covering requirements, stakeholders, risk, business cases, architecture (C4, Wardley, ADRs), research, vendor procurement (G-Cloud/DOS), UK Government compliance (GDS, TCoP, Secure by Design, NCSC CAF, Orange/Green Book), EU regulations (GDPR, NIS2, AI Act, DORA, CRA, DSA, Data Act), French government compliance (SecNumCloud, ANSSI, EBIOS, CNIL, DINUM, PSSI), Austrian compliance (DSG/DSGVO, NISG, BVergG), UAE Federal compliance (PDPL, IAS, AI Charter, sovereign cloud, UAE Pass), DevOps/MLOps/FinOps, and traceability. ArcKit v4.13.0 adds /arckit:build, a Claude Code-only parallel build harness that orchestrates end-to-end artefact generation against a YAML recipe (uk-saas, uk-mod-sovereign, uae-federal-ai).
 
 ArcKit is distributed as a Claude Code plugin, a Gemini CLI extension, a GitHub Copilot prompt pack, a Codex CLI extension, an OpenCode CLI extension, and a Python CLI (`arckit init`). Source code and issue tracker: https://github.com/tractorjuice/arc-kit.
 
@@ -16,7 +16,8 @@ Every command reads a template from `.arckit/templates/`, creates or reuses a nu
 
 ## Commands
 
-- [Command reference](https://arckit.org/commands.html): Searchable HTML catalogue of all 68 commands with parameters and examples.
+- [Command reference](https://arckit.org/commands.html): Searchable HTML catalogue of all 71 commands with parameters and examples.
+- [Build harness guide](https://arckit.org/guides/build.md): `/arckit:build` parallel artefact generation via subagent isolation with YAML recipes (Claude Code only, v4.13.0+).
 - [Dependency matrix](https://arckit.org/DEPENDENCY-MATRIX.md): Which commands require which prerequisites.
 - [Workflow diagrams](https://arckit.org/WORKFLOW-DIAGRAMS.md): Visual flow from project init through procurement.
 - [Guides index](https://arckit.org/guides.html): Per-command usage guides.
@@ -149,6 +150,11 @@ French government (apply on top of EU baseline):
 - [Presentation](https://arckit.org/guides/presentation.md): `/arckit.presentation` MARP decks.
 - [Glossary](https://arckit.org/guides/glossary.md): `/arckit.glossary` terminology.
 - [GitHub Pages](https://arckit.org/guides/pages.md): `/arckit.pages` documentation site generator.
+
+## Articles and essays
+
+- [Articles index](https://arckit.org/articles.html): Long-form essays on ArcKit's design, the GDS / G-Cloud / UN Global Platform context, and platform-by-platform comparisons.
+- [Why ArcKit needed a build harness](https://arckit.org/article-viewer.html?a=2026-05-03-build-harness-parallel-architecture-generation): v4.13.0 launch piece for `/arckit:build` (The GDS Harness) — orchestration model, recipes, live-run evidence.
 
 ## Roles
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -2,18 +2,32 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
     <url>
         <loc>https://arckit.org/</loc>
+        <lastmod>2026-05-03</lastmod>
         <changefreq>weekly</changefreq>
         <priority>1.0</priority>
     </url>
     <url>
         <loc>https://arckit.org/commands.html</loc>
+        <lastmod>2026-05-03</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.9</priority>
     </url>
     <url>
         <loc>https://arckit.org/guides.html</loc>
+        <lastmod>2026-05-03</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://arckit.org/articles.html</loc>
+        <lastmod>2026-05-03</lastmod>
+        <changefreq>weekly</changefreq>
+        <priority>0.8</priority>
+    </url>
+    <url>
+        <loc>https://arckit.org/article-viewer.html</loc>
+        <changefreq>monthly</changefreq>
+        <priority>0.5</priority>
     </url>
     <url>
         <loc>https://arckit.org/roles.html</loc>
@@ -28,6 +42,7 @@
     </url>
     <url>
         <loc>https://arckit.org/getting-started.html</loc>
+        <lastmod>2026-05-03</lastmod>
         <changefreq>monthly</changefreq>
         <priority>0.8</priority>
     </url>


### PR DESCRIPTION
## Summary

Three documentation surfaces refreshed for the v4.13.0 release. Pairs with PR #414 (uae-federal-ai recipe).

## Changes

### sitemap.xml

- Add `articles.html` (priority 0.8, weekly changefreq)
- Add `article-viewer.html` (priority 0.5, monthly)
- Refresh `lastmod=2026-05-03` on home, commands, guides, getting-started entries

### llms.txt

- Lead paragraph: 68 → 71 commands, 18 → 34 community commands
- Adds Austrian + UAE Federal compliance to the regulatory list
- Mentions `/arckit:build` harness with the three built-in recipes (`uk-saas`, `uk-mod-sovereign`, `uae-federal-ai`)
- New build harness guide link under § Commands
- New § "Articles and essays" with index + the v4.13.0 launch essay

### docs/getting-started.html

New "Faster path (Claude Code only)" notification banner directly after the existing Vibe Start banner. Mirrors the Vibe Start banner's structure for consistency:

- Headline: "The GDS Harness &mdash; `/arckit:build`"
- Three example invocations (`--plan`, default, `--recipe` forms)
- Three built-in recipes listed with target counts (31, 32, 47)
- Customization pattern (`.arckit/recipes/`) explained
- Resumability via `state.json` explained
- Cross-link to `docs/guides/build.md`

## Test plan

- [ ] `articles.html` and `article-viewer.html` both reachable from sitemap
- [ ] `getting-started.html` renders the new banner correctly under the existing Vibe Start one
- [ ] llms.txt counts align with what CLAUDE.md and the README claim (71 official + 34 community)

## Notes

- `uae-federal-ai` is referenced in this PR but only ships in PR #414 (currently open). After both merge, all three recipes are documented and shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)