### PR TITLE
feat(claude): default [CLASSIFICATION] from ${user_config.default_classification}

### DIFF
--- a/arckit-claude/agents/arckit-aws-research.md
+++ b/arckit-claude/agents/arckit-aws-research.md
@@ -272,7 +272,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-azure-research.md
+++ b/arckit-claude/agents/arckit-azure-research.md
@@ -263,7 +263,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-datascout.md
+++ b/arckit-claude/agents/arckit-datascout.md
@@ -449,7 +449,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 14
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gcp-research.md
+++ b/arckit-claude/agents/arckit-gcp-research.md
@@ -264,7 +264,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gov-code-search.md
+++ b/arckit-claude/agents/arckit-gov-code-search.md
@@ -236,7 +236,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 11
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gov-landscape.md
+++ b/arckit-claude/agents/arckit-gov-landscape.md
@@ -302,7 +302,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 14
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-gov-reuse.md
+++ b/arckit-claude/agents/arckit-gov-reuse.md
@@ -294,7 +294,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 11
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/agents/arckit-research.md
+++ b/arckit-claude/agents/arckit-research.md
@@ -270,7 +270,7 @@ Auto-populate fields:
 - `[VERSION]` = determined version from Step 9
 - `[DATE]` = current date (YYYY-MM-DD)
 - `[STATUS]` = "DRAFT"
-- `[CLASSIFICATION]` = "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` = `${user_config.default_classification}` when set; otherwise "OFFICIAL" (UK Gov) or "PUBLIC"
 
 Include the generation metadata footer:
 

--- a/arckit-claude/commands/adr.md
+++ b/arckit-claude/commands/adr.md
@@ -347,7 +347,7 @@ ADRs are multi-instance documents. Version detection depends on whether you are 
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/ai-playbook.md
+++ b/arckit-claude/commands/ai-playbook.md
@@ -386,7 +386,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/analyze.md
+++ b/arckit-claude/commands/analyze.md
@@ -1357,7 +1357,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/atrs.md
+++ b/arckit-claude/commands/atrs.md
@@ -278,7 +278,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/backlog.md
+++ b/arckit-claude/commands/backlog.md
@@ -1503,7 +1503,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/data-mesh-contract.md
+++ b/arckit-claude/commands/data-mesh-contract.md
@@ -372,7 +372,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/data-model.md
+++ b/arckit-claude/commands/data-model.md
@@ -232,7 +232,7 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-DATA-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" (UK Gov) or "PUBLIC"
 
 ### User-provided fields
 

