### PR TITLE
feat: session telemetry — duration_ms, MCP calls, agent spawns

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -271,6 +271,24 @@ When a stamp is actually written, the hook emits `hookSpecificOutput.updatedTool
 
 Companion PostToolUse hook on `Write` against `projects/**` that incrementally updates `docs/manifest.json` so the documentation site stays current without a full `/arckit:pages` re-run. On a successful update it emits `hookSpecificOutput.updatedToolOutput` with the document ID and target slot (e.g. `ARC-001-REQ-v1.0 → 001-test/documents`). Because `provenance-stamp.mjs` runs after this hook and overwrites its `updatedToolOutput`, the manifest signal is re-surfaced from `provenance-stamp.mjs` whenever a `docs/manifest.json` exists.
 
+#### Session telemetry (`telemetry.mjs` + `session-learner.mjs`)
+
+Lightweight telemetry recorder registered for three events:
+
+- **PostToolUse** (matcher `.*`) — records `{ tool, duration_ms }` for every tool call (Claude Code v2.1.119+ `duration_ms` field). Pure-latency records exclude `TaskCreate` and `mcp__govreposcrape__*` calls so the duration histogram isn't polluted by long-running async tools.
+- **PostToolUse** (same registration, branched by tool name) — records `{ server, tool, args }` for `mcp__govreposcrape__*` calls. Args are sanitised (long strings replaced with length markers, nested objects flattened to `<object>`) so the JSONL stays small.
+- **TaskCreated** (matcher `.*`, Claude Code v2.1.84+) — records `{ agent }` for every agent spawn via the Task tool.
+
+Events are appended to `.arckit/memory/.telemetry.jsonl` during the session. `session-learner.mjs` reads, summarises, and truncates the file at Stop / StopFailure, adding a single line to each session entry, e.g.:
+
+```text
+- **Telemetry:** 47 tool calls (p50=12ms, p95=4200ms) | 3 agents (arckit-research×2, arckit-datascout) | MCP: govreposcrape×8
+```
+
+Telemetry is best-effort — any failure (write error, malformed line, missing field) is swallowed silently so it never breaks a session.
+
+> **Note on `type: "mcp_tool"` (v2.1.118)**: This Claude Code feature lets a hook *invoke* an MCP tool as its action (alternative to `type: "command"` / `type: "prompt"`). It does **not** filter hooks to fire only on MCP tool calls. ArcKit logs `govreposcrape` calls via the existing tool-name matcher pattern (`mcp__govreposcrape__.*`); no `type: "mcp_tool"` registration is needed for telemetry.
+
 ### Project Structure Created by `arckit init`
 
 ```text

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A comprehensive book-length guide to ArcKit — covering every subsystem (comman
 
 ### Installation
 
-**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.117+**):
+**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.121+**):
 
 ```text
 /plugin marketplace add tractorjuice/arc-kit
@@ -65,7 +65,7 @@ Then install from the Discover tab.
 >
 > This uses `git sparse-checkout` to limit the clone to `.claude-plugin/` (the marketplace catalog) and `arckit-claude/` (the plugin itself). Works with Claude Code's documented marketplace sparse flag. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 70 official commands (plus 34 community-contributed), 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
-> **Why v2.1.117?** This version corrects Opus 4.7's `/context` calculation to use the model's native 1M window instead of 200K, so ArcKit's long deep-research and synthesis sessions no longer autocompact prematurely. It also loads agent frontmatter `mcpServers` for `--agent` sessions (lets research agents declare their own MCP surface), surfaces `gh` rate-limit hints inline (benefits the 10 research agents and govreposcrape callers), and fixes WebFetch hangs on very large HTML pages. Carries forward the v2.1.111+ unlocks: Opus 4.7 `xhigh` effort tier (used by deep-research agents), Auto mode without `--enable-auto-mode`, read-only bash glob patterns without permission prompts; and the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
+> **Why v2.1.121?** ArcKit now uses MCP `alwaysLoad` to eager-load AWS Knowledge and Microsoft Learn tools at session start (skips a discovery round-trip on `/arckit:aws-research` and `/arckit:azure-research`), and PostToolUse `hookSpecificOutput.updatedToolOutput` so provenance-stamp and manifest hooks surface their effects to the model in-band — both v2.1.121 features. The release flow uses `claude plugin tag --dry-run` (v2.1.118) to validate plugin/marketplace version agreement, and the session-telemetry hook records `duration_ms` on every tool call (v2.1.119). Carries forward the v2.1.117 unlocks: Opus 4.7 `/context` correctly sized to 1M instead of 200K (long research sessions no longer autocompact early) and agent frontmatter `mcpServers` loading for `--agent` sessions; the v2.1.111+ unlocks: Opus 4.7 `xhigh` effort tier, Auto mode without `--enable-auto-mode`, read-only bash glob patterns without permission prompts; and the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 
 **Gemini CLI** — install the ArcKit extension:
 
@@ -1528,7 +1528,7 @@ Key references live in `docs/` and top-level guides:
 
 - **Python 3.11+**
 - **Git** (optional but recommended)
-- **AI Coding Agent**: [Claude Code](https://www.anthropic.com/claude-code) v2.1.117+ (via plugin), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (via extension), [OpenCode CLI](https://opencode.net/cli) (via CLI), or [OpenAI Codex CLI](https://chatgpt.com/features/codex) (via CLI)
+- **AI Coding Agent**: [Claude Code](https://www.anthropic.com/claude-code) v2.1.121+ (via plugin), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (via extension), [OpenCode CLI](https://opencode.net/cli) (via CLI), or [OpenAI Codex CLI](https://chatgpt.com/features/codex) (via CLI)
 - **uv** for package management: [Install uv](https://docs.astral.sh/uv/)
 
 ---

--- a/arckit-claude/README.md
+++ b/arckit-claude/README.md
@@ -32,13 +32,13 @@ claude --plugin-dir /path/to/arc-kit/arckit-claude
 
 ## Prerequisites
 
-- **Claude Code** v2.1.117 or later (recommended minimum)
+- **Claude Code** v2.1.121 or later (recommended minimum)
 - **Bash** shell (for helper scripts)
 - For `/arckit:aws-research`: AWS Knowledge MCP server (included)
 - For `/arckit:azure-research`: Microsoft Learn MCP server (included)
 - For `/arckit:gcp-research`: Google Developer Knowledge MCP (requires `GOOGLE_API_KEY` — see [MCP Servers](#mcp-servers))
 
-> **Why v2.1.117?** This version corrects Opus 4.7's `/context` calculation to use the model's native 1M window instead of 200K, so ArcKit's long deep-research and synthesis sessions no longer autocompact prematurely. It also loads agent frontmatter `mcpServers` for `--agent` sessions (lets research agents declare their own MCP surface), surfaces `gh` rate-limit hints inline (benefits the 10 research agents and govreposcrape callers), and fixes WebFetch hangs on very large HTML pages. Carries forward the v2.1.111+ unlocks: Opus 4.7 `xhigh` effort tier (used by deep-research agents), Auto mode without `--enable-auto-mode`, read-only bash glob patterns without permission prompts; and the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
+> **Why v2.1.121?** ArcKit now uses MCP `alwaysLoad` to eager-load AWS Knowledge and Microsoft Learn tools at session start (skips a discovery round-trip on `/arckit:aws-research` and `/arckit:azure-research`), and PostToolUse `hookSpecificOutput.updatedToolOutput` so provenance-stamp and manifest hooks surface their effects to the model in-band — both v2.1.121 features. The release flow uses `claude plugin tag --dry-run` (v2.1.118) to validate plugin/marketplace version agreement, and the session-telemetry hook records `duration_ms` on every tool call (v2.1.119). Carries forward the v2.1.117 unlocks: Opus 4.7 `/context` correctly sized to 1M instead of 200K (long research sessions no longer autocompact early) and agent frontmatter `mcpServers` loading for `--agent` sessions; the v2.1.111+ unlocks: Opus 4.7 `xhigh` effort tier, Auto mode without `--enable-auto-mode`, read-only bash glob patterns without permission prompts; and the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 
 ## Quick Start
 

--- a/arckit-claude/docs/guides/mcp-servers.md
+++ b/arckit-claude/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.117 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.121 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
 
 ### Optional: Long-session prompt cache (Claude Code v2.1.108+)

--- a/arckit-claude/hooks/hooks.json
+++ b/arckit-claude/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "ArcKit hooks: session init, version check, session learner (Stop + StopFailure), project context injection, filename enforcement, MCP tool auto-allow, security protection (file protection, secret detection, secret file scanning), and provenance stamping on artefact writes (PostToolUse Write|Edit)",
+  "description": "ArcKit hooks: session init, version check, session learner (Stop + StopFailure), project context injection, filename enforcement, MCP tool auto-allow, security protection (file protection, secret detection, secret file scanning), provenance stamping on artefact writes (PostToolUse Write|Edit), and telemetry recording (PostToolUse for hook duration_ms + govreposcrape MCP calls; TaskCreated for agent spawns)",
   "hooks": {
     "Stop": [
       {
@@ -199,6 +199,28 @@
             "if": "Edit(/projects/**)",
             "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/provenance-stamp.mjs",
             "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/telemetry.mjs",
+            "timeout": 3
+          }
+        ]
+      }
+    ],
+    "TaskCreated": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node ${CLAUDE_PLUGIN_ROOT}/hooks/telemetry.mjs",
+            "timeout": 3
           }
         ]
       }

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -17,7 +17,7 @@
  * Output (stdout): empty (notification hook, no output required)
  */
 
