### PR TITLE
docs: remove references to the retired arckit-book repo

### DIFF
--- a/.devin/wiki.json
+++ b/.devin/wiki.json
@@ -2,7 +2,7 @@
   "repo_notes": [
     {
       "author": "ArcKit maintainers",
-      "content": "AUTHORITATIVE OVERVIEW — before generating anything, read the book at https://github.com/tractorjuice/arckit-book (docs/book/ARCKIT-BOOK.md) — the canonical, maintainer-written description of ArcKit. It supersedes any inference drawn from file structure alone. Next, read `CLAUDE.md` (project instructions) and `README.md` (quick start + distribution overview). Prefer paraphrasing from these three files over reconstructing meaning from code."
+      "content": "AUTHORITATIVE OVERVIEW — before generating anything, read `CLAUDE.md` (project instructions) and `README.md` (quick start + distribution overview) — the canonical, maintainer-written description of ArcKit. They supersede any inference drawn from file structure alone. Prefer paraphrasing from these two files over reconstructing meaning from code."
     },
     {
       "author": "ArcKit maintainers",

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 - 🔗 Maintaining requirements traceability
 - 📎 Citation traceability for external documents (inline `[DOC-CN]` markers with source quotes)
 
-## 📖 The ArcKit Book
-
-A comprehensive book-length guide to ArcKit — covering every subsystem (commands, agents, hooks, skills, MCP servers, multi-AI distribution, templates, autoresearch) — now lives in its own repository: **[tractorjuice/arckit-book](https://github.com/tractorjuice/arckit-book)**.
-
 ## Star History
 
 <a href="https://www.star-history.com/?repos=tractorjuice%2Farc-kit&type=date&legend=top-left">


### PR DESCRIPTION
## Summary

The `tractorjuice/arckit-book` repository is no longer available, so the README link to it returns a 404 — reported in #536 by @gdvallance.

Per maintainer direction, removing the book references rather than restoring the link.

## Changes

- **`README.md`** — dropped the "📖 The ArcKit Book" section (the 404 link).
- **`.devin/wiki.json`** — rewrote the "AUTHORITATIVE OVERVIEW" repo note so AI agents are pointed at `CLAUDE.md` + `README.md` (the live canonical sources) instead of the dead `arckit-book` URL.

## Deliberately left

Two **historical CHANGELOG entries** (`CHANGELOG.md`, `arckit-claude/CHANGELOG.md`) that record the original move of book content to `tractorjuice/arckit-book` (#324, #325) — left intact as an accurate record of past releases, consistent with not rewriting changelog history.

The dozen `book` matches in `*/skills/mermaid-syntax/references/config-directives.md` are unrelated (Mermaid sequence-diagram example dialogue), not arckit-book references.

Closes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)