### PR TITLE
docs(site): split homepage stat cards into Jurisdictions, Sectors, Agents

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -525,16 +525,16 @@
                     <div class="app-stat-label">Governance Harness</div>
                 </div>
                 <div class="app-stat-card">
-                    <div class="app-stat-number">9</div>
-                    <div class="app-stat-label">Overlays</div>
+                    <div class="app-stat-number">7</div>
+                    <div class="app-stat-label">Jurisdictions</div>
+                </div>
+                <div class="app-stat-card">
+                    <div class="app-stat-number">2</div>
+                    <div class="app-stat-label">Sectors</div>
                 </div>
                 <div class="app-stat-card">
                     <div class="app-stat-number">16</div>
-                    <div class="app-stat-label">Research Agents</div>
-                </div>
-                <div class="app-stat-card">
-                    <div class="app-stat-number">6</div>
-                    <div class="app-stat-label">AI Assistants</div>
+                    <div class="app-stat-label">Agents</div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

Relabels the four homepage stat cards in `docs/index.html`:

| Before | After |
|--------|-------|
| 1 · Governance Harness | 1 · Governance Harness |
| 9 · Overlays | 7 · Jurisdictions |
| 16 · Research Agents | 2 · Sectors |
| 6 · AI Assistants | 16 · Agents |

- **Jurisdictions (7):** Austria, Australia, Canada, EU, France, UAE, USA
- **Sectors (2):** UK Finance, UK NHS
- **Agents (16):** 10 single-tier plus 6 reader/writer subagents in `arckit-claude/agents/`. Renamed from "Research Agents" because the count now includes non-research subagents.
- Dropped the "AI Assistants" card to keep the grid at four.

Counts verified against the repo (overlay plugin directories and `arckit-claude/agents/`), not just the prior labels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)