### PR TITLE
docs: decouple hero strapline + meta tags from command counts

### DIFF
--- a/docs/guides.html
+++ b/docs/guides.html
@@ -4,19 +4,19 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit Command Guides - 102 usage guides (plus 36 community overlays) for enterprise architecture governance commands organized by category.">
+    <meta name="description" content="ArcKit Command Guides - step-by-step usage guides for the officially-maintained baseline plus community-contributed jurisdictional overlays, organised by category.">
     <title>Command Guides - ArcKit</title>
     <meta name="keywords" content="ArcKit guides, architecture governance guides, command usage, workflow steps, UK government architecture">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="Command Guides - ArcKit">
-    <meta property="og:description" content="102 step-by-step usage guides (plus 36 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta property="og:description" content="Step-by-step usage guides for ArcKit enterprise architecture governance commands — officially-maintained baseline plus community-contributed jurisdictional overlays, organised by category.">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/guides.html">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="Command Guides - ArcKit">
-    <meta name="twitter:description" content="102 step-by-step usage guides (plus 36 community overlays) for ArcKit enterprise architecture governance commands, organised by category.">
+    <meta name="twitter:description" content="Step-by-step usage guides for ArcKit enterprise architecture governance commands — officially-maintained baseline plus community-contributed jurisdictional overlays, organised by category.">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <link rel="canonical" href="https://arckit.org/guides.html">
     <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin>
@@ -235,7 +235,7 @@
                 "@type": "CollectionPage",
                 "@id": "https://arckit.org/guides.html",
                 "name": "Command Guides - ArcKit",
-                "description": "102 step-by-step usage guides (plus 36 community overlays) for ArcKit enterprise architecture governance commands, organised by category.",
+                "description": "Step-by-step usage guides for ArcKit enterprise architecture governance commands — officially-maintained baseline plus community-contributed jurisdictional overlays, organised by category.",
                 "isPartOf": { "@type": "WebSite", "name": "ArcKit", "url": "https://arckit.org" }
             },
             {
@@ -281,9 +281,9 @@
 
     <div class="app-page-hero app-page-hero--guides">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">102 Guides + 36 Community Overlays</span>
+            <span class="app-page-hero__stat">Guides + Community Overlays</span>
             <h1 class="app-page-hero__title">Command Guides</h1>
-            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline organised into 12 categories, plus 36 community-contributed EU, French, Austrian, and UAE public-sector overlays in dedicated sections.</p>
+            <p class="app-page-hero__description">Step-by-step usage guides for the officially-maintained baseline, plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA) in dedicated sections.</p>
         </div>
     </div>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. 135 AI-assisted commands (71 core + 64 community-contributed overlays) covering UK, EU, France, Austria, Canada, UAE, Australia, and USA governance frameworks.">
+    <meta name="description" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement Toolkit. AI-assisted commands covering a UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).">
     <meta name="keywords" content="enterprise architecture, UK government, EU, France, Austria, Canada, UAE, Australia, GDS, GDPR, AI Act, NIS2, ANSSI, PDPL, DISP, Essential Eight, architecture governance, vendor procurement, ArcKit, compliance, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta property="og:description" content="135 AI-assisted commands for systematic, compliant architecture governance — UK Government baseline plus EU, France, Austria, Canada, UAE, Australia, and USA community overlays.">
+    <meta property="og:description" content="AI-assisted commands for systematic, compliant architecture governance — UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - Enterprise Architecture Governance & Vendor Procurement">
-    <meta name="twitter:description" content="135 AI-assisted commands for systematic, compliant architecture governance — UK Government baseline plus EU, France, Austria, Canada, UAE, Australia, and USA community overlays.">
+    <meta name="twitter:description" content="AI-assisted commands for systematic, compliant architecture governance — UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - Enterprise Architecture Governance & Vendor Procurement</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -358,7 +358,7 @@
                 "@id": "https://arckit.org/#website",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "135 AI-assisted commands for systematic, compliant architecture governance across UK, EU, France, Austria, Canada, UAE, Australia, and USA jurisdictions.",
+                "description": "AI-assisted commands for systematic, compliant architecture governance across UK, EU, France, Austria, Canada, UAE, Australia, and USA jurisdictions.",
                 "publisher": { "@id": "https://arckit.org/#organization" },
                 "inLanguage": "en-GB"
             },
@@ -367,7 +367,7 @@
                 "@id": "https://arckit.org/",
                 "url": "https://arckit.org/",
                 "name": "ArcKit - Enterprise Architecture Governance & Vendor Procurement",
-                "description": "135 AI-assisted commands for systematic, compliant project delivery — UK Government baseline plus EU, France, Austria, Canada, UAE, Australia, and USA community overlays.",
+                "description": "AI-assisted commands for systematic, compliant project delivery — UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).",
                 "isPartOf": { "@id": "https://arckit.org/#website" },
                 "about": { "@id": "https://arckit.org/#software" },
                 "primaryImageOfPage": "https://arckit.org/og-image.png"
@@ -381,7 +381,7 @@
                 "applicationCategory": "DeveloperApplication",
                 "applicationSubCategory": "Enterprise Architecture Governance",
                 "operatingSystem": "macOS, Linux, Windows",
