### PR TITLE
feat(215): capture + surface session effort tier (item #27)

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -1890,6 +1890,7 @@
         // ============================================
         let manifest = null;
         let healthData = null;
+        let telemetryData = null;
         let documentCache = new Map();
         let allDocuments = [];
         let currentTocObserver = null;
@@ -2174,6 +2175,17 @@
                                 project: projectName,
                                 category: 'Tech Notes',
                                 searchText: `${doc.title} tech note technology ${projectName}`.toLowerCase()
+                            });
+                        });
+                    }
+
+                    if (project.dataSourceProfiles) {
+                        project.dataSourceProfiles.forEach(doc => {
+                            allDocuments.push({
+                                ...doc,
+                                project: projectName,
+                                category: 'Data Source Profiles',
+                                searchText: `${doc.title} data source profile api dataset ${projectName}`.toLowerCase()
                             });
                         });
                     }
@@ -2950,6 +2962,107 @@
                         <div class="app-dashboard-panel">
                             <h3>Findings by Type</h3>
                             ${healthRightHtml}
+                        </div>
+                    </div>
+                `;
+            }
+
+            // Row 6: Session Telemetry (only if telemetryData exists)
+            if (telemetryData && Array.isArray(telemetryData.sessions) && telemetryData.sessions.length > 0) {
+                const sessions = telemetryData.sessions;
+                const recent = sessions.slice(0, 10); // last 10 for aggregates
+                const display = sessions.slice(0, 5);  // last 5 in the table
+
+                // Aggregate over last 10 sessions
+                let totalToolCalls = 0;
+                let totalAgents = 0;
+                let totalMcp = 0;
+                let p50Sum = 0;
+                let p50Count = 0;
+                const effortMix = {}; // tier → count
+                recent.forEach(s => {
+                    if (typeof s.effort === 'string' && s.effort) {
+                        effortMix[s.effort] = (effortMix[s.effort] || 0) + 1;
+                    }
+                    const t = s.telemetry;
+                    if (!t) return;
+                    if (typeof t.toolCalls === 'number') totalToolCalls += t.toolCalls;
+                    if (typeof t.p50 === 'number') { p50Sum += t.p50; p50Count++; }
+                    if (Array.isArray(t.agents)) t.agents.forEach(a => { totalAgents += a.count || 0; });
+                    if (Array.isArray(t.mcp)) t.mcp.forEach(m => { totalMcp += m.count || 0; });
+                });
+                const medianP50 = p50Count > 0 ? Math.round(p50Sum / p50Count) : null;
+
+                // Effort tier ordering for stable rendering (low → max).
+                const EFFORT_ORDER = ['low', 'medium', 'high', 'xhigh', 'max'];
+                const effortEntries = EFFORT_ORDER
+                    .filter(k => effortMix[k])
+                    .map(k => `${k}: ${effortMix[k]}`)
+                    .concat(
+                        Object.keys(effortMix)
+                            .filter(k => !EFFORT_ORDER.includes(k))
+                            .map(k => `${k}: ${effortMix[k]}`)
+                    );
+                const effortMixLabel = effortEntries.length > 0 ? effortEntries.join(' · ') : '—';
+
+                let activityLeftHtml = `
+                    <div class="app-dashboard-bar-row">
+                        <div class="app-dashboard-bar-label" style="min-width:130px">Tool calls</div>
+                        <div class="app-dashboard-bar-value">${totalToolCalls.toLocaleString()}</div>
+                    </div>
+                    <div class="app-dashboard-bar-row">
+                        <div class="app-dashboard-bar-label" style="min-width:130px">Median p50 latency</div>
+                        <div class="app-dashboard-bar-value">${medianP50 !== null ? medianP50 + ' ms' : '—'}</div>
+                    </div>
+                    <div class="app-dashboard-bar-row">
+                        <div class="app-dashboard-bar-label" style="min-width:130px">Agents spawned</div>
+                        <div class="app-dashboard-bar-value">${totalAgents.toLocaleString()}</div>
+                    </div>
+                    <div class="app-dashboard-bar-row">
+                        <div class="app-dashboard-bar-label" style="min-width:130px">MCP calls</div>
+                        <div class="app-dashboard-bar-value">${totalMcp.toLocaleString()}</div>
+                    </div>
+                    <div class="app-dashboard-bar-row">
+                        <div class="app-dashboard-bar-label" style="min-width:130px">Effort mix</div>
+                        <div class="app-dashboard-bar-value" style="font-size:0.8rem">${escapeHtml(effortMixLabel)}</div>
+                    </div>
+                `;
+                activityLeftHtml += `<p style="color:var(--text-muted);font-size:0.75rem;margin-top:0.75rem;">Across last ${recent.length} session${recent.length === 1 ? '' : 's'} — ${sessions.length} total tracked.</p>`;
+
+                let activityRightHtml = '<ul class="app-dashboard-checklist">';
+                display.forEach(s => {
+                    const dt = s.ts ? new Date(s.ts) : null;
+                    const dateLabel = dt ? `${dt.toLocaleDateString()} ${dt.toTimeString().slice(0, 5)}` : '?';
+                    const t = s.telemetry || {};
+                    const parts = [];
+                    if (typeof t.toolCalls === 'number') parts.push(`${t.toolCalls} tools`);
+                    if (typeof t.p50 === 'number') parts.push(`p50=${t.p50}ms`);
+                    if (Array.isArray(t.agents) && t.agents.length > 0) {
+                        const total = t.agents.reduce((sum, a) => sum + (a.count || 0), 0);
+                        parts.push(`${total} agent${total === 1 ? '' : 's'}`);
+                    }
+                    if (Array.isArray(t.mcp) && t.mcp.length > 0) {
+                        const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
+                        parts.push(`${total} MCP`);
+                    }
+                    const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
+                    const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
+                    const effortChip = (typeof s.effort === 'string' && s.effort)
+                        ? ` <span style="display:inline-block;font-size:0.7rem;padding:1px 6px;border-radius:8px;background:var(--surface-muted,#eef2f7);color:var(--text-muted);margin-left:4px">${escapeHtml(s.effort)}</span>`
+                        : '';
+                    activityRightHtml += `<li><strong>${escapeHtml(dateLabel)}</strong>${failureMark} — <span style="color:var(--text-muted)">${escapeHtml(s.type || 'general')}</span>${effortChip}: ${escapeHtml(summary)}</li>`;
+                });
+                activityRightHtml += '</ul>';
+
+                html += `
+                    <div class="app-dashboard-panels">
+                        <div class="app-dashboard-panel">
+                            <h3>Session Telemetry</h3>
+                            ${activityLeftHtml}
+                        </div>
+                        <div class="app-dashboard-panel">
+                            <h3>Recent Sessions</h3>
+                            ${activityRightHtml}
                         </div>
                     </div>
                 `;
@@ -4105,6 +4218,12 @@
                 listHtml += renderVersionedDocList(project.techNotes);
             }
 
+            // Data Source Profiles
+            if (project.dataSourceProfiles && project.dataSourceProfiles.length > 0) {
+                listHtml += `<li class="app-nav-category">Data Source Profiles</li>`;
+                listHtml += renderVersionedDocList(project.dataSourceProfiles);
+            }
+
             // External Documents (mention only - not clickable)
             if (project.external && project.external.length > 0) {
                 listHtml += `<li class="app-nav-category">External Documents</li>`;
@@ -4785,6 +4904,18 @@
                     }
                 } catch (e) {
                     // health.json not available — dashboard renders without health panel
+                }
+
+                // Optionally load session telemetry (graceful if missing).
+                // Written by arckit-claude/hooks/session-learner.mjs at Stop /
+                // StopFailure when docs/ exists. See "Plugin Hooks" in CLAUDE.md.
+                try {
+                    const telemetryResponse = await fetch('telemetry.json');
+                    if (telemetryResponse.ok) {
+                        telemetryData = await telemetryResponse.json();
+                    }
+                } catch (e) {
+                    // telemetry.json not available — dashboard renders without activity panel
                 }
 
                 // Update footer

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`session-learner.mjs` and `telemetry.mjs` capture session effort level** (#215 item #27). Claude Code v2.1.133 started passing `effort.level` in hook input JSON and `$CLAUDE_EFFORT` as an env var. The effort tier is now recorded on every telemetry JSONL record (`hook_duration`, `mcp_call`, `agent_spawn`) and on every `.arckit/memory/sessions.md` entry, plus the `docs/telemetry.json` per-session record. Enables effort-aware p95 comparison (e.g. `xhigh` vs `max` for the same tool) and supports the Phase 5 audit of which `effort: max` commands could be downgraded. Silently omitted on older clients or when no explicit effort was set.
+
 ### Changed
 
 - **All 16 hook entries in `hooks.json` migrated to `args: string[]` exec form** (#215 item #24). Claude Code v2.1.139 added the exec form (`command: "node"` + `args: ["..."]`) as an alternative to the legacy single-string `command: "node /path/to/x.mjs"`. The harness now execs the binary directly instead of parsing a shell-quoted command line, eliminating shell-quoting / metacharacter pitfalls in `${CLAUDE_PLUGIN_ROOT}`-substituted paths. `arckit-claude/hooks/README.md` and `docs/PLATFORM-COMPARISON.md` document the new form.

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - **`session-learner.mjs` and `telemetry.mjs` capture session effort level** (#215 item #27). Claude Code v2.1.133 started passing `effort.level` in hook input JSON and `$CLAUDE_EFFORT` as an env var. The effort tier is now recorded on every telemetry JSONL record (`hook_duration`, `mcp_call`, `agent_spawn`) and on every `.arckit/memory/sessions.md` entry, plus the `docs/telemetry.json` per-session record. Enables effort-aware p95 comparison (e.g. `xhigh` vs `max` for the same tool) and supports the Phase 5 audit of which `effort: max` commands could be downgraded. Silently omitted on older clients or when no explicit effort was set.
+- **Effort mix surfaced on the `/arckit:pages` dashboard.** The Session Telemetry panel now shows an "Effort mix" row (e.g. `high: 4 · max: 2`) aggregated across the last 10 sessions, and each row in the Recent Sessions list carries an effort-tier chip next to the session type. Rendered only when at least one session has an effort tag — pre-v2.1.133 captures degrade gracefully to the previous layout.
 
 ### Changed
 

--- a/arckit-claude/hooks/README.md
+++ b/arckit-claude/hooks/README.md
@@ -60,15 +60,20 @@ Lightweight telemetry recorder registered for three events:
 - **PostToolUse** (same registration, branched by tool name) — records `{ server, tool, args }` for `mcp__govreposcrape__*` calls. Args are sanitised (long strings replaced with length markers, nested objects flattened to `<object>`) so the JSONL stays small.
 - **TaskCreated** (matcher `.*`, Claude Code v2.1.84+) — records `{ agent }` for every agent spawn via the Task tool.
 
+Every record also carries an **`effort`** field (Claude Code v2.1.133+) when the harness supplies one — read from hookInput `effort.level` or the `$CLAUDE_EFFORT` env var. Omitted on older clients or when no explicit effort was set. The effort tag enables comparing e.g. p95 latency at `xhigh` vs `max` for the same tool, and supports the Phase 5 audit of which `effort: max` commands could be downgraded.
+
+The session-level effort is also surfaced in `.arckit/memory/sessions.md` (one extra line per entry) and in the `docs/telemetry.json` per-session record (top-level `effort` field), so the dashboard "Recent Sessions" panel can colour-code sessions by effort tier.
+
 Events are appended to `.arckit/memory/.telemetry.jsonl` during the session. `session-learner.mjs` reads, summarises, and truncates the file at Stop / StopFailure, adding a single line to each session entry, e.g.:
 
 ```text