-import { writeFileSync, mkdirSync } from 'node:fs';
+import { writeFileSync, mkdirSync, unlinkSync } from 'node:fs';
 import { join } from 'node:path';
 import { execFileSync } from 'node:child_process';
 import { isDir, isFile, readText, parseHookInput } from './hook-utils.mjs';
@@ -157,6 +157,30 @@ if (commitSummaries.length > 0) {
   }
 }
 
+// ── Telemetry summary (Claude Code v2.1.84 / v2.1.118 / v2.1.119) ──
+// Read .telemetry.jsonl written by telemetry.mjs across the session,
+// roll it up into a one-line summary, and truncate so it doesn't grow
+// across sessions. Silent when the file is absent or empty.
+const telemetryFile = join(memoryDir, '.telemetry.jsonl');
+if (isFile(telemetryFile)) {
+  const raw = readText(telemetryFile) || '';
+  const events = [];
+  for (const line of raw.split('\n')) {
+    if (!line.trim()) continue;
+    try {
+      events.push(JSON.parse(line));
+    } catch {
+      // skip malformed line — telemetry must never break a session
+    }
+  }
+  if (events.length > 0) {
+    const summary = summariseTelemetry(events);
+    if (summary) entry += `- **Telemetry:** ${summary}\n`;
+  }
+  // Truncate (delete) so next session starts clean. Failure is non-fatal.
+  try { unlinkSync(telemetryFile); } catch { /* ignore */ }
+}
+
 // Ensure memory directory exists
 mkdirSync(memoryDir, { recursive: true });
 
