### PR TITLE
docs: adopt Claude Code Remote Control + push notifications (#369)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -234,6 +234,18 @@ Recommended ArcKit usage:
 - **Long `/arckit.research` or `/arckit.datascout` runs** — redirect agent bash/shell output to a log file and ask Claude to `Monitor` the tail, so progress surfaces without blocking the main conversation.
 - **Overnight autoresearch loops** (see `docs/guides/autoresearch.md`) — tail the scoring log from a second session via `tail -F scripts/autoresearch/runs/*.log` wrapped by Monitor.
 
+### Remote Control + push notifications (user-facing)
+
+[Claude Code Remote Control](https://code.claude.com/docs/en/remote-control) (v2.1.110+) lets users drive a local session from claude.ai/code or the mobile app. Combined with `/config → Push when Claude decides`, the phone gets a notification when long-running work finishes or hits a decision point. ArcKit's minimum Claude Code floor (v2.1.117) already covers this.
+
+Best fit for ArcKit:
+
+- **Research-heavy commands** (`/arckit.research`, `/arckit.datascout`, `/arckit.aws-research`, `/arckit.azure-research`, `/arckit.gcp-research`, `/arckit.grants`) — agents routinely run 10+ minutes; user guides cover the pattern in each guide's "Long runs" section.
+- **Overnight `autoresearch` loops** — see `docs/guides/autoresearch.md` § "Phone pings via Remote Control".
+- **Stale-artifact monitor** — pair the `stale-artifact-scan` monitor (above) with RC + push so artifact owners get a phone nudge when reviews lapse.
+
+Constraints: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, the local `claude` process must keep running, and `/ultrareview` flows do not compose with RC. RC is Claude Code only — the converter does not propagate any RC-related config to Codex/Gemini/OpenCode/Copilot extensions.
+
 ### Plugin Hooks
 
 Hook handlers live under `arckit-claude/hooks/` and are registered in `arckit-claude/hooks/hooks.json`. Supported hook events include `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `StopFailure`, `PermissionRequest`, plus the newer `PostCompact` (v2.1.76), `FileChanged`/`CwdChanged`/`TaskCreated` (v2.1.83–84), `PermissionDenied` (v2.1.89), and `PreCompact` blocking (v2.1.105).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -236,7 +236,7 @@ Recommended ArcKit usage:
 
 ### Remote Control + push notifications (user-facing)
 
-[Claude Code Remote Control](https://code.claude.com/docs/en/remote-control) (v2.1.110+) lets users drive a local session from claude.ai/code or the mobile app. Combined with `/config → Push when Claude decides`, the phone gets a notification when long-running work finishes or hits a decision point. ArcKit's minimum Claude Code floor (v2.1.117) already covers this.
+[Claude Code Remote Control](https://code.claude.com/docs/en/remote-control) (v2.1.110+) lets users drive a local session from claude.ai/code or the mobile app. Combined with `/config → Push when Claude decides`, the phone gets a notification when long-running work finishes or hits a decision point. ArcKit's minimum Claude Code floor (v2.1.121) already covers this.
 
 Best fit for ArcKit:
 

--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -47,7 +47,7 @@ claude remote-control
 
 Drive the worktree session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone pings when an iteration keeps a change above the score threshold or when the loop hits a decision point. Combined with `ENABLE_PROMPT_CACHING_1H=1` (see Tips below), you can run autoresearch overnight and check progress from anywhere.
 
-Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off, and the local `claude` process must keep running. ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off, and the local `claude` process must keep running. ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 ---
 

--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -37,6 +37,18 @@ Monitor scripts/autoresearch/runs/*.log and summarise each new iteration
 
 The `Monitor` tool (Claude Code v2.1.98+) tails stdout from a background `tail -F` and delivers each new scoring line to Claude as a notification. You get progress updates on demand without interrupting the experiment loop in the main session. Requires Claude Code v2.1.98 or later.
 
+### Phone pings via Remote Control
+
+For overnight runs where you actually walk away from the laptop, pair the autoresearch session with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the worktree session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone pings when an iteration keeps a change above the score threshold or when the loop hits a decision point. Combined with `ENABLE_PROMPT_CACHING_1H=1` (see Tips below), you can run autoresearch overnight and check progress from anywhere.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off, and the local `claude` process must keep running. ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
 ---
 
 ## How It Works

--- a/docs/guides/aws-research.md
+++ b/docs/guides/aws-research.md
@@ -66,6 +66,20 @@ Outputs: `projects/<id>/research/ARC-<id>-AWRS-v1.0.md`
 
 ---
 
+## Long runs: Remote Control + push notifications
+
+`/arckit.aws-research` frequently exceeds 10 minutes as the agent issues dozens of AWS Knowledge MCP calls and fetches full documentation pages for cost and compliance analysis. To avoid babysitting the terminal, pair it with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
+
+---
+
 ## MCP Tools Used
 
 The command uses five AWS Knowledge MCP tools:

--- a/docs/guides/aws-research.md
+++ b/docs/guides/aws-research.md
@@ -74,7 +74,7 @@ Outputs: `projects/<id>/research/ARC-<id>-AWRS-v1.0.md`
 claude remote-control
 ```
 
-Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
 

--- a/docs/guides/azure-research.md
+++ b/docs/guides/azure-research.md
@@ -74,7 +74,7 @@ Outputs: `projects/<id>/research/ARC-<id>-AZRS-v1.0.md`
 claude remote-control
 ```
 
-Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
 

--- a/docs/guides/azure-research.md
+++ b/docs/guides/azure-research.md
@@ -66,6 +66,20 @@ Outputs: `projects/<id>/research/ARC-<id>-AZRS-v1.0.md`
 
 ---
 
+## Long runs: Remote Control + push notifications
+
+`/arckit.azure-research` frequently exceeds 10 minutes as the agent issues dozens of Microsoft Learn MCP calls and fetches full documentation pages for cost and compliance analysis. To avoid babysitting the terminal, pair it with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
+
+---
+
 ## MCP Tools Used
 
 The command uses three Microsoft Learn MCP tools:

--- a/docs/guides/datascout.md
+++ b/docs/guides/datascout.md
@@ -62,6 +62,20 @@ Outputs: `projects/<id>/ARC-<id>-DSCT-v1.0.md`
 
 ---
 
+## Long runs: Remote Control + push notifications
+
+`/arckit.datascout` frequently exceeds 10 minutes as the agent crawls open data portals, API catalogues, and commercial provider documentation. To avoid babysitting the terminal, pair it with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (data source shortlist confirmation, licensing trade-off). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
+
+---
+
 ## Output Highlights
 
 - **Data needs analysis** extracted from requirements (DR/FR/INT/NFR)

--- a/docs/guides/datascout.md
+++ b/docs/guides/datascout.md
@@ -70,7 +70,7 @@ Outputs: `projects/<id>/ARC-<id>-DSCT-v1.0.md`
 claude remote-control
 ```
 
-Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (data source shortlist confirmation, licensing trade-off). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (data source shortlist confirmation, licensing trade-off). ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
 

--- a/docs/guides/gcp-research.md
+++ b/docs/guides/gcp-research.md
@@ -78,6 +78,20 @@ Outputs: `projects/<id>/research/ARC-<id>-GCRS-v1.0.md`
 
 ---
 
+## Long runs: Remote Control + push notifications
+
+`/arckit.gcp-research` frequently exceeds 10 minutes as the agent issues dozens of Google Developer Knowledge MCP calls and fetches full documentation pages for cost and compliance analysis. To avoid babysitting the terminal, pair it with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
+
+---
+
 ## MCP Tools Used
 
 The command uses three Google Developer Knowledge MCP tools:

--- a/docs/guides/gcp-research.md
+++ b/docs/guides/gcp-research.md
@@ -86,7 +86,7 @@ Outputs: `projects/<id>/research/ARC-<id>-GCRS-v1.0.md`
 claude remote-control
 ```
 
-Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (service shortlist confirmation, region selection). ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
 

--- a/docs/guides/grants.md
+++ b/docs/guides/grants.md
@@ -29,6 +29,20 @@ Outputs:
 
 ---
 
+## Long runs: Remote Control + push notifications
+
+`/arckit.grants` frequently exceeds 10 minutes as the agent crawls UKRI, Innovate UK, NIHR, charitable foundations, and accelerator programmes for live deadlines and eligibility criteria. To avoid babysitting the terminal, pair it with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (programme shortlist confirmation, eligibility ambiguity). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
+
+---
+
 ## Briefing Structure
 
 | Section | Contents |

--- a/docs/guides/grants.md
+++ b/docs/guides/grants.md
@@ -37,7 +37,7 @@ Outputs:
 claude remote-control
 ```
 
-Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (programme shortlist confirmation, eligibility ambiguity). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (programme shortlist confirmation, eligibility ambiguity). ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
 

--- a/docs/guides/research.md
+++ b/docs/guides/research.md
@@ -34,6 +34,20 @@ Outputs: `projects/<id>/ARC-<id>-RSCH-v1.0.md` plus optional CSV of suppliers.
 
 ---
 
+## Long runs: Remote Control + push notifications
+
+`/arckit.research` frequently exceeds 10 minutes once the agent starts pulling vendor pricing pages, G-Cloud listings, and product reviews. To avoid babysitting the terminal, pair it with [Claude Code Remote Control](https://code.claude.com/docs/en/remote-control):
+
+```bash
+claude remote-control
+```
+
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (vendor shortlist confirmation, build vs buy direction). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+
+Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
+
+---
+
 ## Output Highlights
 
 - Option catalogue with pros, cons, pricing, support model.

--- a/docs/guides/research.md
+++ b/docs/guides/research.md
@@ -42,7 +42,7 @@ Outputs: `projects/<id>/ARC-<id>-RSCH-v1.0.md` plus optional CSV of suppliers.
 claude remote-control
 ```
 
-Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (vendor shortlist confirmation, build vs buy direction). ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement.
+Drive the session from claude.ai/code or the mobile app, then enable `/config → Push when Claude decides` so your phone gets a notification on completion or when the agent reaches a decision point (vendor shortlist confirmation, build vs buy direction). ArcKit's minimum Claude Code floor (v2.1.121) already covers the v2.1.110 RC requirement.
 
 Caveats: Pro/Max plans only (no API keys, no Bedrock/Vertex/Foundry), push is a single on/off so chatty agents can over-notify, and the local `claude` process must keep running.
 


### PR DESCRIPTION
## Summary

- Adds a "Long runs: Remote Control + push notifications" section to the six research-heavy command guides (`research`, `datascout`, `aws-research`, `azure-research`, `gcp-research`, `grants`) — each tailored to that command's typical decision points.
- Adds a "Phone pings via Remote Control" subsection to `autoresearch.md`, sibling to the existing Monitor guidance, oriented at overnight runs paired with `ENABLE_PROMPT_CACHING_1H=1`.
- Adds a "Remote Control + push notifications (user-facing)" section to `CLAUDE.md` under the Monitor Tool docs, including pairing with the existing `stale-artifact-scan` monitor.

ArcKit's minimum Claude Code floor (v2.1.117) already covers the v2.1.110 RC requirement, so no version bump is needed. RC is Claude Code only, so the converter does not propagate any related config to Codex/Gemini/OpenCode/Copilot extensions.

Closes #369.

## Test plan

- [x] `npx markdownlint-cli2` clean across all 8 changed files
- [ ] Manual review: each command guide's RC section names a decision point appropriate to that command
- [ ] Manual review: caveats consistent across guides (Pro/Max only, single push toggle, local process must run, no Bedrock/Vertex/Foundry)

🤖 Generated with [Claude Code](https://claude.com/claude-code)