-                "description": "ArcKit is an open-source Enterprise Architecture Governance and Vendor Procurement toolkit distributed as a plugin or extension for AI coding assistants — Claude Code, Gemini CLI, GitHub Copilot, OpenAI Codex CLI, and OpenCode CLI. It provides 135 slash commands (71 official UK Government baseline plus 64 community-contributed overlays for the EU, France, Austria, Canada, the UAE, Australia, and the USA) that generate architecture artefacts using versioned templates with full traceability.",
+                "description": "ArcKit is an open-source Enterprise Architecture Governance and Vendor Procurement toolkit distributed as a plugin or extension for AI coding assistants — Claude Code, Gemini CLI, GitHub Copilot, OpenAI Codex CLI, and OpenCode CLI. It provides slash commands across an official UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA) that generate architecture artefacts using versioned templates with full traceability.",
                 "softwareVersion": "4.21.0",
                 "license": "https://github.com/tractorjuice/arc-kit/blob/main/LICENSE",
                 "codeRepository": "https://github.com/tractorjuice/arc-kit",
@@ -414,7 +414,7 @@
                         "name": "What is ArcKit?",
                         "acceptedAnswer": {
                             "@type": "Answer",
-                            "text": "ArcKit is an open-source Enterprise Architecture Governance and Vendor Procurement toolkit. It provides 135 AI-assisted slash commands (71 official plus 64 community-contributed overlays) that turn architecture governance from scattered documents into a systematic, template-driven workflow with full traceability from stakeholders through requirements to design and tests."
+                            "text": "ArcKit is an open-source Enterprise Architecture Governance and Vendor Procurement toolkit. It provides AI-assisted slash commands across an official UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA) that turn architecture governance from scattered documents into a systematic, template-driven workflow with full traceability from stakeholders through requirements to design and tests."
                         }
                     },
                     {
@@ -537,7 +537,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">135 AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts. The UK Government baseline (71 core commands) ships alongside community-contributed overlays for the EU, France, Austria, Canada, UAE, Australia, and USA.</p>
+            <p class="govuk-body">AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts. The UK Government baseline ships alongside community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">
@@ -657,7 +657,7 @@
                     <p class="app-jurisdiction-card__desc">FedRAMP authorization, FISMA / NIST 800-53 Rev 5, CISA Zero Trust Maturity, OMB M-19-17 ICAM, NIST AI RMF, OMB M-24-10/M-25-21 AI assurance, E-Gov §208 PIA, EO 14028 SBOM. Install: <code>claude plugin install arckit arckit-us</code>.</p>
                 </a>
             </div>
-            <p class="govuk-body govuk-!-margin-top-4"><a href="commands.html" class="govuk-link">Browse all 135 commands &rarr;</a></p>
+            <p class="govuk-body govuk-!-margin-top-4"><a href="commands.html" class="govuk-link">Browse all commands &rarr;</a></p>
         </div>
 
         <!-- 4b. Government Code Discovery -->
@@ -689,7 +689,7 @@
         <!-- 5. Works with your AI -->
         <div class="govuk-width-container govuk-!-margin-top-9" id="multi-ai">
             <h2 class="govuk-heading-l">Works with your AI</h2>
-            <p class="govuk-body">All 71 core commands plus 64 community overlays (135 total) produce identical outputs across AI systems. Choose the platform that fits your workflow.</p>
+            <p class="govuk-body">Every core command and community overlay produces identical outputs across AI systems. Choose the platform that fits your workflow.</p>
 
             <div class="app-ai-compact">
                 <div class="app-ai-compact-card app-ai-compact-card--premier">
@@ -996,7 +996,7 @@
             <div class="app-explore-grid">
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="commands.html" class="govuk-link">AI Commands</a></h3>
-                    <p class="govuk-body-s">Browse all 135 commands (71 core + 64 community overlays) across 13 baseline categories and 7 community overlay categories. Filter by jurisdiction, tier, status, or category.</p>
+                    <p class="govuk-body-s">Browse every command across the official baseline plus community jurisdictional overlay categories. Filter by jurisdiction, tier, status, or category.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>


### PR DESCRIPTION
## Summary

- Removes hard-coded counts (135 / 71 / 64 / 102 / 36 / 139 / 68) from `docs/index.html` and `docs/guides.html` — meta descriptions, OG/Twitter cards, JSON-LD descriptions, hero strapline, "Browse all N commands" link, FAQ answers, "What is ArcKit?" body, "Works with your AI" intro, and Explore card
- Rephrases scope qualitatively: *"UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA)"*
- Same intent as #514 (which decoupled counts on `commands.html`), now extended to the landing page + guides index

## Why

Every overlay addition (Canada, Australia, USA, and the upcoming UK NHS sector overlay on #501) forces a sweep across ~10 copy locations to bump the same number. Decoupling keeps the site honest without maintenance churn.

## Test plan

- [ ] Visual check `docs/index.html` hero + What is ArcKit? + Works with your AI + Explore card render correctly
- [ ] Visual check `docs/guides.html` hero strapline reads correctly
- [ ] `view-source:` on both pages — confirm meta description / OG / Twitter / JSON-LD all updated
- [ ] No CSS regressions (the lone remaining `135` in `index.html` is a `linear-gradient` angle, unrelated)