@@ -188,3 +212,63 @@ writeFileSync(sessionsFile, output);
 writeFileSync(lastSessionFile, now.toISOString());
 
 process.exit(0);
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Roll up telemetry events from telemetry.mjs into a single line for
+ * the session entry. Records:
+ *   - hook_duration{tool, duration_ms}: per-tool latency histogram
+ *   - mcp_call{server, tool, args}:     MCP call count (govreposcrape only)
+ *   - agent_spawn{agent}:               agent spawn counts
+ *
+ * Returns a one-line string or null if nothing meaningful to report.
+ */
+function summariseTelemetry(events) {
+  const durationsByTool = new Map(); // tool → array of duration_ms
+  const mcpCalls = new Map();        // server → count
+  const agentSpawns = new Map();     // agent → count
+
+  for (const ev of events) {
+    if (ev.kind === 'hook_duration' && ev.tool && typeof ev.duration_ms === 'number') {
+      if (!durationsByTool.has(ev.tool)) durationsByTool.set(ev.tool, []);
+      durationsByTool.get(ev.tool).push(ev.duration_ms);
+    } else if (ev.kind === 'mcp_call' && ev.server) {
+      mcpCalls.set(ev.server, (mcpCalls.get(ev.server) || 0) + 1);
+    } else if (ev.kind === 'agent_spawn' && ev.agent) {
+      agentSpawns.set(ev.agent, (agentSpawns.get(ev.agent) || 0) + 1);
+    }
+  }
+
+  const parts = [];
+
+  if (durationsByTool.size > 0) {
+    // Compute total tool calls and overall p50/p95
+    const all = [];
+    for (const arr of durationsByTool.values()) all.push(...arr);
+    all.sort((a, b) => a - b);
+    const p50 = all[Math.floor(all.length * 0.5)];
+    const p95 = all[Math.floor(all.length * 0.95)];
+    parts.push(`${all.length} tool calls (p50=${p50}ms, p95=${p95}ms)`);
+  }
+
+  if (agentSpawns.size > 0) {
+    const total = [...agentSpawns.values()].reduce((a, b) => a + b, 0);
+    const top = [...agentSpawns.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([a, n]) => (n > 1 ? `${a}×${n}` : a))
+      .join(', ');
+    parts.push(`${total} agent${total === 1 ? '' : 's'} (${top})`);
+  }
+
+  if (mcpCalls.size > 0) {
+    const top = [...mcpCalls.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([s, n]) => `${s}×${n}`)
+      .join(', ');
+    parts.push(`MCP: ${top}`);
+  }
+
+  return parts.length > 0 ? parts.join(' | ') : null;
+}

