### PR TITLE
feat(arckit-build): add research wave to uk-saas + uk-mod-sovereign (default on, with ORG_RESEARCH)

### DIFF
--- a/arckit-claude/skills/arckit-build/recipes/uk-mod-sovereign.yaml
+++ b/arckit-claude/skills/arckit-build/recipes/uk-mod-sovereign.yaml
@@ -41,6 +41,29 @@ optional_targets:
                  algorithm transparency notice for the on-prem AI route
     default: false   # not all sovereign deployments are public-facing
                      # enough to warrant ATRS publication
+  # Research wave (default-on, opt-out with --exclude). Org research
+  # writes to projects/000-global/research/ so the org context is shared.
+  # Per-project research is per-project. Note: gov-reuse is omitted from
+  # the sovereign recipe because public gov-code-reuse research isn't
+  # typically applicable to MOD / accredited deployments.
+  ORG_RESEARCH:
+    description: Target organisation research — strategy, structure, existing systems. Output to projects/000-global/research/.
+    default: true
+  RESEARCH:
+    description: Technology and vendor market research (build vs buy, TCO)
+    default: true
+  AWS_RESEARCH:
+    description: AWS service availability and architecture patterns
+    default: true
+  AZURE_RESEARCH:
+    description: Azure service availability and architecture patterns
+    default: true
+  GCP_RESEARCH:
+    description: Google Cloud service availability and architecture patterns
+    default: true
+  DATASCOUT:
+    description: External data source discovery — only when REQ specifies external data ingestion
+    default: false
 
 post_build_hooks:
   - skill: arckit:health
@@ -78,6 +101,51 @@ targets:
     args: "{NAME}"
     output: { project: "{P}-{NAME}", type: STKE }
     deps: [PRIN]
+
+  # --- Research wave (default-on, parallel, before ADRs) ----------------
+  # Org research runs first (no deps) and writes to 000-global so every
+  # project in the repo inherits the same target-organisation context.
+  - id: ORG_RESEARCH
+    skill: arckit:research
+    topic: "Target organisation strategy, structure, and existing systems (sovereign deployment context)"
+    args: "{NAME} target-organisation strategy structure existing-systems sovereign-context"
+    output: { project: "000-global", type: RSCH, subfolder: research, multi_instance: true }
+    deps: []
+
+  - id: RESEARCH
+    skill: arckit:research
+    topic: "Technology and vendor market research — sovereign deployment options"
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: RSCH, subfolder: research, multi_instance: true }
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: AWS_RESEARCH
+    skill: arckit:aws-research
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: AWRS, subfolder: research, multi_instance: true }
+    topic: "AWS service availability + architecture patterns + sovereign / GovCloud options"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: AZURE_RESEARCH
+    skill: arckit:azure-research
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: AZRS, subfolder: research, multi_instance: true }
+    topic: "Azure service availability + Azure Government / Azure for Sovereignty"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: GCP_RESEARCH
+    skill: arckit:gcp-research
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: GCRS, subfolder: research, multi_instance: true }
+    topic: "Google Cloud service availability + sovereign cloud options"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: DATASCOUT
+    skill: arckit:datascout
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: DSCT, subfolder: research, multi_instance: true }
+    topic: "External data source discovery (sovereign-compatible feeds only)"
+    deps: [REQ, ORG_RESEARCH]
 
   # --- ADR set: sovereign-specific topics --------------------------------
   # Rewritten from uk-saas defaults to reflect air-gapped operation.

--- a/arckit-claude/skills/arckit-build/recipes/uk-saas.yaml
+++ b/arckit-claude/skills/arckit-build/recipes/uk-saas.yaml
@@ -24,7 +24,7 @@ defaults:
   version: "1.0"
 
 # Optional targets are skipped unless explicitly enabled.
-# - default: true → built unless excluded
+# - default: true → built unless excluded with --exclude {ID}
 # - default: false (or absent) → built only with --enable {ID}
 optional_targets:
   AIP:
@@ -33,6 +33,31 @@ optional_targets:
   SVCASS:
     description: Service Standard Assessment — public-service-style
     default: true
+  # Research wave (default-on, opt-out with --exclude). All research
+  # outputs land in research/ subfolders. ORG_RESEARCH writes to
+  # projects/000-global/research/ so the org context is shared across
+  # every project in the repo. Other research targets are per-project.
+  ORG_RESEARCH:
+    description: Target organisation research — strategy, structure, existing systems. Output to projects/000-global/research/. Run before any project-specific work so subsequent technology research and ADRs inherit the org context.
+    default: true
+  RESEARCH:
+    description: Technology and vendor market research (build vs buy, TCO)
+    default: true
+  AWS_RESEARCH:
+    description: AWS service availability and architecture patterns (skip with --exclude AWS_RESEARCH if AWS not in scope)
+    default: true
+  AZURE_RESEARCH:
+    description: Azure service availability and architecture patterns (skip with --exclude AZURE_RESEARCH if Azure not in scope)
+    default: true
+  GCP_RESEARCH:
+    description: Google Cloud service availability and architecture patterns (skip with --exclude GCP_RESEARCH if GCP not in scope)
+    default: true
+  GOV_REUSE:
+    description: UK government code reuse research via govreposcrape — what's already been built across central / local / NHS
+    default: true
+  DATASCOUT:
+    description: External data source discovery (APIs, datasets, open data portals) — only when REQ specifies external data ingestion
+    default: false
 
 # Hooks run after the final target wave, in parallel.
 post_build_hooks:
