### PR TITLE
docs(site): revert nav brand to text wordmark

### DIFF
--- a/docs/article-viewer.html
+++ b/docs/article-viewer.html
@@ -59,13 +59,11 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus { color: #ffffff; text-decoration: none; }
-        .app-nav-bar__brand img { height: 32px; width: auto; display: block; }
         .app-nav-bar__list {
             display: flex;
             list-style: none;
@@ -212,9 +210,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/articles.html
+++ b/docs/articles.html
@@ -65,21 +65,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__list {
@@ -286,9 +279,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/commands.html
+++ b/docs/commands.html
@@ -93,21 +93,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -492,9 +485,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item app-nav-bar__item--active"><a href="commands.html">AI Commands</a></li>

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -93,21 +93,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -273,9 +266,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -93,21 +93,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -330,9 +323,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/guide-viewer.html
+++ b/docs/guide-viewer.html
@@ -68,21 +68,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__list {
@@ -292,9 +285,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -93,21 +93,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -266,9 +259,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -289,21 +289,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -489,9 +482,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/roles.html
+++ b/docs/roles.html
@@ -93,21 +93,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -224,9 +217,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>

--- a/docs/use-cases.html
+++ b/docs/use-cases.html
@@ -93,21 +93,14 @@
             font-size: 1.125rem;
             font-weight: 700;
             text-decoration: none;
-            padding: 0.5rem 1.25rem;
-            display: flex;
-            align-items: center;
+            padding: 0.75rem 1.25rem;
+            display: block;
         }
 
         .app-nav-bar__brand:hover,
         .app-nav-bar__brand:focus {
             color: #ffffff;
             text-decoration: none;
-        }
-
-        .app-nav-bar__brand img {
-            height: 32px;
-            width: auto;
-            display: block;
         }
 
         .app-nav-bar__toggle {
@@ -212,9 +205,7 @@
 
     <nav class="app-nav-bar" aria-label="Main navigation">
         <div class="govuk-width-container app-nav-bar__inner">
-            <a href="index.html" class="app-nav-bar__brand" aria-label="ArcKit home">
-                <img src="assets/ArcKit_Logo_Horizontal_Light.svg" alt="ArcKit">
-            </a>
+            <a href="index.html" class="app-nav-bar__brand">ArcKit</a>
             <button class="app-nav-bar__toggle" aria-expanded="false" aria-controls="nav-menu" onclick="var l=document.getElementById('nav-menu');var o=l.classList.toggle('app-nav-bar__list--open');this.setAttribute('aria-expanded',o)">&#9776; Menu</button>
             <ul class="app-nav-bar__list" id="nav-menu">
                 <li class="app-nav-bar__item"><a href="commands.html">AI Commands</a></li>


### PR DESCRIPTION
## Summary

- Reverts the nav brand from the Horizontal Light logo back to bold text "ArcKit" across all 10 top-level pages.
- The logo wasn't reading on the new brand-navy bar (#0B1F33).
- Nav bar stays navy.

## Test plan

- [ ] All 10 pages show white "ArcKit" text in the nav, not an image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)