### PR TITLE
docs(site): UK NHS card → 'sector overlay' (drop 'second')

### DIFF
--- a/docs/guides.html
+++ b/docs/guides.html
@@ -659,7 +659,7 @@
                 </div>
             </div>
 
-            <!-- UK NHS Clinical Safety Overlay (second sector overlay) -->
+            <!-- UK NHS Clinical Safety Overlay (sector overlay) -->
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> UK NHS Clinical Safety Overlay

--- a/docs/index.html
+++ b/docs/index.html
@@ -670,7 +670,7 @@
                 <a href="commands.html?jurisdiction=uk-nhs" class="app-jurisdiction-card govuk-link--no-visited-state">
                     <div class="app-jurisdiction-card__flag">🩺</div>
                     <div class="app-jurisdiction-card__title">UK NHS (sector)</div>
-                    <span class="app-jurisdiction-card__badge app-jurisdiction-card__badge--community">Community · 4 commands · second sector overlay</span>
+                    <span class="app-jurisdiction-card__badge app-jurisdiction-card__badge--community">Community · 4 commands · sector overlay</span>
                     <p class="app-jurisdiction-card__desc">NHS DCB0129 (manufacturer) and DCB0160 (deployer) Clinical Safety Case + Hazard Log (Marcus Baw SAFETY.md spec), NHS DTAC v3, UK MDR 2002 + EU MDR 2017/745 software-as-medical-device (SaMD / AIaMD) classification.</p>
                 </a>
             </div>


### PR DESCRIPTION
## Summary

- `docs/index.html` UK NHS card badge: `Community · 4 commands · second sector overlay` → `Community · 4 commands · sector overlay`.
- `docs/guides.html` matching HTML comment tidied to match.

## Note

`docs/articles.html:323` also contains "The second sector overlay" inside the v5.4.0 NHS launch hero **image alt text** — left as-is because the alt describes the hero image which still bears that headline. Regenerate the image first if we want that phrasing dropped too.

🤖 Generated with [Claude Code](https://claude.com/claude-code)