### PR TITLE
docs(472): /fast mode + MCP_TOOL_TIMEOUT env var

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,8 @@ Commands exist in multiple formats across the distribution. The plugin source is
 
 Effort and `keep-coding-instructions` are stripped by the converter for non-Claude targets.
 
+**Fast mode** (`/fast` toggle) runs the current Opus model with faster output — same model, no smaller-model downgrade. As of Claude Code v2.1.142 the default backing model for `/fast` is **Opus 4.7** (was Opus 4.6 pre-v2.1.142). `/fast` is unrelated to the `effort:` frontmatter — the two compose: a command with `effort: xhigh` still benefits from `/fast` if the user has toggled it.
+
 ### Agent System
 
 Some commands delegate to **autonomous agents** (`arckit-claude/agents/arckit-{name}.md`) that run as subprocesses via the Task tool. Agents are used for commands that perform extensive web research (>10 WebSearch/WebFetch/MCP calls) to keep that context isolated from the main conversation.

--- a/docs/guides/aws-research.md
+++ b/docs/guides/aws-research.md
@@ -31,6 +31,8 @@ Add to your Claude Code MCP configuration (`~/.claude/claude_desktop_config.json
 
 After installation, restart Claude Code to load the MCP server.
 
+**Slow corporate network?** On TLS-inspecting proxies, VPN tunnels, or congested links, large-scope research prompts can exceed Claude Code's default per-request fetch timeout. Set `MCP_TOOL_TIMEOUT=300000` (5 minutes, in milliseconds) before launching Claude — see [MCP per-request timeout](mcp-servers.md#optional-mcp-per-request-timeout-claude-code-v21142) in the MCP setup guide. Requires Claude Code v2.1.142+.
+
 ### Project Prerequisites
 
 - Requirements document (`ARC-*-REQ-*.md`) - **MANDATORY**

--- a/docs/guides/azure-research.md
+++ b/docs/guides/azure-research.md
@@ -31,6 +31,8 @@ Add to your Claude Code MCP configuration (`~/.claude/claude_desktop_config.json
 
 After installation, restart Claude Code to load the MCP server.
 
+**Slow corporate network?** On TLS-inspecting proxies, VPN tunnels, or congested links, large-scope research prompts can exceed Claude Code's default per-request fetch timeout. Set `MCP_TOOL_TIMEOUT=300000` (5 minutes, in milliseconds) before launching Claude — see [MCP per-request timeout](mcp-servers.md#optional-mcp-per-request-timeout-claude-code-v21142) in the MCP setup guide. Requires Claude Code v2.1.142+.
+
 ### Project Prerequisites
 
 - Requirements document (`ARC-*-REQ-*.md`) - **MANDATORY**

--- a/docs/guides/gcp-research.md
+++ b/docs/guides/gcp-research.md
@@ -42,6 +42,8 @@ export GOOGLE_API_KEY="your-api-key-here"
 
 After installation, restart Claude Code to load the MCP server.
 
+**Slow corporate network?** On TLS-inspecting proxies, VPN tunnels, or congested links, large-scope research prompts can exceed Claude Code's default per-request fetch timeout. Set `MCP_TOOL_TIMEOUT=300000` (5 minutes, in milliseconds) before launching Claude — see [MCP per-request timeout](mcp-servers.md#optional-mcp-per-request-timeout-claude-code-v21142) in the MCP setup guide. Requires Claude Code v2.1.142+.
+
 ### Project Prerequisites
 
 - Requirements document (`ARC-*-REQ-*.md`) - **MANDATORY**

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -35,6 +35,20 @@ claude
 
 Recommended for: overnight `autoresearch` runs, multi-command workflows (`/arckit:requirements` -> `/arckit:data-model` -> `/arckit:components`), and research agents that re-read large project context. Verify cache uplift in your Anthropic billing dashboard (`cache_read_input_tokens` should grow as a fraction of input tokens).
 
+### Optional: MCP per-request timeout (Claude Code v2.1.142+)
+
+The three bundled cloud-research MCP servers (`aws-knowledge`, `microsoft-learn`, `google-developer-knowledge`) are remote HTTP servers reached from your machine. Behind corporate proxies, TLS-inspecting gateways, or slow links, individual fetches inside a single tool call can exceed Claude Code's default per-request timeout — surfacing as `MCP tool call failed: timeout` in the middle of a long `/arckit:aws-research`, `/arckit:azure-research`, or `/arckit:gcp-research` run.
+
+Claude Code v2.1.142 made `MCP_TOOL_TIMEOUT` honour the per-request fetch timeout for remote servers (previously it only governed initial connect). Raise it for cloud-research sessions on slow networks:
+
+```bash
+# 5-minute per-request timeout (default is 60s)
+export MCP_TOOL_TIMEOUT=300000
+claude
+```
+
+The value is milliseconds. Recommended for: corporate networks with TLS-inspecting proxies, VPN-tunnelled connections, and large-scope research prompts that trigger many `microsoft_docs_fetch` / `aws___read_documentation` / `get_document` calls in sequence. On a healthy direct connection the default is fine — only set this when you see timeout failures.
+
 ### Step 1: Add the marketplace
 
 In Claude Code, run:


### PR DESCRIPTION
Two documentation tasks from #472.

## Summary

- **CLAUDE.md** — adds a Fast mode note next to the effort: frontmatter docs. Captures the v2.1.142 default change (Opus 4.6 → Opus 4.7), clarifies that `/fast` is independent of and composes with the `effort:` frontmatter.
- **`docs/guides/mcp-servers.md`** — new "Optional: MCP per-request timeout (Claude Code v2.1.142+)" section covering `MCP_TOOL_TIMEOUT` for the three bundled cloud-research MCP servers (`aws-knowledge`, `microsoft-learn`, `google-developer-knowledge`). v2.1.142 made the env var honour the per-request fetch timeout for remote servers — previously connect-only. Recommends 300000 ms (5 minutes) for corporate networks with TLS-inspecting proxies.
- **`docs/guides/{aws,azure,gcp}-research.md`** — each gains a one-line cross-reference under the MCP installation block so users seeing timeout failures in their actual research workflow are pointed to the knob.

Closes the two documentation tasks on #472.

## Test plan

- [x] `npx markdownlint-cli2` clean on all 5 changed files
- [ ] Confirm anchor `#optional-mcp-per-request-timeout-claude-code-v21142` renders correctly in the docs site

🤖 Generated with [Claude Code](https://claude.com/claude-code)