### PR TITLE
docs(test-repos): add v51-prs-database and v52-uae-caio-playbook

### DIFF
--- a/docs/TEST-REPOS.md
+++ b/docs/TEST-REPOS.md
@@ -26,6 +26,8 @@ ArcKit maintains public test repos on GitHub (pattern: `arckit-test-project-v*`)
 | v46 | sdg | ArcKit SDG Mono-Repo: 17 UN SDGs, 78 UK Government technology projects |
 | v47 | dft-transforming-city-regions | DfT Transforming City Regions funding system |
 | v50 | post-office-horizon | Post Office Horizon |
+| v51 | prs-database | UK PRS Database under Renters' Rights Act 2025 |
+| v52 | uae-caio-playbook | UAE CAIO Playbook for the 24-month agentic AI mandate |
 
 ## Plugin-Based Setup (since 2026-02-07)
 


### PR DESCRIPTION
## Summary

- Add the two newest public test repos to `docs/TEST-REPOS.md`:
  - **v51 — prs-database** (UK PRS Database under Renters' Rights Act 2025)
  - **v52 — uae-caio-playbook** (UAE CAIO Playbook for the 24-month agentic AI mandate)
- Three other repos created since the last refresh (v20, v48, v49) are PRIVATE and intentionally not listed, per the public-only listing convention noted in `project_test_repos` memory.
- v44-australian-gov was deleted upstream; memory has been refreshed separately.

## Test plan

- [x] `markdownlint-cli2 docs/TEST-REPOS.md` passes
- [x] Both repo slugs verified via `gh repo view` (PUBLIC, descriptions match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)