### PR TITLE
fix: wrap monitors under experimental block (v2.1.129+)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -129,7 +129,7 @@ Notable hooks: provenance stamping, manifest auto-update, session telemetry, sec
 
 ### Plugin Monitors
 
-Background monitors declared via the `monitors` key in `plugin.json` (v2.1.105+). Each entry runs as a persistent subprocess; stdout lines are delivered as session notifications. Schema: `name`, `command` (supports `${CLAUDE_PLUGIN_ROOT}` and `${user_config.*}`), `description`, `when` (`always` or `on-skill-invoke:<skill>`).
+Background monitors declared via the `experimental.monitors` key in `plugin.json` (v2.1.105+, moved under `experimental` in v2.1.129). Each entry runs as a persistent subprocess; stdout lines are delivered as session notifications. Schema: `name`, `command` (supports `${CLAUDE_PLUGIN_ROOT}` and `${user_config.*}`), `description`, `when` (`always` or `on-skill-invoke:<skill>`).
 
 Current monitor: `stale-artifact-scan` runs `arckit-claude/scripts/bash/detect-stale-artifacts.sh` at session start in repos with `projects/`, emitting one line per artefact whose Document Control `Next Review Date` is overdue, or whose status is `DRAFT` and untouched in 14+ days.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A comprehensive book-length guide to ArcKit — covering every subsystem (comman
 
 ### Installation
 
-**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.121+**):
+**Claude Code** (premier experience) — install the ArcKit plugin (requires **v2.1.129+**):
 
 First, make sure Claude Code is on the latest version:
 
@@ -73,7 +73,7 @@ Then install from the Discover tab.
 >
 > This uses `git sparse-checkout` to limit the clone to `.claude-plugin/` (the marketplace catalog) and `arckit-claude/` (the plugin itself). Works with Claude Code's documented marketplace sparse flag. Claude Code is the **primary development platform** for ArcKit and provides the most complete experience: all 70 official commands (plus 46 community-contributed), 10 autonomous research agents, 5 automation hooks (session init, project context injection, filename enforcement, output validation, impact scan), bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, govreposcrape), and automatic updates via the marketplace. See [Why Claude Code?](#why-claude-code) below.
 