@@ -87,6 +112,60 @@ targets:
     args: "{NAME}"
     output: { project: "{P}-{NAME}", type: STKE }
     deps: [PRIN]
+
+  # --- Research wave (default-on, parallel, before ADRs) ----------------
+  # Org research runs first (no deps) and writes to 000-global so every
+  # project in the repo inherits the same target-organisation context.
+  # Per-project technology research depends on the org research being
+  # in place plus REQ being known.
+  - id: ORG_RESEARCH
+    skill: arckit:research
+    topic: "Target organisation strategy, structure, and existing systems"
+    args: "{NAME} target-organisation strategy structure existing-systems"
+    output: { project: "000-global", type: RSCH, subfolder: research, multi_instance: true }
+    deps: []
+
+  - id: RESEARCH
+    skill: arckit:research
+    topic: "Technology and vendor market research (build vs buy, TCO)"
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: RSCH, subfolder: research, multi_instance: true }
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: AWS_RESEARCH
+    skill: arckit:aws-research
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: AWRS, subfolder: research, multi_instance: true }
+    topic: "AWS service availability + architecture patterns + UK region"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: AZURE_RESEARCH
+    skill: arckit:azure-research
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: AZRS, subfolder: research, multi_instance: true }
+    topic: "Azure service availability + architecture patterns + UK South / UK West"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: GCP_RESEARCH
+    skill: arckit:gcp-research
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: GCRS, subfolder: research, multi_instance: true }
+    topic: "Google Cloud service availability + architecture patterns + europe-west2"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: GOV_REUSE
+    skill: arckit:gov-reuse
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: GOVR, subfolder: research, multi_instance: true }
+    topic: "UK government code reuse search via govreposcrape"
+    deps: [REQ, ORG_RESEARCH]
+
+  - id: DATASCOUT
+    skill: arckit:datascout
+    args: "{P}"
+    output: { project: "{P}-{NAME}", type: DSCT, subfolder: research, multi_instance: true }
+    topic: "External data source discovery (APIs, datasets, open data)"
+    deps: [REQ, ORG_RESEARCH]
 
   # --- ADR set (parallel, all share deps) --------------------------------
   - id: ADR-001


### PR DESCRIPTION
## Summary

Backports the research wave pattern from the new `uae-federal-ai` recipe (PR #414) to the two original UK recipes — and goes further by adding **`ORG_RESEARCH`**, an upstream research target that produces target-organisation context shared across every project in the repo.

Both recipes go from 31/32 → **38 targets each**, with the new research targets default-on and opt-out via `--exclude`.

## New target shape: `ORG_RESEARCH`

```yaml
- id: ORG_RESEARCH
  skill: arckit:research
  topic: "Target organisation strategy, structure, and existing systems"
  args: "{NAME} target-organisation strategy structure existing-systems"
  output: { project: "000-global", type: RSCH, subfolder: research, multi_instance: true }
  deps: []
```

- Output lives in `projects/000-global/research/` — shared across every project in the repo
- Runs in W0 alongside `PRIN` (no deps)
- Every per-project research target deps on `ORG_RESEARCH`, so context flows org → project

## Per-project research targets (all default-on, `--exclude` to skip)

### `uk-saas`

| Target | Skill | Topic |
|--------|-------|-------|
| `RESEARCH` | `arckit:research` | General tech / vendor / build-vs-buy |
| `AWS_RESEARCH` | `arckit:aws-research` | UK region availability + patterns |
| `AZURE_RESEARCH` | `arckit:azure-research` | UK South / UK West availability |
| `GCP_RESEARCH` | `arckit:gcp-research` | europe-west2 availability |
| `GOV_REUSE` | `arckit:gov-reuse` | UK government code reuse search |
| `DATASCOUT` | `arckit:datascout` | External data sources (default **off** — opt-in only) |

### `uk-mod-sovereign`

Same five plus `DATASCOUT` (default off). `GOV_REUSE` deliberately omitted — public gov-code-reuse research isn't typically applicable to MOD / accredited deployments.

## Behaviour change

Existing builds running `/arckit:build 001` will now produce **6 additional research artefacts** by default (5 for sovereign). Users who don't want them can opt out per-target with `--exclude RESEARCH` etc., or wholesale by editing `.arckit/recipes/uk-saas.yaml`.

## Design notes

- **No ADR deps on research targets.** Research is informational; ADRs proceed in their own wave. Architects read research outputs when drafting ADRs rather than the harness blocking on them.
- **Output paths use `subfolder: research` and `multi_instance: true`**, matching the existing convention for `/arckit:research` and friends.
- **GCP_RESEARCH added even where GCP isn't currently in scope** — research is exploratory by nature; opting it out is a one-flag decision per build.

## Validation

```
uk-saas:           38 targets, 9 optional, deps ok
uk-mod-sovereign:  38 targets, 9 optional, deps ok
```

## Follow-up

`uae-federal-ai` (PR #414) needs `ORG_RESEARCH` adding for consistency. Will amend that PR once this one lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)