### PR TITLE
docs(au): contributors page entry + 8 per-command guides (post-v5.0.0 cleanup)

### DIFF
--- a/arckit-claude/docs/guides/au-ai-assurance.md
+++ b/arckit-claude/docs/guides/au-ai-assurance.md
@@ -1,0 +1,84 @@
+# Australian AI Assurance Baseline Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-ai-assurance` generates an AI assurance baseline against the Digital Transformation Agency's AI Assurance Framework and the Responsible AI Policy v2.0 (effective December 2025). It captures the AI system's risk classification, runs the assurance assessment against the Framework's principles, surfaces the Privacy Act AI-decision notification posture (Tranche 1 reforms, December 2024), captures ISO 42001 readiness, and surfaces the human-oversight and accountability model.
+
+The AI Assurance Framework is the operational expression of Australia's responsible-AI commitments for Federal entities. For DISP suppliers offering AI-enabled services to Defence, this is the gate artefact alongside the ISM SoA. The Tranche 1 Privacy Act reforms add a discrete obligation around automated decision-making notifications that the assurance baseline must address.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | AI system description, intended use, user populations |
+| `/arckit.au-pia` output (`ARC-<id>-AUPIA-v1.0.md`) | Automated decision-making notification posture |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Training, validation, and inference data flows |
+| Risk register (`ARC-<id>-RISK-v1.0.md`) | AI-specific risks (bias, drift, hallucination, misuse) |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Model architecture, hosting, monitoring posture |
+
+---
+
+## Command
+
+```bash
+/arckit.au-ai-assurance <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUAIA-v1.0.md`
+
+---
+
+## Assurance Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Risk classification, headline assurance posture, residual issues, decisions for accountable authority |
+| AI System Description | Use case, deployment context, lifecycle stage |
+| Risk Classification | Per the AI Assurance Framework rubric: low / medium / high / unacceptable |
+| Principle-by-Principle Assessment | Each Framework principle: posture, evidence, gaps, mitigations |
+| Responsible AI Policy v2.0 Conformance | Specific obligations: usage register, deployment approval, ministerial visibility |
+| Privacy Act Tranche 1 Notification | Automated decision-making notification posture and pathway |
+| Human Oversight Model | Where humans remain in the loop, escalation criteria, override workflow |
+| ISO 42001 Readiness | Gap analysis against ISO/IEC 42001 (AI management systems) for organisations targeting certification |
+| Monitoring & Drift | Performance metrics, drift detection, retraining triggers |
+| Incident Response | AI-specific incident criteria (hallucination, bias drift, misuse, model compromise) |
+| Maintenance Cadence | Quarterly review minimum; per-release for active development |
+
+---
+
+## Regulatory Anchors
+
+- **DTA AI Assurance Framework** — primary assurance methodology (current version)
+- **Responsible AI Policy v2.0** — effective December 2025; usage transparency obligations
+- **Privacy Act 1988 (Cth)** — Tranche 1 reforms (Dec 2024): automated decision-making notification
+- **ISO/IEC 42001** — AI management system standard; voluntary but increasingly procurement-relevant
+- **NSW AI Assurance Framework** — sub-federal reference; non-binding for Commonwealth but informative
+- **DTA Generative AI Framework / Guardrails** — generative-AI-specific extensions
+
+---
+
+## When to Run
+
+- For any AI / ML system entering Federal use; for DISP suppliers shipping AI to Defence
+- Pre-deployment and at each material model change (retraining, new use case, new population)
+- Quarterly minimum once Live; per-release in active development
+- On regulatory update (Framework version change, new policy version)
+
+---
+
+## Common Pitfalls
+
+- **Treating LLMs as low risk by default** — generative AI in customer-facing or decision-support contexts is typically medium or high. Map honestly.
+- **Missing the Tranche 1 notification trigger** — automated decisions that affect individuals trigger notification obligations under the amended Privacy Act. Cross-check the PIA explicitly.
+- **No drift monitoring** — assurance is a posture at a point in time. Without continuous monitoring, the posture lapses immediately.
+- **ISO 42001 confused with conformance** — readiness is a gap analysis, not a certification claim. Mark certification status explicitly.
+
+---
+
+## Handoff
+
+Cross-references `/arckit.au-pia` (automated decision-making notification), `/arckit.au-ism-controls` (technical controls for model serving), and feeds `/arckit.au-disp-attestation` (DISP supplier AI assurance evidence for Defence-facing systems).

--- a/arckit-claude/docs/guides/au-disp-attestation.md
+++ b/arckit-claude/docs/guides/au-disp-attestation.md
@@ -1,0 +1,90 @@
+# Australian DISP Member Self-Attestation Pack Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-disp-attestation` generates a Defence Industry Security Program (DISP) Member self-attestation pack. It consolidates the evidence base across the 4 DISP security domains (Governance, Personnel Security, Physical Security, Information &amp; Cyber), captures the Foreign Ownership Control & Influence (FOCI) declaration, surfaces the supply-chain security posture, and structures the annual board attestation that DISP membership requires.
+
+DISP is the Department of Defence's supplier-side security accreditation. Level 2 (the most common operational ceiling for non-classified Defence work) requires demonstrable evidence across all four domains and depends on E8 ML2 as the cyber baseline. This pack is the consolidation artefact that the other AU commands feed into — run it last.
+
+---
+
+## Inputs
+
+This is the consolidation artefact. It draws from every other AU command's output:
+
+| Artefact | Purpose |
+|----------|---------|
+| `/arckit.au-e8-posture` (`ARC-<id>-AUE8-v1.0.md`) | E8 ML2+ baseline for the cyber domain |
+| `/arckit.au-ism-controls` (`ARC-<id>-AUISM-v1.0.md`) | ISM SoA underpinning Information & Cyber |
+| `/arckit.au-pia` (`ARC-<id>-AUPIA-v1.0.md`) | Personal information handling for Information & Cyber |
+| `/arckit.au-ndb-playbook` (`ARC-<id>-AUNDB-v1.0.md`) | Breach response capability |
+| `/arckit.au-pspf` (`ARC-<id>-AUPSPF-v1.0.md`) | PSPF maturity for Governance, Personnel, Physical, Information |
+| `/arckit.au-ai-assurance` (`ARC-<id>-AUAIA-v1.0.md`) | AI assurance for Defence-facing AI systems |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, security advisor, FOCI signatory |
+| Risk register (`ARC-<id>-RISK-v1.0.md`) | Supplier-side risks |
+
+---
+
+## Command
+
+```bash
+/arckit.au-disp-attestation <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUDISP-v1.0.md`
+
+---
+
+## Pack Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | DISP level targeted, attestation status, headline gaps, board action required |
+| Member Identity | Legal entity, ABN, ownership tree, accountable individuals |
+| Foreign Ownership Control & Influence (FOCI) Declaration | Ownership, control, influence; mitigation arrangements where required |
+| Domain 1 — Governance | Security governance, risk, accountability; evidence cross-references to PSPF Outcome 1 |
+| Domain 2 — Personnel Security | Vetting, ongoing suitability, separation; evidence from PSPF Outcome 3 |
+| Domain 3 — Physical Security | Premises, certified zones, custody; evidence from PSPF Outcome 4 |
+| Domain 4 — Information & Cyber | E8, ISM, PIA, NDB evidence; AI assurance for AI-enabled Defence services |
+| Supply Chain Security | Sub-contractor vetting, supply-chain risk register, security clauses |
+| Incident History | Material security incidents in attestation window |
+| Annual Board Attestation | Statement signed by accountable authority confirming the posture |
+| Maintenance Cadence | Annual attestation cycle; per-incident updates |
+
+---
+
+## Regulatory Anchors
+
+- **DISP Member Manual** — authoritative source for DISP-level requirements
+- **Defence Security Principles Framework (DSPF)** — incorporated by reference for DISP suppliers
+- **ASD Essential Eight Maturity Model** — ML2 baseline for DISP Level 2
+- **ASD Information Security Manual** — control evidence base for Domain 4
+- **Privacy Act 1988 (Cth)** — for personal information handling
+- **Protective Security Policy Framework** — referenced across Domains 1, 2, 3, 4
+- **Cyber Security Act 2024 (Cth)** — incident-reporting interactions
+
+---
+
+## When to Run
+
+- During DISP application or upgrade (Level 1 → 2 → 3)
+- Annually for ongoing DISP members (the attestation cycle)
+- On material change to FOCI, leadership, or the security posture (re-attestation may be required)
+- On significant security incident in attestation window
+
+---
+
+## Common Pitfalls
+
+- **Treating it as paperwork** — DISP attestation is a board-level statement of fact. Inaccuracies create criminal exposure under Defence security legislation. Validate every cross-reference.
+- **Thin FOCI declaration** — full ownership tree is required, including indirect control. Engage corporate counsel early if ownership is non-trivial.
+- **Inheriting evidence without verification** — if Domain 4 cites the ISM SoA, the underlying SoA must be current and accurate. Don't cite stale evidence.
+- **Missing sub-contractor coverage** — DISP suppliers carry obligations across the supply chain. Sub-contractor vetting evidence must be in the pack.
+
+---
+
+## Handoff
+
+This is the consolidation artefact for DISP attestation. It is read by the Department of Defence, Defence Industry Security Branch, and (where relevant) procurement-side security assessors. After board sign-off, the attestation cycle resets for 12 months.

