### PR TITLE
fix: extend citation traceability to MCP queries and web fetches (#283)

### DIFF
--- a/arckit-claude/references/citation-instructions.md
+++ b/arckit-claude/references/citation-instructions.md
@@ -1,10 +1,22 @@
-# Citation Instructions for External Documents
+# Citation Instructions for Source Material
 
-When ArcKit commands read external documents (from `external/`, `policies/`, `vendors/`), use this citation system to create traceability from generated content back to source material.
+When ArcKit commands gather evidence from source material — files in `external/`, `policies/`, `vendors/`, MCP server queries, or web pages fetched at runtime — use this citation system to create traceability from generated content back to that source material.
 
-## Document Abbreviation Rules
+Three source types are covered:
 
-Derive a short Doc ID from each external filename:
+- **Document** — A file on disk under `external/`, `policies/`, or `vendors/`
+- **MCP Query** — A query sent to an MCP server (e.g., `search_uk_gov_code`, AWS Knowledge `search_documentation`)
+- **Web URL** — A URL fetched at runtime via WebFetch
+
+WebSearch (search-only, no fetch) is exploratory and does not produce citations. Cite a URL only once it has actually been fetched.
+
+The instructions extend the existing `Document Register` / `Citations` / `Unreferenced Documents` template tables — the column names and structure stay the same, but each column's semantics now cover MCP queries and web URLs as well as files. Treat "Doc ID" as the generic Source ID for any source type.
+
+## Source ID Rules
+
+Derive a short Source ID for each piece of source material. The same Source ID is used in the Document Register and in inline citation markers.
+
+### Documents (files)
 
 1. Strip the file extension (`.pdf`, `.docx`, `.xlsx`, etc.)
 2. Strip version numbers (`-v2`, `-v1.0`, `_v3`, etc.)
@@ -13,29 +25,49 @@ Derive a short Doc ID from each external filename:
 
 **Examples:**
 
-| Filename | Doc ID | Derivation |
-|----------|--------|------------|
+| Filename | Source ID | Derivation |
+|----------|-----------|------------|
 | privacy-policy.pdf | PP | **P**rivacy **P**olicy |
 | security-framework-v2.docx | SF | **S**ecurity **F**ramework |
 | data-protection-impact-assessment.pdf | DPIA | **D**ata **P**rotection **I**mpact **A**ssessment |
 | nhs-digital-service-manual.pdf | NDSM | **N**HS **D**igital **S**ervice **M**anual |
 | cloud-hosting-strategy.pdf | CHS | **C**loud **H**osting **S**trategy |
 
-**Collision handling:** If two documents produce the same abbreviation, append a numeric suffix to the second (e.g., `PP`, `PP2`). Alternatively, use more letters from the distinguishing word (e.g., `PRIV` for privacy-policy vs `PROC` for procurement-process).
+### MCP Queries
+
+Use a fixed per-server prefix plus a sequential query index. One Source ID per **unique query** to an MCP server (not per call — if the same query was issued multiple times, it is one citation source).
+
+| MCP Server | Prefix | Example Source ID |
+|------------|--------|-------------------|
+| govreposcrape | GRSC | `GRSC-Q1`, `GRSC-Q2` |
+| AWS Knowledge | AWSK | `AWSK-Q1` |
+| Microsoft Learn | MSL | `MSL-Q1` |
+| Google Developer Knowledge | GDK | `GDK-Q1` |
+| DataCommons | DC | `DC-Q1` |
+
+For MCP servers not listed above, derive a short uppercase prefix from the server name (e.g., `linear-mcp` → `LIN`).
+
+### Web URLs
+
+Use the prefix `WEB` plus a sequential index. One Source ID per **unique URL** fetched (not per call — refetching the same URL is one citation source).
+
+Examples: `WEB-1`, `WEB-2`, `WEB-3`.
+
+**Collision handling:** If two distinct sources collide on a derived ID, append a numeric suffix to the second (e.g., `PP`, `PP2`).
 
 ## Citation ID Format
 
-Each citation uses the format: `[{DOC_ID}-C{N}]`
+Each inline citation uses the format: `[{SOURCE_ID}-C{N}]`
 
-- `DOC_ID` — The document abbreviation from the table above
+- `SOURCE_ID` — The Source ID derived above
 - `C` — Literal "C" for "citation"
-- `N` — Sequential number per document, starting at 1
+- `N` — Sequential number per source, starting at 1
 
-Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`
+Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`, `[GRSC-Q1-C1]`, `[AWSK-Q1-C1]`, `[WEB-1-C1]`.
 
 ## Inline Marker Placement
 
-Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source document. Do not group citations at the end of paragraphs — attach them to the specific claim.
+Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source. Do not group citations at the end of paragraphs — attach them to the specific claim.
 
 **Examples:**
 
@@ -49,6 +81,14 @@ The system must encrypt all personal data at rest using AES-256 [SF-C1] and in t
 
 ```text
 Risk R-005: Non-compliance with data retention policy [PP-C3] could result in ICO enforcement action.
+```
+
+```text
+East Sussex County Council have published `Escc.ActiveDirectory` [WEB-1-C1], a reusable .NET library for AD lookups, identified via govreposcrape search [GRSC-Q1-C1].
+```
+
+```text
+Amazon Bedrock Guardrails support PII redaction across input and output flows [AWSK-Q1-C1].
 ```
 
 ## Category Assignment
@@ -66,61 +106,63 @@ Assign each citation a usage category describing how the source material was use
 - **Stakeholder Need** — Source captures stakeholder goals, concerns, or expectations
 - **Integration Requirement** — Source defines interfaces with external systems
 - **Procurement Constraint** — Source restricts or guides procurement approach
+- **Reuse Evidence** — Source demonstrates an existing implementation that informs build vs reuse analysis
+- **Market Evidence** — Source provides vendor, pricing, or capability data informing options analysis
 
 ## Quoting Rules
 
-For each citation, quote the **specific passage** from the source document that informed the finding:
+For each citation, capture the **specific evidence** from the source that informed the finding:
 
-1. Keep quotes to 1-3 sentences — enough to verify the source, not a full extract
-2. Use double quotes around the passage
-3. Include the page number, section number, or heading if identifiable
-4. If the source is a table or diagram, describe the relevant content rather than quoting verbatim
+1. **Documents and Web URLs** — Quote 1-3 sentences verbatim. Use double quotes. Include page number, section number, or heading if identifiable.
+2. **MCP Queries** — Summarise the result set rather than quoting (e.g., `"3 repos returned: east-sussex-county-council/Escc.ActiveDirectory, hmrc/auth-stub, dwp/identity-verifier"`). For documentation-style MCP responses (AWS Knowledge, Microsoft Learn), quote the salient passage as for documents.
+3. **Tables, diagrams, code blocks** — Describe the relevant content rather than quoting verbatim.
 
 ## External References Section Structure
 
-Populate the `## External References` section in the template with three sub-tables:
+Populate the `## External References` section in the template with three sub-tables. The template ships with these tables already; the rules below describe how to fill them for each source type without changing column structure.
 
 ### Document Register
 
-Lists every external document that was read, whether or not it was cited.
+Lists every source that was consulted (documents, MCP queries, fetched URLs), whether or not it was cited.
 
-| Doc ID | Filename | Type | Source Location | Description |
-|--------|----------|------|-----------------|-------------|
-
-- **Doc ID** — The abbreviation derived using the rules above
-- **Filename** — Original filename as found in the directory
-- **Type** — Document type (e.g., Policy, Standard, Strategy, RFP, Specification, Report, Guidance)
-- **Source Location** — Directory path relative to `projects/` (e.g., `001-project/external/`, `000-global/policies/`)
-- **Description** — Brief description of the document's purpose
+| Column | Documents | MCP Queries | Web URLs |
+|--------|-----------|-------------|----------|
+| **Doc ID** | Source ID derived from filename (e.g., `PP`) | Per-server prefix + query index (e.g., `GRSC-Q1`) | `WEB-N` (e.g., `WEB-1`) |
+| **Filename** | Original filename (e.g., `privacy-policy.pdf`) | MCP tool + query (e.g., `search_uk_gov_code("active directory C#")`) | Full URL (e.g., `https://github.com/east-sussex-county-council/Escc.ActiveDirectory`) |
+| **Type** | Document type (Policy / Standard / RFP / etc.) | `MCP Query` | `Web URL` |
+| **Source Location** | Directory path relative to `projects/` (e.g., `001-project/external/`) | MCP server name (e.g., `govreposcrape`) | Domain (e.g., `github.com`) |
+| **Description** | Brief description of the document's purpose | Result count + brief summary (e.g., `8 repos returned, top 3 relevant`) | Page title or what was being looked up |
 
 ### Citations
 
-Lists every inline citation used in the document body.
+Lists every inline citation used in the document body. Schema unchanged.
 
 | Citation ID | Doc ID | Page/Section | Category | Quoted Passage |
 |-------------|--------|--------------|----------|----------------|
 
-- **Citation ID** — The `[DOC_ID-CN]` marker used inline
+- **Citation ID** — The `[SOURCE_ID-CN]` marker used inline
 - **Doc ID** — Cross-reference to the Document Register
-- **Page/Section** — Page number, section number, or heading where the passage was found. Use "—" if not identifiable
+- **Page/Section** — Page number, section number, heading, or MCP result index where the evidence was found. Use "—" if not applicable.
 - **Category** — One of the categories listed above
-- **Quoted Passage** — The specific passage that informed the finding
+- **Quoted Passage** — The verbatim quote (documents, web pages, doc-style MCP responses) or result summary (search-style MCP responses)
 
 ### Unreferenced Documents
 
-Lists external documents that were read but did not contribute to this artifact. This demonstrates that all input documents were reviewed.
+Lists sources that were consulted but did not contribute to this artifact. Demonstrates that all retrieved material was reviewed. Now also covers MCP queries that returned nothing useful and fetched URLs that proved off-topic.
 
 | Filename | Source Location | Reason |
 |----------|-----------------|--------|
 
-- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Covers operational procedures outside scope of this artifact")
+- **Filename** — Filename, MCP query, or URL (mirroring the Document Register's Filename column)
+- **Source Location** — Directory path, MCP server name, or domain
+- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Returned no results", "Covers operational procedures outside scope of this artifact")
 
-### When No External Documents Exist
+### When No Source Material Was Consulted
 
-If no external documents were provided or found, retain the placeholder row in the Document Register:
+If no documents, MCP queries, or web fetches were used, retain the placeholder row in the Document Register:
 
 | Doc ID | Filename | Type | Source Location | Description |
 |--------|----------|------|-----------------|-------------|
-| *None provided* | — | — | — | — |
+| *None consulted* | — | — | — | — |
 
 Omit the Citations and Unreferenced Documents sub-tables.

--- a/arckit-codex/references/citation-instructions.md
+++ b/arckit-codex/references/citation-instructions.md
@@ -1,10 +1,22 @@
-# Citation Instructions for External Documents
+# Citation Instructions for Source Material
 
-When ArcKit commands read external documents (from `external/`, `policies/`, `vendors/`), use this citation system to create traceability from generated content back to source material.
+When ArcKit commands gather evidence from source material — files in `external/`, `policies/`, `vendors/`, MCP server queries, or web pages fetched at runtime — use this citation system to create traceability from generated content back to that source material.
 
-## Document Abbreviation Rules
+Three source types are covered:
 
-Derive a short Doc ID from each external filename:
+- **Document** — A file on disk under `external/`, `policies/`, or `vendors/`
+- **MCP Query** — A query sent to an MCP server (e.g., `search_uk_gov_code`, AWS Knowledge `search_documentation`)
+- **Web URL** — A URL fetched at runtime via WebFetch
+
+WebSearch (search-only, no fetch) is exploratory and does not produce citations. Cite a URL only once it has actually been fetched.
+
+The instructions extend the existing `Document Register` / `Citations` / `Unreferenced Documents` template tables — the column names and structure stay the same, but each column's semantics now cover MCP queries and web URLs as well as files. Treat "Doc ID" as the generic Source ID for any source type.
+
+## Source ID Rules
+
+Derive a short Source ID for each piece of source material. The same Source ID is used in the Document Register and in inline citation markers.
+
+### Documents (files)
 
 1. Strip the file extension (`.pdf`, `.docx`, `.xlsx`, etc.)
 2. Strip version numbers (`-v2`, `-v1.0`, `_v3`, etc.)
@@ -13,29 +25,49 @@ Derive a short Doc ID from each external filename:
 
 **Examples:**
 
-| Filename | Doc ID | Derivation |
-|----------|--------|------------|
+| Filename | Source ID | Derivation |
+|----------|-----------|------------|
 | privacy-policy.pdf | PP | **P**rivacy **P**olicy |
 | security-framework-v2.docx | SF | **S**ecurity **F**ramework |
 | data-protection-impact-assessment.pdf | DPIA | **D**ata **P**rotection **I**mpact **A**ssessment |
 | nhs-digital-service-manual.pdf | NDSM | **N**HS **D**igital **S**ervice **M**anual |
 | cloud-hosting-strategy.pdf | CHS | **C**loud **H**osting **S**trategy |
 
-**Collision handling:** If two documents produce the same abbreviation, append a numeric suffix to the second (e.g., `PP`, `PP2`). Alternatively, use more letters from the distinguishing word (e.g., `PRIV` for privacy-policy vs `PROC` for procurement-process).
+### MCP Queries
+
+Use a fixed per-server prefix plus a sequential query index. One Source ID per **unique query** to an MCP server (not per call — if the same query was issued multiple times, it is one citation source).
+
+| MCP Server | Prefix | Example Source ID |
+|------------|--------|-------------------|
+| govreposcrape | GRSC | `GRSC-Q1`, `GRSC-Q2` |
+| AWS Knowledge | AWSK | `AWSK-Q1` |
+| Microsoft Learn | MSL | `MSL-Q1` |
+| Google Developer Knowledge | GDK | `GDK-Q1` |
+| DataCommons | DC | `DC-Q1` |
+
+For MCP servers not listed above, derive a short uppercase prefix from the server name (e.g., `linear-mcp` → `LIN`).
+
+### Web URLs
+
+Use the prefix `WEB` plus a sequential index. One Source ID per **unique URL** fetched (not per call — refetching the same URL is one citation source).
+
+Examples: `WEB-1`, `WEB-2`, `WEB-3`.
+
+**Collision handling:** If two distinct sources collide on a derived ID, append a numeric suffix to the second (e.g., `PP`, `PP2`).
 
 ## Citation ID Format
 
-Each citation uses the format: `[{DOC_ID}-C{N}]`
+Each inline citation uses the format: `[{SOURCE_ID}-C{N}]`
 
-- `DOC_ID` — The document abbreviation from the table above
+- `SOURCE_ID` — The Source ID derived above
 - `C` — Literal "C" for "citation"
-- `N` — Sequential number per document, starting at 1
+- `N` — Sequential number per source, starting at 1
 
-Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`
+Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`, `[GRSC-Q1-C1]`, `[AWSK-Q1-C1]`, `[WEB-1-C1]`.
 
 ## Inline Marker Placement
 
-Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source document. Do not group citations at the end of paragraphs — attach them to the specific claim.
+Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source. Do not group citations at the end of paragraphs — attach them to the specific claim.
 
 **Examples:**
 
@@ -49,6 +81,14 @@ The system must encrypt all personal data at rest using AES-256 [SF-C1] and in t
 
 ```text
 Risk R-005: Non-compliance with data retention policy [PP-C3] could result in ICO enforcement action.
+```
+
+```text
+East Sussex County Council have published `Escc.ActiveDirectory` [WEB-1-C1], a reusable .NET library for AD lookups, identified via govreposcrape search [GRSC-Q1-C1].
+```
+
+```text
+Amazon Bedrock Guardrails support PII redaction across input and output flows [AWSK-Q1-C1].
 ```
 
 ## Category Assignment
@@ -66,61 +106,63 @@ Assign each citation a usage category describing how the source material was use
 - **Stakeholder Need** — Source captures stakeholder goals, concerns, or expectations
 - **Integration Requirement** — Source defines interfaces with external systems
 - **Procurement Constraint** — Source restricts or guides procurement approach
+- **Reuse Evidence** — Source demonstrates an existing implementation that informs build vs reuse analysis
+- **Market Evidence** — Source provides vendor, pricing, or capability data informing options analysis
 
 ## Quoting Rules
 
-For each citation, quote the **specific passage** from the source document that informed the finding:
+For each citation, capture the **specific evidence** from the source that informed the finding:
 
-1. Keep quotes to 1-3 sentences — enough to verify the source, not a full extract
-2. Use double quotes around the passage
-3. Include the page number, section number, or heading if identifiable
-4. If the source is a table or diagram, describe the relevant content rather than quoting verbatim
+1. **Documents and Web URLs** — Quote 1-3 sentences verbatim. Use double quotes. Include page number, section number, or heading if identifiable.
+2. **MCP Queries** — Summarise the result set rather than quoting (e.g., `"3 repos returned: east-sussex-county-council/Escc.ActiveDirectory, hmrc/auth-stub, dwp/identity-verifier"`). For documentation-style MCP responses (AWS Knowledge, Microsoft Learn), quote the salient passage as for documents.
+3. **Tables, diagrams, code blocks** — Describe the relevant content rather than quoting verbatim.
 
 ## External References Section Structure
 
-Populate the `## External References` section in the template with three sub-tables:
+Populate the `## External References` section in the template with three sub-tables. The template ships with these tables already; the rules below describe how to fill them for each source type without changing column structure.
 
 ### Document Register
 
-Lists every external document that was read, whether or not it was cited.
+Lists every source that was consulted (documents, MCP queries, fetched URLs), whether or not it was cited.
 
-| Doc ID | Filename | Type | Source Location | Description |
-|--------|----------|------|-----------------|-------------|
-
-- **Doc ID** — The abbreviation derived using the rules above
-- **Filename** — Original filename as found in the directory
-- **Type** — Document type (e.g., Policy, Standard, Strategy, RFP, Specification, Report, Guidance)
-- **Source Location** — Directory path relative to `projects/` (e.g., `001-project/external/`, `000-global/policies/`)
-- **Description** — Brief description of the document's purpose
+| Column | Documents | MCP Queries | Web URLs |
+|--------|-----------|-------------|----------|
+| **Doc ID** | Source ID derived from filename (e.g., `PP`) | Per-server prefix + query index (e.g., `GRSC-Q1`) | `WEB-N` (e.g., `WEB-1`) |
+| **Filename** | Original filename (e.g., `privacy-policy.pdf`) | MCP tool + query (e.g., `search_uk_gov_code("active directory C#")`) | Full URL (e.g., `https://github.com/east-sussex-county-council/Escc.ActiveDirectory`) |
+| **Type** | Document type (Policy / Standard / RFP / etc.) | `MCP Query` | `Web URL` |
+| **Source Location** | Directory path relative to `projects/` (e.g., `001-project/external/`) | MCP server name (e.g., `govreposcrape`) | Domain (e.g., `github.com`) |
+| **Description** | Brief description of the document's purpose | Result count + brief summary (e.g., `8 repos returned, top 3 relevant`) | Page title or what was being looked up |
 
 ### Citations
 
-Lists every inline citation used in the document body.
+Lists every inline citation used in the document body. Schema unchanged.
 
 | Citation ID | Doc ID | Page/Section | Category | Quoted Passage |
 |-------------|--------|--------------|----------|----------------|
 
-- **Citation ID** — The `[DOC_ID-CN]` marker used inline
+- **Citation ID** — The `[SOURCE_ID-CN]` marker used inline
 - **Doc ID** — Cross-reference to the Document Register
-- **Page/Section** — Page number, section number, or heading where the passage was found. Use "—" if not identifiable
+- **Page/Section** — Page number, section number, heading, or MCP result index where the evidence was found. Use "—" if not applicable.
 - **Category** — One of the categories listed above
-- **Quoted Passage** — The specific passage that informed the finding
+- **Quoted Passage** — The verbatim quote (documents, web pages, doc-style MCP responses) or result summary (search-style MCP responses)
 
 ### Unreferenced Documents
 
-Lists external documents that were read but did not contribute to this artifact. This demonstrates that all input documents were reviewed.
+Lists sources that were consulted but did not contribute to this artifact. Demonstrates that all retrieved material was reviewed. Now also covers MCP queries that returned nothing useful and fetched URLs that proved off-topic.
 
 | Filename | Source Location | Reason |
 |----------|-----------------|--------|
 
-- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Covers operational procedures outside scope of this artifact")
+- **Filename** — Filename, MCP query, or URL (mirroring the Document Register's Filename column)
+- **Source Location** — Directory path, MCP server name, or domain
+- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Returned no results", "Covers operational procedures outside scope of this artifact")
 
-### When No External Documents Exist
+### When No Source Material Was Consulted
 
-If no external documents were provided or found, retain the placeholder row in the Document Register:
+If no documents, MCP queries, or web fetches were used, retain the placeholder row in the Document Register:
 
 | Doc ID | Filename | Type | Source Location | Description |
 |--------|----------|------|-----------------|-------------|
-| *None provided* | — | — | — | — |
+| *None consulted* | — | — | — | — |
 
 Omit the Citations and Unreferenced Documents sub-tables.

--- a/arckit-copilot/references/citation-instructions.md
+++ b/arckit-copilot/references/citation-instructions.md
@@ -1,10 +1,22 @@
-# Citation Instructions for External Documents
+# Citation Instructions for Source Material
 
-When ArcKit commands read external documents (from `external/`, `policies/`, `vendors/`), use this citation system to create traceability from generated content back to source material.
+When ArcKit commands gather evidence from source material — files in `external/`, `policies/`, `vendors/`, MCP server queries, or web pages fetched at runtime — use this citation system to create traceability from generated content back to that source material.
 
-## Document Abbreviation Rules
+Three source types are covered:
 
-Derive a short Doc ID from each external filename:
+- **Document** — A file on disk under `external/`, `policies/`, or `vendors/`
+- **MCP Query** — A query sent to an MCP server (e.g., `search_uk_gov_code`, AWS Knowledge `search_documentation`)
+- **Web URL** — A URL fetched at runtime via WebFetch
+
+WebSearch (search-only, no fetch) is exploratory and does not produce citations. Cite a URL only once it has actually been fetched.
+
+The instructions extend the existing `Document Register` / `Citations` / `Unreferenced Documents` template tables — the column names and structure stay the same, but each column's semantics now cover MCP queries and web URLs as well as files. Treat "Doc ID" as the generic Source ID for any source type.
+
+## Source ID Rules
+
+Derive a short Source ID for each piece of source material. The same Source ID is used in the Document Register and in inline citation markers.
+
+### Documents (files)
 
 1. Strip the file extension (`.pdf`, `.docx`, `.xlsx`, etc.)
 2. Strip version numbers (`-v2`, `-v1.0`, `_v3`, etc.)
@@ -13,29 +25,49 @@ Derive a short Doc ID from each external filename:
 
 **Examples:**
 
-| Filename | Doc ID | Derivation |
-|----------|--------|------------|
+| Filename | Source ID | Derivation |
+|----------|-----------|------------|
 | privacy-policy.pdf | PP | **P**rivacy **P**olicy |
 | security-framework-v2.docx | SF | **S**ecurity **F**ramework |
 | data-protection-impact-assessment.pdf | DPIA | **D**ata **P**rotection **I**mpact **A**ssessment |
 | nhs-digital-service-manual.pdf | NDSM | **N**HS **D**igital **S**ervice **M**anual |
 | cloud-hosting-strategy.pdf | CHS | **C**loud **H**osting **S**trategy |
 
-**Collision handling:** If two documents produce the same abbreviation, append a numeric suffix to the second (e.g., `PP`, `PP2`). Alternatively, use more letters from the distinguishing word (e.g., `PRIV` for privacy-policy vs `PROC` for procurement-process).
+### MCP Queries
+
+Use a fixed per-server prefix plus a sequential query index. One Source ID per **unique query** to an MCP server (not per call — if the same query was issued multiple times, it is one citation source).
+
+| MCP Server | Prefix | Example Source ID |
+|------------|--------|-------------------|
+| govreposcrape | GRSC | `GRSC-Q1`, `GRSC-Q2` |
+| AWS Knowledge | AWSK | `AWSK-Q1` |
+| Microsoft Learn | MSL | `MSL-Q1` |
+| Google Developer Knowledge | GDK | `GDK-Q1` |
+| DataCommons | DC | `DC-Q1` |
+
+For MCP servers not listed above, derive a short uppercase prefix from the server name (e.g., `linear-mcp` → `LIN`).
+
+### Web URLs
+
+Use the prefix `WEB` plus a sequential index. One Source ID per **unique URL** fetched (not per call — refetching the same URL is one citation source).
+
+Examples: `WEB-1`, `WEB-2`, `WEB-3`.
+
+**Collision handling:** If two distinct sources collide on a derived ID, append a numeric suffix to the second (e.g., `PP`, `PP2`).
 
 ## Citation ID Format
 
-Each citation uses the format: `[{DOC_ID}-C{N}]`
+Each inline citation uses the format: `[{SOURCE_ID}-C{N}]`
 
-- `DOC_ID` — The document abbreviation from the table above
+- `SOURCE_ID` — The Source ID derived above
 - `C` — Literal "C" for "citation"
-- `N` — Sequential number per document, starting at 1
+- `N` — Sequential number per source, starting at 1
 
-Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`
+Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`, `[GRSC-Q1-C1]`, `[AWSK-Q1-C1]`, `[WEB-1-C1]`.
 
 ## Inline Marker Placement
 
-Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source document. Do not group citations at the end of paragraphs — attach them to the specific claim.
+Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source. Do not group citations at the end of paragraphs — attach them to the specific claim.
 
 **Examples:**
 
@@ -49,6 +81,14 @@ The system must encrypt all personal data at rest using AES-256 [SF-C1] and in t
 
 ```text
 Risk R-005: Non-compliance with data retention policy [PP-C3] could result in ICO enforcement action.
+```
+
+```text
+East Sussex County Council have published `Escc.ActiveDirectory` [WEB-1-C1], a reusable .NET library for AD lookups, identified via govreposcrape search [GRSC-Q1-C1].
+```
+
+```text
+Amazon Bedrock Guardrails support PII redaction across input and output flows [AWSK-Q1-C1].
 ```
 
 ## Category Assignment
@@ -66,61 +106,63 @@ Assign each citation a usage category describing how the source material was use
 - **Stakeholder Need** — Source captures stakeholder goals, concerns, or expectations
 - **Integration Requirement** — Source defines interfaces with external systems
 - **Procurement Constraint** — Source restricts or guides procurement approach
+- **Reuse Evidence** — Source demonstrates an existing implementation that informs build vs reuse analysis
+- **Market Evidence** — Source provides vendor, pricing, or capability data informing options analysis
 
 ## Quoting Rules
 
-For each citation, quote the **specific passage** from the source document that informed the finding:
+For each citation, capture the **specific evidence** from the source that informed the finding:
 
-1. Keep quotes to 1-3 sentences — enough to verify the source, not a full extract
-2. Use double quotes around the passage
-3. Include the page number, section number, or heading if identifiable
-4. If the source is a table or diagram, describe the relevant content rather than quoting verbatim
+1. **Documents and Web URLs** — Quote 1-3 sentences verbatim. Use double quotes. Include page number, section number, or heading if identifiable.
+2. **MCP Queries** — Summarise the result set rather than quoting (e.g., `"3 repos returned: east-sussex-county-council/Escc.ActiveDirectory, hmrc/auth-stub, dwp/identity-verifier"`). For documentation-style MCP responses (AWS Knowledge, Microsoft Learn), quote the salient passage as for documents.
+3. **Tables, diagrams, code blocks** — Describe the relevant content rather than quoting verbatim.
 
 ## External References Section Structure
 
-Populate the `## External References` section in the template with three sub-tables:
+Populate the `## External References` section in the template with three sub-tables. The template ships with these tables already; the rules below describe how to fill them for each source type without changing column structure.
 
 ### Document Register
 
-Lists every external document that was read, whether or not it was cited.
+Lists every source that was consulted (documents, MCP queries, fetched URLs), whether or not it was cited.
 
-| Doc ID | Filename | Type | Source Location | Description |
-|--------|----------|------|-----------------|-------------|
-
-- **Doc ID** — The abbreviation derived using the rules above
-- **Filename** — Original filename as found in the directory
-- **Type** — Document type (e.g., Policy, Standard, Strategy, RFP, Specification, Report, Guidance)
-- **Source Location** — Directory path relative to `projects/` (e.g., `001-project/external/`, `000-global/policies/`)
-- **Description** — Brief description of the document's purpose
+| Column | Documents | MCP Queries | Web URLs |
+|--------|-----------|-------------|----------|
+| **Doc ID** | Source ID derived from filename (e.g., `PP`) | Per-server prefix + query index (e.g., `GRSC-Q1`) | `WEB-N` (e.g., `WEB-1`) |
+| **Filename** | Original filename (e.g., `privacy-policy.pdf`) | MCP tool + query (e.g., `search_uk_gov_code("active directory C#")`) | Full URL (e.g., `https://github.com/east-sussex-county-council/Escc.ActiveDirectory`) |
+| **Type** | Document type (Policy / Standard / RFP / etc.) | `MCP Query` | `Web URL` |
+| **Source Location** | Directory path relative to `projects/` (e.g., `001-project/external/`) | MCP server name (e.g., `govreposcrape`) | Domain (e.g., `github.com`) |
+| **Description** | Brief description of the document's purpose | Result count + brief summary (e.g., `8 repos returned, top 3 relevant`) | Page title or what was being looked up |
 
 ### Citations
 
-Lists every inline citation used in the document body.
+Lists every inline citation used in the document body. Schema unchanged.
 
 | Citation ID | Doc ID | Page/Section | Category | Quoted Passage |
 |-------------|--------|--------------|----------|----------------|
 
-- **Citation ID** — The `[DOC_ID-CN]` marker used inline
+- **Citation ID** — The `[SOURCE_ID-CN]` marker used inline
 - **Doc ID** — Cross-reference to the Document Register
-- **Page/Section** — Page number, section number, or heading where the passage was found. Use "—" if not identifiable
+- **Page/Section** — Page number, section number, heading, or MCP result index where the evidence was found. Use "—" if not applicable.
 - **Category** — One of the categories listed above
-- **Quoted Passage** — The specific passage that informed the finding
+- **Quoted Passage** — The verbatim quote (documents, web pages, doc-style MCP responses) or result summary (search-style MCP responses)
 
 ### Unreferenced Documents
 
-Lists external documents that were read but did not contribute to this artifact. This demonstrates that all input documents were reviewed.
+Lists sources that were consulted but did not contribute to this artifact. Demonstrates that all retrieved material was reviewed. Now also covers MCP queries that returned nothing useful and fetched URLs that proved off-topic.
 
 | Filename | Source Location | Reason |
 |----------|-----------------|--------|
 
-- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Covers operational procedures outside scope of this artifact")
+- **Filename** — Filename, MCP query, or URL (mirroring the Document Register's Filename column)
+- **Source Location** — Directory path, MCP server name, or domain
+- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Returned no results", "Covers operational procedures outside scope of this artifact")
 
-### When No External Documents Exist
+### When No Source Material Was Consulted
 
-If no external documents were provided or found, retain the placeholder row in the Document Register:
+If no documents, MCP queries, or web fetches were used, retain the placeholder row in the Document Register:
 
 | Doc ID | Filename | Type | Source Location | Description |
 |--------|----------|------|-----------------|-------------|
-| *None provided* | — | — | — | — |
+| *None consulted* | — | — | — | — |
 
 Omit the Citations and Unreferenced Documents sub-tables.

--- a/arckit-gemini/references/citation-instructions.md
+++ b/arckit-gemini/references/citation-instructions.md
@@ -1,10 +1,22 @@
-# Citation Instructions for External Documents
+# Citation Instructions for Source Material
 
-When ArcKit commands read external documents (from `external/`, `policies/`, `vendors/`), use this citation system to create traceability from generated content back to source material.
+When ArcKit commands gather evidence from source material — files in `external/`, `policies/`, `vendors/`, MCP server queries, or web pages fetched at runtime — use this citation system to create traceability from generated content back to that source material.
 
-## Document Abbreviation Rules
+Three source types are covered:
 
-Derive a short Doc ID from each external filename:
+- **Document** — A file on disk under `external/`, `policies/`, or `vendors/`
+- **MCP Query** — A query sent to an MCP server (e.g., `search_uk_gov_code`, AWS Knowledge `search_documentation`)
+- **Web URL** — A URL fetched at runtime via WebFetch
+
+WebSearch (search-only, no fetch) is exploratory and does not produce citations. Cite a URL only once it has actually been fetched.
+
+The instructions extend the existing `Document Register` / `Citations` / `Unreferenced Documents` template tables — the column names and structure stay the same, but each column's semantics now cover MCP queries and web URLs as well as files. Treat "Doc ID" as the generic Source ID for any source type.
+
+## Source ID Rules
+
+Derive a short Source ID for each piece of source material. The same Source ID is used in the Document Register and in inline citation markers.
+
+### Documents (files)
 
 1. Strip the file extension (`.pdf`, `.docx`, `.xlsx`, etc.)
 2. Strip version numbers (`-v2`, `-v1.0`, `_v3`, etc.)
@@ -13,29 +25,49 @@ Derive a short Doc ID from each external filename:
 
 **Examples:**
 
-| Filename | Doc ID | Derivation |
-|----------|--------|------------|
+| Filename | Source ID | Derivation |
+|----------|-----------|------------|
 | privacy-policy.pdf | PP | **P**rivacy **P**olicy |
 | security-framework-v2.docx | SF | **S**ecurity **F**ramework |
 | data-protection-impact-assessment.pdf | DPIA | **D**ata **P**rotection **I**mpact **A**ssessment |
 | nhs-digital-service-manual.pdf | NDSM | **N**HS **D**igital **S**ervice **M**anual |
 | cloud-hosting-strategy.pdf | CHS | **C**loud **H**osting **S**trategy |
 
-**Collision handling:** If two documents produce the same abbreviation, append a numeric suffix to the second (e.g., `PP`, `PP2`). Alternatively, use more letters from the distinguishing word (e.g., `PRIV` for privacy-policy vs `PROC` for procurement-process).
+### MCP Queries
+
+Use a fixed per-server prefix plus a sequential query index. One Source ID per **unique query** to an MCP server (not per call — if the same query was issued multiple times, it is one citation source).
+
+| MCP Server | Prefix | Example Source ID |
+|------------|--------|-------------------|
+| govreposcrape | GRSC | `GRSC-Q1`, `GRSC-Q2` |
+| AWS Knowledge | AWSK | `AWSK-Q1` |
+| Microsoft Learn | MSL | `MSL-Q1` |
+| Google Developer Knowledge | GDK | `GDK-Q1` |
+| DataCommons | DC | `DC-Q1` |
+
+For MCP servers not listed above, derive a short uppercase prefix from the server name (e.g., `linear-mcp` → `LIN`).
+
+### Web URLs
+
+Use the prefix `WEB` plus a sequential index. One Source ID per **unique URL** fetched (not per call — refetching the same URL is one citation source).
+
+Examples: `WEB-1`, `WEB-2`, `WEB-3`.
+
+**Collision handling:** If two distinct sources collide on a derived ID, append a numeric suffix to the second (e.g., `PP`, `PP2`).
 
 ## Citation ID Format
 
-Each citation uses the format: `[{DOC_ID}-C{N}]`
+Each inline citation uses the format: `[{SOURCE_ID}-C{N}]`
 
-- `DOC_ID` — The document abbreviation from the table above
+- `SOURCE_ID` — The Source ID derived above
 - `C` — Literal "C" for "citation"
-- `N` — Sequential number per document, starting at 1
+- `N` — Sequential number per source, starting at 1
 
-Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`
+Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`, `[GRSC-Q1-C1]`, `[AWSK-Q1-C1]`, `[WEB-1-C1]`.
 
 ## Inline Marker Placement
 
-Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source document. Do not group citations at the end of paragraphs — attach them to the specific claim.
+Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source. Do not group citations at the end of paragraphs — attach them to the specific claim.
 
 **Examples:**
 
@@ -49,6 +81,14 @@ The system must encrypt all personal data at rest using AES-256 [SF-C1] and in t
 
 ```text
 Risk R-005: Non-compliance with data retention policy [PP-C3] could result in ICO enforcement action.
+```
+
+```text
+East Sussex County Council have published `Escc.ActiveDirectory` [WEB-1-C1], a reusable .NET library for AD lookups, identified via govreposcrape search [GRSC-Q1-C1].
+```
+
+```text
+Amazon Bedrock Guardrails support PII redaction across input and output flows [AWSK-Q1-C1].
 ```
 
 ## Category Assignment
@@ -66,61 +106,63 @@ Assign each citation a usage category describing how the source material was use
 - **Stakeholder Need** — Source captures stakeholder goals, concerns, or expectations
 - **Integration Requirement** — Source defines interfaces with external systems
 - **Procurement Constraint** — Source restricts or guides procurement approach
+- **Reuse Evidence** — Source demonstrates an existing implementation that informs build vs reuse analysis
+- **Market Evidence** — Source provides vendor, pricing, or capability data informing options analysis
 
 ## Quoting Rules
 
-For each citation, quote the **specific passage** from the source document that informed the finding:
+For each citation, capture the **specific evidence** from the source that informed the finding:
 
-1. Keep quotes to 1-3 sentences — enough to verify the source, not a full extract
-2. Use double quotes around the passage
-3. Include the page number, section number, or heading if identifiable
-4. If the source is a table or diagram, describe the relevant content rather than quoting verbatim
+1. **Documents and Web URLs** — Quote 1-3 sentences verbatim. Use double quotes. Include page number, section number, or heading if identifiable.
+2. **MCP Queries** — Summarise the result set rather than quoting (e.g., `"3 repos returned: east-sussex-county-council/Escc.ActiveDirectory, hmrc/auth-stub, dwp/identity-verifier"`). For documentation-style MCP responses (AWS Knowledge, Microsoft Learn), quote the salient passage as for documents.
+3. **Tables, diagrams, code blocks** — Describe the relevant content rather than quoting verbatim.
 
 ## External References Section Structure
 
-Populate the `## External References` section in the template with three sub-tables:
+Populate the `## External References` section in the template with three sub-tables. The template ships with these tables already; the rules below describe how to fill them for each source type without changing column structure.
 
 ### Document Register
 
-Lists every external document that was read, whether or not it was cited.
+Lists every source that was consulted (documents, MCP queries, fetched URLs), whether or not it was cited.
 
-| Doc ID | Filename | Type | Source Location | Description |
-|--------|----------|------|-----------------|-------------|
-
-- **Doc ID** — The abbreviation derived using the rules above
-- **Filename** — Original filename as found in the directory
-- **Type** — Document type (e.g., Policy, Standard, Strategy, RFP, Specification, Report, Guidance)
-- **Source Location** — Directory path relative to `projects/` (e.g., `001-project/external/`, `000-global/policies/`)
-- **Description** — Brief description of the document's purpose
+| Column | Documents | MCP Queries | Web URLs |
+|--------|-----------|-------------|----------|
+| **Doc ID** | Source ID derived from filename (e.g., `PP`) | Per-server prefix + query index (e.g., `GRSC-Q1`) | `WEB-N` (e.g., `WEB-1`) |
+| **Filename** | Original filename (e.g., `privacy-policy.pdf`) | MCP tool + query (e.g., `search_uk_gov_code("active directory C#")`) | Full URL (e.g., `https://github.com/east-sussex-county-council/Escc.ActiveDirectory`) |
+| **Type** | Document type (Policy / Standard / RFP / etc.) | `MCP Query` | `Web URL` |
+| **Source Location** | Directory path relative to `projects/` (e.g., `001-project/external/`) | MCP server name (e.g., `govreposcrape`) | Domain (e.g., `github.com`) |
+| **Description** | Brief description of the document's purpose | Result count + brief summary (e.g., `8 repos returned, top 3 relevant`) | Page title or what was being looked up |
 
 ### Citations
 
-Lists every inline citation used in the document body.
+Lists every inline citation used in the document body. Schema unchanged.
 
 | Citation ID | Doc ID | Page/Section | Category | Quoted Passage |
 |-------------|--------|--------------|----------|----------------|
 
-- **Citation ID** — The `[DOC_ID-CN]` marker used inline
+- **Citation ID** — The `[SOURCE_ID-CN]` marker used inline
 - **Doc ID** — Cross-reference to the Document Register
-- **Page/Section** — Page number, section number, or heading where the passage was found. Use "—" if not identifiable
+- **Page/Section** — Page number, section number, heading, or MCP result index where the evidence was found. Use "—" if not applicable.
 - **Category** — One of the categories listed above
-- **Quoted Passage** — The specific passage that informed the finding
+- **Quoted Passage** — The verbatim quote (documents, web pages, doc-style MCP responses) or result summary (search-style MCP responses)
 
 ### Unreferenced Documents
 
-Lists external documents that were read but did not contribute to this artifact. This demonstrates that all input documents were reviewed.
+Lists sources that were consulted but did not contribute to this artifact. Demonstrates that all retrieved material was reviewed. Now also covers MCP queries that returned nothing useful and fetched URLs that proved off-topic.
 
 | Filename | Source Location | Reason |
 |----------|-----------------|--------|
 
-- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Covers operational procedures outside scope of this artifact")
+- **Filename** — Filename, MCP query, or URL (mirroring the Document Register's Filename column)
+- **Source Location** — Directory path, MCP server name, or domain
+- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Returned no results", "Covers operational procedures outside scope of this artifact")
 
-### When No External Documents Exist
+### When No Source Material Was Consulted
 
-If no external documents were provided or found, retain the placeholder row in the Document Register:
+If no documents, MCP queries, or web fetches were used, retain the placeholder row in the Document Register:
 
 | Doc ID | Filename | Type | Source Location | Description |
 |--------|----------|------|-----------------|-------------|
-| *None provided* | — | — | — | — |
+| *None consulted* | — | — | — | — |
 
 Omit the Citations and Unreferenced Documents sub-tables.

--- a/arckit-opencode/references/citation-instructions.md
+++ b/arckit-opencode/references/citation-instructions.md
@@ -1,10 +1,22 @@
-# Citation Instructions for External Documents
+# Citation Instructions for Source Material
 
-When ArcKit commands read external documents (from `external/`, `policies/`, `vendors/`), use this citation system to create traceability from generated content back to source material.
+When ArcKit commands gather evidence from source material — files in `external/`, `policies/`, `vendors/`, MCP server queries, or web pages fetched at runtime — use this citation system to create traceability from generated content back to that source material.
 
-## Document Abbreviation Rules
+Three source types are covered:
 
-Derive a short Doc ID from each external filename:
+- **Document** — A file on disk under `external/`, `policies/`, or `vendors/`
+- **MCP Query** — A query sent to an MCP server (e.g., `search_uk_gov_code`, AWS Knowledge `search_documentation`)
+- **Web URL** — A URL fetched at runtime via WebFetch
+
+WebSearch (search-only, no fetch) is exploratory and does not produce citations. Cite a URL only once it has actually been fetched.
+
+The instructions extend the existing `Document Register` / `Citations` / `Unreferenced Documents` template tables — the column names and structure stay the same, but each column's semantics now cover MCP queries and web URLs as well as files. Treat "Doc ID" as the generic Source ID for any source type.
+
+## Source ID Rules
+
+Derive a short Source ID for each piece of source material. The same Source ID is used in the Document Register and in inline citation markers.
+
+### Documents (files)
 
 1. Strip the file extension (`.pdf`, `.docx`, `.xlsx`, etc.)
 2. Strip version numbers (`-v2`, `-v1.0`, `_v3`, etc.)
@@ -13,29 +25,49 @@ Derive a short Doc ID from each external filename:
 
 **Examples:**
 
-| Filename | Doc ID | Derivation |
-|----------|--------|------------|
+| Filename | Source ID | Derivation |
+|----------|-----------|------------|
 | privacy-policy.pdf | PP | **P**rivacy **P**olicy |
 | security-framework-v2.docx | SF | **S**ecurity **F**ramework |
 | data-protection-impact-assessment.pdf | DPIA | **D**ata **P**rotection **I**mpact **A**ssessment |
 | nhs-digital-service-manual.pdf | NDSM | **N**HS **D**igital **S**ervice **M**anual |
 | cloud-hosting-strategy.pdf | CHS | **C**loud **H**osting **S**trategy |
 
-**Collision handling:** If two documents produce the same abbreviation, append a numeric suffix to the second (e.g., `PP`, `PP2`). Alternatively, use more letters from the distinguishing word (e.g., `PRIV` for privacy-policy vs `PROC` for procurement-process).
+### MCP Queries
+
+Use a fixed per-server prefix plus a sequential query index. One Source ID per **unique query** to an MCP server (not per call — if the same query was issued multiple times, it is one citation source).
+
+| MCP Server | Prefix | Example Source ID |
+|------------|--------|-------------------|
+| govreposcrape | GRSC | `GRSC-Q1`, `GRSC-Q2` |
+| AWS Knowledge | AWSK | `AWSK-Q1` |
+| Microsoft Learn | MSL | `MSL-Q1` |
+| Google Developer Knowledge | GDK | `GDK-Q1` |
+| DataCommons | DC | `DC-Q1` |
+
+For MCP servers not listed above, derive a short uppercase prefix from the server name (e.g., `linear-mcp` → `LIN`).
+
+### Web URLs
+
+Use the prefix `WEB` plus a sequential index. One Source ID per **unique URL** fetched (not per call — refetching the same URL is one citation source).
+
+Examples: `WEB-1`, `WEB-2`, `WEB-3`.
+
+**Collision handling:** If two distinct sources collide on a derived ID, append a numeric suffix to the second (e.g., `PP`, `PP2`).
 
 ## Citation ID Format
 
-Each citation uses the format: `[{DOC_ID}-C{N}]`
+Each inline citation uses the format: `[{SOURCE_ID}-C{N}]`
 
-- `DOC_ID` — The document abbreviation from the table above
+- `SOURCE_ID` — The Source ID derived above
 - `C` — Literal "C" for "citation"
-- `N` — Sequential number per document, starting at 1
+- `N` — Sequential number per source, starting at 1
 
-Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`
+Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`, `[GRSC-Q1-C1]`, `[AWSK-Q1-C1]`, `[WEB-1-C1]`.
 
 ## Inline Marker Placement
 
-Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source document. Do not group citations at the end of paragraphs — attach them to the specific claim.
+Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source. Do not group citations at the end of paragraphs — attach them to the specific claim.
 
 **Examples:**
 
@@ -49,6 +81,14 @@ The system must encrypt all personal data at rest using AES-256 [SF-C1] and in t
 
 ```text
 Risk R-005: Non-compliance with data retention policy [PP-C3] could result in ICO enforcement action.
+```
+
+```text
+East Sussex County Council have published `Escc.ActiveDirectory` [WEB-1-C1], a reusable .NET library for AD lookups, identified via govreposcrape search [GRSC-Q1-C1].
+```
+
+```text
+Amazon Bedrock Guardrails support PII redaction across input and output flows [AWSK-Q1-C1].
 ```
 
 ## Category Assignment
@@ -66,61 +106,63 @@ Assign each citation a usage category describing how the source material was use
 - **Stakeholder Need** — Source captures stakeholder goals, concerns, or expectations
 - **Integration Requirement** — Source defines interfaces with external systems
 - **Procurement Constraint** — Source restricts or guides procurement approach
+- **Reuse Evidence** — Source demonstrates an existing implementation that informs build vs reuse analysis
+- **Market Evidence** — Source provides vendor, pricing, or capability data informing options analysis
 
 ## Quoting Rules
 
-For each citation, quote the **specific passage** from the source document that informed the finding:
+For each citation, capture the **specific evidence** from the source that informed the finding:
 
-1. Keep quotes to 1-3 sentences — enough to verify the source, not a full extract
-2. Use double quotes around the passage
-3. Include the page number, section number, or heading if identifiable
-4. If the source is a table or diagram, describe the relevant content rather than quoting verbatim
+1. **Documents and Web URLs** — Quote 1-3 sentences verbatim. Use double quotes. Include page number, section number, or heading if identifiable.
+2. **MCP Queries** — Summarise the result set rather than quoting (e.g., `"3 repos returned: east-sussex-county-council/Escc.ActiveDirectory, hmrc/auth-stub, dwp/identity-verifier"`). For documentation-style MCP responses (AWS Knowledge, Microsoft Learn), quote the salient passage as for documents.
+3. **Tables, diagrams, code blocks** — Describe the relevant content rather than quoting verbatim.
 
 ## External References Section Structure
 
-Populate the `## External References` section in the template with three sub-tables:
+Populate the `## External References` section in the template with three sub-tables. The template ships with these tables already; the rules below describe how to fill them for each source type without changing column structure.
 
 ### Document Register
 
-Lists every external document that was read, whether or not it was cited.
+Lists every source that was consulted (documents, MCP queries, fetched URLs), whether or not it was cited.
 
-| Doc ID | Filename | Type | Source Location | Description |
-|--------|----------|------|-----------------|-------------|
-
-- **Doc ID** — The abbreviation derived using the rules above
-- **Filename** — Original filename as found in the directory
-- **Type** — Document type (e.g., Policy, Standard, Strategy, RFP, Specification, Report, Guidance)
-- **Source Location** — Directory path relative to `projects/` (e.g., `001-project/external/`, `000-global/policies/`)
-- **Description** — Brief description of the document's purpose
+| Column | Documents | MCP Queries | Web URLs |
+|--------|-----------|-------------|----------|
+| **Doc ID** | Source ID derived from filename (e.g., `PP`) | Per-server prefix + query index (e.g., `GRSC-Q1`) | `WEB-N` (e.g., `WEB-1`) |
+| **Filename** | Original filename (e.g., `privacy-policy.pdf`) | MCP tool + query (e.g., `search_uk_gov_code("active directory C#")`) | Full URL (e.g., `https://github.com/east-sussex-county-council/Escc.ActiveDirectory`) |
+| **Type** | Document type (Policy / Standard / RFP / etc.) | `MCP Query` | `Web URL` |
+| **Source Location** | Directory path relative to `projects/` (e.g., `001-project/external/`) | MCP server name (e.g., `govreposcrape`) | Domain (e.g., `github.com`) |
+| **Description** | Brief description of the document's purpose | Result count + brief summary (e.g., `8 repos returned, top 3 relevant`) | Page title or what was being looked up |
 
 ### Citations
 
-Lists every inline citation used in the document body.
+Lists every inline citation used in the document body. Schema unchanged.
 
 | Citation ID | Doc ID | Page/Section | Category | Quoted Passage |
 |-------------|--------|--------------|----------|----------------|
 
-- **Citation ID** — The `[DOC_ID-CN]` marker used inline
+- **Citation ID** — The `[SOURCE_ID-CN]` marker used inline
 - **Doc ID** — Cross-reference to the Document Register
-- **Page/Section** — Page number, section number, or heading where the passage was found. Use "—" if not identifiable
+- **Page/Section** — Page number, section number, heading, or MCP result index where the evidence was found. Use "—" if not applicable.
 - **Category** — One of the categories listed above
-- **Quoted Passage** — The specific passage that informed the finding
+- **Quoted Passage** — The verbatim quote (documents, web pages, doc-style MCP responses) or result summary (search-style MCP responses)
 
 ### Unreferenced Documents
 
-Lists external documents that were read but did not contribute to this artifact. This demonstrates that all input documents were reviewed.
+Lists sources that were consulted but did not contribute to this artifact. Demonstrates that all retrieved material was reviewed. Now also covers MCP queries that returned nothing useful and fetched URLs that proved off-topic.
 
 | Filename | Source Location | Reason |
 |----------|-----------------|--------|
 
-- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Covers operational procedures outside scope of this artifact")
+- **Filename** — Filename, MCP query, or URL (mirroring the Document Register's Filename column)
+- **Source Location** — Directory path, MCP server name, or domain
+- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Returned no results", "Covers operational procedures outside scope of this artifact")
 
-### When No External Documents Exist
+### When No Source Material Was Consulted
 
-If no external documents were provided or found, retain the placeholder row in the Document Register:
+If no documents, MCP queries, or web fetches were used, retain the placeholder row in the Document Register:
 
 | Doc ID | Filename | Type | Source Location | Description |
 |--------|----------|------|-----------------|-------------|
-| *None provided* | — | — | — | — |
+| *None consulted* | — | — | — | — |
 
 Omit the Citations and Unreferenced Documents sub-tables.

--- a/arckit-paperclip/references/citation-instructions.md
+++ b/arckit-paperclip/references/citation-instructions.md
@@ -1,10 +1,22 @@
-# Citation Instructions for External Documents
+# Citation Instructions for Source Material
 
-When ArcKit commands read external documents (from `external/`, `policies/`, `vendors/`), use this citation system to create traceability from generated content back to source material.
+When ArcKit commands gather evidence from source material — files in `external/`, `policies/`, `vendors/`, MCP server queries, or web pages fetched at runtime — use this citation system to create traceability from generated content back to that source material.
 
-## Document Abbreviation Rules
+Three source types are covered:
 
-Derive a short Doc ID from each external filename:
+- **Document** — A file on disk under `external/`, `policies/`, or `vendors/`
+- **MCP Query** — A query sent to an MCP server (e.g., `search_uk_gov_code`, AWS Knowledge `search_documentation`)
+- **Web URL** — A URL fetched at runtime via WebFetch
+
+WebSearch (search-only, no fetch) is exploratory and does not produce citations. Cite a URL only once it has actually been fetched.
+
+The instructions extend the existing `Document Register` / `Citations` / `Unreferenced Documents` template tables — the column names and structure stay the same, but each column's semantics now cover MCP queries and web URLs as well as files. Treat "Doc ID" as the generic Source ID for any source type.
+
+## Source ID Rules
+
+Derive a short Source ID for each piece of source material. The same Source ID is used in the Document Register and in inline citation markers.
+
+### Documents (files)
 
 1. Strip the file extension (`.pdf`, `.docx`, `.xlsx`, etc.)
 2. Strip version numbers (`-v2`, `-v1.0`, `_v3`, etc.)
@@ -13,29 +25,49 @@ Derive a short Doc ID from each external filename:
 
 **Examples:**
 
-| Filename | Doc ID | Derivation |
-|----------|--------|------------|
+| Filename | Source ID | Derivation |
+|----------|-----------|------------|
 | privacy-policy.pdf | PP | **P**rivacy **P**olicy |
 | security-framework-v2.docx | SF | **S**ecurity **F**ramework |
 | data-protection-impact-assessment.pdf | DPIA | **D**ata **P**rotection **I**mpact **A**ssessment |
 | nhs-digital-service-manual.pdf | NDSM | **N**HS **D**igital **S**ervice **M**anual |
 | cloud-hosting-strategy.pdf | CHS | **C**loud **H**osting **S**trategy |
 
-**Collision handling:** If two documents produce the same abbreviation, append a numeric suffix to the second (e.g., `PP`, `PP2`). Alternatively, use more letters from the distinguishing word (e.g., `PRIV` for privacy-policy vs `PROC` for procurement-process).
+### MCP Queries
+
+Use a fixed per-server prefix plus a sequential query index. One Source ID per **unique query** to an MCP server (not per call — if the same query was issued multiple times, it is one citation source).
+
+| MCP Server | Prefix | Example Source ID |
+|------------|--------|-------------------|
+| govreposcrape | GRSC | `GRSC-Q1`, `GRSC-Q2` |
+| AWS Knowledge | AWSK | `AWSK-Q1` |
+| Microsoft Learn | MSL | `MSL-Q1` |
+| Google Developer Knowledge | GDK | `GDK-Q1` |
+| DataCommons | DC | `DC-Q1` |
+
+For MCP servers not listed above, derive a short uppercase prefix from the server name (e.g., `linear-mcp` → `LIN`).
+
+### Web URLs
+
+Use the prefix `WEB` plus a sequential index. One Source ID per **unique URL** fetched (not per call — refetching the same URL is one citation source).
+
+Examples: `WEB-1`, `WEB-2`, `WEB-3`.
+
+**Collision handling:** If two distinct sources collide on a derived ID, append a numeric suffix to the second (e.g., `PP`, `PP2`).
 
 ## Citation ID Format
 
-Each citation uses the format: `[{DOC_ID}-C{N}]`
+Each inline citation uses the format: `[{SOURCE_ID}-C{N}]`
 
-- `DOC_ID` — The document abbreviation from the table above
+- `SOURCE_ID` — The Source ID derived above
 - `C` — Literal "C" for "citation"
-- `N` — Sequential number per document, starting at 1
+- `N` — Sequential number per source, starting at 1
 
-Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`
+Examples: `[PP-C1]`, `[PP-C2]`, `[SF-C1]`, `[DPIA-C3]`, `[GRSC-Q1-C1]`, `[AWSK-Q1-C1]`, `[WEB-1-C1]`.
 
 ## Inline Marker Placement
 
-Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source document. Do not group citations at the end of paragraphs — attach them to the specific claim.
+Place citation markers **immediately after** the requirement, finding, risk, or statement that was informed by the source. Do not group citations at the end of paragraphs — attach them to the specific claim.
 
 **Examples:**
 
@@ -49,6 +81,14 @@ The system must encrypt all personal data at rest using AES-256 [SF-C1] and in t
 
 ```text
 Risk R-005: Non-compliance with data retention policy [PP-C3] could result in ICO enforcement action.
+```
+
+```text
+East Sussex County Council have published `Escc.ActiveDirectory` [WEB-1-C1], a reusable .NET library for AD lookups, identified via govreposcrape search [GRSC-Q1-C1].
+```
+
+```text
+Amazon Bedrock Guardrails support PII redaction across input and output flows [AWSK-Q1-C1].
 ```
 
 ## Category Assignment
@@ -66,61 +106,63 @@ Assign each citation a usage category describing how the source material was use
 - **Stakeholder Need** — Source captures stakeholder goals, concerns, or expectations
 - **Integration Requirement** — Source defines interfaces with external systems
 - **Procurement Constraint** — Source restricts or guides procurement approach
+- **Reuse Evidence** — Source demonstrates an existing implementation that informs build vs reuse analysis
+- **Market Evidence** — Source provides vendor, pricing, or capability data informing options analysis
 
 ## Quoting Rules
 
-For each citation, quote the **specific passage** from the source document that informed the finding:
+For each citation, capture the **specific evidence** from the source that informed the finding:
 
-1. Keep quotes to 1-3 sentences — enough to verify the source, not a full extract
-2. Use double quotes around the passage
-3. Include the page number, section number, or heading if identifiable
-4. If the source is a table or diagram, describe the relevant content rather than quoting verbatim
+1. **Documents and Web URLs** — Quote 1-3 sentences verbatim. Use double quotes. Include page number, section number, or heading if identifiable.
+2. **MCP Queries** — Summarise the result set rather than quoting (e.g., `"3 repos returned: east-sussex-county-council/Escc.ActiveDirectory, hmrc/auth-stub, dwp/identity-verifier"`). For documentation-style MCP responses (AWS Knowledge, Microsoft Learn), quote the salient passage as for documents.
+3. **Tables, diagrams, code blocks** — Describe the relevant content rather than quoting verbatim.
 
 ## External References Section Structure
 
-Populate the `## External References` section in the template with three sub-tables:
+Populate the `## External References` section in the template with three sub-tables. The template ships with these tables already; the rules below describe how to fill them for each source type without changing column structure.
 
 ### Document Register
 
-Lists every external document that was read, whether or not it was cited.
+Lists every source that was consulted (documents, MCP queries, fetched URLs), whether or not it was cited.
 
-| Doc ID | Filename | Type | Source Location | Description |
-|--------|----------|------|-----------------|-------------|
-
-- **Doc ID** — The abbreviation derived using the rules above
-- **Filename** — Original filename as found in the directory
-- **Type** — Document type (e.g., Policy, Standard, Strategy, RFP, Specification, Report, Guidance)
-- **Source Location** — Directory path relative to `projects/` (e.g., `001-project/external/`, `000-global/policies/`)
-- **Description** — Brief description of the document's purpose
+| Column | Documents | MCP Queries | Web URLs |
+|--------|-----------|-------------|----------|
+| **Doc ID** | Source ID derived from filename (e.g., `PP`) | Per-server prefix + query index (e.g., `GRSC-Q1`) | `WEB-N` (e.g., `WEB-1`) |
+| **Filename** | Original filename (e.g., `privacy-policy.pdf`) | MCP tool + query (e.g., `search_uk_gov_code("active directory C#")`) | Full URL (e.g., `https://github.com/east-sussex-county-council/Escc.ActiveDirectory`) |
+| **Type** | Document type (Policy / Standard / RFP / etc.) | `MCP Query` | `Web URL` |
+| **Source Location** | Directory path relative to `projects/` (e.g., `001-project/external/`) | MCP server name (e.g., `govreposcrape`) | Domain (e.g., `github.com`) |
+| **Description** | Brief description of the document's purpose | Result count + brief summary (e.g., `8 repos returned, top 3 relevant`) | Page title or what was being looked up |
 
 ### Citations
 
-Lists every inline citation used in the document body.
+Lists every inline citation used in the document body. Schema unchanged.
 
 | Citation ID | Doc ID | Page/Section | Category | Quoted Passage |
 |-------------|--------|--------------|----------|----------------|
 
-- **Citation ID** — The `[DOC_ID-CN]` marker used inline
+- **Citation ID** — The `[SOURCE_ID-CN]` marker used inline
 - **Doc ID** — Cross-reference to the Document Register
-- **Page/Section** — Page number, section number, or heading where the passage was found. Use "—" if not identifiable
+- **Page/Section** — Page number, section number, heading, or MCP result index where the evidence was found. Use "—" if not applicable.
 - **Category** — One of the categories listed above
-- **Quoted Passage** — The specific passage that informed the finding
+- **Quoted Passage** — The verbatim quote (documents, web pages, doc-style MCP responses) or result summary (search-style MCP responses)
 
 ### Unreferenced Documents
 
-Lists external documents that were read but did not contribute to this artifact. This demonstrates that all input documents were reviewed.
+Lists sources that were consulted but did not contribute to this artifact. Demonstrates that all retrieved material was reviewed. Now also covers MCP queries that returned nothing useful and fetched URLs that proved off-topic.
 
 | Filename | Source Location | Reason |
 |----------|-----------------|--------|
 
-- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Covers operational procedures outside scope of this artifact")
+- **Filename** — Filename, MCP query, or URL (mirroring the Document Register's Filename column)
+- **Source Location** — Directory path, MCP server name, or domain
+- **Reason** — Brief explanation (e.g., "No content relevant to requirements", "Returned no results", "Covers operational procedures outside scope of this artifact")
 
-### When No External Documents Exist
+### When No Source Material Was Consulted
 
-If no external documents were provided or found, retain the placeholder row in the Document Register:
+If no documents, MCP queries, or web fetches were used, retain the placeholder row in the Document Register:
 
 | Doc ID | Filename | Type | Source Location | Description |
 |--------|----------|------|-----------------|-------------|
-| *None provided* | — | — | — | — |
+| *None consulted* | — | — | — | — |
 
 Omit the Citations and Unreferenced Documents sub-tables.


### PR DESCRIPTION
Closes #283.

## Problem

Citation instructions in `arckit-claude/references/citation-instructions.md` only covered files under `external/`, `policies/`, `vendors/`. The 10 research agents (gov-reuse, research, datascout, aws/azure/gcp-research, gov-code-search, gov-landscape, grants) gather most of their evidence via MCP servers and WebFetch, leaving the External References section empty even when the body cites GitHub URLs and MCP-sourced findings inline.

The trigger was a 459-line gov-reuse output noted in #283 that referenced 18 govreposcrape MCP calls and 5 WebFetched GitHub repos in the body but produced an empty Document Register.

## Approach

Extend the existing `Document Register` / `Citations` / `Unreferenced Documents` tables to cover three source types in the same column structure:

- **Document** — files on disk (unchanged behaviour)
- **MCP Query** — one row per unique query; per-server prefix (`GRSC`, `AWSK`, `MSL`, `GDK`, `DC`) plus a `Q`-index, so collisions don't happen across servers
- **Web URL** — one row per unique fetched URL with `WEB-N` prefix

Per the issue review, granularity is **per unique query / per unique URL**, not per call — refetching or re-querying does not bloat the register. WebSearch (search-only, no fetch) is exploratory and does not produce citations.

## Why no template changes

The 70+ templates already ship with these three sub-tables. Aligning the instructions with the **existing 5-column structure** (rather than introducing a new "Source Type" column) keeps the change to a single file. The Doc ID column now holds the generic Source ID, Filename holds either filename / MCP query / URL, Type holds either document type / `MCP Query` / `Web URL`, and Source Location holds either path / MCP server name / domain.

## Categories added

Two new citation categories that the research agents need but didn't have:

- **Reuse Evidence** — for gov-reuse / gov-landscape findings
- **Market Evidence** — for vendor/pricing data from research / aws-research / etc.

## Files

- `arckit-claude/references/citation-instructions.md` — source of truth, rewritten
- `arckit-{codex,copilot,gemini,opencode,paperclip}/references/citation-instructions.md` — regenerated by `scripts/converter.py`

No agent files changed — all 10 research agents already point at `citation-instructions.md` via the same one-line directive (verified in `gov-reuse.md:65`).

## Test plan

- [x] Markdown lint passes (`npx markdownlint-cli2 arckit-claude/references/citation-instructions.md`)
- [x] Converter runs cleanly and propagates the change to all 5 extension formats
- [ ] Smoke test: rerun `/arckit:gov-reuse` against an existing test repo and verify the External References section is now populated with MCP queries and fetched URLs (recommend reviewer does this against one of the v34–v43 test repos)

## Related

- Issue #282 (managed agents, closed/merged via #284) — surfaced the gap during managed-agent testing