--- a/arckit-claude/hooks/telemetry.mjs
+++ b/arckit-claude/hooks/telemetry.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Telemetry Recorder — multi-purpose hook
+ *
+ * Registered for several events; the input's `hook_event_name` (or the
+ * fields present) tells us which kind of record to write. Each invocation
+ * appends one JSON line to `.arckit/memory/.telemetry.jsonl`. The file is
+ * read and truncated by `session-learner.mjs` on Stop, so it stays small
+ * across sessions.
+ *
+ * Records (one of):
+ *
+ *   {"ts":"...","kind":"hook_duration","tool":"Write","duration_ms":42}
+ *     - emitted on PostToolUse for every tool with duration_ms (Claude Code
+ *       v2.1.119+). Skipped silently when duration_ms is absent (older
+ *       client, PreToolUse-rejected calls, etc.)
+ *
+ *   {"ts":"...","kind":"mcp_call","server":"govreposcrape","tool":"...","args":{...}}
+ *     - emitted on PostToolUse for MCP calls matching `mcp__govreposcrape__.*`.
+ *       Records the called tool name and its arguments (sanitised — only
+ *       primitive values kept, large blobs replaced with `<…>`).
+ *
+ *   {"ts":"...","kind":"agent_spawn","agent":"arckit-research"}
+ *     - emitted on TaskCreated (v2.1.84+). Records the spawned agent's
+ *       subagent_type so session-learner can summarise agent usage.
+ *
+ * Hook Type:  PostToolUse | TaskCreated
+ * Input:      JSON hook input (shape varies by event)
+ * Output:     none (silent telemetry; tool output unchanged)
+ * Exit:       0 always (telemetry must never break a session)
+ */
+
+import { appendFileSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { isDir, parseHookInput } from './hook-utils.mjs';
+
+const data = parseHookInput();
+const cwd = data.cwd || process.cwd();
+
+// Only collect telemetry inside an ArcKit project. No project = no .arckit
+// directory = nowhere to write the JSONL anyway.
+if (!isDir(join(cwd, '.arckit'))) process.exit(0);
+
+const event = data.hook_event_name || data.hookEventName || '';
+const tool = data.tool_name || '';
+
+let record = null;
+const ts = new Date().toISOString();
+
+if (event === 'TaskCreated' || tool === 'TaskCreate') {
+  // TaskCreated: the spawned agent is in tool_input.subagent_type
+  const agent = data.tool_input?.subagent_type || data.tool_input?.agent || null;
+  if (agent) {
+    record = { ts, kind: 'agent_spawn', agent };
+  }
+} else if (tool.startsWith('mcp__govreposcrape__')) {
+  // MCP call recording for govreposcrape
+  // Tool name shape: mcp__<server>__<tool>
+  const parts = tool.split('__');
+  const server = parts[1] || 'unknown';
+  const mcpTool = parts.slice(2).join('__') || 'unknown';
+  record = {
+    ts,
+    kind: 'mcp_call',
+    server,
+    tool: mcpTool,
+    args: sanitiseArgs(data.tool_input),
+  };
+} else if (typeof data.duration_ms === 'number') {
+  // PostToolUse duration recording (v2.1.119+).
+  // Skip TaskCreate and govreposcrape MCP calls — those are recorded
+  // under their own kinds above; we only want pure latency for everything
+  // else (Write/Edit/Bash/etc.) so the duration histogram is uncluttered.
+  if (tool && tool !== 'TaskCreate' && !tool.startsWith('mcp__govreposcrape__')) {
+    record = { ts, kind: 'hook_duration', tool, duration_ms: data.duration_ms };
+  }
+}
+
+if (record) {
+  const memoryDir = join(cwd, '.arckit', 'memory');
+  try {
+    mkdirSync(memoryDir, { recursive: true });
+    appendFileSync(join(memoryDir, '.telemetry.jsonl'), JSON.stringify(record) + '\n');
+  } catch {
+    // Telemetry must never break a session. Swallow any write failure.
+  }
+}
+
+process.exit(0);
+
+// ── Helpers ────────────────────────────────────────────────────────────
+
+/**
+ * Reduce tool_input down to primitive values + short strings so the
+ * telemetry file stays small. Long strings (e.g. file content) are
+ * replaced with a length marker. Nested objects are flattened to
+ * `<object>`.
+ */
+function sanitiseArgs(input) {
+  if (!input || typeof input !== 'object') return null;
+  const out = {};
+  for (const [k, v] of Object.entries(input)) {
+    if (v === null || v === undefined) {
+      out[k] = v;
+    } else if (typeof v === 'string') {
+      out[k] = v.length > 200 ? `<string len=${v.length}>` : v;
+    } else if (typeof v === 'number' || typeof v === 'boolean') {
+      out[k] = v;
+    } else if (Array.isArray(v)) {
+      out[k] = `<array len=${v.length}>`;
+    } else {
+      out[k] = '<object>';
+    }
+  }
+  return out;
+}

--- a/arckit-claude/hooks/version-check.mjs
+++ b/arckit-claude/hooks/version-check.mjs
@@ -8,7 +8,7 @@
  *   2. Claude Code minimum — reads `$CLAUDE_CODE_VERSION` (if set) or runs
  *      `claude --version` via spawnSync, and warns when the client is below
  *      MIN_CLAUDE_CODE_VERSION (features like userConfig, hook `if:`, skill
- *      `paths:` depend on v2.1.83+/v2.1.117+). Silent on detection failure.
+ *      `paths:` depend on v2.1.83+/v2.1.121+). Silent on detection failure.
  *
  * Hook Type: SessionStart
  * Input (stdin): JSON with session_id, cwd, etc.