--- a/arckit-claude/docs/guides/au-dss.md
+++ b/arckit-claude/docs/guides/au-dss.md
@@ -1,0 +1,76 @@
+# Australian DTA Digital Service Standard Conformance Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-dss` generates a conformance assessment against the Digital Transformation Agency's Digital Service Standard (13 criteria). It scopes the service in delivery-phase terms (Discovery / Alpha / Beta / Live), evaluates each of the 13 criteria with evidence and gaps, captures the cross-jurisdictional procurement implications under the Commonwealth Procurement Rules (November 2025 overhaul), and surfaces the readiness posture for DTA assessment.
+
+The DTA DSS is the Australian counterpart to the UK GDS Service Standard. The conformance assessment is the gate that Australian Federal services use to demonstrate user-centred, accessible, and accountable design before launch.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, user needs, accessibility targets |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | User populations, accountable authority, partners |
+| Strategy (`ARC-<id>-STRAT-v1.0.md`) | Programme phase, success measures |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Technical posture, accessibility implementation |
+
+---
+
+## Command
+
+```bash
+/arckit.au-dss <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUDSS-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Headline conformance, gaps to launch, DTA assessment readiness |
+| Service Scope | Description, owner, user populations, current delivery phase |
+| Criterion-by-Criterion Assessment | All 13 criteria: posture, evidence cited, gaps, planned remediation |
+| Accessibility (WCAG 2.2 AA) | Conformance level, audit evidence, remediation backlog |
+| Procurement Implications | CPR November 2025 obligations, ICT supplier ethical conduct, AI transparency clauses |
+| Performance Measures | KPIs aligned to DSS criteria 1, 8, and 13 |
+| Treatment & Monitoring | Outstanding remediation, review cadence, governance routes |
+
+---
+
+## Regulatory Anchors
+
+- **DTA Digital Service Standard** — 13 criteria (authoritative source for scoring)
+- **DTA Digital Service Standard Guidance** — criterion-by-criterion interpretation
+- **WCAG 2.2 AA** — accessibility target referenced by Criterion 9
+- **Commonwealth Procurement Rules (November 2025 overhaul)** — supplier ethical conduct, AI transparency
+- **PGPA Act 2013 s16** — federal accountable-authority duties
+
+---
+
+## When to Run
+
+- At each delivery-phase gate (end of Discovery, end of Alpha, end of Beta, pre-Live)
+- On material change to user-facing design, accessibility implementation, or accountability model
+- Refresh annually in steady-state Live to track residual conformance
+
+---
+
+## Common Pitfalls
+
+- **Marking criteria green without dated evidence** — every "met" criterion needs an evidence pointer (research output, audit report, monitoring dashboard) with a date. Older than 12 months is stale.
+- **Confusing WCAG 2.1 AA with 2.2 AA** — Criterion 9 references the current target. Verify against the version cited in current DTA guidance.
+- **Skipping the procurement criteria** — Criterion 13 (sustainability and value for money) materially changed with the CPR November 2025 overhaul. Cite the new obligations explicitly.
+
+---
+
+## Handoff
+
+Feeds the assurance package alongside `/arckit.au-pia` (Privacy Act compliance) and `/arckit.au-e8-posture` (cyber baseline). Pre-Live and Live phase artefacts cross-reference DSS conformance evidence in `/arckit.au-disp-attestation` for supplier-side accreditation.

--- a/arckit-claude/docs/guides/au-e8-posture.md
+++ b/arckit-claude/docs/guides/au-e8-posture.md
@@ -1,0 +1,73 @@
+# Australian Essential Eight Maturity Posture Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-e8-posture` generates an ASD Essential Eight maturity posture against the Australian Signals Directorate's Essential Eight Maturity Model. It scores each of the eight mitigation strategies (application control, patch applications, configure Microsoft Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups) against maturity levels ML0–ML3, captures the evidence base, identifies the maturity uplift path, and surfaces the DISP-aligned target (ML2 baseline for DISP Level 2 supplier accreditation).
+
+The Essential Eight is the ASD's prioritised baseline for mitigating cyber security incidents and is the cyber baseline that DISP, federal entities, and most Commonwealth procurements measure against. The artefact this command produces is therefore a foundational input to almost every other Australian Federal security or assurance artefact — run it early.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, hosting model, user populations |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Sensitive data categories that drive control intensity |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, security operations owner |
+
+---
+
+## Command
+
+```bash
+/arckit.au-e8-posture <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUE8-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Current maturity by strategy, gap to target maturity, headline residual risks |
+| Scope | In-scope systems, business units, environments (production / staging / non-production) |
+| Maturity Assessment per Strategy | For each of the 8: current ML, target ML, evidence cited, gap analysis, planned uplift |
+| Uplift Plan | Sequenced remediation with effort, dependencies, and DISP-attestation deadline alignment |
+| Residual Risk Statement | Risks accepted, treatments in flight, escalation path |
+| Maintenance Cadence | Re-assessment frequency, change triggers, ASD update tracking |
+
+---
+
+## Regulatory Anchors
+
+- **ASD Essential Eight Maturity Model** — eight mitigation strategies, maturity levels ML0–ML3 (the authoritative source for scoring rubric)
+- **ASD Information Security Manual (ISM)** — control-level detail referenced by E8 strategies (cross-reference via `/arckit.au-ism-controls`)
+- **Defence Industry Security Program (DISP) Levels 1–3** — ML2 mandated for DISP Level 2 supplier accreditation
+- **Commonwealth Procurement Rules (November 2025 overhaul)** — cyber maturity questions in standard supplier responses
+
+---
+
+## When to Run
+
+- Early in delivery, immediately after stakeholders and requirements — before HLD or detailed security design
+- Re-run on material change to hosting, identity, or admin access model
+- Refresh annually at minimum; DISP suppliers refresh on the attestation cadence (typically 12 months)
+
+---
+
+## Common Pitfalls
+
+- **Scoping too wide** — assessing the whole organisation when the artefact is service-specific produces a low-confidence score. Tighten scope to the service or DISP-accredited business unit.
+- **Missing evidence date** — every cited evidence item needs a "verified on" date so reviewers can judge currency. Make the date a hard field.
+- **Confusing ML2 with "good enough"** — ML2 is the DISP baseline, not a security ceiling. Where the residual risk justifies it, target ML3 on individual strategies.
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-disp-attestation` (DISP Member self-attestation pack consolidates E8 evidence), `/arckit.au-pspf` (PSPF cross-references E8 baselines), and `/arckit.au-ism-controls` (ISM Statement of Applicability draws from the same control evidence).

