### PR TITLE
docs(site): revert stacked logo in home hero (colour clash)

### DIFF
--- a/docs/heroes.css
+++ b/docs/heroes.css
@@ -62,19 +62,6 @@
     line-height: 1.15;
 }
 
-/* Logo variant — replaces title text with brand lockup */
-.app-page-hero__title--logo {
-    line-height: 0;
-    margin: 0.5rem 0 1rem;
-}
-
-.app-page-hero__title--logo img {
-    height: clamp(140px, 22vw, 220px);
-    width: auto;
-    max-width: 100%;
-    display: block;
-}
-
 /* Description text */
 .app-page-hero__description {
     color: rgba(255, 255, 255, 0.88);

--- a/docs/index.html
+++ b/docs/index.html
@@ -519,9 +519,7 @@
     <div class="app-page-hero app-page-hero--home" id="hero">
         <div class="govuk-width-container app-page-hero__content">
             <span class="app-page-hero__stat">The Enterprise Architecture Governance Harness</span>
-            <h1 class="app-page-hero__title app-page-hero__title--logo">
-                <img src="assets/ArcKit_Logo_Stacked_Light.svg" alt="ArcKit" width="280" height="280">
-            </h1>
+            <h1 class="app-page-hero__title">ArcKit</h1>
             <p class="app-page-hero__description">Wrap your AI coding assistant in a template-driven, audit-ready governance harness.</p>
             <p class="app-page-hero__version" id="hero-version"></p>
         </div>


### PR DESCRIPTION
## Summary

- Removes the Stacked Light logo from the home hero — its teal accent clashed with the hero's burgundy gradient (`#6b1d2a → #3d1020`). Reverted to the text H1.
- Keeps the updated stat badge ("The Enterprise Architecture Governance Harness") and refreshed description from #530.
- Nav logos remain in place (Horizontal Light on `#0b0c0c` is brand-aligned).

## Test plan

- [ ] `index.html` hero shows the text "ArcKit" H1 again, with the updated badge/description.
- [ ] Nav logo unchanged on all pages.
🤖 Generated with [Claude Code](https://claude.com/claude-code)