### PR TITLE
docs(site): nav bar bg → brand navy #0B1F33

### DIFF
--- a/docs/article-viewer.html
+++ b/docs/article-viewer.html
@@ -43,7 +43,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/articles.html
+++ b/docs/articles.html
@@ -47,7 +47,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -46,7 +46,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -46,7 +46,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -46,7 +46,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/guide-viewer.html
+++ b/docs/guide-viewer.html
@@ -50,7 +50,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -46,7 +46,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/index.html
+++ b/docs/index.html
@@ -246,7 +246,7 @@
 
         /* Sticky Navigation Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/roles.html
+++ b/docs/roles.html
@@ -46,7 +46,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -46,7 +46,7 @@
 
         /* Nav Bar */
         .app-nav-bar {
-            background: #0b0c0c;
+            background: #0B1F33;
             position: sticky;
             top: 0;
             z-index: 100;


### PR DESCRIPTION
## Summary

Swap the nav bar background from `#0b0c0c` (near-black) to brand navy `#0B1F33` across all 10 top-level pages — the colour the Horizontal Light logo was designed for. Brings the wordmark and teal accent into the intended contrast.

## Test plan

- [ ] Nav bar now reads as navy, not black, on all pages.
- [ ] Logo wordmark/accent look correct against the new bg.

🤖 Generated with [Claude Code](https://claude.com/claude-code)