--- a/arckit-claude/docs/guides/au-ism-controls.md
+++ b/arckit-claude/docs/guides/au-ism-controls.md
@@ -1,0 +1,78 @@
+# Australian ISM Statement of Applicability Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-ism-controls` generates a Statement of Applicability against the Australian Signals Directorate's Information Security Manual (ISM). It scopes the system, surveys the 17 ISM control domains for in-scope controls, scores each control's implementation posture with evidence, captures the residual risk, and surfaces the IRAP-assessable posture (Information Security Registered Assessors Program — the Australian government's cloud-inheritance and external-assessment programme).
+
+The ISM is the authoritative control library for Australian Federal entities and DISP suppliers. The SoA is the gate artefact for IRAP assessment, security accreditation, and PSPF Outcome 4 (Information Security).
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, hosting model, data flows |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Sensitivity categories driving control intensity |
+| `/arckit.au-e8-posture` output (`ARC-<id>-AUE8-v1.0.md`) | Cyber baseline that the ISM SoA cross-references |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Architecture, identity model, key management |
+
+---
+
+## Command
+
+```bash
+/arckit.au-ism-controls <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUISM-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Coverage, gaps, IRAP readiness, accreditation posture |
+| System Scope | Description, owner, classification ceiling, hosting environments |
+| Domain-by-Domain Analysis | All 17 ISM control domains: applicability, implementation posture, evidence, gaps |
+| Control Inheritance | Inherited controls from underlying cloud or platform (cite IRAP assessment letters where relied on) |
+| Residual Risk Statement | Risks accepted, escalation path, treatment commitments |
+| IRAP Posture | Whether the system is IRAP-assessable, target assessment date, scope boundary |
+| Accreditation Strategy | Internal accreditation route or cross-jurisdictional accreditation (Cyber-Hub, etc.) |
+| Maintenance Cadence | Re-assessment frequency, change triggers, ISM update tracking (ASD publishes quarterly) |
+
+---
+
+## Regulatory Anchors
+
+- **ASD Information Security Manual (ISM)** — 17 control domains; quarterly-updated control library
+- **PSPF Outcome 4 (Information Security)** — federal accountability framework that cites the ISM as authoritative
+- **IRAP (Information Security Registered Assessors Program)** — primary external-assessment route, especially for cloud inheritance
+- **Cyber Security Act 2024 (Cth)** — incident reporting obligations relevant to security incidents tracked against ISM controls
+- **PGPA Act 2013 s16** — federal accountable-authority duties
+
+---
+
+## When to Run
+
+- During HLD / detailed design, after the architecture has stabilised enough to enumerate control inheritance
+- Before IRAP assessment kicks off (the SoA is the input to the assessor's scoping)
+- Re-run on material architecture change or quarterly ISM update where control changes affect the system
+- DISP Level 2+ suppliers refresh on the attestation cycle
+
+---
+
+## Common Pitfalls
+
+- **Treating every ISM control as in-scope** — the SoA is about applicability. Mark out-of-scope controls explicitly with rationale; assessors flag thin-scoping faster than thick-scoping.
+- **Claiming inheritance without an IRAP letter** — cloud or platform inheritance requires a current IRAP assessment letter. Without it, the control is not inherited — it's the customer's to implement.
+- **Stale evidence dates** — ISM controls reference fresh evidence (logs, configs, scan output). Mark anything older than the assessment window as stale.
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-disp-attestation` (DISP Information & Cyber domain draws heavily from the ISM SoA), `/arckit.au-pspf` (PSPF Outcome 4 cites ISM SoA evidence), and feeds the IRAP assessor scoping package.

--- a/arckit-claude/docs/guides/au-ndb-playbook.md
+++ b/arckit-claude/docs/guides/au-ndb-playbook.md
@@ -1,0 +1,80 @@
+# Australian Notifiable Data Breach Response Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-ndb-playbook` generates an operational response playbook under the OAIC Notifiable Data Breaches scheme (Privacy Act 1988 Part IIIC). It captures the assessment criteria for an eligible data breach, the 30-day investigation clock, the notification decision logic, the workflow for notifying affected individuals and the OAIC, and the post-incident review obligations including remediation tracking and lessons-learned capture.
+
+The NDB playbook is operational — it is read in the middle of an incident, not at design time. It must be precise about timeframes, roles, and decision criteria. Where the playbook depends on the eligible-data-breach test, the language follows OAIC guidance verbatim.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| `/arckit.au-pia` output (`ARC-<id>-AUPIA-v1.0.md`) | Personal information inventory; eligible-data-breach criteria already drafted |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, privacy officer, security incident commander |
+| Risk register (`ARC-<id>-RISK-v1.0.md`) | Data-breach risks identified at design time |
+| Runbooks (`ARC-<id>-RBK-v1.0.md`) | Existing incident response procedures the NDB workflow plugs into |
+
+---
+
+## Command
+
+```bash
+/arckit.au-ndb-playbook <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUNDB-v1.0.md`
+
+---
+
+## Playbook Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Activation Criteria | When to enter the NDB workflow vs treat as general incident |
+| Roles & Responsibilities | Accountable authority, privacy officer, incident commander, comms lead, OAIC liaison |
+| Phase 1 — Containment & Initial Triage | First 24 hours: contain, preserve evidence, initial scoping |
+| Phase 2 — Eligible-Data-Breach Assessment | 30-day clock; serious-harm test against OAIC guidance |
+| Phase 3 — Notification Decisions | Trigger criteria, escalation matrix, individuals vs OAIC vs both |
+| Phase 4 — Notification Execution | Templates, channels, timing, language requirements |
+| Phase 5 — Post-Incident Review | Lessons learned, remediation, public-register updates |
+| Decision Tree | Visual flow from detection through notification or no-notification |
+| Templates | Standard wording for individual notifications, OAIC report, board briefing |
+| External Dependencies | OAIC contact protocol, legal counsel, forensics partner |
+| Quarterly Review | Refresh cadence, regulatory-update tracking |
+
+---
+
+## Regulatory Anchors
+
+- **Privacy Act 1988 (Cth) Part IIIC** — Notifiable Data Breaches scheme (statutory basis)
+- **OAIC Notifiable Data Breach guidance** — authoritative interpretation of "eligible data breach" and "serious harm"
+- **Privacy and Other Legislation Amendment Act 2024** (Tranche 1) — enhanced statutory tort and class-action exposure
+- **Cyber Security Act 2024 (Cth)** — adjacent incident-reporting obligations that may run in parallel to NDB
+
+---
+
+## When to Run
+
+- Author this at service design, not in the middle of an incident
+- Refresh after every actual NDB event (lessons-learned)
+- Refresh on material OAIC guidance change or Privacy Act amendment
+- Refresh on accountable-authority or privacy-officer change
+
+---
+
+## Common Pitfalls
+
+- **Conflating the 30-day clock with the notification clock** — the 30-day clock is for the eligible-data-breach assessment. Once eligibility is confirmed, notification must be as soon as practicable. These are distinct.
+- **No pre-drafted notification text** — incident teams under pressure write poor notifications. Templates with placeholder fields cut time-to-notify significantly.
+- **Missing the OAIC liaison path** — the playbook must name a specific individual responsible for OAIC contact, with backup. "The privacy officer" is not specific enough.
+
+---
+
+## Handoff
+
+Tied tightly to `/arckit.au-pia` (PIA establishes the eligible-data-breach criteria) and the operational runbooks (`/arckit.operationalize`). Cited as evidence in `/arckit.au-disp-attestation` (DISP information protection domain) and `/arckit.au-pspf` (PSPF Outcome 4 incident management).

