### PR TITLE
feat: PostToolUse updatedToolOutput on provenance + manifest hooks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -265,6 +265,12 @@ Stamped fields:
 
 If neither effort nor build context is available (e.g. a non-ArcKit command edited the file), the hook skips stamping entirely — no empty block. Existing artefacts pre-dating the hook are stamped on the next Write/Edit.
 
+When a stamp is actually written, the hook emits `hookSpecificOutput.updatedToolOutput` (Claude Code v2.1.121+) so the model sees a one-line summary — effort requested vs. effective, downgrade reason if any, and (on Write) a confirmation that `docs/manifest.json` was auto-updated by `update-manifest.mjs` upstream. On no-op runs (no harness fields, file unchanged) the hook stays silent and the original tool output is preserved.
+
+#### Manifest auto-update (`update-manifest.mjs`)
+
+Companion PostToolUse hook on `Write` against `projects/**` that incrementally updates `docs/manifest.json` so the documentation site stays current without a full `/arckit:pages` re-run. On a successful update it emits `hookSpecificOutput.updatedToolOutput` with the document ID and target slot (e.g. `ARC-001-REQ-v1.0 → 001-test/documents`). Because `provenance-stamp.mjs` runs after this hook and overwrites its `updatedToolOutput`, the manifest signal is re-surfaced from `provenance-stamp.mjs` whenever a `docs/manifest.json` exists.
+
 ### Project Structure Created by `arckit init`
 
 ```text

--- a/arckit-claude/hooks/hook-utils.mjs
+++ b/arckit-claude/hooks/hook-utils.mjs
@@ -301,6 +301,32 @@ export function extractRiskEntries(content) {
   return risks;
 }
 
+// ── Hook Output ──
+
+/**
+ * Emit a PostToolUse `hookSpecificOutput.updatedToolOutput` payload to stdout.
+ * Replaces the tool output the model sees with our string. Use this when the
+ * hook actually did something the model should know about (e.g. stamped a
+ * file, updated a manifest); stay silent (do not call this) when the hook
+ * was a no-op so the original tool output is preserved.
+ *
+ * Available since Claude Code v2.1.121 for all tools (was Bash-only before).
+ * When multiple PostToolUse hooks emit on the same tool call, the last hook's
+ * payload wins — so a downstream hook must include any signal earlier hooks
+ * needed to surface.
+ *
+ * @param {string} text - The string to present to the model as the tool output.
+ */
+export function emitUpdatedToolOutput(text) {
+  const payload = {
+    hookSpecificOutput: {
+      hookEventName: 'PostToolUse',
+      updatedToolOutput: text,
+    },
+  };
+  process.stdout.write(JSON.stringify(payload));
+}
+
 // ── Hook Input ──
 
 /**

--- a/arckit-claude/hooks/provenance-stamp.mjs
+++ b/arckit-claude/hooks/provenance-stamp.mjs
@@ -43,14 +43,23 @@
  * Hook Type: PostToolUse
  * Matcher:   Write|Edit
  * Input:     JSON { tool_name, tool_input: { file_path }, cwd }
- * Output:    none
+ * Output:    On successful stamp, a hookSpecificOutput payload with
+ *            updatedToolOutput so the model can see what was recorded
+ *            (Claude Code v2.1.121+). Silent when no stamp was needed
+ *            (e.g. block was null, or content unchanged) so the original
+ *            tool output is preserved.
+ *
+ *            For Write tool calls this hook runs after update-manifest.mjs
+ *            and its updatedToolOutput overwrites that hook's. To avoid
+ *            losing the manifest signal, we re-surface it here when a
+ *            docs/manifest.json file exists at the repo root.
  * Exit:      0 always
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join, basename, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isFile, findRepoRoot, parseHookInput } from './hook-utils.mjs';
+import { isFile, findRepoRoot, parseHookInput, emitUpdatedToolOutput } from './hook-utils.mjs';
 
 const PLUGIN_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 
@@ -281,5 +290,37 @@ const block = buildProvenanceBlock({
   timestamp: new Date().toISOString(),
 });
 
-if (block !== null) stampFile(filePath, block);
+const stamped = block !== null && stampFile(filePath, block);
+
+// Emit hookSpecificOutput.updatedToolOutput so the model sees what the hook
+// did. Silent when nothing changed so the original tool output is preserved.
+if (stamped) {
+  const verb = tool === 'Edit' ? 'edited' : 'written';
+  const lines = [`File ${verb}: ${filePath}`];
+
+  // Effort signal — what the model knows it asked for vs what was applied.
+  if (effortRequested && effortEffective) {
+    const effortMsg = effortDowngraded
+      ? `effort: requested=${effortRequested}, effective=${effortEffective} (downgraded — model does not support that level)`
+      : `effort: requested=${effortRequested}, effective=${effortEffective}`;
+    lines.push(`[ArcKit] provenance stamped (${effortMsg})`);
+  } else if (build) {
+    lines.push(`[ArcKit] provenance stamped (build: ${build.recipe || '?'}/${build.target})`);
+  } else {
+    lines.push(`[ArcKit] provenance stamped`);
+  }
+
+  // Re-surface the update-manifest signal on Write — that hook ran first
+  // and its updatedToolOutput is overwritten by ours. Re-check the same
+  // precondition (manifest file exists) so we only mention it when relevant.
+  if (tool === 'Write' && repoRoot) {
+    const manifestPath = join(repoRoot, 'docs', 'manifest.json');
+    if (isFile(manifestPath)) {
+      lines.push(`[ArcKit] docs/manifest.json auto-updated`);
+    }
+  }
+
+  emitUpdatedToolOutput(lines.join('\n'));
+}
+
 process.exit(0);

--- a/arckit-claude/hooks/update-manifest.mjs
+++ b/arckit-claude/hooks/update-manifest.mjs
@@ -14,14 +14,21 @@
  * Hook Type: PostToolUse
  * Matcher: Write
  * Input (stdin):  JSON { tool_name, tool_input: { file_path, content }, cwd }
- * Output (stdout): none (PostToolUse hooks are silent)
+ * Output (stdout): On successful manifest update, a hookSpecificOutput
+ *                  payload with updatedToolOutput so the model sees that
+ *                  the manifest stayed in sync (Claude Code v2.1.121+).
+ *                  Silent on no-op so original tool output is preserved.
+ *                  NOTE: provenance-stamp.mjs also runs on PostToolUse Write
+ *                  and emits its own updatedToolOutput, which will overwrite
+ *                  this one. provenance-stamp re-surfaces the manifest signal
+ *                  in its message — see that hook for the merged output.
  * Exit codes:      0 always
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
 import { join, basename, resolve } from 'node:path';
 import { DOC_TYPES, SUBDIR_MAP } from '../config/doc-types.mjs';
-import { isDir, isFile, findRepoRoot, parseHookInput } from './hook-utils.mjs';
+import { isDir, isFile, findRepoRoot, parseHookInput, emitUpdatedToolOutput } from './hook-utils.mjs';
 
 // ── Static data (derived from central config) ──
 
@@ -161,6 +168,9 @@ if (projectDirName === '000-global') {
   // Update timestamp and write
   manifest.generated = new Date().toISOString();
   writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+  emitUpdatedToolOutput(
+    `File written: ${filePath}\n[ArcKit] docs/manifest.json updated: ${documentId} → global`,
+  );
   process.exit(0);
 }
 
@@ -206,4 +216,7 @@ project[targetKey].push(newEntry);
 // Update timestamp and write
 manifest.generated = new Date().toISOString();
 writeFileSync(manifestPath, JSON.stringify(manifest, null, 2), 'utf8');
+emitUpdatedToolOutput(
+  `File written: ${filePath}\n[ArcKit] docs/manifest.json updated: ${documentId} → ${projectDirName}/${targetKey}`,
+);
 process.exit(0);


### PR DESCRIPTION
## Summary

Wires Claude Code v2.1.121 PostToolUse `hookSpecificOutput.updatedToolOutput` into the two PostToolUse hooks that previously edited files silently. The model now sees a one-line summary of what each hook did, instead of just the bare tool result.

This is the **Tier 2 biggest single lever** from #427.

## What the model now sees

On `Write` of an ArcKit artefact under `projects/**`:

```
File written: <path>
[ArcKit] provenance stamped (effort: requested=max, effective=max)
[ArcKit] docs/manifest.json auto-updated
```

When the model requests `effort: max` on a Sonnet model that doesn't support it:

```
File written: <path>
[ArcKit] provenance stamped (effort: requested=max, effective=high (downgraded — model does not support that level))
[ArcKit] docs/manifest.json auto-updated
```

On `Edit`:

```
File edited: <path>
[ArcKit] provenance stamped (effort: requested=high, effective=high)
```

On no-op (non-ArcKit file, no harness fields, content unchanged) — the hook stays **silent** and the original tool output is preserved.

## Implementation

- New `emitUpdatedToolOutput()` helper in `hook-utils.mjs` writes the PostToolUse `hookSpecificOutput` JSON to stdout. Documents the multi-hook ordering caveat — when several PostToolUse hooks fire on the same tool call, the last one's payload wins.
- `update-manifest.mjs` emits on successful manifest update (both `000-global` and numbered-project branches).
- `provenance-stamp.mjs` emits on successful stamp. Because it runs **after** `update-manifest.mjs` on Write and would otherwise overwrite its `updatedToolOutput`, it re-surfaces the manifest signal by re-checking the same precondition (`docs/manifest.json` exists).

## Why graph-inject.mjs is not in this PR

#427 listed `graph-inject.mjs` alongside the other two, but `graph-inject.mjs` is a **UserPromptSubmit** hook, not PostToolUse — `updatedToolOutput` doesn't apply there. It already returns context to the model via its own UserPromptSubmit mechanism. Excluded by design; will note this on the issue.

## Test plan

- [x] Smoke test: Write to ARC file → emits combined provenance + manifest message — passed
- [x] Smoke test: Edit to ARC file → emits provenance only (no manifest mention) — passed
- [x] Smoke test: Edit to non-ARC file → silent, exit 0 — passed
- [x] Smoke test: empty stdin → silent, exit 0 — passed
- [x] `jq` validates JSON output of both hooks — passed
- [x] `node --check` on all three modified `.mjs` files — passed
- [x] `markdownlint-cli2 CLAUDE.md` — 0 errors
- [ ] End-to-end in a test repo (deferred — needs a Claude Code session post-merge)

## Tracking

Closes part of #427 (Tier 2, biggest single lever). PR 3 (telemetry bundle: `duration_ms` + `type:\"mcp_tool\"` + `TaskCreated`) follows next.

Parent: #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)