### PR TITLE
docs(site): swap text wordmark for ArcKit brand logos

### DIFF
--- a/docs/article-viewer.html
+++ b/docs/article-viewer.html
@@ -59,11 +59,13 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus { color: #ffffff; text-decoration: none; }
+        .app-nav-bar__brand img { height: 32px; width: auto; display: block; }
         .app-nav-bar__list {
             display: flex;
             list-style: none;
@@ -210,7 +212,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/articles.html
+++ b/docs/articles.html
@@ -65,14 +65,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__list {
@@ -279,7 +286,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -93,14 +93,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -485,7 +492,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item app-nav-bar__item--active"><a href="commands.html">AI Commands</a></li>

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -93,14 +93,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -266,7 +273,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -93,14 +93,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -323,7 +330,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/guide-viewer.html
+++ b/docs/guide-viewer.html
@@ -68,14 +68,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__list {
@@ -285,7 +292,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -93,14 +93,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -259,7 +266,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/heroes.css
+++ b/docs/heroes.css
@@ -62,6 +62,19 @@
     line-height: 1.15;
 }
 
+/* Logo variant — replaces title text with brand lockup */
+.app-page-hero__title--logo {
+    line-height: 0;
+    margin: 0.5rem 0 1rem;
+}
+
+.app-page-hero__title--logo img {
+    height: clamp(140px, 22vw, 220px);
+    width: auto;
+    max-width: 100%;
+    display: block;
+}
+
 /* Description text */
 .app-page-hero__description {
     color: rgba(255, 255, 255, 0.88);

--- a/docs/index.html
+++ b/docs/index.html
@@ -289,14 +289,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -482,7 +489,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>
@@ -509,9 +518,11 @@
     <!-- 1. Hero -->
     <div class="app-page-hero app-page-hero--home" id="hero">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">Enterprise Architecture Toolkit</span>
-            <h1 class="app-page-hero__title">ArcKit</h1>
-            <p class="app-page-hero__description">Transform architecture chaos into systematic, audit-ready governance.</p>
+            <span class="app-page-hero__stat">The Enterprise Architecture Governance Harness</span>
+            <h1 class="app-page-hero__title app-page-hero__title--logo">
+                <img src="assets/ArcKit_Logo_Stacked_Light.svg" alt="ArcKit" width="280" height="280">
+            </h1>
+            <p class="app-page-hero__description">Wrap your AI coding assistant in a template-driven, audit-ready governance harness.</p>
             <p class="app-page-hero__version" id="hero-version"></p>
         </div>
     </div>

--- a/docs/roles.html
+++ b/docs/roles.html
@@ -93,14 +93,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -217,7 +224,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -93,14 +93,21 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.75rem 1.25rem;
-            display: block;
+            padding: 0.5rem 1.25rem;
+            display: flex;
+            align-items: center;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
+        }
+
+        .app-nav-bar__brand img {
+            height: 32px;
+            width: auto;
+            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -205,7 +212,9 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
+            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
+                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
+            </a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>


### PR DESCRIPTION
## Summary

- **Nav (10 pages)**: replaced the text `ArcKit` brand with `ArcKit_Logo_Horizontal_Light.svg` (light artwork for the dark `#0b0c0c` nav bar), 32px tall, with `aria-label="ArcKit home"` for screen readers.
- **Home hero**: H1 text `ArcKit` → `ArcKit_Logo_Stacked_Light.svg` wrapped in the `<h1>` (image `alt="ArcKit"` keeps the heading semantic for SEO/a11y). Logo is responsive via `clamp(140px, 22vw, 220px)`.
- **Hero copy**: stat badge "Enterprise Architecture Toolkit" → "The Enterprise Architecture Governance Harness"; description refreshed to match the harness positioning.

No new assets — all logos already shipped under `docs/assets/`.

## Test plan

- [ ] Open `index.html` locally — confirm the stacked logo renders in the hero, scales on a narrow viewport, and the H1 still announces "ArcKit" to a screen reader.
- [ ] Open each of `commands.html`, `articles.html`, `guides.html`, `roles.html`, `use-cases.html`, `getting-started.html`, `contributors.html`, `article-viewer.html`, `guide-viewer.html` — confirm the horizontal logo appears in the nav at 32px height with no layout jump.
- [ ] Toggle the theme switch — logo should still be readable (Light variant on dark nav is theme-independent).
- [ ] Verify on arckit.org after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)