--- a/arckit-claude/docs/guides/au-pia.md
+++ b/arckit-claude/docs/guides/au-pia.md
@@ -1,0 +1,72 @@
+# Australian Privacy Impact Assessment Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-pia` generates an Australian Privacy Impact Assessment under the Privacy Act 1988 (Cth) and the 13 Australian Privacy Principles. It captures the entity's APP entity status, scopes the personal information lifecycle, runs an APP-by-APP applicability and compliance analysis, registers privacy risks with mitigations, captures cross-border disclosure flows under APP 8, and surfaces the OAIC notification posture under the Notifiable Data Breaches scheme (Privacy Act Part IIIC).
+
+The PIA is a recognised due diligence artefact for Australian Federal entities and APP entities generally. The Privacy Act Tranche 1 reforms (December 2024) introduced new accountability, consent, and automated-decision-making obligations — the PIA explicitly addresses where these apply. Mark anything dependent on the Tranche 2 reforms as `<PENDING TRANCHE 2>` and revisit when the reforms enter force.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, decision logic, automated decision-making scope |
+| Data requirements (`ARC-<id>-DR-v1.0.md`) | Per-element personal information inventory and sensitivity flags |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Entities and relationships carrying personal information |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Subject populations, partner agencies, processors, offshore recipients |
+
+---
+
+## Command
+
+```bash
+/arckit.au-pia <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUPIA-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | APP entity status, headline privacy risks, OAIC notification posture, Tranche 1 obligations |
+| Programme / System Description | Description, owner, subject populations, lifecycle stage, personal information lifecycle |
+| APP Entity Status | Whether the entity is APP-covered, exemptions claimed, small business operator status |
+| APP-by-APP Analysis | All 13 APPs: applicability, current compliance posture, evidence, gaps |
+| Personal Information Inventory | Per-element: type, sensitivity flag, lawful basis, retention, recipients |
+| Cross-Border Disclosure (APP 8) | Offshore recipients, jurisdictions, enforceability assessment |
+| Automated Decision-Making (Tranche 1) | Where automated decisions affect individuals, notification posture, human-review pathway |
+| Privacy Risk Register | Risks, likelihood, impact, mitigations, residual risk |
+| NDB Posture | Eligible-data-breach assessment criteria, notification decision logic, OAIC reporting workflow |
+| Treatment & Monitoring | Mitigations in flight, review cadence, change triggers |
+
+---
+
+## Regulatory Anchors
+
+- **Privacy Act 1988 (Cth)** — primary statute; 13 APPs in Schedule 1
+- **Privacy and Other Legislation Amendment Act 2024** (Tranche 1 reforms) — children's privacy, statutory tort, automated decisions, transparency
+- **OAIC Notifiable Data Breaches scheme** (Privacy Act Part IIIC) — eligible-data-breach definition, notification timeframes
+- **OAIC Australian Privacy Principles guidelines** — authoritative interpretation
+- **APP 8** — cross-border disclosure accountability; *Australian Privacy Foundation v ALRC* and OAIC guidance
+
+---
+
+## When to Run
+
+- Whenever a new service collects, holds, uses, or discloses personal information
+- On material change to processing activities, recipients, or retention periods
+- Before launch of any service triggering Tranche 1 obligations (notably automated decisions affecting individuals)
+- Refresh annually or on material privacy-incident learnings
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-ndb-playbook` (NDB playbook uses the personal information inventory and breach decision criteria), `/arckit.au-disp-attestation` (DISP information protection domain cites PIA evidence), and `/arckit.au-ai-assurance` (AI Assurance cross-references automated decision-making notification posture).

--- a/arckit-claude/docs/guides/au-pspf.md
+++ b/arckit-claude/docs/guides/au-pspf.md
@@ -1,0 +1,81 @@
+# Australian Protective Security Policy Framework Scorecard Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-pspf` generates a scorecard against the Australian Government Protective Security Policy Framework (PSPF). It captures alignment with the 4 PSPF outcomes (security governance, information security, personnel security, physical security), evaluates against the 16 core requirements, surfaces the maturity posture per requirement, and captures the action plan for areas below target maturity.
+
+The PSPF is the umbrella protective-security policy for Australian federal entities. The scorecard is read by accountable authorities (PGPA Act 2013 s16 duties) and by sectoral regulators (Defence, intelligence agencies, critical infrastructure operators). For DISP suppliers it underpins the security domains the DISP attestation pack consolidates.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, hosting model, personnel requirements |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, security advisor, vetting officer |
+| `/arckit.au-ism-controls` output (`ARC-<id>-AUISM-v1.0.md`) | Information security evidence for Outcome 4 |
+| `/arckit.au-e8-posture` output (`ARC-<id>-AUE8-v1.0.md`) | Cyber baseline for Outcome 4 |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Physical environment, personnel scope, information flows |
+
+---
+
+## Command
+
+```bash
+/arckit.au-pspf <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUPSPF-v1.0.md`
+
+---
+
+## Scorecard Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Outcome-level maturity posture, headline gaps, board / accountable-authority attention |
+| Scope | Business unit / service / system covered; out-of-scope statement |
+| Outcome 1 — Security Governance | 4 core requirements: leadership, risk, accountability, security culture |
+| Outcome 2 — Information Security | 4 core requirements: information assets, sharing, IT systems, accreditation |
+| Outcome 3 — Personnel Security | 4 core requirements: ongoing suitability, separation, foreign influence, AGSVA |
+| Outcome 4 — Physical Security | 4 core requirements: physical environments, certified zones, custody, equipment |
+| Per-Requirement Scoring | For each of 16: target maturity, current maturity, evidence, gap analysis, action plan |
+| Cross-References | Citations to ISM SoA, E8 posture, PIA, DSS conformance, DISP attestation |
+| Maintenance Cadence | Annual refresh minimum; on material change to scope or environment |
+
+---
+
+## Regulatory Anchors
+
+- **Protective Security Policy Framework (PSPF)** — Attorney-General's Department, current edition
+- **PSPF Implementation Guides** — per-requirement interpretation
+- **ASD Information Security Manual** — incorporated by reference for Outcome 4
+- **PGPA Act 2013 s16** — federal accountable-authority duties; PSPF is the operational expression
+- **Australian Government Security Vetting Agency (AGSVA)** — clearance authority for Outcome 3
+- **Cyber Security Act 2024 (Cth)** — adjacent incident-reporting obligations on Outcome 4
+
+---
+
+## When to Run
+
+- During design and pre-launch as part of the accreditation evidence base
+- Annually as part of the accountable-authority assurance cycle
+- On material change to the security scope: new physical premises, new personnel population, new classification ceiling
+- DISP Level 2+ suppliers refresh on attestation cadence
+
+---
+
+## Common Pitfalls
+
+- **Treating Outcome 2 as redundant with the ISM SoA** — the PSPF Outcome 2 view is wider (information assets including non-digital, sharing arrangements, accreditation). The ISM SoA is the technical evidence base, not a substitute.
+- **Skipping personnel separation** — Outcome 3.2 (separation) is regularly under-evidenced. Document the off-boarding workflow with named owners.
+- **Missing AGSVA vetting evidence** — claims about cleared personnel require concrete evidence (clearance ID, currency date) — not narrative.
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-disp-attestation` (DISP physical security, personnel security, and information protection domains draw directly from the PSPF scorecard). Cross-references back to `/arckit.au-ism-controls`, `/arckit.au-e8-posture`, and `/arckit.au-pia` (information protection evidence).

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -382,6 +382,23 @@
                         <li>Citation verification pass across all AT commands</li>
                     </ul>
                 </div>
+
+                <div class="app-contributor-card">
+                    <div class="app-contributor-card__header">
+                        <div class="app-contributor-card__avatar">R</div>
+                        <div>
+                            <p class="app-contributor-card__name"><a href="https://github.com/royster70">@royster70</a></p>
+                            <span class="app-contributor-card__role app-contributor-card__role--code">Code Contributor</span>
+                            <span class="app-contributor-card__role app-contributor-card__role--feature">Domain Maintainer (AU)</span>
+                        </div>
+                    </div>
+                    <p class="govuk-body-s">Authored the Australian Federal / DISP-supplier overlay end-to-end against a real Australian SMB engagement (DISP Level 2 in progress, OFFICIAL:Sensitive). Validated all eight commands across nine evaluation runs producing ~4,093 lines of compliance artefacts with a 25/25 scorecard pass and zero UK-framework leakage. Recipe topology, doc-type registrations (including the corrective inclusion of the CA regime that had been missing since v4.15.0), and converter outputs all verified before submission.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>8 Australian Federal &amp; DISP-supplier commands (ASD Essential Eight, ISM, DTA DSS, Privacy Act 1988 PIA, OAIC NDB, PSPF, AI Assurance, DISP attestation)</li>
+                        <li><code>au-federal</code> build recipe (35 targets, 9 build waves)</li>
+                        <li>Validation scorecard with reproducible mechanical-grep evidence</li>
+                    </ul>
+                </div>
             </div>
 
             <!-- Feature Requesters & Bug Reporters -->

--- a/docs/guides/au-ai-assurance.md
+++ b/docs/guides/au-ai-assurance.md
@@ -1,0 +1,84 @@
+# Australian AI Assurance Baseline Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-ai-assurance` generates an AI assurance baseline against the Digital Transformation Agency's AI Assurance Framework and the Responsible AI Policy v2.0 (effective December 2025). It captures the AI system's risk classification, runs the assurance assessment against the Framework's principles, surfaces the Privacy Act AI-decision notification posture (Tranche 1 reforms, December 2024), captures ISO 42001 readiness, and surfaces the human-oversight and accountability model.
+
+The AI Assurance Framework is the operational expression of Australia's responsible-AI commitments for Federal entities. For DISP suppliers offering AI-enabled services to Defence, this is the gate artefact alongside the ISM SoA. The Tranche 1 Privacy Act reforms add a discrete obligation around automated decision-making notifications that the assurance baseline must address.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | AI system description, intended use, user populations |
+| `/arckit.au-pia` output (`ARC-<id>-AUPIA-v1.0.md`) | Automated decision-making notification posture |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Training, validation, and inference data flows |
+| Risk register (`ARC-<id>-RISK-v1.0.md`) | AI-specific risks (bias, drift, hallucination, misuse) |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Model architecture, hosting, monitoring posture |
+
+---
+
+## Command
+
+```bash
+/arckit.au-ai-assurance <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUAIA-v1.0.md`
+
+---
+
+## Assurance Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Risk classification, headline assurance posture, residual issues, decisions for accountable authority |
+| AI System Description | Use case, deployment context, lifecycle stage |
+| Risk Classification | Per the AI Assurance Framework rubric: low / medium / high / unacceptable |
+| Principle-by-Principle Assessment | Each Framework principle: posture, evidence, gaps, mitigations |
+| Responsible AI Policy v2.0 Conformance | Specific obligations: usage register, deployment approval, ministerial visibility |
+| Privacy Act Tranche 1 Notification | Automated decision-making notification posture and pathway |
+| Human Oversight Model | Where humans remain in the loop, escalation criteria, override workflow |
+| ISO 42001 Readiness | Gap analysis against ISO/IEC 42001 (AI management systems) for organisations targeting certification |
+| Monitoring & Drift | Performance metrics, drift detection, retraining triggers |
+| Incident Response | AI-specific incident criteria (hallucination, bias drift, misuse, model compromise) |
+| Maintenance Cadence | Quarterly review minimum; per-release for active development |
+
+---
+
+## Regulatory Anchors
+
+- **DTA AI Assurance Framework** — primary assurance methodology (current version)
+- **Responsible AI Policy v2.0** — effective December 2025; usage transparency obligations
+- **Privacy Act 1988 (Cth)** — Tranche 1 reforms (Dec 2024): automated decision-making notification
+- **ISO/IEC 42001** — AI management system standard; voluntary but increasingly procurement-relevant
+- **NSW AI Assurance Framework** — sub-federal reference; non-binding for Commonwealth but informative
+- **DTA Generative AI Framework / Guardrails** — generative-AI-specific extensions
+
+---
+
+## When to Run
+
+- For any AI / ML system entering Federal use; for DISP suppliers shipping AI to Defence
+- Pre-deployment and at each material model change (retraining, new use case, new population)
+- Quarterly minimum once Live; per-release in active development
+- On regulatory update (Framework version change, new policy version)
+
+---
+
+## Common Pitfalls
+
+- **Treating LLMs as low risk by default** — generative AI in customer-facing or decision-support contexts is typically medium or high. Map honestly.
+- **Missing the Tranche 1 notification trigger** — automated decisions that affect individuals trigger notification obligations under the amended Privacy Act. Cross-check the PIA explicitly.
+- **No drift monitoring** — assurance is a posture at a point in time. Without continuous monitoring, the posture lapses immediately.
+- **ISO 42001 confused with conformance** — readiness is a gap analysis, not a certification claim. Mark certification status explicitly.
+
+---
+
+## Handoff
+
+Cross-references `/arckit.au-pia` (automated decision-making notification), `/arckit.au-ism-controls` (technical controls for model serving), and feeds `/arckit.au-disp-attestation` (DISP supplier AI assurance evidence for Defence-facing systems).

