### PR TITLE
fix(wardley): owm-to-mermaid evolve-line numbers + inline build/buy/outsource decorators (#508)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -74,3 +74,6 @@ jobs:
 
       - name: Wardley label-tidy hook tests
         run: node --test tests/plugin/tidy-wardley-labels.test.mjs tests/plugin/wardley-tidy.test.mjs tests/plugin/owm-tidy.test.mjs
+
+      - name: OWM-to-Mermaid converter tests
+        run: node --test tests/plugin/owm-to-mermaid.test.mjs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `owm-to-mermaid.mjs` no longer mis-parses `evolve` lines whose quoted component name contains an embedded number (#508). The target-evolution regex is now anchored at end-of-line, so `evolve "Foo (Project 003)" 0.74` is converted faithfully instead of truncating the name and dropping the real target.
+- `owm-to-mermaid.mjs` now passes inline `(build)` / `(buy)` / `(outsource)` decorators through to the Mermaid output (#508), alongside the existing `(inertia)` support. Authors no longer need to add trailing standalone `build "<Name>"` / `buy "<Name>"` / `outsource "<Name>"` directives to get sourcing decorators on the converted Mermaid map.
 - `/arckit:health` now flags **DRAFT staleness** and **overdue reviews** — the two signals the session-start `stale-artifact-scan` monitor was already reporting (#509). Adds two detection rules: `STALE-DRAFT` (MEDIUM, status=DRAFT unchanged for > 30 days by default, configurable via `STALE_DRAFT_DAYS=N`) and `REVIEW-OVERDUE` (HIGH, Document Control `Next Review Date` in the past on non-DRAFT/SUPERSEDED/ARCHIVED artifacts). The monitor's draft threshold moves from 14 days to 30 to match. Both surfaces now agree on the same set of artifacts.
 
 ## [5.0.4] - 2026-05-22

--- a/arckit-claude/CHANGELOG.md
+++ b/arckit-claude/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- `owm-to-mermaid.mjs` no longer mis-parses `evolve` lines whose quoted component name contains an embedded number (#508). The target-evolution regex is now anchored at end-of-line.
+- `owm-to-mermaid.mjs` now passes inline `(build)` / `(buy)` / `(outsource)` decorators through to the Mermaid output (#508), alongside the existing `(inertia)` support. Standalone `build "<Name>"` / `buy "<Name>"` / `outsource "<Name>"` directives are no longer required for sourcing decorators on the converted map.
 - `/arckit:health` now flags **DRAFT staleness** and **overdue reviews** — the two signals the session-start `stale-artifact-scan` monitor was already reporting (#509). New detection rules `STALE-DRAFT` (MEDIUM, threshold `STALE_DRAFT_DAYS=30` by default, configurable per invocation) and `REVIEW-OVERDUE` (HIGH, skips DRAFT/SUPERSEDED/ARCHIVED). The monitor's draft threshold moves from 14 days to 30 to align with the new rule. `docs/health.json` `byType` now always includes both new rule IDs (0 when there are no findings).
 
 ## [5.0.4] - 2026-05-22

--- a/arckit-claude/scripts/owm-to-mermaid.mjs
+++ b/arckit-claude/scripts/owm-to-mermaid.mjs
@@ -240,6 +240,8 @@ export function convert(owm, filename = '') {
       const cname = mcomp[1].trim();
       const coords = mcomp[2];
       const hasInertia = /\binertia\s*$/i.test(s);
+      const inlineSrcMatch = s.match(/\((build|buy|outsource)\)/i);
+      const inlineSrc = inlineSrcMatch ? inlineSrcMatch[1].toLowerCase() : null;
       // Preserve `label [dx, dy]` from the remainder after the coord closing `]`.
       // Label offsets are integers in the Label grammar (INT, not WARDLEY_NUMBER).
       const coordsEnd = s.indexOf(coords) + coords.length;
@@ -258,7 +260,8 @@ export function convert(owm, filename = '') {
       } else {
         let line = `component ${qname} ${coords}${labelSuffix}`;
         const decorators = [];
-        if (sourcing[cname.toLowerCase()]) decorators.push(`(${sourcing[cname.toLowerCase()]})`);
+        const src = inlineSrc || sourcing[cname.toLowerCase()];
+        if (src) decorators.push(`(${src})`);
         if (hasInertia) decorators.push('(inertia)');
         if (decorators.length) line += ' ' + decorators.join(' ');
         out.push(line);
@@ -276,8 +279,9 @@ export function convert(owm, filename = '') {
       continue;
     }
 
-    // evolve
-    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)/i);
+    // evolve — anchor target at end so quoted names with embedded digits
+    // (e.g. "Foo (Project 003)") aren't mis-parsed by the lazy name group.
+    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)\s*$/i);
     if (mev) {
       out.push(`evolve ${quoteName(mev[1].trim())} ${mev[2]}`);
       continue;

--- a/arckit-codex/scripts/owm-to-mermaid.mjs
+++ b/arckit-codex/scripts/owm-to-mermaid.mjs
@@ -240,6 +240,8 @@ export function convert(owm, filename = '') {
       const cname = mcomp[1].trim();
       const coords = mcomp[2];
       const hasInertia = /\binertia\s*$/i.test(s);
+      const inlineSrcMatch = s.match(/\((build|buy|outsource)\)/i);
+      const inlineSrc = inlineSrcMatch ? inlineSrcMatch[1].toLowerCase() : null;
       // Preserve `label [dx, dy]` from the remainder after the coord closing `]`.
       // Label offsets are integers in the Label grammar (INT, not WARDLEY_NUMBER).
       const coordsEnd = s.indexOf(coords) + coords.length;
@@ -258,7 +260,8 @@ export function convert(owm, filename = '') {
       } else {
         let line = `component ${qname} ${coords}${labelSuffix}`;
         const decorators = [];
-        if (sourcing[cname.toLowerCase()]) decorators.push(`(${sourcing[cname.toLowerCase()]})`);
+        const src = inlineSrc || sourcing[cname.toLowerCase()];
+        if (src) decorators.push(`(${src})`);
         if (hasInertia) decorators.push('(inertia)');
         if (decorators.length) line += ' ' + decorators.join(' ');
         out.push(line);
@@ -276,8 +279,9 @@ export function convert(owm, filename = '') {
       continue;
     }
 
-    // evolve
-    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)/i);
+    // evolve — anchor target at end so quoted names with embedded digits
+    // (e.g. "Foo (Project 003)") aren't mis-parsed by the lazy name group.
+    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)\s*$/i);
     if (mev) {
       out.push(`evolve ${quoteName(mev[1].trim())} ${mev[2]}`);
       continue;

--- a/arckit-copilot/scripts/owm-to-mermaid.mjs
+++ b/arckit-copilot/scripts/owm-to-mermaid.mjs
@@ -240,6 +240,8 @@ export function convert(owm, filename = '') {
       const cname = mcomp[1].trim();
       const coords = mcomp[2];
       const hasInertia = /\binertia\s*$/i.test(s);
+      const inlineSrcMatch = s.match(/\((build|buy|outsource)\)/i);
+      const inlineSrc = inlineSrcMatch ? inlineSrcMatch[1].toLowerCase() : null;
       // Preserve `label [dx, dy]` from the remainder after the coord closing `]`.
       // Label offsets are integers in the Label grammar (INT, not WARDLEY_NUMBER).
       const coordsEnd = s.indexOf(coords) + coords.length;
@@ -258,7 +260,8 @@ export function convert(owm, filename = '') {
       } else {
         let line = `component ${qname} ${coords}${labelSuffix}`;
         const decorators = [];
-        if (sourcing[cname.toLowerCase()]) decorators.push(`(${sourcing[cname.toLowerCase()]})`);
+        const src = inlineSrc || sourcing[cname.toLowerCase()];
+        if (src) decorators.push(`(${src})`);
         if (hasInertia) decorators.push('(inertia)');
         if (decorators.length) line += ' ' + decorators.join(' ');
         out.push(line);
@@ -276,8 +279,9 @@ export function convert(owm, filename = '') {
       continue;
     }
 
-    // evolve
-    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)/i);
+    // evolve — anchor target at end so quoted names with embedded digits
+    // (e.g. "Foo (Project 003)") aren't mis-parsed by the lazy name group.
+    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)\s*$/i);
     if (mev) {
       out.push(`evolve ${quoteName(mev[1].trim())} ${mev[2]}`);
       continue;

--- a/arckit-opencode/scripts/owm-to-mermaid.mjs
+++ b/arckit-opencode/scripts/owm-to-mermaid.mjs
@@ -240,6 +240,8 @@ export function convert(owm, filename = '') {
       const cname = mcomp[1].trim();
       const coords = mcomp[2];
       const hasInertia = /\binertia\s*$/i.test(s);
+      const inlineSrcMatch = s.match(/\((build|buy|outsource)\)/i);
+      const inlineSrc = inlineSrcMatch ? inlineSrcMatch[1].toLowerCase() : null;
       // Preserve `label [dx, dy]` from the remainder after the coord closing `]`.
       // Label offsets are integers in the Label grammar (INT, not WARDLEY_NUMBER).
       const coordsEnd = s.indexOf(coords) + coords.length;
@@ -258,7 +260,8 @@ export function convert(owm, filename = '') {
       } else {
         let line = `component ${qname} ${coords}${labelSuffix}`;
         const decorators = [];
-        if (sourcing[cname.toLowerCase()]) decorators.push(`(${sourcing[cname.toLowerCase()]})`);
+        const src = inlineSrc || sourcing[cname.toLowerCase()];
+        if (src) decorators.push(`(${src})`);
         if (hasInertia) decorators.push('(inertia)');
         if (decorators.length) line += ' ' + decorators.join(' ');
         out.push(line);
@@ -276,8 +279,9 @@ export function convert(owm, filename = '') {
       continue;
     }
 
-    // evolve
-    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)/i);
+    // evolve — anchor target at end so quoted names with embedded digits
+    // (e.g. "Foo (Project 003)") aren't mis-parsed by the lazy name group.
+    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)\s*$/i);
     if (mev) {
       out.push(`evolve ${quoteName(mev[1].trim())} ${mev[2]}`);
       continue;

--- a/tests/plugin/owm-to-mermaid.test.mjs
+++ b/tests/plugin/owm-to-mermaid.test.mjs
@@ -1,0 +1,68 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+const { convert } = await import(
+  resolve('arckit-claude/scripts/owm-to-mermaid.mjs')
+);
+
+test('issue #508 bug 1 — evolve target preserved when quoted name contains an embedded number', () => {
+  const src = [
+    'title Test',
+    'component "IPAD data products (Project 003)" [0.5, 0.6]',
+    'evolve "IPAD data products (Project 003)" 0.74',
+  ].join('\n');
+  const out = convert(src);
+  assert.match(out, /evolve "IPAD data products \(Project 003\)" 0\.74/);
+  assert.doesNotMatch(out, /evolve "'IPAD/);
+  assert.doesNotMatch(out, /\b003\s*$/m);
+});
+
+test('issue #508 bug 2 — inline (build) decorator is passed through', () => {
+  const out = convert('component "X" [0.5, 0.5] (build)');
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(build\)/);
+});
+
+test('issue #508 bug 2 — inline (buy) decorator is passed through', () => {
+  const out = convert('component "X" [0.5, 0.5] (buy)');
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(buy\)/);
+});
+
+test('issue #508 bug 2 — inline (outsource) decorator is passed through', () => {
+  const out = convert('component "X" [0.5, 0.5] (outsource)');
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(outsource\)/);
+});
+
+test('inline (build) composes with trailing inertia', () => {
+  const out = convert('component "X" [0.5, 0.5] (build) inertia');
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(build\) \(inertia\)/);
+});
+
+test('inline decorator wins over standalone sourcing line for same component', () => {
+  const src = [
+    'component "X" [0.5, 0.5] (build)',
+    'buy "X"',
+  ].join('\n');
+  const out = convert(src);
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(build\)/);
+  assert.doesNotMatch(out, /\(buy\)/);
+});
+
+test('standalone build "X" line still applies when no inline decorator', () => {
+  const src = [
+    'component "X" [0.5, 0.5]',
+    'build "X"',
+  ].join('\n');
+  const out = convert(src);
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(build\)/);
+});
+
+test('regression — unquoted name with trailing single number still parses', () => {
+  const out = convert('evolve Foo 0.5');
+  assert.match(out, /evolve "Foo" 0\.5/);
+});
+
+test('regression — inertia-only component unchanged', () => {
+  const out = convert('component "X" [0.5, 0.5] inertia');
+  assert.match(out, /component "X" \[0\.5, 0\.5\] \(inertia\)/);
+});