@@ -20,7 +20,7 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isFile, readText, parseHookInput } from './hook-utils.mjs';
 
-const MIN_CLAUDE_CODE_VERSION = '2.1.117';
+const MIN_CLAUDE_CODE_VERSION = '2.1.121';
 
 parseHookInput(); // consume stdin (required by hook protocol)
 
@@ -42,7 +42,11 @@ if (clientVersion && compareVersions(clientVersion, MIN_CLAUDE_CODE_VERSION) < 0
     `- Hook \`if:\` conditions that narrow triggering (needs v2.1.85)\n` +
     `- Opus 4.7 \`xhigh\` effort tier and Auto mode (needs v2.1.111)\n` +
     `- Opus 4.7 \`/context\` correctly sized to 1M instead of 200K — long research sessions no longer autocompact early (needs v2.1.117)\n` +
-    `- Agent frontmatter \`mcpServers\` loaded for \`--agent\` sessions (needs v2.1.117)\n\n` +
+    `- Agent frontmatter \`mcpServers\` loaded for \`--agent\` sessions (needs v2.1.117)\n` +
+    `- \`claude plugin tag\` validates plugin/marketplace version agreement before release (needs v2.1.118)\n` +
+    `- Hook \`duration_ms\` recorded on PostToolUse for session telemetry (needs v2.1.119)\n` +
+    `- MCP server \`alwaysLoad\` skips tool-search deferral so AWS Knowledge / Microsoft Learn tools are loaded eagerly (needs v2.1.121)\n` +
+    `- PostToolUse \`hookSpecificOutput.updatedToolOutput\` for all tools — provenance and manifest hooks now surface their work to the model (needs v2.1.121)\n\n` +
     `Update with: \`claude update\``
   );
   process.stderr.write(`[ArcKit] Claude Code v${clientVersion} is below required v${MIN_CLAUDE_CODE_VERSION}\n`);

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -10,7 +10,7 @@ This guide covers installing the ArcKit plugin, configuring MCP servers, and com
 
 ### Prerequisites
 