+- **Effort:** high
 - **Telemetry:** 47 tool calls (p50=12ms, p95=4200ms) | 3 agents (arckit-research×2, arckit-datascout) | MCP: govreposcrape×8
 ```
 
 Telemetry is best-effort — any failure (write error, malformed line, missing field) is swallowed silently so it never breaks a session.
 
-When `docs/` exists (i.e. the project has run `/arckit:pages`), `session-learner.mjs` also writes a structured rollup to `docs/telemetry.json` (newer-first, capped at 50 sessions) so the dashboard can render a "Session Telemetry" + "Recent Sessions" panel. Each record contains `{ ts, type, isFailure, commits, filesChanged, artifacts, telemetry: { toolCalls, p50, p95, agents, mcp } }`. The dashboard fetches `telemetry.json` with the same graceful-fallback pattern as `health.json` — projects without a `docs/` directory render the dashboard exactly as before.
+When `docs/` exists (i.e. the project has run `/arckit:pages`), `session-learner.mjs` also writes a structured rollup to `docs/telemetry.json` (newer-first, capped at 50 sessions) so the dashboard can render a "Session Telemetry" + "Recent Sessions" panel. Each record contains `{ ts, type, isFailure, effort?, commits, filesChanged, artifacts, telemetry: { toolCalls, p50, p95, agents, mcp } }`. The dashboard fetches `telemetry.json` with the same graceful-fallback pattern as `health.json` — projects without a `docs/` directory render the dashboard exactly as before.
 
 > **Note on `type: "mcp_tool"` (v2.1.118)**: This Claude Code feature lets a hook *invoke* an MCP tool as its action (alternative to `type: "command"` / `type: "prompt"`). It does **not** filter hooks to fire only on MCP tool calls. ArcKit logs `govreposcrape` calls via the existing tool-name matcher pattern (`mcp__govreposcrape__.*`); no `type: "mcp_tool"` registration is needed for telemetry.
 

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -30,6 +30,11 @@ const cwd = data.cwd || '.';
 const isFailure = !!(data.error || data.reason || data.hookEventName === 'StopFailure');
 const failureReason = data.error?.message || data.error?.type || data.reason || data.error || null;
 
+// Effort level the session was running at (Claude Code v2.1.133+).
+// Preferred: hookInput `effort.level`. Fallback: `$CLAUDE_EFFORT` env var.
+// May be null on older clients or when no explicit effort was set.
+const effortLevel = (data.effort && typeof data.effort === 'object' ? data.effort.level : null) || process.env.CLAUDE_EFFORT || null;
+
 // Only proceed if we're inside an ArcKit project. Detect either:
 //   - .arckit/ — CLI scaffolding from `arckit init`
 //   - projects/ — plugin-only install
@@ -138,6 +143,9 @@ let entry = `### ${dateStr} ${timeStr} — ${entryType}\n\n`;
 if (isFailure) {
   entry += `- **Status:** session interrupted by API error\n`;
 }