--- a/docs/guides/au-disp-attestation.md
+++ b/docs/guides/au-disp-attestation.md
@@ -1,0 +1,90 @@
+# Australian DISP Member Self-Attestation Pack Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-disp-attestation` generates a Defence Industry Security Program (DISP) Member self-attestation pack. It consolidates the evidence base across the 4 DISP security domains (Governance, Personnel Security, Physical Security, Information &amp; Cyber), captures the Foreign Ownership Control & Influence (FOCI) declaration, surfaces the supply-chain security posture, and structures the annual board attestation that DISP membership requires.
+
+DISP is the Department of Defence's supplier-side security accreditation. Level 2 (the most common operational ceiling for non-classified Defence work) requires demonstrable evidence across all four domains and depends on E8 ML2 as the cyber baseline. This pack is the consolidation artefact that the other AU commands feed into — run it last.
+
+---
+
+## Inputs
+
+This is the consolidation artefact. It draws from every other AU command's output:
+
+| Artefact | Purpose |
+|----------|---------|
+| `/arckit.au-e8-posture` (`ARC-<id>-AUE8-v1.0.md`) | E8 ML2+ baseline for the cyber domain |
+| `/arckit.au-ism-controls` (`ARC-<id>-AUISM-v1.0.md`) | ISM SoA underpinning Information & Cyber |
+| `/arckit.au-pia` (`ARC-<id>-AUPIA-v1.0.md`) | Personal information handling for Information & Cyber |
+| `/arckit.au-ndb-playbook` (`ARC-<id>-AUNDB-v1.0.md`) | Breach response capability |
+| `/arckit.au-pspf` (`ARC-<id>-AUPSPF-v1.0.md`) | PSPF maturity for Governance, Personnel, Physical, Information |
+| `/arckit.au-ai-assurance` (`ARC-<id>-AUAIA-v1.0.md`) | AI assurance for Defence-facing AI systems |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, security advisor, FOCI signatory |
+| Risk register (`ARC-<id>-RISK-v1.0.md`) | Supplier-side risks |
+
+---
+
+## Command
+
+```bash
+/arckit.au-disp-attestation <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUDISP-v1.0.md`
+
+---
+
+## Pack Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | DISP level targeted, attestation status, headline gaps, board action required |
+| Member Identity | Legal entity, ABN, ownership tree, accountable individuals |
+| Foreign Ownership Control & Influence (FOCI) Declaration | Ownership, control, influence; mitigation arrangements where required |
+| Domain 1 — Governance | Security governance, risk, accountability; evidence cross-references to PSPF Outcome 1 |
+| Domain 2 — Personnel Security | Vetting, ongoing suitability, separation; evidence from PSPF Outcome 3 |
+| Domain 3 — Physical Security | Premises, certified zones, custody; evidence from PSPF Outcome 4 |
+| Domain 4 — Information & Cyber | E8, ISM, PIA, NDB evidence; AI assurance for AI-enabled Defence services |
+| Supply Chain Security | Sub-contractor vetting, supply-chain risk register, security clauses |
+| Incident History | Material security incidents in attestation window |
+| Annual Board Attestation | Statement signed by accountable authority confirming the posture |
+| Maintenance Cadence | Annual attestation cycle; per-incident updates |
+
+---
+
+## Regulatory Anchors
+
+- **DISP Member Manual** — authoritative source for DISP-level requirements
+- **Defence Security Principles Framework (DSPF)** — incorporated by reference for DISP suppliers
+- **ASD Essential Eight Maturity Model** — ML2 baseline for DISP Level 2
+- **ASD Information Security Manual** — control evidence base for Domain 4
+- **Privacy Act 1988 (Cth)** — for personal information handling
+- **Protective Security Policy Framework** — referenced across Domains 1, 2, 3, 4
+- **Cyber Security Act 2024 (Cth)** — incident-reporting interactions
+
+---
+
+## When to Run
+
+- During DISP application or upgrade (Level 1 → 2 → 3)
+- Annually for ongoing DISP members (the attestation cycle)
+- On material change to FOCI, leadership, or the security posture (re-attestation may be required)
+- On significant security incident in attestation window
+
+---
+
+## Common Pitfalls
+
+- **Treating it as paperwork** — DISP attestation is a board-level statement of fact. Inaccuracies create criminal exposure under Defence security legislation. Validate every cross-reference.
+- **Thin FOCI declaration** — full ownership tree is required, including indirect control. Engage corporate counsel early if ownership is non-trivial.
+- **Inheriting evidence without verification** — if Domain 4 cites the ISM SoA, the underlying SoA must be current and accurate. Don't cite stale evidence.
+- **Missing sub-contractor coverage** — DISP suppliers carry obligations across the supply chain. Sub-contractor vetting evidence must be in the pack.
+
+---
+
+## Handoff
+
+This is the consolidation artefact for DISP attestation. It is read by the Department of Defence, Defence Industry Security Branch, and (where relevant) procurement-side security assessors. After board sign-off, the attestation cycle resets for 12 months.