-- **Claude Code** v2.1.117 or later (or **Claude Cowork** desktop app)
+- **Claude Code** v2.1.121 or later (or **Claude Cowork** desktop app)
 - **Bash** shell (for helper scripts)
 
 ### Optional: Long-session prompt cache (Claude Code v2.1.108+)


### PR DESCRIPTION
## Summary

Adds a lightweight telemetry recorder that captures three classes of event during a session and rolls them into a one-line summary on the session entry written by `session-learner.mjs` at Stop / StopFailure. Closes the **Tier 2 telemetry bundle** from #427.

## What gets recorded

| Event source | What | Claude Code version |
|---|---|---|
| PostToolUse `.*` | Per-tool `duration_ms` (excluding TaskCreate + govreposcrape) | v2.1.119+ |
| PostToolUse `mcp__govreposcrape__*` | MCP server, tool, sanitised args | (existing matcher) |
| TaskCreated `.*` | Agent spawn (`subagent_type`) | v2.1.84+ |

Output added to each session entry in `.arckit/memory/sessions.md`:

```
- **Telemetry:** 47 tool calls (p50=12ms, p95=4200ms) | 3 agents (arckit-research×2, arckit-datascout) | MCP: govreposcrape×8
```

## Note on `type: "mcp_tool"` from #427

The v2.1.118 `type: \"mcp_tool\"` capability **invokes** MCP tools as a hook action (alternative to `type: \"command\"` / `type: \"prompt\"`); it does NOT filter hooks to fire only on MCP calls (which is what #427 implied). MCP-call matching here uses the existing `mcp__govreposcrape__.*` tool-name pattern — no new `type` registration is needed. Documented in `CLAUDE.md` and on #427.

## Implementation

- **`arckit-claude/hooks/telemetry.mjs`** (new, 100 lines) — multi-purpose hook. Branches by `hook_event_name` / tool name to write the right JSONL record to `.arckit/memory/.telemetry.jsonl`. Silent on any write failure — telemetry must never break a session.
- **`arckit-claude/hooks/session-learner.mjs`** — reads the JSONL on Stop, computes overall p50/p95, top-3 agents, MCP server counts, appends a one-line summary to the session entry, and deletes the file so the next session starts clean. Malformed lines are skipped gracefully.
- **`arckit-claude/hooks/hooks.json`** — adds two registrations (PostToolUse `.*`, TaskCreated `.*`) and updates the description.
- **`CLAUDE.md`** — documents the new hook under \"Plugin Hooks\" and notes the `type: \"mcp_tool\"` misreading.

## Privacy / size considerations

- MCP `args` are sanitised: long strings (>200 chars) replaced with `<string len=N>`, arrays/nested objects flattened. No file content or large payloads stored.
- File is deleted at every Stop, so it never accumulates across sessions.
- Telemetry only writes inside an ArcKit project (no `.arckit/` directory → no writes).

## Test plan

- [x] Smoke test: PostToolUse Write/Edit → `hook_duration` records — passed
- [x] Smoke test: PostToolUse `mcp__govreposcrape__search_uk_gov_code` → `mcp_call` record — passed
- [x] Smoke test: TaskCreated → `agent_spawn` record — passed
- [x] Smoke test: session-learner reads + summarises + truncates — passed (sample output verified)
- [x] No-telemetry session: session entry has no Telemetry line — passed
- [x] Malformed JSONL: handled gracefully, no crash — passed
- [x] `node --check` on `telemetry.mjs` and `session-learner.mjs` — passed
- [x] `jq` validates `hooks.json` — passed
- [x] `markdownlint-cli2 CLAUDE.md` — 0 errors

## Tracking

Closes the Tier 2 telemetry bundle from #427. Combined with #428 (Tier 1) and #429 (Tier 2 biggest lever), this completes Tier 1 + Tier 2 of the v2.1.117–v2.1.128 capability adoption.

Parent: #215.

🤖 Generated with [Claude Code](https://claude.com/claude-code)