+if (effortLevel) {
+  entry += `- **Effort:** ${effortLevel}\n`;
+}
 entry += `- **Commits:** ${commitCount} | **Files changed:** ${files.length}\n`;
 
 if (projectArtifacts.size > 0) {
@@ -244,6 +252,7 @@ if (isDir(docsDir)) {
     filesChanged: files.length,
     artifacts: serialiseArtifacts(projectArtifacts),
   };
+  if (effortLevel) sessionRecord.effort = effortLevel;
   if (telemetryRollup) sessionRecord.telemetry = telemetryRollup;
 
   // Newer-first; cap at 50 (≈ a few weeks of daily use).

--- a/arckit-claude/hooks/telemetry.mjs
+++ b/arckit-claude/hooks/telemetry.mjs
@@ -10,19 +10,24 @@
  *
  * Records (one of):
  *
- *   {"ts":"...","kind":"hook_duration","tool":"Write","duration_ms":42}
+ *   {"ts":"...","kind":"hook_duration","tool":"Write","duration_ms":42,"effort":"high"}
  *     - emitted on PostToolUse for every tool with duration_ms (Claude Code
  *       v2.1.119+). Skipped silently when duration_ms is absent (older
  *       client, PreToolUse-rejected calls, etc.)
  *
- *   {"ts":"...","kind":"mcp_call","server":"govreposcrape","tool":"...","args":{...}}
+ *   {"ts":"...","kind":"mcp_call","server":"govreposcrape","tool":"...","args":{...},"effort":"high"}
  *     - emitted on PostToolUse for MCP calls matching `mcp__govreposcrape__.*`.
  *       Records the called tool name and its arguments (sanitised — only
  *       primitive values kept, large blobs replaced with `<…>`).
  *
- *   {"ts":"...","kind":"agent_spawn","agent":"arckit-research"}
+ *   {"ts":"...","kind":"agent_spawn","agent":"arckit-research","effort":"max"}
  *     - emitted on TaskCreated (v2.1.84+). Records the spawned agent's
  *       subagent_type so session-learner can summarise agent usage.
+ *
+ * Every record also carries the session's `effort` level (Claude Code
+ * v2.1.133+) when the harness supplies one — read from hookInput
+ * `effort.level` or the `$CLAUDE_EFFORT` env var. Omitted on older
+ * clients or when no explicit effort was set.
  *
  * Hook Type:  PostToolUse | TaskCreated
  * Input:      JSON hook input (shape varies by event)