--- a/arckit-claude/commands/dfd.md
+++ b/arckit-claude/commands/dfd.md
@@ -306,7 +306,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/diagram.md
+++ b/arckit-claude/commands/diagram.md
@@ -800,7 +800,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/dld-review.md
+++ b/arckit-claude/commands/dld-review.md
@@ -200,7 +200,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/dos.md
+++ b/arckit-claude/commands/dos.md
@@ -106,7 +106,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/evaluate.md
+++ b/arckit-claude/commands/evaluate.md
@@ -133,7 +133,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/gcloud-clarify.md
+++ b/arckit-claude/commands/gcloud-clarify.md
@@ -219,7 +219,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/gcloud-search.md
+++ b/arckit-claude/commands/gcloud-search.md
@@ -103,7 +103,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/glossary.md
+++ b/arckit-claude/commands/glossary.md
@@ -190,7 +190,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` -> Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` -> Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` -> Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` -> Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/hld-review.md
+++ b/arckit-claude/commands/hld-review.md
@@ -189,7 +189,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/jsp-936.md
+++ b/arckit-claude/commands/jsp-936.md
@@ -2007,7 +2007,7 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-JSP936-v[VERSION]` → Generated document ID (for filename: `ARC-{PROJECT_ID}-JSP936-v1.0.md`)
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" (UK Gov) or "PUBLIC"
 
 ### User-provided fields
 

--- a/arckit-claude/commands/maturity-model.md
+++ b/arckit-claude/commands/maturity-model.md
@@ -229,7 +229,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` -> Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` -> Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` -> Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` -> Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/mod-secure.md
+++ b/arckit-claude/commands/mod-secure.md
@@ -257,7 +257,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/plan.md
+++ b/arckit-claude/commands/plan.md
@@ -421,7 +421,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/presentation.md
+++ b/arckit-claude/commands/presentation.md
@@ -231,7 +231,7 @@ Before generating the document ID, check if a previous version exists:
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Pending fields** (leave as [PENDING] until manually updated):
 

--- a/arckit-claude/commands/principles.md
+++ b/arckit-claude/commands/principles.md
@@ -101,7 +101,7 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-PRIN-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" (UK Gov) or "PUBLIC"
 
 ### User-provided fields
 

--- a/arckit-claude/commands/requirements.md
+++ b/arckit-claude/commands/requirements.md
@@ -187,7 +187,7 @@ Before generating the document ID, check if a previous version exists:
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/risk.md
+++ b/arckit-claude/commands/risk.md
@@ -391,7 +391,7 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-RISK-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" (UK Gov) or "PUBLIC"
 
 ### User-provided fields
 

--- a/arckit-claude/commands/roadmap.md
+++ b/arckit-claude/commands/roadmap.md
@@ -334,7 +334,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/secure.md
+++ b/arckit-claude/commands/secure.md
@@ -223,7 +223,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/servicenow.md
+++ b/arckit-claude/commands/servicenow.md
@@ -406,7 +406,7 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-SNOW-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" (UK Gov) or "PUBLIC"
 
 ### User-provided fields
 

--- a/arckit-claude/commands/sobc.md
+++ b/arckit-claude/commands/sobc.md
@@ -254,7 +254,7 @@ Before generating the document ID, check if a previous version exists:
 - `[VERSION]` → Determined version from Step 0
 - `[DATE]` / `[YYYY-MM-DD]` → Current date in YYYY-MM-DD format
 - `[DOCUMENT_TYPE_NAME]` → "Strategic Outline Business Case (SOBC)"
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "INTERNAL" for private sector
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "INTERNAL" for private sector
 - `[STATUS]` → "DRAFT" for new documents
 
 **User-specified fields** (must be confirmed with user):

--- a/arckit-claude/commands/sow.md
+++ b/arckit-claude/commands/sow.md
@@ -202,7 +202,7 @@ Before generating the document ID, check if a previous version exists:
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/stakeholders.md
+++ b/arckit-claude/commands/stakeholders.md
@@ -139,7 +139,7 @@ Before completing the document, populate document information fields:
 - `[DOCUMENT_TYPE_NAME]` → Document purpose
 - `ARC-[PROJECT_ID]-STKE-v[VERSION]` → Generated document ID
 - `[STATUS]` → "DRAFT" for new documents
-- `[CLASSIFICATION]` → Default to "OFFICIAL" (UK Gov) or "PUBLIC"
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" (UK Gov) or "PUBLIC"
 
 ### User-provided fields
 

--- a/arckit-claude/commands/strategy.md
+++ b/arckit-claude/commands/strategy.md
@@ -240,7 +240,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/tcop.md
+++ b/arckit-claude/commands/tcop.md
@@ -127,7 +127,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/traceability.md
+++ b/arckit-claude/commands/traceability.md
@@ -195,7 +195,7 @@ The hook provides the existing TRAC version and a suggested next version. Use th
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 **Calculated fields**:
 

--- a/arckit-claude/commands/wardley.climate.md
+++ b/arckit-claude/commands/wardley.climate.md
@@ -382,7 +382,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.doctrine.md
+++ b/arckit-claude/commands/wardley.doctrine.md
@@ -277,7 +277,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.gameplay.md
+++ b/arckit-claude/commands/wardley.gameplay.md
@@ -387,7 +387,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.md
+++ b/arckit-claude/commands/wardley.md
@@ -431,7 +431,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 

--- a/arckit-claude/commands/wardley.value-chain.md
+++ b/arckit-claude/commands/wardley.value-chain.md
@@ -275,7 +275,7 @@ Before completing the document, populate ALL document control fields in the head
 
 - `[PROJECT_NAME]` → Full project name from project metadata or user input
 - `[OWNER_NAME_AND_ROLE]` → Document owner (prompt user if not in metadata)
-- `[CLASSIFICATION]` → Default to "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
+- `[CLASSIFICATION]` → Default to `${user_config.default_classification}`; if unavailable, use "OFFICIAL" for UK Gov, "PUBLIC" otherwise (or prompt user)
 
 *Calculated fields*:
 


### PR DESCRIPTION
## Summary

Wire the existing `default_classification` `userConfig` field into the **Document Control** field instructions of every Claude command and agent that has a `[CLASSIFICATION]` line. When the user has set a default classification in plugin config, commands use it; otherwise they fall back to the prior `OFFICIAL`-for-UK-Gov / `PUBLIC`-otherwise heuristic (or prompt user).

**Touches 38 commands + 8 agents, 1 line each. 46 insertions / 46 deletions. No hooks, no plugin.json, no templates, no converter.**

## Relationship to #396

This PR is a minimal, current-`main`-based salvage of #396's intent. #396 is 112+ commits stale (merge-base between v4.7 and v4.8) and would silently revert ~90,000 lines of merged work (v4.8.0 → v4.22.0) if merged. Rather than rebase 112 commits over that revert, this PR cherry-picks only the safest fragment: the `${user_config.default_classification}` default.

Out of scope (versus #396):

- **`[OWNER_NAME_AND_ROLE]` ← `${user_config.organisation_name}` default.** The schema defines `organisation_name` as the org string (e.g. _"HM Revenue & Customs"_); `[OWNER_NAME_AND_ROLE]` is a person + role (e.g. _"Jane Doe, Chief Architect"_). These are different fields. Either a new `default_owner` `userConfig` field needs adding first, or this default should remain user-prompted. Punted to a follow-up.
- **Governance-framework-mode toggle on UK-by-definition commands** (`tcop`, `service-assessment`, `secure`, `atrs`, `ai-playbook`). A TCoP review with TCoP references removed isn't a thing; non-UK jurisdictions are covered by the community overlays.
- **`arckit-claude/hooks/governance-scan.mjs`** (748 lines). Was unregistered in `hooks.json`, dead code on arrival; ~700 lines duplicate `graph-inject.mjs`.

If those follow-ups are wanted, they should be separate PRs with proper schema bumps / hook design.

## Preserved fallback wording

Each file's existing fallback wording (`OFFICIAL` for UK Gov, `PUBLIC` otherwise — with minor variants per file: `INTERNAL` for `sobc.md` private-sector, no `(or prompt user)` tail on `dfd.md`, etc.) is kept verbatim after `if unavailable, …`. Behaviour with `user_config.default_classification` unset is therefore unchanged.

## Test plan

- [x] `markdownlint-cli2` clean on all 46 changed files
- [x] All 46 substitutions matched exactly once (no duplicate or missed lines)
- [ ] Manual smoke test: with `default_classification: OFFICIAL-SENSITIVE` set in plugin config, run `/arckit:adr` in a test repo and confirm the Document Control table picks up the value
- [ ] Manual smoke test: with `default_classification` unset, confirm the prior `OFFICIAL`/`PUBLIC` heuristic still applies

## Follow-ups (not in this PR)

- Optional: run `scripts/converter.py` to propagate to Codex/OpenCode/Gemini/Copilot extensions (converter rewrites `${user_config.KEY}` → `${KEY}` shell-env fallback for those targets). Holding off here to keep the PR minimal and Claude-only, matching #396's scope.
- Decide on the `[OWNER_NAME_AND_ROLE]` story: add `default_owner` `userConfig` field, or keep prompt-only.