### PR TITLE
fix: support Windows validation paths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,8 @@ projects/
 # Legacy local directories (no longer generated)
 .codex/
 .opencode/
+.agents/skills/
+.claude/worktrees/
 
 
 # Gemini extension - generated files (static files are checked in)

--- a/arckit-claude/hooks/allow-plugin-internals.mjs
+++ b/arckit-claude/hooks/allow-plugin-internals.mjs
@@ -92,8 +92,9 @@ function isUnderPluginRoot(p) {
   if (!p || typeof p !== 'string') return false;
   // Resolve to absolute, then check prefix. Don't follow symlinks; the
   // plugin's distributed files are real files in a marketplace cache.
-  const abs = resolve(p);
-  return abs === PLUGIN_ROOT || abs.startsWith(PLUGIN_ROOT + '/');
+  const abs = resolve(p).replaceAll('\\', '/');
+  const root = PLUGIN_ROOT.replaceAll('\\', '/');
+  return abs === root || abs.startsWith(root + '/');
 }
 
 function commandTouchesPluginScripts(cmd) {

--- a/arckit-codex/hooks/arckit-codex-hook.mjs
+++ b/arckit-codex/hooks/arckit-codex-hook.mjs
@@ -343,8 +343,9 @@ function isUnderPluginRoot(filePath) {
   if (!filePath || typeof filePath !== "string") {
     return false;
   }
-  const absolute = resolve(filePath);
-  return absolute === PLUGIN_ROOT || absolute.startsWith(`${PLUGIN_ROOT}/`);
+  const absolute = resolve(filePath).replaceAll("\\", "/");
+  const root = PLUGIN_ROOT.replaceAll("\\", "/");
+  return absolute === root || absolute.startsWith(`${root}/`);
 }
 
 function isArcKitTempfile(filePath) {

--- a/scripts/tests/test-doc-types-dual-registration.mjs
+++ b/scripts/tests/test-doc-types-dual-registration.mjs
@@ -16,7 +16,7 @@
  */
 
 import { readFile } from 'node:fs/promises';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { dirname, resolve } from 'node:path';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -25,7 +25,7 @@ const repoRoot = resolve(__dirname, '..', '..');
 const docTypesPath = resolve(repoRoot, 'arckit-claude/config/doc-types.mjs');
 const pagesPath = resolve(repoRoot, 'arckit-claude/commands/pages.md');
 
-const { DOC_TYPES } = await import(docTypesPath);
+const { DOC_TYPES } = await import(pathToFileURL(docTypesPath).href);
 const docTypesCodes = new Set(Object.keys(DOC_TYPES));
 
 const pagesContent = await readFile(pagesPath, 'utf8');


### PR DESCRIPTION
## Summary

Separates the Windows/local validation infra fixes from the AU federal OT/SOCI community overlay PR.

This PR keeps the changes narrowly scoped to infrastructure hygiene:

- Normalize plugin-root path comparisons in the Claude hook and generated Codex hook so Windows paths are compared consistently.
- Import `doc-types.mjs` via `pathToFileURL()` in the dual-registration validator so Node ESM loading works on Windows absolute paths.
- Ignore local `.agents/skills/` and `.claude/worktrees/` folders created during agent/worktree development.

## Why separate

These fixes are useful and correct, but they are not part of the AU federal overlay behaviour. Keeping them separate makes tractorjuice/arc-kit#539 easier to review and revert as a unit.

## Validation

- `node scripts/tests/test-doc-types-dual-registration.mjs` -> PASS
- `pytest tests/codex/test_codex_extension.py -q` -> 28 passed