### PR TITLE
chore: gitignore local investor / pitch drafts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,11 @@ arckit-gemini/docs/
 docs/articles/
 .tmp*
 
+# Local investor / pitch drafts (kept off the published toolkit; tracked
+# docs/INVESTOR-REPORT.md is the single shared artefact)
+docs/INVESTOR-DECK.*
+docs/INVESTOR-REPORT-hero.*
+
 # Git worktrees
 .worktrees/
 


### PR DESCRIPTION
## Summary

- Adds `docs/INVESTOR-DECK.*` and `docs/INVESTOR-REPORT-hero.*` to `.gitignore`.
- Stops local drafts (a 12K markdown deck, a 2.3M `.pptx`, and 138K of hero PNG/SVG) from showing up as untracked noise on every `git status`, and prevents them from being swept up by an accidental `git add`.
- The tracked `docs/INVESTOR-REPORT.md` (May 1, commit `bd39b4ec`) remains the single shared investor artefact in the repo.

## Test plan

- [x] `git check-ignore -v docs/INVESTOR-DECK.{md,pptx} docs/INVESTOR-REPORT-hero.{png,svg}` reports each as ignored by the new lines.
- [x] `git check-ignore -v docs/INVESTOR-REPORT.md` reports nothing — tracked file unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)