--- a/docs/guides/au-dss.md
+++ b/docs/guides/au-dss.md
@@ -1,0 +1,76 @@
+# Australian DTA Digital Service Standard Conformance Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-dss` generates a conformance assessment against the Digital Transformation Agency's Digital Service Standard (13 criteria). It scopes the service in delivery-phase terms (Discovery / Alpha / Beta / Live), evaluates each of the 13 criteria with evidence and gaps, captures the cross-jurisdictional procurement implications under the Commonwealth Procurement Rules (November 2025 overhaul), and surfaces the readiness posture for DTA assessment.
+
+The DTA DSS is the Australian counterpart to the UK GDS Service Standard. The conformance assessment is the gate that Australian Federal services use to demonstrate user-centred, accessible, and accountable design before launch.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, user needs, accessibility targets |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | User populations, accountable authority, partners |
+| Strategy (`ARC-<id>-STRAT-v1.0.md`) | Programme phase, success measures |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Technical posture, accessibility implementation |
+
+---
+
+## Command
+
+```bash
+/arckit.au-dss <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUDSS-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Headline conformance, gaps to launch, DTA assessment readiness |
+| Service Scope | Description, owner, user populations, current delivery phase |
+| Criterion-by-Criterion Assessment | All 13 criteria: posture, evidence cited, gaps, planned remediation |
+| Accessibility (WCAG 2.2 AA) | Conformance level, audit evidence, remediation backlog |
+| Procurement Implications | CPR November 2025 obligations, ICT supplier ethical conduct, AI transparency clauses |
+| Performance Measures | KPIs aligned to DSS criteria 1, 8, and 13 |
+| Treatment & Monitoring | Outstanding remediation, review cadence, governance routes |
+
+---
+
+## Regulatory Anchors
+
+- **DTA Digital Service Standard** — 13 criteria (authoritative source for scoring)
+- **DTA Digital Service Standard Guidance** — criterion-by-criterion interpretation
+- **WCAG 2.2 AA** — accessibility target referenced by Criterion 9
+- **Commonwealth Procurement Rules (November 2025 overhaul)** — supplier ethical conduct, AI transparency
+- **PGPA Act 2013 s16** — federal accountable-authority duties
+
+---
+
+## When to Run
+
+- At each delivery-phase gate (end of Discovery, end of Alpha, end of Beta, pre-Live)
+- On material change to user-facing design, accessibility implementation, or accountability model
+- Refresh annually in steady-state Live to track residual conformance
+
+---
+
+## Common Pitfalls
+
+- **Marking criteria green without dated evidence** — every "met" criterion needs an evidence pointer (research output, audit report, monitoring dashboard) with a date. Older than 12 months is stale.
+- **Confusing WCAG 2.1 AA with 2.2 AA** — Criterion 9 references the current target. Verify against the version cited in current DTA guidance.
+- **Skipping the procurement criteria** — Criterion 13 (sustainability and value for money) materially changed with the CPR November 2025 overhaul. Cite the new obligations explicitly.
+
+---
+
+## Handoff
+
+Feeds the assurance package alongside `/arckit.au-pia` (Privacy Act compliance) and `/arckit.au-e8-posture` (cyber baseline). Pre-Live and Live phase artefacts cross-reference DSS conformance evidence in `/arckit.au-disp-attestation` for supplier-side accreditation.

--- a/docs/guides/au-e8-posture.md
+++ b/docs/guides/au-e8-posture.md
@@ -1,0 +1,73 @@
+# Australian Essential Eight Maturity Posture Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-e8-posture` generates an ASD Essential Eight maturity posture against the Australian Signals Directorate's Essential Eight Maturity Model. It scores each of the eight mitigation strategies (application control, patch applications, configure Microsoft Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups) against maturity levels ML0–ML3, captures the evidence base, identifies the maturity uplift path, and surfaces the DISP-aligned target (ML2 baseline for DISP Level 2 supplier accreditation).
+
+The Essential Eight is the ASD's prioritised baseline for mitigating cyber security incidents and is the cyber baseline that DISP, federal entities, and most Commonwealth procurements measure against. The artefact this command produces is therefore a foundational input to almost every other Australian Federal security or assurance artefact — run it early.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, hosting model, user populations |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Sensitive data categories that drive control intensity |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, security operations owner |
+
+---
+
+## Command
+
+```bash
+/arckit.au-e8-posture <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUE8-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Current maturity by strategy, gap to target maturity, headline residual risks |
+| Scope | In-scope systems, business units, environments (production / staging / non-production) |
+| Maturity Assessment per Strategy | For each of the 8: current ML, target ML, evidence cited, gap analysis, planned uplift |
+| Uplift Plan | Sequenced remediation with effort, dependencies, and DISP-attestation deadline alignment |
+| Residual Risk Statement | Risks accepted, treatments in flight, escalation path |
+| Maintenance Cadence | Re-assessment frequency, change triggers, ASD update tracking |
+
+---
+
+## Regulatory Anchors
+
+- **ASD Essential Eight Maturity Model** — eight mitigation strategies, maturity levels ML0–ML3 (the authoritative source for scoring rubric)
+- **ASD Information Security Manual (ISM)** — control-level detail referenced by E8 strategies (cross-reference via `/arckit.au-ism-controls`)
+- **Defence Industry Security Program (DISP) Levels 1–3** — ML2 mandated for DISP Level 2 supplier accreditation
+- **Commonwealth Procurement Rules (November 2025 overhaul)** — cyber maturity questions in standard supplier responses
+
+---
+
+## When to Run
+
+- Early in delivery, immediately after stakeholders and requirements — before HLD or detailed security design
+- Re-run on material change to hosting, identity, or admin access model
+- Refresh annually at minimum; DISP suppliers refresh on the attestation cadence (typically 12 months)
+
+---
+
+## Common Pitfalls
+
+- **Scoping too wide** — assessing the whole organisation when the artefact is service-specific produces a low-confidence score. Tighten scope to the service or DISP-accredited business unit.
+- **Missing evidence date** — every cited evidence item needs a "verified on" date so reviewers can judge currency. Make the date a hard field.
+- **Confusing ML2 with "good enough"** — ML2 is the DISP baseline, not a security ceiling. Where the residual risk justifies it, target ML3 on individual strategies.
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-disp-attestation` (DISP Member self-attestation pack consolidates E8 evidence), `/arckit.au-pspf` (PSPF cross-references E8 baselines), and `/arckit.au-ism-controls` (ISM Statement of Applicability draws from the same control evidence).

