### PR TITLE
feat(autoresearch): explicit stop conditions, no more loop-forever

### DIFF
--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -4,7 +4,7 @@
 
 ArcKit includes an autonomous prompt optimisation system inspired by [karpathy/autoresearch](https://github.com/karpathy/autoresearch). It lets Claude Code iteratively improve any command prompt by running it, scoring the output, tweaking the prompt, and keeping or discarding the change based on whether quality improved.
 
-You start a run and walk away. The system loops until you stop it.
+You start a run and walk away. The system loops until a stop condition fires — score target hit, iteration budget exhausted, or double plateau detected. See [Stopping Conditions](#stopping-conditions) below for the defaults and how to tune them.
 
 ---
 
@@ -25,7 +25,7 @@ Claude will:
 3. Run the command, score the output, log the baseline
 4. Enter the experiment loop -- tweaking, re-running, keeping or discarding
 
-To stop: interrupt Claude at any time. The worktree has the best prompt.
+To stop early: interrupt Claude at any time. Otherwise the loop self-terminates on a stop condition (see [Stopping Conditions](#stopping-conditions)). Either way, the worktree has the best prompt.
 
 ### Watching progress without blocking the main session
 
@@ -72,6 +72,7 @@ Each iteration follows the same cycle:
 8. **Compare** to the previous best score
 9. **Keep or discard** based on a minimum delta threshold (>= 0.3)
 10. **Log** the result to `results.tsv`
+11. **Check stop conditions** — exit if score target hit, iteration budget exhausted, or double plateau detected (see [Stopping Conditions](#stopping-conditions))
 
 If discarded, the prompt is reverted via `git checkout` to the previous best version. The full history (including discards) is preserved in `results.tsv`.
 
@@ -160,16 +161,30 @@ c3d4e5f PASS        9.0    discard  derive NFR targets from context (delta < 0.3
 d4e5f6g PASS        9.2    keep     add use case structure instruction
 ```
 
-Status values: `keep`, `discard`, `plateau`, `crash`.
+Status values: `keep`, `discard`, `plateau`, `crash`, `complete`, `budget-exhausted`.
 
 ### Plateau Detection
 
-If 5 consecutive iterations are discarded, the system shifts strategy:
+If 15 consecutive iterations are discarded, the system shifts strategy:
 
 - Re-reads the template for unaddressed sections
 - Reviews the quality checklist for uncovered criteria
 - Tries prompt simplification
 - Combines ideas from previous near-misses
+
+A `plateau` row is logged when the trigger fires; the strategy shift resets the discard streak.
+
+### Stopping Conditions
+
+The loop runs until one of three explicit stop conditions fires (no "run forever" mode). All three are tunable inline at the top of step 12 in `program.md`:
+
+| Condition | Default | Final status row | Meaning |
+|-----------|---------|------------------|---------|
+| Score target | `best >= 9.5` | `complete` | Quality target reached; further iteration unlikely to pay off |
+| Iteration budget | `iter >= 30` | `budget-exhausted` | Token budget bounded; rerun with higher cap if more headroom is wanted |
+| Double plateau | 2 `plateau` rows within 10 iterations | `complete` | Strategy shift exhausted; diminishing returns |
+
+The final status row carries the reason in its `description` field so `results.tsv` self-documents why the run ended. To extend a run, edit the constants in `program.md` step 12 and re-launch — the constraints in section 4 prohibit the LLM from negotiating past a hit threshold mid-run.
 
 ---
 

--- a/scripts/autoresearch/program.md
+++ b/scripts/autoresearch/program.md
@@ -112,7 +112,9 @@ The combined score is the arithmetic mean of the five dimensions, rounded to one
 
 ## 4. The Experiment Loop
 
-### LOOP FOREVER
+### LOOP UNTIL STOP CONDITION
+
+The loop runs until one of three explicit stop conditions fires (see step 12 below) — score target reached, iteration budget exhausted, or double plateau detected. There is no "loop forever" mode.
 
 1. Read the current command prompt and review `results.tsv` history
 2. Identify ONE specific improvement to the prompt
@@ -145,7 +147,13 @@ The combined score is the arithmetic mean of the five dimensions, rounded to one
 
     Then commit the revert: `"revert: <description> (no improvement)"`
     Do NOT use `git reset --hard` or `git revert`
-12. Go to step 1
+12. **Check stopping conditions** before going back to step 1:
+    - **Score target hit** — if `best >= 9.5`: log a row with status `complete` and description `score target reached (best={best})`, then exit the loop.
+    - **Iteration budget** — if `iter >= 30`: log a row with status `budget-exhausted` and description `30-iteration budget reached (best={best})`, then exit the loop.
+    - **Double plateau** — if the Plateau Detection trigger has fired twice in this run (i.e. two `plateau` rows already logged and the second was within the last 10 iterations): log a row with status `complete` and description `double plateau — diminishing returns`, then exit the loop.
+    - Otherwise: Go to step 1.
+
+    These thresholds are tunable. To extend a run, change the constants here (e.g. `>= 9.7` for higher target, `>= 50` for longer budget) and re-launch — do not let the LLM negotiate past a hit threshold mid-run.
 
 ### Plateau Detection
 
@@ -156,6 +164,8 @@ If the last 15 consecutive iterations have all been discarded (no score improvem
 - Try prompt simplification (removing instructions that don't contribute to score)
 - Try combining ideas from previous near-misses in the results history
 - Try changing `effort:` or `model:` if you haven't already — a different thinking level or model may unlock gains that prompt wording alone cannot
+
+The plateau strategy shift resets the discard streak to 0. If a second plateau marker is logged within 10 iterations of the first, step 12's double-plateau condition fires and the run exits — that's the diminishing-returns signal that further iteration is unlikely to pay off.
 
 ---
 


### PR DESCRIPTION
Closes the `/goal` deferred item on #472 by adding native stop semantics to autoresearch — simpler than `/goal` integration, no v2.1.139 floor dependency, same control.

## Summary

Today's `scripts/autoresearch/program.md` step 12 says "Go to step 1" with no termination. Overnight runs that long since stopped improving keep burning tokens until manually interrupted. Spike on `/goal` (#472 deferred item) revealed that the loop already prints structured status lines and writes to `results.tsv`, so the LLM can self-police on objective numeric thresholds without an external evaluator.

Three explicit stop conditions added to step 12:

| Condition | Default | Final status row | Meaning |
|-----------|---------|------------------|---------|
| Score target | `best >= 9.5` | `complete` | Quality target reached |
| Iteration budget | `iter >= 30` | `budget-exhausted` | Token budget bounded |
| Double plateau | 2 `plateau` rows within 10 iterations | `complete` | Diminishing returns |

The final `results.tsv` row carries the reason in its `description` field — runs self-document why they ended.

## Why not /goal?

`/goal` is a session-scoped Stop-hook wrapper whose evaluator only observes conversation, not the filesystem. Integration would require restructuring the loop to one-iteration-per-turn so the evaluator can fire between turns. Self-policing in `program.md` is simpler:

- Same control (bounded termination)
- No Claude Code v2.1.139 floor dependency
- Works in any AI assistant that runs the program (not Claude Code-only)
- Self-contained — one artifact carries both loop and termination
- Tradeoff: LLM self-policing vs fresh-model evaluator. For objective numeric thresholds against TSV-logged scores this is robust; the "do not negotiate past a hit threshold mid-run" instruction prevents in-context bias.

## Files changed

- `scripts/autoresearch/program.md` — step 12 rewritten; section header "LOOP FOREVER" → "LOOP UNTIL STOP CONDITION"; Plateau Detection notes streak-reset and double-plateau interaction
- `docs/guides/autoresearch.md` — new "Stopping Conditions" subsection with the three-threshold table; Quick Start paragraph + The Loop step list updated; stale `Plateau Detection` count corrected (5 → 15, drifted from program.md)

## Test plan

- [x] `markdownlint-cli2` clean
- [ ] Manual: run `/arckit:autoresearch` against `requirements` with low thresholds (e.g. `best >= 8.6`, `iter >= 3`) — confirm the loop exits cleanly and logs the final row with the expected status / description

🤖 Generated with [Claude Code](https://claude.com/claude-code)