### PR TITLE
docs: surface /arckit:build in commands, guides, and dependency-matrix pages

### DIFF
--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -259,6 +259,16 @@ Publishing command that generates documentation site:
   - Generates GitHub Pages site with Mermaid diagram support
   - Best run when project has substantial documentation to publish
 
+### Meta: Build Harness (orchestrator, not in matrix)
+
+`/arckit:build` is a meta-command that orchestrates parallel execution of every other command listed in this matrix according to a YAML recipe. It produces no artifact of its own — it dispatches subagents that each run one of the per-tier commands above.
+
+- **build** → Depends on: a recipe file (`.arckit/recipes/{name}.yaml` or `${CLAUDE_PLUGIN_ROOT}/skills/arckit-build/recipes/{name}.yaml`)
+  - Built-in recipes: `uk-saas` (31 targets), `uk-mod-sovereign` (32 targets), `uae-federal-ai` (47 targets including a research wave)
+  - Computes the dependency DAG from the recipe and dispatches one parallel wave at a time
+  - **Claude Code only** — depends on parallel `Agent` tool dispatch
+  - Excluded from the matrix above because it depends on every other command transitively
+
 ---
 
 ## Critical Paths

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -603,6 +603,13 @@
                         <td><span class="app-status-tag app-status-live">Live</span></td>
                     </tr>
                     <tr data-status="live" data-category="foundation">
+                        <td><code>/arckit:build</code></td>
+                        <td class="description">Bulk-build the whole architecture in parallel waves via subagent isolation, driven by a YAML recipe (uk-saas / uk-mod-sovereign / uae-federal-ai). One git commit per wave, resumable via state.json. <strong>Claude Code only</strong> (depends on parallel Agent dispatch). New in v4.13.0.</td>
+                        <td>Foundation</td>
+                        <td class="examples">—</td>
+                        <td><span class="app-status-tag app-status-live">Live</span></td>
+                    </tr>
+                    <tr data-status="live" data-category="foundation">
                         <td><code>/arckit.plan</code></td>
                         <td class="description">Create project plan with timeline, phases, gates, and Mermaid diagrams</td>
                         <td>Foundation</td>

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -303,11 +303,12 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Getting Started
-                    <span class="app-guide-category__count">10 guides</span>
+                    <span class="app-guide-category__count">11 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=start" class="govuk-link">Getting Started with ArcKit</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Onboarding with /arckit.start and /arckit.init</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=build" class="govuk-link">Build Harness Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Bulk-build the whole architecture with /arckit:build (Claude Code only, v4.13.0+)</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=init" class="govuk-link">ArcKit Initialization Guide</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Initialize ArcKit projects with arckit init</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=customize" class="govuk-link">Template Customization Guide</a> <span class="app-status-tag app-status-live">LIVE</span> <span class="app-guide-desc">Customize templates for your organization</span></li>
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=template-builder" class="govuk-link">Template Builder Guide</a> <span class="app-status-tag app-status-alpha">ALPHA</span> <span class="app-guide-desc">Build custom document templates</span></li>


### PR DESCRIPTION
## Summary

After v4.13.0 shipped `/arckit:build` (PR #410), three discovery surfaces didn't list it. This PR adds it to all three.

## Changes

| File | Change |
|------|--------|
| `docs/commands.html` | New row in "Foundation" section directly after `/arckit.start`. Description notes Claude-only constraint and three built-in recipes (`uk-saas`, `uk-mod-sovereign`, `uae-federal-ai`). |
| `docs/guides.html` | "Getting Started" guide list count bumped 10 → 11. New entry linking to `docs/guides/build.md` via `guide-viewer.html?guide=build`. |
| `docs/DEPENDENCY-MATRIX.md` | New "Meta: Build Harness (orchestrator, not in matrix)" section after Tier 15. Explains why `/arckit:build` isn't in the DSM (depends on every other command transitively) and provides recipe pointers. |

## Test plan

- [ ] commands.html row appears under Foundation, search/filter find it
- [ ] guides.html shows 11 guides in Getting Started; "Build Harness Guide" link resolves
- [ ] DEPENDENCY-MATRIX.md renders the new Meta section under Tier 15

## Sequencing

Pairs with PR #414 (uae-federal-ai recipe — referenced here) and PR #415 (sitemap, llms.txt, getting-started — already covers some of this in the getting-started banner). All three are independent and can merge in any order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)