### PR DESCRIPTION
## Summary

Two reproducible parser defects in `scripts/owm-to-mermaid.mjs`, both confirmed against v5.0.4 as reported in #508:

1. **`evolve` line truncation on names with embedded numbers** — a quoted component name containing a standalone number (e.g. `"IPAD data products (Project 003)"`) was mis-parsed: the lazy name capture stopped early, the engine took `003` as the evolve target, and the real target (`0.74`) was dropped. Anchoring the target at end-of-line fixes it without affecting unquoted-name behaviour.

2. **Inline `(build)` / `(buy)` / `(outsource)` decorators dropped** — `(inertia)` was already passed through, but the three sourcing decorators were silently discarded, forcing authors to add trailing standalone `build "<Name>"` / `buy "<Name>"` / `outsource "<Name>"` directives to get the same output. Now treated symmetrically with `(inertia)`; inline decorator wins over a standalone directive for the same component.

## Changes

- `arckit-claude/scripts/owm-to-mermaid.mjs` — both fixes (canonical)
- `arckit-codex/`, `arckit-copilot/`, `arckit-opencode/` — converter propagation (gemini's `scripts/` is gitignored, rebuilt at publish time)
- `tests/plugin/owm-to-mermaid.test.mjs` — 9 new tests covering both bug repros, inline composes with inertia, inline-wins-over-standalone, plus regressions for unquoted names and inertia-only
- `.github/workflows/lint-markdown.yml` — wires the new test into CI alongside the existing tidy tests
- `CHANGELOG.md` + `arckit-claude/CHANGELOG.md` entries

## Test plan

- [x] `node --test tests/plugin/owm-to-mermaid.test.mjs` — 9/9 pass locally
- [x] Combined run with existing tidy suites — 30/30 pass locally
- [x] `markdownlint-cli2` on changed `.md` files — clean
- [ ] CI green on PR (codex-plugin + lint)

Closes #508.

🤖 Generated with [Claude Code](https://claude.com/claude-code)