### PR TITLE
docs: add 'What it costs' plugin footprint section to README (#495)

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,6 +237,35 @@ Public demonstration repositories showcase complete ArcKit deliverables:
 
 ---
 
+## What it costs (plugin footprint)
+
+Token cost of installing the `arckit` core plugin in a Claude Code session, captured from `claude plugin details arckit` on v2.1.143+:
+
+- **Always-on per session: ~10,042 tokens** — added to every session's system context, covering the 71 command-skills + 5 utility skills (`architecture-workflow`, `arckit-build`, `mermaid-syntax`, `plantuml-syntax`, `wardley-mapping`) + 16 agent descriptors. Hooks (9 events) and MCP servers (5) are harness-resolved at runtime and not counted.
+- **On-invoke: ~250 to ~60K tokens per command** — paid only when a specific skill or agent fires. Most commands are in the 5–10K range.
+
+### On-invoke cost by command
+
+Costs are estimates from the Claude Code tokenizer and may differ from actual usage. Use this table to budget research-heavy multi-command sessions.
+
+| Tier | Range | Commands |
+|------|-------|----------|
+| Lightweight | <2K | `start`, `init`, `build`, `search`, `impact`, `navigator`, `graph-report`, `framework`, `gov-landscape`, `aws-research`, `azure-research`, `gcp-research` |
+| Standard | 2–7K | `customize`, `score`, `principles`, `mermaid-syntax`, `plantuml-syntax`, `architecture-workflow`, `datascout`, `evaluate`, `hld-review`, `mlops`, `devops`, `finops`, `research`, `tcop`, `wardley-mapping`, `template-builder`, `glossary`, `dld-review`, `traceability`, `stakeholders`, `presentation`, `dfd`, `operationalize`, `requirements`, `maturity-model`, `data-model`, `gov-reuse`, `strategy`, `presentation`, `atrs`, `gov-code-search`, `READER-PATTERN` |
+| Heavy | 7–15K | `wardley.value-chain`, `gcloud-clarify`, `ai-playbook`, `sow`, `sobc`, `risk`, `secure`, `dpia`, `dos`, `mod-secure`, `plan`, `conformance`, `roadmap`, `health`, `wardley.doctrine`, `wardley.gameplay`, `pages`, `servicenow`, `gcloud-search`, `principles-compliance`, `story`, `wardley`, `wardley.climate`, `data-mesh-contract`, `platform-design`, `adr`, `arckit-build`, `grants` |
+| Research-heavy | 15–25K | `service-assessment`, `analyze`, `backlog`, `diagram` |
+| Specialist | >25K | `jsp-936` (~60K — MOD JSP 936 AI assurance, defence-only) |
+
+### Trimming the footprint
+
+- The five utility skills already use `paths:` globs to scope their always-on cost to relevant projects (`mermaid-syntax` only loads under `*.mmd`, `wardley-mapping` under WARD artefacts, etc.). The 71 command-skills are listed but not described in detail in the always-on context — the full prompt only loads on invocation.
+- Community overlays (`arckit-uae`, `arckit-fr`, `arckit-ca`, `arckit-eu`, `arckit-at`, `arckit-au`) are independent plugins — install only the jurisdictions you need. Each adds its own always-on baseline.
+- Heavy commands (`jsp-936`, `analyze`, `diagram`, `backlog`) are on-invoke only; the always-on cost is unaffected by which heavy commands exist.
+
+To measure your own session footprint, run `/context all` (Claude Code v2.1.139+) for per-skill token estimates against your active model.
+
+---
+
 ## Why ArcKit?
 
 ### Problem: Architecture Governance is Broken


### PR DESCRIPTION
## Summary

Closes the last open #495 item — projected plugin cost measurement.

Captured live from `claude plugin details arckit` (Claude Code v2.1.143+) and turned into a new README section between "Explore Example Outputs" and "Why ArcKit?".

## Numbers

- **Always-on per session: ~10,042 tokens** — added to every session covering 71 command-skills + 5 utility skills (`architecture-workflow`, `arckit-build`, `mermaid-syntax`, `plantuml-syntax`, `wardley-mapping`) + 16 agent descriptors. The 9 hook events and 5 MCP servers are harness-resolved and not counted.
- **On-invoke: ~250 to ~60K tokens per command** — most commands sit in the 5–10K band.

## Section content

The new "What it costs (plugin footprint)" section adds:

1. The always-on / on-invoke headline numbers above
2. A tier table grouping all 71+ commands by on-invoke cost:
   - **Lightweight** <2K (12 commands — `start`, `init`, `build`, `search`, `impact`, `navigator`, `graph-report`, `framework`, `gov-landscape`, `aws-research`, `azure-research`, `gcp-research`)
   - **Standard** 2–7K (most of the catalogue)
   - **Heavy** 7–15K (`arckit-build`, `roadmap`, `risk`, `secure`, `plan`, `health`, `principles-compliance`, etc.)
   - **Research-heavy** 15–25K (`service-assessment`, `analyze`, `backlog`, `diagram`)
   - **Specialist** >25K (`jsp-936` alone, ~60K — defence-only)
3. Footprint-trimming notes: `paths:`-scoped utility skills, selective community-overlay install, heavy commands are on-invoke only so they don't bloat the baseline
4. Pointer to `/context all` (v2.1.139+) for live per-session measurement against the user's active model

## Test plan

- [x] `markdownlint-cli2 README.md` — 0 errors
- [x] Tier table groups every command from the captured output
- [ ] Visual review of the rendered section on GitHub once merged

This is the last #495 follow-up; ready to close #495 after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)