### PR TITLE
fix(hooks): validate-arc-filename soft-blocks via decision JSON instead of exit 2

### DIFF
--- a/arckit-claude/hooks/validate-arc-filename.mjs
+++ b/arckit-claude/hooks/validate-arc-filename.mjs
@@ -16,8 +16,12 @@
  * Hook Type: PreToolUse
  * Matcher: Write
  * Input (stdin):  JSON { tool_name, tool_input: { file_path, content }, ... }
- * Output (stdout): JSON with updatedInput for corrected path, or empty for pass-through
- * Exit codes:      0 = allow (with or without corrections), 2 = block (invalid type code)
+ * Output (stdout): JSON with updatedInput for corrected path, {decision: 'block', reason}
+ *                  for invalid type code (model-visible so it can self-correct), or empty
+ *                  for pass-through.
+ * Exit code:       0 in all cases. The block path emits JSON with decision='block' so the
+ *                  rejection reason is fed back to the model rather than failing as a hard
+ *                  permission error (which only the user would see).
  */
 
 import { readFileSync, readdirSync, mkdirSync } from 'node:fs';
@@ -110,10 +114,11 @@ if (tm) {
 // --- Validate doc type code ---
 if (!KNOWN_TYPES.has(docType)) {
   const validList = [...KNOWN_TYPES].sort().join(' ');
-  process.stderr.write(
-    `ArcKit: Unknown document type code '${docType}'. Valid codes: ${validList}\n`
-  );
-  process.exit(2);
+  console.log(JSON.stringify({
+    decision: 'block',
+    reason: `ArcKit: Unknown document type code '${docType}' in '${filename}'. Valid codes: ${validList}. Rename the file using one of those codes and retry.`,
+  }));
+  process.exit(0);
 }
 
 // --- Normalize project ID (3-digit zero-padded) ---


### PR DESCRIPTION
## Summary

Modernises the unknown-doc-type-code rejection path in `validate-arc-filename.mjs` from the legacy `process.exit(2) + stderr` pattern to the `{decision: 'block', reason: ...}` JSON pattern (already used by `score-validator.mjs`).

## Why

Today, if Claude tries to `Write` a file like `ARC-001-FOO-v1.0.md`, the hook hard-blocks via exit code 2 and writes to stderr. The user sees the error in the permission prompt; the model sees nothing actionable. Result: the user has to manually nudge Claude to use a valid type code.

With the JSON `decision: 'block'` pattern, the rejection reason is fed back to the model as a tool error, and Claude can self-correct on the next turn — rename to `ARC-001-REQ-v1.0.md` (or whatever the user actually meant) and retry.

This is the **existing** PreToolUse soft-block pattern, not the new v2.1.139 `continueOnBlock` config (which only applies to PostToolUse hooks). Initially flagged in the v2.1.129–139 delta on #215; on closer inspection the right fix is this pattern modernisation, not waiting for v2.1.139 semantics.

## Changes

- **`arckit-claude/hooks/validate-arc-filename.mjs`**:
  - Header docstring updated to reflect the new output protocol
  - Block path now emits `{decision: 'block', reason}` on stdout with exit 0; reason string includes the offending filename, the full valid-codes list, and an explicit "rename and retry" instruction

## Test plan

- [x] Smoke-test block path: `echo '{"tool_name":"Write","tool_input":{"file_path":"...ARC-001-FOO-v1.0.md","content":"x"}}' | node arckit-claude/hooks/validate-arc-filename.mjs` → emits JSON, exit 0
- [x] Smoke-test happy path: same with `ARC-001-REQ-v1.0.md` → silent, exit 0
- [ ] In a real session, attempt to write `ARC-001-FOO-v1.0.md` and confirm Claude is told the rejection reason and self-corrects

## Related

- Issue #215 — Tier B item from v2.1.129–139 delta comment
- Sibling PR #453 — `monitors` → `experimental` block migration

🤖 Generated with [Claude Code](https://claude.com/claude-code)