### PR TITLE
docs(site): add Chris Nesbitt-Smith to contributors

### DIFF
--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -292,7 +292,7 @@
 
     <div class="app-page-hero app-page-hero--contributors">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">12 Contributors</span>
+            <span class="app-page-hero__stat">13 Contributors</span>
             <h1 class="app-page-hero__title">Contributors</h1>
             <p class="app-page-hero__description">Meet the community members who have shaped ArcKit through code contributions, feature requests, and bug reports. Every contribution matters.</p>
         </div>
@@ -421,6 +421,22 @@
 
                 <div class="app-contributor-card">
                     <div class="app-contributor-card__header">
+                        <div class="app-contributor-card__avatar">C</div>
+                        <div>
+                            <p class="app-contributor-card__name"><a href="https://github.com/chrisns">@chrisns</a> &mdash; Chris Nesbitt-Smith</p>
+                            <span class="app-contributor-card__role app-contributor-card__role--code">Code Contributor</span>
+                        </div>
+                    </div>
+                    <p class="govuk-body-s">Corrected ArcKit's UK accessibility target from the superseded WCAG 2.1 AA to the current WCAG 2.2 AA across the <code>service-assessment</code> command (GDS Service Standard Point 5 evidence checks) and five core templates (<a href="https://github.com/tractorjuice/arc-kit/pull/542" class="govuk-link">#542</a>). Verified against current GOV.UK monitoring guidance and the Public Sector Bodies Accessibility (EU-Exit Amendment) Regulations 2022, and confirmed the French, Canadian, and Australian overlays were already correct so they were deliberately left unchanged.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>WCAG 2.2 AA correction across <code>service-assessment</code> and 5 core templates</li>
+                        <li>Sourced against GOV.UK, legislation.gov.uk, and DWP accessibility guidance</li>
+                        <li>Jurisdictional overlays validated and correctly left unchanged</li>
+                    </ul>
+                </div>
+
+                <div class="app-contributor-card">
+                    <div class="app-contributor-card__header">
                         <div class="app-contributor-card__avatar">M</div>
                         <div>
                             <p class="app-contributor-card__name"><a href="https://github.com/pacharanero">@pacharanero</a> &mdash; Dr Marcus Baw</p>
@@ -521,7 +537,7 @@
 
             <!-- Community Summary -->
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Community Impact</h2>
-            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 7 code contributors, 2 feature requesters, and 3 bug reporters, these 12 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, plugin user-config wiring, and EU / French / Austrian / Australian regulatory compliance coverage.</p>
+            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 8 code contributors, 2 feature requesters, and 3 bug reporters, these 13 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, plugin user-config wiring, accessibility standards alignment, and EU / French / Austrian / Australian regulatory compliance coverage.</p>
 
             <!-- Contributing CTA -->
             <div class="govuk-inset-text govuk-!-margin-top-6">


### PR DESCRIPTION
## Summary

Adds **Chris Nesbitt-Smith ([@chrisns](https://github.com/chrisns))** to the Contributors page as a code contributor, recognising the WCAG 2.1 AA → 2.2 AA accessibility correction merged in #542.

## Changes

- New **Code Contributor** card for `@chrisns` describing the WCAG 2.2 AA fix and its source verification (GOV.UK monitoring guidance, PSBAR 2022 EU-Exit amendment, DWP accessibility manual).
- Hero stat: **12 → 13 Contributors**.
- Community Impact summary: **7 → 8 code contributors**, **12 → 13 individuals**, plus "accessibility standards alignment" added to the contribution-span list.

`@pacharanero` remains uncounted by design (listed as *proposed* NHS maintainer / SAFETY.md spec author, no merged code) — consistent with the existing counting convention on the page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)