### PR TITLE
docs(site): reposition homepage to the harness, not command counts

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -4,18 +4,18 @@
     <meta charset="UTF-8">
     <script>(function(){var t=localStorage.getItem('arckit-theme');if(t==='dark')document.documentElement.classList.add('dark-mode');else if(t==='light')document.documentElement.classList.add('light-mode');else if(window.matchMedia&&window.matchMedia('(prefers-color-scheme: dark)').matches)document.documentElement.classList.add('dark-mode')})();</script>
     <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover">
-    <meta name="description" content="ArcKit - The Enterprise Architecture Governance Harness. AI-assisted commands covering a UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).">
+    <meta name="description" content="ArcKit - The Enterprise Architecture Governance Harness. One harness that wraps your AI coding assistant to produce governed, traceable, audit-ready architecture artefacts, across a UK Government baseline plus community jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS).">
     <meta name="keywords" content="enterprise architecture, UK government, EU, France, Austria, Canada, UAE, Australia, GDS, GDPR, AI Act, NIS2, ANSSI, PDPL, DISP, Essential Eight, architecture governance, strategy, delivery, assurance, compliance, ArcKit, TCOP, secure by design">
     <meta name="author" content="ArcKit">
     <meta property="og:title" content="ArcKit - The Enterprise Architecture Governance Harness">
-    <meta property="og:description" content="AI-assisted commands for systematic, compliant architecture governance — UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).">
+    <meta property="og:description" content="One governance harness that wraps your AI coding assistant for systematic, compliant, audit-ready architecture governance. UK Government baseline plus community jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS).">
     <meta property="og:type" content="website">
     <meta property="og:url" content="https://arckit.org/">
     <meta property="og:site_name" content="ArcKit">
     <meta property="og:image" content="https://arckit.org/og-image.png">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:title" content="ArcKit - The Enterprise Architecture Governance Harness">
-    <meta name="twitter:description" content="AI-assisted commands for systematic, compliant architecture governance — UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).">
+    <meta name="twitter:description" content="One governance harness that wraps your AI coding assistant for systematic, compliant, audit-ready architecture governance. UK Government baseline plus community jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS).">
     <meta name="twitter:image" content="https://arckit.org/og-image.png">
     <title>ArcKit - The Enterprise Architecture Governance Harness</title>
     <link rel="canonical" href="https://arckit.org/">
@@ -362,7 +362,7 @@
                 "@id": "https://arckit.org/#website",
                 "name": "ArcKit",
                 "url": "https://arckit.org",
-                "description": "AI-assisted commands for systematic, compliant architecture governance across UK, EU, France, Austria, Canada, UAE, Australia, and USA jurisdictions.",
+                "description": "One governance harness that wraps AI coding assistants for systematic, compliant architecture governance across UK, EU, France, Austria, Canada, UAE, Australia, and USA jurisdictions.",
                 "publisher": { "@id": "https://arckit.org/#organization" },
                 "inLanguage": "en-GB"
             },
@@ -371,7 +371,7 @@
                 "@id": "https://arckit.org/",
                 "url": "https://arckit.org/",
                 "name": "ArcKit - The Enterprise Architecture Governance Harness",
-                "description": "AI-assisted commands for systematic, compliant project delivery — UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).",
+                "description": "One governance harness wrapping your AI coding assistant for systematic, compliant project delivery. UK Government baseline plus community-contributed jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS).",
                 "isPartOf": { "@id": "https://arckit.org/#website" },
                 "about": { "@id": "https://arckit.org/#software" },
                 "primaryImageOfPage": "https://arckit.org/og-image.png"
@@ -380,12 +380,12 @@
                 "@type": "SoftwareApplication",
                 "@id": "https://arckit.org/#software",
                 "name": "ArcKit",
-                "alternateName": "ArcKit Enterprise Architecture Toolkit",
+                "alternateName": "ArcKit Enterprise Architecture Governance Harness",
                 "url": "https://arckit.org",
                 "applicationCategory": "DeveloperApplication",
                 "applicationSubCategory": "Enterprise Architecture Governance",
                 "operatingSystem": "macOS, Linux, Windows",
