### PR TITLE
chore(site): remove GOV.UK Design System credit from footers

### DIFF
--- a/docs/article-viewer.html
+++ b/docs/article-viewer.html
@@ -267,7 +267,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 

--- a/docs/articles.html
+++ b/docs/articles.html
@@ -787,7 +787,7 @@
                 </div>
             </div>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | MIT License</p>
+            <p class="govuk-body-s">MIT License</p>
         </div>
     </footer>
 

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -4915,7 +4915,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -481,7 +481,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -710,7 +710,7 @@ arckit init my-project --ai copilot</code></pre></div>
                 </div>
             </div>
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | MIT License</p>
+            <p class="govuk-body-s">MIT License</p>
         </div>
     </footer>
 

--- a/docs/guide-viewer.html
+++ b/docs/guide-viewer.html
@@ -336,7 +336,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -665,7 +665,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -930,8 +930,7 @@
 
             <hr class="govuk-section-break govuk-section-break--m govuk-section-break--visible">
 
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | MIT License</p>
-            <p class="govuk-body-s">Note: This site uses system fonts (Helvetica, Arial) as per <a href="https://design-system.service.gov.uk/styles/typeface/" class="govuk-link">GDS guidelines for non-gov.uk domains</a>. GDS Transport font is licensed only for official GOV.UK services.</p>
+            <p class="govuk-body-s">MIT License</p>
         </div>
     </footer>
 

--- a/docs/roles.html
+++ b/docs/roles.html
@@ -395,7 +395,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -396,7 +396,7 @@
 
     <footer class="app-footer">
         <div class="govuk-width-container">
-            <p class="govuk-body-s">Built with <a href="https://design-system.service.gov.uk/" class="govuk-link">GOV.UK Design System</a> | <a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
+            <p class="govuk-body-s"><a href="index.html" class="govuk-link">Back to ArcKit</a> | <a href="https://github.com/tractorjuice/arc-kit" class="govuk-link">GitHub</a> | MIT License</p>
         </div>
     </footer>
 


### PR DESCRIPTION
## Summary

Removes the "Built with GOV.UK Design System" link from the footer on all 10 docs pages. The index.html footer also drops the GDS font-guidelines footnote, leaving a clean "MIT License" line.

The site still imports govuk-frontend for styling — this only removes the visible credit/disclaimer text.

## Test plan

- [ ] Open each docs page and confirm footer no longer mentions GOV.UK Design System
- [ ] After merge, check the live site at arckit.org

🤖 Generated with [Claude Code](https://claude.com/claude-code)