### PR TITLE
fix(graph-inject): surface empty-graph diagnostic on /arckit:health

### DIFF
--- a/arckit-claude/hooks/graph-inject.mjs
+++ b/arckit-claude/hooks/graph-inject.mjs
@@ -965,8 +965,28 @@ function formatHealth(graph, prompt, repoRoot) {
   const sinceArg = text.match(/\bSINCE\s*=\s*(\d{4}-\d{2}-\d{2})/i)?.[1] || null;
   const projectArg = parseProjectArg(prompt, 'health');
 
-  if (graph.projects.length === 0) return null;
-  if (projectArg && graph.projects.length === 0) return null;
+  if (graph.projects.length === 0) {
+    // Surface the failure mode instead of silently exiting — otherwise the
+    // slash-command's manual-fallback path (commands/health.md) makes it look
+    // like the hook never ran. Same pattern as formatTraceability above.
+    const reasons = [
+      `- The repo only has \`projects/000-global/\` artefacts (excluded by the health recipe via \`excludeGlobal: true\`).`,
+      `- The \`projects/\` tree exists but contains no numbered \`NNN-*\` project directories.`,
+    ];
+    if (projectArg) {
+      reasons.push(`- Project filter \`${projectArg}\` matched no project.`);
+    }
+    return [
+      '## Health Pre-processor (hook)',
+      '',
+      `**No projects scanned.** \`graph.projects\` is empty after \`scanAllArtifacts({ excludeGlobal: true })\`.`,
+      '',
+      'Likely causes:',
+      ...reasons,
+      '',
+      'Falling back to manual extraction — the slash command will read artifacts directly.',
+    ].join('\n');
+  }
 
   const baseline = sinceArg ? new Date(sinceArg) : new Date();
   const minLevel = SEVERITY_ORDER[severityArg] || 1;


### PR DESCRIPTION
## Summary

Fixes #433. The `formatHealth` recipe in `graph-inject.mjs` silent-exited via `return null` when `graph.projects` came back empty (most commonly: the repo only has `projects/000-global/` artefacts, which the health recipe excludes via `excludeGlobal: true`). The slash command's documented manual-fallback path then ran all 7 detection rules itself, making it look like the hook never fired.

## What's the same as before

- `formatTraceability` already had this fix applied at `graph-inject.mjs:1239`. This PR brings `formatHealth` into line.
- The slash command's fallback still runs when the hook can't help — that part was correct. The fix is about *visibility* of why the hook returned nothing useful.

## What changed

`arckit-claude/hooks/graph-inject.mjs`, +22/-2:

```js
// Before
if (graph.projects.length === 0) return null;
if (projectArg && graph.projects.length === 0) return null;  // dead code

// After
if (graph.projects.length === 0) {
  return [
    '## Health Pre-processor (hook)',
    '',
    '**No projects scanned.** \`graph.projects\` is empty after \`scanAllArtifacts({ excludeGlobal: true })\`.',
    '',
    'Likely causes:',
    '- The repo only has \`projects/000-global/\` artefacts (excluded by the health recipe via \`excludeGlobal: true\`).',
    '- The \`projects/\` tree exists but contains no numbered \`NNN-*\` project directories.',
    // + project filter line if projectArg present
    '',
    'Falling back to manual extraction — the slash command will read artifacts directly.',
  ].join('\\n');
}
```

The dead-code duplicate guard on the next line is removed at the same time — it was unreachable (the first guard returns regardless of `projectArg`).

## Test plan

- [x] **Empty case (the bug):** repo with only \`projects/000-global/\` → hook emits diagnostic block with three labelled likely causes; \`additionalContext\` is well-formed JSON
- [x] **Happy path:** repo with a numbered project (\`projects/001-test/ARC-001-REQ-v1.0.md\`) → hook still emits findings as before
- [x] \`node --check\` on the modified file
- [ ] End-to-end in a Claude Code session against the original test repo (deferred — the test repo's report is the bug repro)

## Tracking

Closes #433. Reported by a test-repo run that hit the documented manual-fallback path. With this fix, future occurrences will emit an explicit reason in the model's context instead of looking like a hook misfire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)