--- a/docs/guides/au-ism-controls.md
+++ b/docs/guides/au-ism-controls.md
@@ -1,0 +1,78 @@
+# Australian ISM Statement of Applicability Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-ism-controls` generates a Statement of Applicability against the Australian Signals Directorate's Information Security Manual (ISM). It scopes the system, surveys the 17 ISM control domains for in-scope controls, scores each control's implementation posture with evidence, captures the residual risk, and surfaces the IRAP-assessable posture (Information Security Registered Assessors Program — the Australian government's cloud-inheritance and external-assessment programme).
+
+The ISM is the authoritative control library for Australian Federal entities and DISP suppliers. The SoA is the gate artefact for IRAP assessment, security accreditation, and PSPF Outcome 4 (Information Security).
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, hosting model, data flows |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Sensitivity categories driving control intensity |
+| `/arckit.au-e8-posture` output (`ARC-<id>-AUE8-v1.0.md`) | Cyber baseline that the ISM SoA cross-references |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Architecture, identity model, key management |
+
+---
+
+## Command
+
+```bash
+/arckit.au-ism-controls <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUISM-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Coverage, gaps, IRAP readiness, accreditation posture |
+| System Scope | Description, owner, classification ceiling, hosting environments |
+| Domain-by-Domain Analysis | All 17 ISM control domains: applicability, implementation posture, evidence, gaps |
+| Control Inheritance | Inherited controls from underlying cloud or platform (cite IRAP assessment letters where relied on) |
+| Residual Risk Statement | Risks accepted, escalation path, treatment commitments |
+| IRAP Posture | Whether the system is IRAP-assessable, target assessment date, scope boundary |
+| Accreditation Strategy | Internal accreditation route or cross-jurisdictional accreditation (Cyber-Hub, etc.) |
+| Maintenance Cadence | Re-assessment frequency, change triggers, ISM update tracking (ASD publishes quarterly) |
+
+---
+
+## Regulatory Anchors
+
+- **ASD Information Security Manual (ISM)** — 17 control domains; quarterly-updated control library
+- **PSPF Outcome 4 (Information Security)** — federal accountability framework that cites the ISM as authoritative
+- **IRAP (Information Security Registered Assessors Program)** — primary external-assessment route, especially for cloud inheritance
+- **Cyber Security Act 2024 (Cth)** — incident reporting obligations relevant to security incidents tracked against ISM controls
+- **PGPA Act 2013 s16** — federal accountable-authority duties
+
+---
+
+## When to Run
+
+- During HLD / detailed design, after the architecture has stabilised enough to enumerate control inheritance
+- Before IRAP assessment kicks off (the SoA is the input to the assessor's scoping)
+- Re-run on material architecture change or quarterly ISM update where control changes affect the system
+- DISP Level 2+ suppliers refresh on the attestation cycle
+
+---
+
+## Common Pitfalls
+
+- **Treating every ISM control as in-scope** — the SoA is about applicability. Mark out-of-scope controls explicitly with rationale; assessors flag thin-scoping faster than thick-scoping.
+- **Claiming inheritance without an IRAP letter** — cloud or platform inheritance requires a current IRAP assessment letter. Without it, the control is not inherited — it's the customer's to implement.
+- **Stale evidence dates** — ISM controls reference fresh evidence (logs, configs, scan output). Mark anything older than the assessment window as stale.
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-disp-attestation` (DISP Information & Cyber domain draws heavily from the ISM SoA), `/arckit.au-pspf` (PSPF Outcome 4 cites ISM SoA evidence), and feeds the IRAP assessor scoping package.

--- a/docs/guides/au-ndb-playbook.md
+++ b/docs/guides/au-ndb-playbook.md
@@ -1,0 +1,80 @@
+# Australian Notifiable Data Breach Response Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-ndb-playbook` generates an operational response playbook under the OAIC Notifiable Data Breaches scheme (Privacy Act 1988 Part IIIC). It captures the assessment criteria for an eligible data breach, the 30-day investigation clock, the notification decision logic, the workflow for notifying affected individuals and the OAIC, and the post-incident review obligations including remediation tracking and lessons-learned capture.
+
+The NDB playbook is operational — it is read in the middle of an incident, not at design time. It must be precise about timeframes, roles, and decision criteria. Where the playbook depends on the eligible-data-breach test, the language follows OAIC guidance verbatim.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| `/arckit.au-pia` output (`ARC-<id>-AUPIA-v1.0.md`) | Personal information inventory; eligible-data-breach criteria already drafted |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, privacy officer, security incident commander |
+| Risk register (`ARC-<id>-RISK-v1.0.md`) | Data-breach risks identified at design time |
+| Runbooks (`ARC-<id>-RBK-v1.0.md`) | Existing incident response procedures the NDB workflow plugs into |
+
+---
+
+## Command
+
+```bash
+/arckit.au-ndb-playbook <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUNDB-v1.0.md`
+
+---
+
+## Playbook Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Activation Criteria | When to enter the NDB workflow vs treat as general incident |
+| Roles & Responsibilities | Accountable authority, privacy officer, incident commander, comms lead, OAIC liaison |
+| Phase 1 — Containment & Initial Triage | First 24 hours: contain, preserve evidence, initial scoping |
+| Phase 2 — Eligible-Data-Breach Assessment | 30-day clock; serious-harm test against OAIC guidance |
+| Phase 3 — Notification Decisions | Trigger criteria, escalation matrix, individuals vs OAIC vs both |
+| Phase 4 — Notification Execution | Templates, channels, timing, language requirements |
+| Phase 5 — Post-Incident Review | Lessons learned, remediation, public-register updates |
+| Decision Tree | Visual flow from detection through notification or no-notification |
+| Templates | Standard wording for individual notifications, OAIC report, board briefing |
+| External Dependencies | OAIC contact protocol, legal counsel, forensics partner |
+| Quarterly Review | Refresh cadence, regulatory-update tracking |
+
+---
+
+## Regulatory Anchors
+
+- **Privacy Act 1988 (Cth) Part IIIC** — Notifiable Data Breaches scheme (statutory basis)
+- **OAIC Notifiable Data Breach guidance** — authoritative interpretation of "eligible data breach" and "serious harm"
+- **Privacy and Other Legislation Amendment Act 2024** (Tranche 1) — enhanced statutory tort and class-action exposure
+- **Cyber Security Act 2024 (Cth)** — adjacent incident-reporting obligations that may run in parallel to NDB
+
+---
+
+## When to Run
+
+- Author this at service design, not in the middle of an incident
+- Refresh after every actual NDB event (lessons-learned)
+- Refresh on material OAIC guidance change or Privacy Act amendment
+- Refresh on accountable-authority or privacy-officer change
+
+---
+
+## Common Pitfalls
+
+- **Conflating the 30-day clock with the notification clock** — the 30-day clock is for the eligible-data-breach assessment. Once eligibility is confirmed, notification must be as soon as practicable. These are distinct.
+- **No pre-drafted notification text** — incident teams under pressure write poor notifications. Templates with placeholder fields cut time-to-notify significantly.
+- **Missing the OAIC liaison path** — the playbook must name a specific individual responsible for OAIC contact, with backup. "The privacy officer" is not specific enough.
+
+---
+
+## Handoff
+
+Tied tightly to `/arckit.au-pia` (PIA establishes the eligible-data-breach criteria) and the operational runbooks (`/arckit.operationalize`). Cited as evidence in `/arckit.au-disp-attestation` (DISP information protection domain) and `/arckit.au-pspf` (PSPF Outcome 4 incident management).

