### PR TITLE
ci: wire shared-asset drift check (closes #520)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Doc-type collision check
         run: python3 scripts/check_doctype_collisions.py
 
+      - name: Shared-asset drift check (closes #520)
+        run: python3 scripts/sync-shared-assets.py --check
+        
       - uses: actions/setup-node@v4
         with:
           node-version: "20"


### PR DESCRIPTION
Follow-up to #524 — adds the `.github/workflows/lint-markdown.yml` step that PAT-scope blocked from landing in that PR.

## Change

```yaml
      - name: Shared-asset drift check (closes #520)
        run: python3 scripts/sync-shared-assets.py --check
```

Runs after the existing doc-type collision check. If any community-overlay copy of a shared partial or reference has drifted from the core source (in `arckit-claude/templates/_partials/` or `arckit-claude/references/`), CI fails with the path that drifted and a remediation hint pointing at `scripts/sync-shared-assets.py`.

## Why no `paths:` filter expansion

The existing `**/*.md` filter already triggers the workflow on any overlay copy edit (the synced files are all `.md`). The only edge case not covered is a change to `scripts/sync-shared-assets.py` itself with no markdown changes — rare enough to skip; if it matters later, add the filter then.

Closes #520.

🤖 Generated with [Claude Code](https://claude.com/claude-code)