@@ -48,6 +53,13 @@ if (!isDir(join(cwd, '.arckit')) && !isDir(join(cwd, 'projects'))) process.exit(
 
 const event = data.hook_event_name || data.hookEventName || '';
 const tool = data.tool_name || '';
+
+// Effort level the call was running at (Claude Code v2.1.133+). Preferred:
+// hookInput `effort.level`. Fallback: `$CLAUDE_EFFORT` env var. Null on
+// older clients or when no explicit effort was set. Attached to every
+// record so downstream analysis can compare e.g. p95 latency at `xhigh`
+// vs `max` for the same tool.
+const effortLevel = (data.effort && typeof data.effort === 'object' ? data.effort.level : null) || process.env.CLAUDE_EFFORT || null;
 
 let record = null;
 const ts = new Date().toISOString();
@@ -82,6 +94,7 @@ if (event === 'TaskCreated' || tool === 'TaskCreate') {
 }
 
 if (record) {
+  if (effortLevel) record.effort = effortLevel;
   const memoryDir = join(cwd, '.arckit', 'memory');
   try {
     mkdirSync(memoryDir, { recursive: true });

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -2979,7 +2979,11 @@
                 let totalMcp = 0;
                 let p50Sum = 0;
                 let p50Count = 0;
+                const effortMix = {}; // tier → count
                 recent.forEach(s => {
+                    if (typeof s.effort === 'string' && s.effort) {
+                        effortMix[s.effort] = (effortMix[s.effort] || 0) + 1;
+                    }
                     const t = s.telemetry;
                     if (!t) return;
                     if (typeof t.toolCalls === 'number') totalToolCalls += t.toolCalls;
@@ -2988,6 +2992,18 @@
                     if (Array.isArray(t.mcp)) t.mcp.forEach(m => { totalMcp += m.count || 0; });
                 });
                 const medianP50 = p50Count > 0 ? Math.round(p50Sum / p50Count) : null;
+
+                // Effort tier ordering for stable rendering (low → max).
+                const EFFORT_ORDER = ['low', 'medium', 'high', 'xhigh', 'max'];
+                const effortEntries = EFFORT_ORDER
+                    .filter(k => effortMix[k])
+                    .map(k => `${k}: ${effortMix[k]}`)
+                    .concat(
+                        Object.keys(effortMix)
+                            .filter(k => !EFFORT_ORDER.includes(k))
+                            .map(k => `${k}: ${effortMix[k]}`)
+                    );
+                const effortMixLabel = effortEntries.length > 0 ? effortEntries.join(' · ') : '—';
 
                 let activityLeftHtml = `
                     <div class="app-dashboard-bar-row">
@@ -3005,6 +3021,10 @@
                     <div class="app-dashboard-bar-row">
                         <div class="app-dashboard-bar-label" style="min-width:130px">MCP calls</div>
                         <div class="app-dashboard-bar-value">${totalMcp.toLocaleString()}</div>
+                    </div>
+                    <div class="app-dashboard-bar-row">
+                        <div class="app-dashboard-bar-label" style="min-width:130px">Effort mix</div>
+                        <div class="app-dashboard-bar-value" style="font-size:0.8rem">${escapeHtml(effortMixLabel)}</div>
                     </div>
                 `;
                 activityLeftHtml += `<p style="color:var(--text-muted);font-size:0.75rem;margin-top:0.75rem;">Across last ${recent.length} session${recent.length === 1 ? '' : 's'} — ${sessions.length} total tracked.</p>`;
@@ -3027,7 +3047,10 @@
                     }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
-                    activityRightHtml += `<li><strong>${escapeHtml(dateLabel)}</strong>${failureMark} — <span style="color:var(--text-muted)">${escapeHtml(s.type || 'general')}</span>: ${escapeHtml(summary)}</li>`;
+                    const effortChip = (typeof s.effort === 'string' && s.effort)
+                        ? ` <span style="display:inline-block;font-size:0.7rem;padding:1px 6px;border-radius:8px;background:var(--surface-muted,#eef2f7);color:var(--text-muted);margin-left:4px">${escapeHtml(s.effort)}</span>`
+                        : '';
+                    activityRightHtml += `<li><strong>${escapeHtml(dateLabel)}</strong>${failureMark} — <span style="color:var(--text-muted)">${escapeHtml(s.type || 'general')}</span>${effortChip}: ${escapeHtml(summary)}</li>`;
                 });
                 activityRightHtml += '</ul>';
 


