### PR TITLE
docs(start): note Claude Code v2.1.157 "workflow" keyword trigger (#522 item 54)

### DIFF
--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -67,6 +67,8 @@ $arckit-init
 $arckit-principles
 ```
 
+> **Claude Code users — the word "workflow" can trigger dynamic workflows.** From Claude Code v2.1.157, typing the word *workflow* in a free-text prompt may trigger the built-in dynamic-workflows feature, which fans work out across many agents. That is unrelated to the ArcKit command sequences this guide also calls "workflows". The trigger fires only on free-text prompts — invoking a slash command (`/arckit.start`) or the `architecture-workflow` skill is never affected. If a workflow request appears when you did not want it, press `alt+w` or backspace immediately after the keyword to dismiss it. To turn the keyword trigger off for the session, run `/config` and disable **Workflow keyword trigger**. Other platforms (Codex, Gemini, OpenCode, Copilot) have no equivalent trigger.
+
 ---
 
 ## Vibe Start — The 3-Prompt Super Prompt


### PR DESCRIPTION
## Summary

Adds a one-paragraph callout to the onboarding guide (`docs/guides/start.md`) about the **Claude Code v2.1.157 dynamic-workflow keyword trigger**, placed at the exact spot where users are about to type "workflow"-adjacent prompts (the **Step 1: Run the workflow** section).

Addresses **item 54** of #522.

## Why this, and why here

The trigger fires on the literal word **"workflow"** in a *free-text prompt*. ArcKit has an unusually high "workflow" surface area, so its users are more exposed than average to an accidental trigger:

- The onboarding guide's first instruction is literally **"Step 1: Run the workflow"**, and the Vibe Start section describes the "standard delivery workflow".
- `/arckit.start`'s `argument-hint` is `"[workflow focus, e.g. 'new project', 'procurement', 'governance review']"` — so users naturally type free text like `governance review workflow`.
- The `architecture-workflow` skill tells users they can "trigger it by asking about ... workflow recommendations".
- "workflow" appears across **~30 command/skill files** total.

## Research & impact testing

- **What actually triggers:** only free-text prompt input. Verified that slash-command invocation (`/arckit.start`) and Skill-tool dispatch of `architecture-workflow` do **not** contain/trigger the keyword — so the note is precise about scope rather than alarmist.
- **Mitigations confirmed against the v2.1.157 changelog:** dismiss a stray trigger with `alt+w` or backspace immediately after the keyword; disable for the session via `/config` -> **Workflow keyword trigger** (the exact setting name shipped in v2.1.157).
- **Cross-platform:** Codex / Gemini / OpenCode / Copilot have no equivalent trigger, so the callout is scoped to Claude Code users (the guide is multi-platform).
- **No floor bump needed:** this is client behaviour, not a hard gate — consistent with the #522 recommendation to hold the floor at v2.1.156.

## Scope

- One file, two inserted lines: `docs/guides/start.md`.
- `markdownlint-cli2` clean on the changed file.
- No code, command, or template changes; nothing for the converter to regenerate (this guide is not a converter-generated artefact).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
