### PR TITLE
fix(release): add arckit-us to tag-plugins.sh PLUGINS array

### DIFF
--- a/scripts/tag-plugins.sh
+++ b/scripts/tag-plugins.sh
@@ -23,7 +23,7 @@ if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
   exit 1
 fi
 
-PLUGINS=(arckit-claude arckit-uae arckit-fr arckit-ca arckit-eu arckit-at arckit-au)
+PLUGINS=(arckit-claude arckit-uae arckit-fr arckit-ca arckit-eu arckit-at arckit-au arckit-us)
 
 CREATED=0
 SKIPPED=0


### PR DESCRIPTION
## Summary

- The v5.1.0 release (PR #512) shipped `arckit-us` as the 8th marketplace plugin and wired it into `bump-version.sh` and `converter.py`, but missed `scripts/tag-plugins.sh`
- The per-plugin native tag `arckit-us--v5.1.0` had to be created and pushed manually during the v5.1.0 release flow
- One-line fix: add `arckit-us` to the PLUGINS array so the next release picks it up automatically

## Background

`scripts/tag-plugins.sh` creates the bookkeeping tags that the Claude Code plugin system uses to resolve exact versions from marketplace history (`<plugin-name>--vX.Y.Z`). It runs after the umbrella `vX.Y.Z` tag has triggered `release.yml`. The PLUGINS array is hard-coded, so any new community overlay must be added in two places (`bump-version.sh` and `tag-plugins.sh`); this PR closes the second gap for `arckit-us`.

A longer-term refactor would auto-discover plugins via glob or via `.claude-plugin/marketplace.json`, removing the dual-registration; out of scope for this fix.

## Test plan

- [x] Script edits: one-line array extension, no logic change
- [ ] Smoke test on next release: `scripts/tag-plugins.sh <version>` reports `Done — created 8 native plugin tag(s)` (was 7 in v5.1.0)

🤖 Generated with [Claude Code](https://claude.com/claude-code)