### PR DESCRIPTION
## Summary

- **Capture**: `session-learner.mjs` and `telemetry.mjs` now read the session's effort tier from hookInput `effort.level` (Claude Code v2.1.133+) or `$CLAUDE_EFFORT` env var. Tag is attached to every telemetry JSONL record (`hook_duration`, `mcp_call`, `agent_spawn`) and every entry in `.arckit/memory/sessions.md` + `docs/telemetry.json`.
- **Surface**: `/arckit:pages` dashboard's Session Telemetry panel gains an "Effort mix" row (e.g. `high: 4 · max: 2`) aggregated across the last 10 sessions, and each row in the Recent Sessions list shows an effort chip next to the session type.
- **Graceful**: Renders identically on pre-v2.1.133 captures — the effort fields are simply omitted.

Closes item #27 on #215. Stacked on top of #468 (item #25) → #467 (item #24).

## Why

Phase 5 of #215 calls for an audit of `effort: max` commands to identify candidates for `xhigh` downgrade. Without effort tagging, every telemetry record was effort-blind — there was no way to compare e.g. p95 latency at `xhigh` vs `max` for the same tool. Now the data is in both the JSONL stream (per-call granularity) and the per-session rollup (for human review on the dashboard).

## Files changed

- `arckit-claude/hooks/session-learner.mjs` — adds `effortLevel` capture; surfaces it as a `**Effort:** <tier>` line in `sessions.md` and as a top-level `effort` field in the `docs/telemetry.json` per-session record
- `arckit-claude/hooks/telemetry.mjs` — adds `effort` field to every JSONL record (top-level alongside `kind`, `ts`); JSDoc updated
- `arckit-claude/hooks/README.md` — Session Telemetry section documents the new effort tagging
- `arckit-claude/templates/pages-template.html` — dashboard "Effort mix" row + per-session effort chip
- `.arckit/templates/pages-template.html` — synced to the plugin copy. **Side-effect cleanup**: this file was missing the entire Session Telemetry block (pre-existing drift from when telemetry was first added — CLI-scaffolded projects via `arckit init` were rendering an older dashboard). Syncing here corrects that.
- `arckit-claude/CHANGELOG.md` — Unreleased entries (one for capture, one for dashboard)

## Test plan

- [ ] Smoke-tested locally: hookInput `{effort: {level: "xhigh"}}` writes `**Effort:** xhigh` to `sessions.md`; `CLAUDE_EFFORT=max` env var fallback works identically; `telemetry.mjs` records gain `"effort": "high"` when the env var is set during a PostToolUse
- [ ] `node --check` passes on both hook files
- [ ] `npx markdownlint-cli2` clean on changed `.md` files
- [ ] Manual: run `/arckit:pages` on a test repo after a session at `effort: high`, confirm "Effort mix" row renders and the recent-sessions row shows the chip
- [ ] Manual: confirm pre-v2.1.133 captures (no `effort` field) render the panel without the row/chip

## Notes

- The user requested the dashboard piece mid-PR; rather than splitting, both the data capture and the surface live here together since they're the same feature.
- The `.arckit/templates/` drift sync is incidental but lands here because the template-sync rule in CLAUDE.md applies to any touched template. The diff includes the previously-missing Session Telemetry block plus the new `dataSourceProfiles` document-cache entry that the plugin copy already had.

🤖 Generated with [Claude Code](https://claude.com/claude-code)