### PR TITLE
docs(seo): register plugin-split article in llms.txt + sitemap

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -197,6 +197,7 @@ French government (apply on top of EU baseline):
 
 - [Articles index](https://arckit.org/articles.html): Long-form essays on ArcKit's design, the GDS / G-Cloud / UN Global Platform context, and platform-by-platform comparisons.
 - [Why ArcKit needed a build harness](https://arckit.org/article-viewer.html?a=2026-05-03-build-harness-parallel-architecture-generation): v4.13.0 launch piece for `/arckit:build` (The GDS Harness) — orchestration model, recipes, live-run evidence.
+- [The token budget behind ArcKit's plugin split](https://arckit.org/article-viewer.html?a=2026-05-20-plugin-split-token-budget): why v5.0.0 split into seven marketplace plugins, grounded in real `claude plugin details` token data (core ~10,042 tokens always-on, six overlays ~5,249 combined, ~34% always-on cut for single-jurisdiction users); includes an eight-step guide to splitting a monolithic plugin.
 
 ## Roles
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -26,7 +26,7 @@
     </url>
     <url>
         <loc>https://arckit.org/articles.html</loc>
-        <lastmod>2026-05-16</lastmod>
+        <lastmod>2026-05-20</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.8</priority>
     </url>


### PR DESCRIPTION
## Summary

Follow-up to #502. The new token-budget article was added to the Articles page but not registered for SEO / LLM discovery.

- **`docs/llms.txt`** — adds the article to the "Articles and essays" section so LLM crawlers surface it.
- **`docs/sitemap.xml`** — bumps the `articles.html` `<lastmod>` from 2026-05-16 to 2026-05-20.

## Notes

- The sitemap does **not** enumerate individual articles (only `articles.html` and `article-viewer.html`), so there is no per-article URL to add. Worth a separate look later: query-param article URLs (`?a=slug`) are not individually crawlable.
- `llms.txt`'s "Articles and essays" section is curated and currently lags — it is also missing the 18/19 May articles. Out of scope here; flagged for a follow-up.

Doc-only, no version bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)