-                "description": "ArcKit is The Enterprise Architecture Governance Harness — an open-source toolkit covering strategy, architecture, delivery, and assurance distributed as a plugin or extension for AI coding assistants — Claude Code, Gemini CLI, GitHub Copilot, OpenAI Codex CLI, and OpenCode CLI. It provides slash commands across an official UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA) that generate architecture artefacts using versioned templates with full traceability.",
+                "description": "ArcKit is The Enterprise Architecture Governance Harness: open-source, covering strategy, architecture, delivery, and assurance, distributed as a plugin or extension for AI coding assistants — Claude Code, Gemini CLI, GitHub Copilot, OpenAI Codex CLI, and OpenCode CLI. It wraps the assistant with slash commands across an official UK Government baseline plus community-contributed jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS) that generate architecture artefacts using versioned templates with full traceability.",
                 "softwareVersion": "4.21.0",
                 "license": "https://github.com/tractorjuice/arc-kit/blob/main/LICENSE",
                 "codeRepository": "https://github.com/tractorjuice/arc-kit",
@@ -419,7 +419,7 @@
                         "name": "What is ArcKit?",
                         "acceptedAnswer": {
                             "@type": "Answer",
-                            "text": "ArcKit is The Enterprise Architecture Governance Harness — an open-source toolkit covering strategy, architecture, delivery, and assurance. It provides AI-assisted slash commands across an official UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA) and sector overlays (UK Finance Payments, UK NHS Clinical Safety) that turn architecture governance from scattered documents into a systematic, template-driven workflow with full traceability from stakeholders through requirements to design and tests."
+                            "text": "ArcKit is The Enterprise Architecture Governance Harness: open-source, covering strategy, architecture, delivery, and assurance. It wraps your AI coding assistant with slash commands across an official UK Government baseline plus community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA) and sector overlays (UK Finance Payments, UK NHS Clinical Safety) that turn architecture governance from scattered documents into a systematic, template-driven workflow with full traceability from stakeholders through requirements to design and tests."
                         }
                     },
                     {
@@ -521,20 +521,20 @@
         <div class="govuk-width-container govuk-!-margin-top-6">
             <div class="app-stats-grid">
                 <div class="app-stat-card">
-                    <div class="app-stat-number">125</div>
-                    <div class="app-stat-label">AI Commands</div>
+                    <div class="app-stat-number">1</div>
+                    <div class="app-stat-label">Governance Harness</div>
+                </div>
+                <div class="app-stat-card">
+                    <div class="app-stat-number">9</div>
+                    <div class="app-stat-label">Overlays</div>
+                </div>
+                <div class="app-stat-card">
+                    <div class="app-stat-number">16</div>
+                    <div class="app-stat-label">Research Agents</div>
                 </div>
                 <div class="app-stat-card">
                     <div class="app-stat-number">6</div>
-                    <div class="app-stat-label">Jurisdictions</div>
-                </div>
-                <div class="app-stat-card">
-                    <div class="app-stat-number">10</div>
-                    <div class="app-stat-label">Autonomous Agents</div>
-                </div>
-                <div class="app-stat-card">
-                    <div class="app-stat-number">47</div>
-                    <div class="app-stat-label">Dependencies Mapped</div>
+                    <div class="app-stat-label">AI Assistants</div>
                 </div>
             </div>
         </div>
@@ -542,7 +542,7 @@
         <!-- 3. What is ArcKit? -->
         <div class="govuk-width-container govuk-!-margin-top-9">
             <h2 class="govuk-heading-l">What is ArcKit?</h2>
-            <p class="govuk-body">AI-assisted commands that generate complete governance documents &mdash; from stakeholder analysis and risk registers to design reviews and traceability matrices. Each command produces template-driven, audit-ready artifacts. The UK Government baseline ships alongside community-contributed jurisdictional overlays (EU, France, Austria, Canada, UAE, Australia, USA).</p>
+            <p class="govuk-body">ArcKit is one governance harness that wraps your AI coding assistant: it gates, traces, and provenance-stamps everything the assistant produces. From stakeholder analysis and risk registers to design reviews and traceability matrices, every artifact is template-driven and audit-ready. A UK Government baseline ships alongside community-contributed jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS).</p>
 
             <div class="app-feature-grid">
                 <div class="app-feature-card">


### PR DESCRIPTION
Repositions arckit.org to the harness framing (the #528 rebrand), away from leading with command counts.

- **Stats bar:** \`125 AI Commands\` → **\`1 Governance Harness\`**; corrected the stale \`6\` → \`9\` overlays and \`10\` → \`16\` research agents; \`47 Dependencies\` → \`6 AI Assistants\`.
- **"What is ArcKit?", meta, og/twitter, and all JSON-LD** now lead with the harness wrapping the AI coding assistant rather than "AI-assisted commands"/"toolkit".
- JSON-LD validated as still-parsing.

Per-overlay command counts remain in the jurisdiction reference cards (functional, they link into the command browser).

🤖 Generated with [Claude Code](https://claude.com/claude-code)