### PR TITLE
feat(site): link to ArcKit FDE from arckit.org

### DIFF
--- a/docs/article-viewer.html
+++ b/docs/article-viewer.html
@@ -216,6 +216,7 @@
                 <li class="app-nav-bar__item app-nav-bar__item--active"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/articles.html
+++ b/docs/articles.html
@@ -285,6 +285,7 @@
                 <li class="app-nav-bar__item app-nav-bar__item--active"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -491,6 +491,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -272,6 +272,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item app-nav-bar__item--active"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -329,6 +329,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item app-nav-bar__item--active"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/guide-viewer.html
+++ b/docs/guide-viewer.html
@@ -291,6 +291,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -265,6 +265,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/index.html
+++ b/docs/index.html
@@ -377,6 +377,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">
@@ -918,6 +919,7 @@
                 <div class="govuk-grid-column-one-third">
                     <h3 class="govuk-heading-s">Links</h3>
                     <ul class="govuk-list">
+                        <li><a href="https://tractorjuice.github.io/arckit-fde/" class="govuk-link">ArcKit FDE (Forward Deploy Engineering)</a></li>
                         <li><a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub Repository</a></li>
                         <li><a href="https://github.com/tractorjuice/arc-kit/issues" class="govuk-link">Report Issues</a></li>
                         <li><a href="https://github.com/tractorjuice/arc-kit/releases" class="govuk-link">Releases</a></li>

--- a/docs/roles.html
+++ b/docs/roles.html
@@ -223,6 +223,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -211,6 +211,7 @@
                 <li class="app-nav-bar__item"><a href="articles.html">Articles</a></li>
                 <li class="app-nav-bar__item"><a href="getting-started.html">Getting Started</a></li>
                 <li class="app-nav-bar__item"><a href="contributors.html">Contributors</a></li>
+                <li class="app-nav-bar__item"><a href="https://tractorjuice.github.io/arckit-fde/">FDE</a></li>
             </ul>
             <div class="app-nav-bar__icons">
                 <a href="https://github.com/tractorjuice/arc-kit" class="app-icon-link" aria-label="GitHub repository" title="GitHub repository">


### PR DESCRIPTION
## Summary

- Adds top-nav **FDE** link to https://tractorjuice.github.io/arckit-fde/ on all 10 docs pages (index, commands, use-cases, guides, roles, articles, article-viewer, guide-viewer, getting-started, contributors).
- Adds **ArcKit FDE (Forward Deploy Engineering)** entry at the top of the index.html footer Links section.

## Test plan

- [ ] Open docs/index.html locally and click the FDE nav item and footer link
- [ ] Open one of each page type and confirm the FDE nav item is present
- [ ] After merge, check the live site at arckit.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)