--- a/docs/guides/au-pia.md
+++ b/docs/guides/au-pia.md
@@ -1,0 +1,72 @@
+# Australian Privacy Impact Assessment Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-pia` generates an Australian Privacy Impact Assessment under the Privacy Act 1988 (Cth) and the 13 Australian Privacy Principles. It captures the entity's APP entity status, scopes the personal information lifecycle, runs an APP-by-APP applicability and compliance analysis, registers privacy risks with mitigations, captures cross-border disclosure flows under APP 8, and surfaces the OAIC notification posture under the Notifiable Data Breaches scheme (Privacy Act Part IIIC).
+
+The PIA is a recognised due diligence artefact for Australian Federal entities and APP entities generally. The Privacy Act Tranche 1 reforms (December 2024) introduced new accountability, consent, and automated-decision-making obligations — the PIA explicitly addresses where these apply. Mark anything dependent on the Tranche 2 reforms as `<PENDING TRANCHE 2>` and revisit when the reforms enter force.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, decision logic, automated decision-making scope |
+| Data requirements (`ARC-<id>-DR-v1.0.md`) | Per-element personal information inventory and sensitivity flags |
+| Data model (`ARC-<id>-DMOD-v1.0.md`) | Entities and relationships carrying personal information |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Subject populations, partner agencies, processors, offshore recipients |
+
+---
+
+## Command
+
+```bash
+/arckit.au-pia <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUPIA-v1.0.md`
+
+---
+
+## Assessment Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | APP entity status, headline privacy risks, OAIC notification posture, Tranche 1 obligations |
+| Programme / System Description | Description, owner, subject populations, lifecycle stage, personal information lifecycle |
+| APP Entity Status | Whether the entity is APP-covered, exemptions claimed, small business operator status |
+| APP-by-APP Analysis | All 13 APPs: applicability, current compliance posture, evidence, gaps |
+| Personal Information Inventory | Per-element: type, sensitivity flag, lawful basis, retention, recipients |
+| Cross-Border Disclosure (APP 8) | Offshore recipients, jurisdictions, enforceability assessment |
+| Automated Decision-Making (Tranche 1) | Where automated decisions affect individuals, notification posture, human-review pathway |
+| Privacy Risk Register | Risks, likelihood, impact, mitigations, residual risk |
+| NDB Posture | Eligible-data-breach assessment criteria, notification decision logic, OAIC reporting workflow |
+| Treatment & Monitoring | Mitigations in flight, review cadence, change triggers |
+
+---
+
+## Regulatory Anchors
+
+- **Privacy Act 1988 (Cth)** — primary statute; 13 APPs in Schedule 1
+- **Privacy and Other Legislation Amendment Act 2024** (Tranche 1 reforms) — children's privacy, statutory tort, automated decisions, transparency
+- **OAIC Notifiable Data Breaches scheme** (Privacy Act Part IIIC) — eligible-data-breach definition, notification timeframes
+- **OAIC Australian Privacy Principles guidelines** — authoritative interpretation
+- **APP 8** — cross-border disclosure accountability; *Australian Privacy Foundation v ALRC* and OAIC guidance
+
+---
+
+## When to Run
+
+- Whenever a new service collects, holds, uses, or discloses personal information
+- On material change to processing activities, recipients, or retention periods
+- Before launch of any service triggering Tranche 1 obligations (notably automated decisions affecting individuals)
+- Refresh annually or on material privacy-incident learnings
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-ndb-playbook` (NDB playbook uses the personal information inventory and breach decision criteria), `/arckit.au-disp-attestation` (DISP information protection domain cites PIA evidence), and `/arckit.au-ai-assurance` (AI Assurance cross-references automated decision-making notification posture).

--- a/docs/guides/au-pspf.md
+++ b/docs/guides/au-pspf.md
@@ -1,0 +1,81 @@
+# Australian Protective Security Policy Framework Scorecard Playbook
+
+> **Guide Origin**: Community | **ArcKit Version**: [VERSION]
+
+`/arckit.au-pspf` generates a scorecard against the Australian Government Protective Security Policy Framework (PSPF). It captures alignment with the 4 PSPF outcomes (security governance, information security, personnel security, physical security), evaluates against the 16 core requirements, surfaces the maturity posture per requirement, and captures the action plan for areas below target maturity.
+
+The PSPF is the umbrella protective-security policy for Australian federal entities. The scorecard is read by accountable authorities (PGPA Act 2013 s16 duties) and by sectoral regulators (Defence, intelligence agencies, critical infrastructure operators). For DISP suppliers it underpins the security domains the DISP attestation pack consolidates.
+
+---
+
+## Inputs
+
+| Artefact | Purpose |
+|----------|---------|
+| Requirements (`ARC-<id>-REQ-v1.0.md`) | Service description, hosting model, personnel requirements |
+| Stakeholders (`ARC-<id>-STKE-v1.0.md`) | Accountable authority, security advisor, vetting officer |
+| `/arckit.au-ism-controls` output (`ARC-<id>-AUISM-v1.0.md`) | Information security evidence for Outcome 4 |
+| `/arckit.au-e8-posture` output (`ARC-<id>-AUE8-v1.0.md`) | Cyber baseline for Outcome 4 |
+| HLD (`ARC-<id>-HLD-v1.0.md`) | Physical environment, personnel scope, information flows |
+
+---
+
+## Command
+
+```bash
+/arckit.au-pspf <project ID or service description>
+```
+
+Output: `projects/<id>/ARC-<id>-AUPSPF-v1.0.md`
+
+---
+
+## Scorecard Structure
+
+| Section | Contents |
+|---------|----------|
+| Document Control | Australian classification (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET / TOP SECRET) |
+| Revision History | Version, date, author, changes, approvals |
+| Executive Summary | Outcome-level maturity posture, headline gaps, board / accountable-authority attention |
+| Scope | Business unit / service / system covered; out-of-scope statement |
+| Outcome 1 — Security Governance | 4 core requirements: leadership, risk, accountability, security culture |
+| Outcome 2 — Information Security | 4 core requirements: information assets, sharing, IT systems, accreditation |
+| Outcome 3 — Personnel Security | 4 core requirements: ongoing suitability, separation, foreign influence, AGSVA |
+| Outcome 4 — Physical Security | 4 core requirements: physical environments, certified zones, custody, equipment |
+| Per-Requirement Scoring | For each of 16: target maturity, current maturity, evidence, gap analysis, action plan |
+| Cross-References | Citations to ISM SoA, E8 posture, PIA, DSS conformance, DISP attestation |
+| Maintenance Cadence | Annual refresh minimum; on material change to scope or environment |
+
+---
+
+## Regulatory Anchors
+
+- **Protective Security Policy Framework (PSPF)** — Attorney-General's Department, current edition
+- **PSPF Implementation Guides** — per-requirement interpretation
+- **ASD Information Security Manual** — incorporated by reference for Outcome 4
+- **PGPA Act 2013 s16** — federal accountable-authority duties; PSPF is the operational expression
+- **Australian Government Security Vetting Agency (AGSVA)** — clearance authority for Outcome 3
+- **Cyber Security Act 2024 (Cth)** — adjacent incident-reporting obligations on Outcome 4
+
+---
+
+## When to Run
+
+- During design and pre-launch as part of the accreditation evidence base
+- Annually as part of the accountable-authority assurance cycle
+- On material change to the security scope: new physical premises, new personnel population, new classification ceiling
+- DISP Level 2+ suppliers refresh on attestation cadence
+
+---
+
+## Common Pitfalls
+
+- **Treating Outcome 2 as redundant with the ISM SoA** — the PSPF Outcome 2 view is wider (information assets including non-digital, sharing arrangements, accreditation). The ISM SoA is the technical evidence base, not a substitute.
+- **Skipping personnel separation** — Outcome 3.2 (separation) is regularly under-evidenced. Document the off-boarding workflow with named owners.
+- **Missing AGSVA vetting evidence** — claims about cleared personnel require concrete evidence (clearance ID, currency date) — not narrative.
+
+---
+
+## Handoff
+
+Foundational input to `/arckit.au-disp-attestation` (DISP physical security, personnel security, and information protection domains draw directly from the PSPF scorecard). Cross-references back to `/arckit.au-ism-controls`, `/arckit.au-e8-posture`, and `/arckit.au-pia` (information protection evidence).


### PR DESCRIPTION
## Summary

Picks up two gaps PR #441 explicitly deferred when it landed (as the AU community plugin via the v5.0.0 split):

1. **@royster70 not on the contributors page** — every other domain maintainer (@gtonic AT, @thomas-jardinet EU/FR) is listed.
2. **No per-command guides for AU** — every other community jurisdiction (CA, EU, FR, AT) has per-command playbooks in \`docs/guides/\`.

## What this PR adds

### Contributors page
- New @royster70 card under Code Contributors with the **AU Domain Maintainer** badge.
- Highlights: 8 AU commands, \`au-federal\` recipe, validation scorecard, the corrective CA-regime catch from #441.

### 8 per-command guides
Each follows the CA pattern: Inputs / Command / Assessment Structure / Regulatory Anchors / When to Run / Common Pitfalls / Handoff. Shipped in both \`docs/guides/\` (site-published) and \`arckit-claude/docs/guides/\` (plugin source — matches the convention used by the other community jurisdictions pending a later refactor that moves community guides into their plugin dirs).

| Guide | Topic |
|---|---|
| \`au-e8-posture\` | ASD Essential Eight maturity posture (ML0–ML3) |
| \`au-pia\` | Privacy Act 1988 s33D PIA (13 APPs + Tranche 1 reforms) |
| \`au-dss\` | DTA Digital Service Standard (13 criteria) |
| \`au-ism-controls\` | ASD ISM Statement of Applicability (17 control domains, IRAP-assessable) |
| \`au-ndb-playbook\` | OAIC Notifiable Data Breach response playbook (Part IIIC) |
| \`au-pspf\` | Protective Security Policy Framework (4 outcomes / 16 core requirements) |
| \`au-ai-assurance\` | DTA AI Assurance Framework + Responsible AI Policy v2.0 |
| \`au-disp-attestation\` | DISP Member self-attestation pack (consolidates the above) |

## Reference

PR #441 originally noted: *\"Single overlay guide at \`docs/guides/au-federal-overlay.md\` (UAE-style minimum). Per-command guides in Canada-style can follow in a subsequent PR if you prefer that pattern.\"*

This is that follow-up PR.

## Test plan
- [ ] @royster70 card renders at arckit.org/contributors.html alongside the other domain maintainers
- [ ] AU guides visible at arckit.org/guides.html (or wherever the site indexes them)
- [ ] markdownlint clean (verified locally on all 17 files)
- [ ] Optional: @royster70 review on the per-command guide regulatory framing (pinging them as domain maintainer)

🤖 Generated with [Claude Code](https://claude.com/claude-code)