### PR TITLE
feat(442): cross-reference linter (item 4)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -7,11 +7,15 @@ on:
       - "**/*.md"
       - ".markdownlint-cli2.jsonc"
       - ".github/workflows/lint-markdown.yml"
+      - "scripts/check_references.py"
+      - "arckit-claude/.claude-plugin/plugin.json"
   pull_request:
     paths:
       - "**/*.md"
       - ".markdownlint-cli2.jsonc"
       - ".github/workflows/lint-markdown.yml"
+      - "scripts/check_references.py"
+      - "arckit-claude/.claude-plugin/plugin.json"
 
 jobs:
   lint:
@@ -22,6 +26,16 @@ jobs:
       - uses: DavidAnson/markdownlint-cli2-action@v19
         with:
           globs: "**/*.md"
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install Python deps for reference linter
+        run: pip install pyyaml
+
+      - name: Cross-reference linter
+        run: python3 scripts/check_references.py
 
       - uses: actions/setup-node@v4
         with:

--- a/arckit-claude/agents/arckit-framework.md
+++ b/arckit-claude/agents/arckit-framework.md
@@ -227,7 +227,7 @@ Return ONLY a concise summary to the caller including:
 
 ## Toolchain
 
-- **Templates** — `${CLAUDE_PLUGIN_ROOT}/templates/framework-overview-template.md` · `${CLAUDE_PLUGIN_ROOT}/templates/framework-executive-guide-template.md` (overrides at `.arckit/templates-custom/...`)
+- **Templates** — `${CLAUDE_PLUGIN_ROOT}/templates/framework-overview-template.md` (overrides at `.arckit/templates-custom/...`). The Executive Guide is generated narrative — no template; written from artifact synthesis.
 - **Helpers** — `${CLAUDE_PLUGIN_ROOT}/scripts/bash/create-project.sh` · `${CLAUDE_PLUGIN_ROOT}/scripts/bash/generate-document-id.sh`
 - **External tools** — none (no web, no MCP — synthesis only)
 - **Related commands** — `/arckit:navigator` (project coverage) · `/arckit:traceability` (cross-reference validation) · `/arckit:strategy` (executive synthesis)

--- a/arckit-claude/docs/guides/custom-commands.md
+++ b/arckit-claude/docs/guides/custom-commands.md
@@ -133,10 +133,9 @@ $ARGUMENTS
 
 ## Instructions
 