-> **Why v2.1.121?** ArcKit now uses MCP `alwaysLoad` to eager-load AWS Knowledge and Microsoft Learn tools at session start (skips a discovery round-trip on `/arckit:aws-research` and `/arckit:azure-research`), and PostToolUse `hookSpecificOutput.updatedToolOutput` so provenance-stamp and manifest hooks surface their effects to the model in-band — both v2.1.121 features. The release flow uses `claude plugin tag --dry-run` (v2.1.118) to validate plugin/marketplace version agreement, and the session-telemetry hook records `duration_ms` on every tool call (v2.1.119). Carries forward the v2.1.117 unlocks: Opus 4.7 `/context` correctly sized to 1M instead of 200K (long research sessions no longer autocompact early) and agent frontmatter `mcpServers` loading for `--agent` sessions; the v2.1.111+ unlocks: Opus 4.7 `xhigh` effort tier, Auto mode without `--enable-auto-mode`, read-only bash glob patterns without permission prompts; and the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
+> **Why v2.1.129?** Claude Code v2.1.129 moved the plugin manifest's `monitors` (and `themes`) keys under a top-level `experimental` block — ArcKit's `stale-artifact-scan` background monitor (which warns when `projects/` artefacts are past their `Next Review Date` or stuck in `DRAFT` for 14+ days) is declared via that key and will not load on older clients. The same release also fixed a regression that was silently downgrading the `ENABLE_PROMPT_CACHING_1H` 1-hour prompt cache TTL back to 5 minutes — the autoresearch + multi-command workflow guidance documented in this repo only delivers the promised 1h TTL on v2.1.129+. Carries forward the v2.1.121 unlocks: MCP `alwaysLoad` eager-loads AWS Knowledge and Microsoft Learn tools at session start (skips a discovery round-trip on `/arckit:aws-research` and `/arckit:azure-research`), and PostToolUse `hookSpecificOutput.updatedToolOutput` so provenance-stamp and manifest hooks surface their effects to the model in-band; the v2.1.118–119 release-flow unlocks: `claude plugin tag --dry-run` validates plugin/marketplace version agreement, and the session-telemetry hook records `duration_ms` on every tool call; the v2.1.117 unlocks: Opus 4.7 `/context` correctly sized to 1M instead of 200K (long research sessions no longer autocompact early) and agent frontmatter `mcpServers` loading for `--agent` sessions; the v2.1.111+ unlocks: Opus 4.7 `xhigh` effort tier, Auto mode without `--enable-auto-mode`, read-only bash glob patterns without permission prompts; and the v2.1.97 fixes: `claude plugin update` correctly detects new commits for git-based plugins (critical for ArcKit distribution), MCP HTTP/SSE memory leak fix (~50 MB/hr, affects ArcKit's 5 bundled servers), proper 429 exponential backoff (benefits 10 research agents), Stop/SubagentStop hooks no longer fail on long sessions (affects session-learner), and subagent working directory leak fix.
 
 **Gemini CLI** — install the ArcKit extension:
 
@@ -1559,7 +1559,7 @@ Key references live in `docs/` and top-level guides:
 
 - **Python 3.11+**
 - **Git** (optional but recommended)
-- **AI Coding Agent**: [Claude Code](https://www.anthropic.com/claude-code) v2.1.121+ (via plugin), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (via extension), [OpenCode CLI](https://opencode.net/cli) (via CLI), or [OpenAI Codex CLI](https://chatgpt.com/features/codex) (via CLI)
+- **AI Coding Agent**: [Claude Code](https://www.anthropic.com/claude-code) v2.1.129+ (via plugin), [Gemini CLI](https://github.com/google-gemini/gemini-cli) (via extension), [OpenCode CLI](https://opencode.net/cli) (via CLI), or [OpenAI Codex CLI](https://chatgpt.com/features/codex) (via CLI)
 - **uv** for package management: [Install uv](https://docs.astral.sh/uv/)
 
 ---

--- a/arckit-claude/.claude-plugin/plugin.json
+++ b/arckit-claude/.claude-plugin/plugin.json
@@ -10,14 +10,16 @@
   "repository": "https://github.com/tractorjuice/arc-kit",
   "license": "MIT",
   "mcpServers": "./.mcp.json",
-  "monitors": [
-    {
-      "name": "stale-artifact-scan",
-      "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/bash/detect-stale-artifacts.sh",
-      "description": "Detect ArcKit artifacts with overdue reviews or long-unchanged drafts",
-      "when": "always"
-    }
-  ],
+  "experimental": {
+    "monitors": [
+      {
+        "name": "stale-artifact-scan",
+        "command": "bash ${CLAUDE_PLUGIN_ROOT}/scripts/bash/detect-stale-artifacts.sh",
+        "description": "Detect ArcKit artifacts with overdue reviews or long-unchanged drafts",
+        "when": "always"
+      }
+    ]
+  },
   "userConfig": {
     "GOOGLE_API_KEY": {
       "title": "Google API Key",

--- a/arckit-claude/hooks/version-check.mjs
+++ b/arckit-claude/hooks/version-check.mjs
@@ -20,7 +20,7 @@ import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { isFile, readText, parseHookInput } from './hook-utils.mjs';
 
-const MIN_CLAUDE_CODE_VERSION = '2.1.121';
+const MIN_CLAUDE_CODE_VERSION = '2.1.129';
 
 parseHookInput(); // consume stdin (required by hook protocol)
 
@@ -46,7 +46,9 @@ if (clientVersion && compareVersions(clientVersion, MIN_CLAUDE_CODE_VERSION) < 0
     `- \`claude plugin tag\` validates plugin/marketplace version agreement before release (needs v2.1.118)\n` +
     `- Hook \`duration_ms\` recorded on PostToolUse for session telemetry (needs v2.1.119)\n` +
     `- MCP server \`alwaysLoad\` skips tool-search deferral so AWS Knowledge / Microsoft Learn tools are loaded eagerly (needs v2.1.121)\n` +
-    `- PostToolUse \`hookSpecificOutput.updatedToolOutput\` for all tools — provenance and manifest hooks now surface their work to the model (needs v2.1.121)\n\n` +
+    `- PostToolUse \`hookSpecificOutput.updatedToolOutput\` for all tools — provenance and manifest hooks now surface their work to the model (needs v2.1.121)\n` +
+    `- Plugin \`monitors\` declared under the \`experimental\` block — ArcKit's \`stale-artifact-scan\` monitor will not load on older clients (needs v2.1.129)\n` +
+    `- 1-hour prompt cache TTL fix — \`ENABLE_PROMPT_CACHING_1H\` was being silently downgraded to 5 minutes on earlier versions (needs v2.1.129)\n\n` +
     `Update with: \`claude update\``
   );
   process.stderr.write(`[ArcKit] Claude Code v${clientVersion} is below required v${MIN_CLAUDE_CODE_VERSION}\n`);

--- a/docs/PLATFORM-COMPARISON.md
+++ b/docs/PLATFORM-COMPARISON.md
@@ -15,7 +15,7 @@ Compiled from official docs in early 2026. Sources cited at the end.
 | Subagents | 18 frontmatter fields, allow + deny tool lists | Allowlist only, per-agent MCP isolation | Sandbox + MCP filters, no per-tool list |
 | Hooks | **31 events**, 5 handler types, `if:` filter | ~11 events, command handler | 6 events, regex matcher |
 | MCP servers | `alwaysLoad`, `headersHelper`, per-subagent inline | All eager-load, per-extension | `enabled`/`required`, OAuth store |
-| Background monitors | `monitors` key (stdout → notifications) | None | None |
+| Background monitors | `experimental.monitors` key (stdout → notifications) | None | None |
 | User config (typed) | `userConfig` + keychain | `settings[]` + envVar | env var only |
 | Plugin root variable | `${CLAUDE_PLUGIN_ROOT}`, `${CLAUDE_PLUGIN_DATA}` | `${extensionPath}`, `${workspacePath}`, `${/}` | implicit (relative paths) |
 | Distribution | `/plugin marketplace add` | `gemini extensions install` + gallery | `/plugins` + `marketplace.json` |
@@ -166,7 +166,7 @@ Handler: `command` (JSON stdio + exit-code-2 block). Matcher: regex only — no 
 - **Channels** (`channels`) — message injection for Telegram/Slack/Discord-style integrations, each bound to an MCP server with per-channel `userConfig`.
 - **Plugin-shipped settings.json** — currently supports `agent` (default subagent) and `subagentStatusLine` keys.
 - **Plugin dependencies** — `dependencies` array with semver constraints; `claude plugin prune`/`autoremove` for orphans.
-- **Background monitors** (`monitors` key) — persistent subprocess; `when: always` or `on-skill-invoke:<skill>`; stdout → in-session notifications.
+- **Background monitors** (`experimental.monitors` key, moved from top-level in v2.1.129) — persistent subprocess; `when: always` or `on-skill-invoke:<skill>`; stdout → in-session notifications.
 
 ### Gemini CLI
 


### PR DESCRIPTION
## Summary

Claude Code v2.1.129 moved the plugin manifest's `monitors` (and `themes`) keys under a top-level `experimental` block. ArcKit's `stale-artifact-scan` background monitor was declared at the top level and would not load on v2.1.129+ clients.

This PR wraps the existing monitor under `experimental.monitors`, bumps the documented and enforced minimum Claude Code version to v2.1.129, and updates the surrounding docs.

Spotted during the v2.1.129–139 changelog review on #215 (Tier A — must-fix).

## Changes

- **`arckit-claude/.claude-plugin/plugin.json`** — wrap the `monitors` array under `experimental` per the new schema
- **`arckit-claude/hooks/version-check.mjs`** — bump `MIN_CLAUDE_CODE_VERSION` from `2.1.121` → `2.1.129`; add two bullets to the SessionStart warning (monitors-under-experimental, and the 1h prompt cache TTL regression fix that also landed in v2.1.129)
- **`CLAUDE.md`** — note new `experimental.monitors` key path
- **`docs/PLATFORM-COMPARISON.md`** — update both references (matrix row + Claude-only feature list) to the new key path
- **`README.md`** — bump installation floor (`v2.1.121+` → `v2.1.129+`) and rewrite the "Why v2.1.129?" justification block (monitors compat + 1h cache TTL fix lead, prior justifications carried forward)

## Why bump the floor?

The format change is breaking: top-level `monitors` will not be loaded on v2.1.129+. Bumping the floor to v2.1.129 in the same PR keeps the manifest, the SessionStart warning, and the docs internally consistent. v2.1.129 is also the version that fixed `ENABLE_PROMPT_CACHING_1H` being silently downgraded to 5 minutes — the autoresearch + multi-command guidance shipped in #293 only delivers the documented behaviour at this floor.

## Test plan

- [x] `python -c "import json; json.load(open('arckit-claude/.claude-plugin/plugin.json'))"` — JSON valid
- [x] `node arckit-claude/hooks/version-check.mjs <<< '{}'` — hook runs cleanly with empty stdin
- [x] `npx markdownlint-cli2 CLAUDE.md docs/PLATFORM-COMPARISON.md README.md` — 0 errors
- [ ] Smoke-test on a v2.1.129+ client: confirm `stale-artifact-scan` monitor still emits notifications in a repo with `projects/`
- [ ] Smoke-test on an older client (e.g. v2.1.121): confirm version-check hook now warns with the new minimum + bullets

## Related

- Issue #215 — Tier A item from v2.1.129–139 delta comment ([#issuecomment-4423947104](https://github.com/tractorjuice/arc-kit/issues/215#issuecomment-4423947104))
- Original monitor: shipped in v4.6.10 / #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)