-1. **Read the template** (with user override support):
-   - **First**, check if `.arckit/templates/sla-template.md` exists in the project root
-   - **If found**: Read the user's customised template
-   - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/sla-template.md` (default)
+1. **Read the template**:
+   - Read `.arckit/templates/sla-template.md` from the project root.
+   - If the file is missing, stop and ask the user to create it (custom commands ship their template alongside the command).
 
 2. **Read the project requirements**:
    - Locate `projects/<project-id>/ARC-<id>-REQ-v*.md`

--- a/scripts/check_references.py
+++ b/scripts/check_references.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Resolve every internal reference in the plugin source against disk.
+
+Walks `arckit-claude/` and checks that:
+
+  1. Every `${CLAUDE_PLUGIN_ROOT}/<path>` reference in a `.md` file resolves
+     to an existing file or directory inside `arckit-claude/`.
+  2. Every `handoffs[].command` entry in command frontmatter names an
+     existing command file under `arckit-claude/commands/`.
+  3. Every `${user_config.KEY}` reference names a key declared in
+     `arckit-claude/.claude-plugin/plugin.json` under `userConfig`.
+
+Exits non-zero on any broken reference. Run from repo root:
+
+    python3 scripts/check_references.py
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGIN = ROOT / "arckit-claude"
+PLUGIN_JSON = PLUGIN / ".claude-plugin" / "plugin.json"
+
+REF_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/([^\s`\"')}\]<>]+)")
+USER_CONFIG_RE = re.compile(r"\$\{user_config\.([A-Za-z_][A-Za-z0-9_]*)\}")
+FRONTMATTER_RE = re.compile(r"\A---\s*\n(.*?)\n---\s*\n", re.DOTALL)
+
+
+def is_placeholder(path: str) -> bool:
+    """Skip patterns that are illustrative rather than concrete references."""
+    # Glob wildcards
+    if "*" in path or "?" in path:
+        return True
+    # Brace expansion {a,b} or angle/curly placeholders {NAME}, <name>
+    if "{" in path or "}" in path or "<" in path or ">" in path:
+        return True
+    return False
+
+
+def load_plugin_userconfig_keys() -> set[str]:
+    try:
+        data = json.loads(PLUGIN_JSON.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        print(f"[error] cannot read {PLUGIN_JSON}: {exc}", file=sys.stderr)
+        return set()
+    return set((data.get("userConfig") or {}).keys())
+
+
+def iter_md_files() -> list[Path]:
+    return sorted(p for p in PLUGIN.rglob("*.md") if p.is_file())
+
+
+def line_of(text: str, offset: int) -> int:
+    return text.count("\n", 0, offset) + 1
+
+
+def check_plugin_root_refs(md_path: Path, text: str) -> list[tuple[int, str]]:
+    errors: list[tuple[int, str]] = []
+    for match in REF_RE.finditer(text):
+        rel = match.group(1).rstrip(".,;:)")
+        if is_placeholder(rel):
+            continue
+        target = PLUGIN / rel
+        if not target.exists():
+            errors.append((line_of(text, match.start()), f"${{CLAUDE_PLUGIN_ROOT}}/{rel}"))
+    return errors
+
+
+def check_user_config_refs(md_path: Path, text: str, known_keys: set[str]) -> list[tuple[int, str]]:
+    errors: list[tuple[int, str]] = []
+    for match in USER_CONFIG_RE.finditer(text):
+        key = match.group(1)
+        if key not in known_keys:
+            errors.append((line_of(text, match.start()), f"${{user_config.{key}}}"))
+    return errors
+
+
+def check_handoffs(md_path: Path, text: str, command_slugs: set[str]) -> list[tuple[int, str]]:
+    errors: list[tuple[int, str]] = []
+    fm_match = FRONTMATTER_RE.match(text)
+    if not fm_match:
+        return errors
+    try:
+        fm = yaml.safe_load(fm_match.group(1)) or {}
+    except yaml.YAMLError as exc:
+        return [(1, f"frontmatter YAML parse error: {exc}")]
+    handoffs = fm.get("handoffs")
+    if not isinstance(handoffs, list):
+        return errors
+    fm_line_count = fm_match.group(1).count("\n") + 2
+    for entry in handoffs:
+        if not isinstance(entry, dict):
+            continue
+        target = entry.get("command")
+        if isinstance(target, str) and target not in command_slugs:
+            errors.append((fm_line_count, f"handoffs: → /{target} (no such command)"))
+    return errors
+
+
+def main() -> int:
+    if not PLUGIN.is_dir():
+        print(f"[error] plugin source not found at {PLUGIN}", file=sys.stderr)
+        return 2
+
+    commands_dir = PLUGIN / "commands"
+    command_slugs = {p.stem for p in commands_dir.glob("*.md")}
+    known_user_config = load_plugin_userconfig_keys()
+
+    total_errors = 0
+    files_with_errors = 0
+
+    for md_path in iter_md_files():
+        text = md_path.read_text()
+        errors: list[tuple[int, str]] = []
+        errors.extend(check_plugin_root_refs(md_path, text))
+        errors.extend(check_user_config_refs(md_path, text, known_user_config))
+        if md_path.parent.name == "commands" and md_path.parent.parent == PLUGIN:
+            errors.extend(check_handoffs(md_path, text, command_slugs))
+        if errors:
+            files_with_errors += 1
+            total_errors += len(errors)
+            rel = md_path.relative_to(ROOT)
+            for line, ref in errors:
+                print(f"{rel}:{line}: broken reference: {ref}")
+
+    if total_errors:
+        print(
+            f"\n[fail] {total_errors} broken reference(s) across {files_with_errors} file(s)",
+            file=sys.stderr,
+        )
+        return 1
+    print(f"[ok] checked {len(iter_md_files())} markdown file(s); no broken references")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Closes the **Item 4 — cross-reference linter** workstream from #442. The three other high-impact items from that issue (1 reader/writer split, 2 schema-gated handoffs, 18 tool allowlist) already shipped in #445/#446.

Adds `scripts/check_references.py` and wires it into the existing `lint-markdown` workflow. The linter walks every `.md` file in `arckit-claude/` and verifies:

- `${CLAUDE_PLUGIN_ROOT}/<path>` references resolve to existing files or directories under `arckit-claude/`.
- `handoffs[].command` entries name an existing command slug under `arckit-claude/commands/`.
- `${user_config.KEY}` references name a key declared in `plugin.json` `userConfig`.

Glob/brace/angle-bracket placeholders are skipped so illustrative patterns like `${CLAUDE_PLUGIN_ROOT}/templates/*-template.md` do not false-positive.

## Real bugs caught on first pass

The linter found two broken references already in the tree:

1. `arckit-claude/agents/arckit-framework.md` pointed at a non-existent `framework-executive-guide-template.md`. The executive guide is generated narrative (Step 6 of the agent), not template-driven. Toolchain entry corrected.
2. `arckit-claude/docs/guides/custom-commands.md` tutorial referenced a `${CLAUDE_PLUGIN_ROOT}/templates/sla-template.md` fallback that did not exist. User-authored custom commands ship their template alongside the command, so the plugin-default branch was misleading; rewrote the instruction.

Both fixes are in this PR.

## Test plan

- [x] `python3 scripts/check_references.py` — `[ok] checked 461 markdown file(s); no broken references`
- [x] Manual sanity-check: temporarily breaking a known reference makes the linter fail
- [x] `npx markdownlint-cli2` clean on the two doc fixes
- [ ] CI pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)