### PR TITLE
docs: refresh homepage Latest writing to the 6 newest articles

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -765,199 +765,87 @@
             </div>
             <div class="app-article-teaser-grid">
                 <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-03-community-recipes-wanted">
-                        <img src="articles/2026-05-03-community-recipes-wanted-hero.png" alt="WANTED poster — three shipped ArcKit recipes plus ten open slots for jurisdictional and consultancy recipes">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--guide">Community</span>
-                            <span class="app-article-teaser__date">3 May 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">Wanted: <code>/arckit:build</code> recipes for your jurisdiction</h3>
-                        <p class="app-article-teaser__summary">Three recipes ship with v4.13.1: <code>uk-saas</code>, <code>uk-mod-sovereign</code>, <code>uae-federal-ai</code>. Open call for jurisdictional recipes (EU, Australia, Canada, Germany, France, Singapore) and consultancy / firm bundles (Big 4 / MBB) — composition, not endorsement.</p>
-                        <a href="article-viewer.html?a=2026-05-03-community-recipes-wanted" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-03-build-harness-parallel-architecture-generation">
-                        <img src="articles/2026-05-03-build-harness-parallel-architecture-generation-hero.png" alt="ArcKit v4.13.0: The Build Harness — wave plan with 31 artefacts across 9 parallel waves, stamped 'The GDS Harness'">
+                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-28-v540-uk-nhs-clinical-safety-overlay">
+                        <img src="articles/2026-05-28-v540-uk-nhs-clinical-safety-overlay-hero.png" alt="ArcKit v5.4 UK NHS Clinical Safety Overlay launch hero — the second sector overlay, arckit-uk-nhs with four DCB0129 / DCB0160 / DTAC / MDR commands">
                     </a>
                     <div class="app-article-teaser__body">
                         <div class="app-article-teaser__meta">
                             <span class="app-article-teaser__tag app-article-teaser__tag--release">Release</span>
-                            <span class="app-article-teaser__date">3 May 2026</span>
+                            <span class="app-article-teaser__date">28 May 2026</span>
                         </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit v4.13.0: The Build Harness &mdash; Building a full architecture in one Claude Code session. AKA The GDS Harness</h3>
-                        <p class="app-article-teaser__summary">A new <code>/arckit:build</code> command orchestrates parallel <code>/arckit:*</code> artefact generation via subagent isolation. YAML recipes drive the wave plan, state.json makes the run resumable, and the validate-arc-filename hook handles path allocation. Thirty-one artefacts in under thirty minutes, one git commit per wave.</p>
-                        <a href="article-viewer.html?a=2026-05-03-build-harness-parallel-architecture-generation" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit v5.4: NHS Clinical Safety, the Second Sector Overlay</h3>
+                        <p class="app-article-teaser__summary">ArcKit v5.4 ships <code>arckit-uk-nhs</code>, the tenth marketplace plugin, with four commands covering DCB0129 / DCB0160 clinical safety cases, NHS DTAC v3 procurement assurance, and UK MDR 2002 / EU MDR 2017/745 software-as-medical-device classification &mdash; adopting Dr Marcus Baw's <code>SAFETY.md</code> spec verbatim. Recipe <code>uk-nhs-clinical-safety</code>, 44 targets.</p>
+                        <a href="article-viewer.html?a=2026-05-28-v540-uk-nhs-clinical-safety-overlay" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
                     </div>
                 </article>
                 <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-05-01-consulting-internal-memo-hero.png" alt="Internal Memo, Somewhere in a Big 4 — BID/2026/0411 Lessons Learned">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
-                            <span class="app-article-teaser__date">1 May 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">Internal Memo, Somewhere in a Big 4 Consulting Company</h3>
-                        <p class="app-article-teaser__summary">A fictional partner-group memo on a £680k Phase 0 bid lost to two civil servants and a contractor with a long weekend and ArcKit. What the in-house pack contained, why it was good enough, and what the practice should do about it.</p>
-                        <a href="article-viewer.html?a=2026-05-01-consulting-internal-memo" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-30-uae-overlay-launch-hero.png" alt="ArcKit v4.10 UAE Federal Overlay launch">
+                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-27-v530-uk-finance-payments-overlay">
+                        <img src="articles/2026-05-27-v530-uk-finance-payments-overlay-hero.png" alt="ArcKit v5.3 UK Finance Payments Overlay launch hero — the first sector overlay, arckit-uk-finance with four FCA payments commands">
                     </a>
                     <div class="app-article-teaser__body">
                         <div class="app-article-teaser__meta">
                             <span class="app-article-teaser__tag app-article-teaser__tag--release">Release</span>
-                            <span class="app-article-teaser__date">30 April 2026</span>
+                            <span class="app-article-teaser__date">27 May 2026</span>
                         </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit v4.10: 12 UAE Federal Commands, Community Overlay</h3>
-                        <p class="app-article-teaser__summary">Twelve community-contributed commands covering PDPL, IAS, sovereign cloud residency, UAE Pass, the four Cabinet instruments, AI Charter, autonomy tier, and federal procurement. Recruiting a UAE domain co-maintainer before any official-tier promotion.</p>
-                        <a href="article-viewer.html?a=2026-04-30-uae-overlay-launch" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit v5.3: The First Sector Overlay, for UK Payments</h3>
+                        <p class="app-article-teaser__summary"><code>arckit-uk-finance</code> stays inside the UK but narrows to a single vertical &mdash; payments. Four commands cover the FCA stack for established PSPs, EMIs and PIs: SCA-RTS exemption design, EMI/PI safeguarding (CRITICAL), the Consumer Duty board report, and Critical Third Parties dependency assessment. Recipe <code>uk-fs-payments</code>, 11 targets.</p>
+                        <a href="article-viewer.html?a=2026-05-27-v530-uk-finance-payments-overlay" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
                     </div>
                 </article>
                 <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-30-uae-agentic-decree-arckit-v4-10-hero.png" alt="Decree to 4 instruments to 12 commands policy stack">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
-                            <span class="app-article-teaser__date">30 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">How ArcKit v4.10 Accelerates the UAE's Federal Agentic Decree</h3>
-                        <p class="app-article-teaser__summary">Maps the 23 April Cabinet decree, the four governance instruments, and the federal regulatory baseline directly onto the 12 new uae-* commands.</p>
-                        <a href="article-viewer.html?a=2026-04-30-uae-agentic-decree-arckit-v4-10" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-30-uae-caio-first-90-days-hero.png" alt="UAE CAIO first 90 days four-phase plan">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--guide">Guide</span>
-                            <span class="app-article-teaser__date">30 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">The CAIO's First 90 Days: Delivering the UAE Cabinet Agentic AI Mandate</h3>
-                        <p class="app-article-teaser__summary">For UAE Chief AI Officers under the two-year deadline: requirements, timelines, resources, architecture, and concrete week-one actions.</p>
-                        <a href="article-viewer.html?a=2026-04-30-uae-caio-first-90-days" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-30-uae-agentic-decree-90-day-playbook-hero.png" alt="Conventional vs ArcKit weeks per artefact bar chart">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--guide">Guide</span>
-                            <span class="app-article-teaser__date">30 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">The UAE Agentic Decree: A 90-Day ArcKit Playbook</h3>
-                        <p class="app-article-teaser__summary">Command-by-command, calendar-anchored playbook for the first ninety days, with the acceleration ledger comparing conventional and ArcKit weeks per artefact.</p>
-                        <a href="article-viewer.html?a=2026-04-30-uae-agentic-decree-90-day-playbook" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-30-toolkit-drafts-architect-judges-hero.png" alt="Conventional vs ArcKit working day comparison">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
-                            <span class="app-article-teaser__date">30 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">The Toolkit Drafts. The Architect Judges.</h3>
-                        <p class="app-article-teaser__summary">Why the architect's working day under agentic tooling shifts from drafting to judging, and what that does to the architecture-to-engineering ratio.</p>
-                        <a href="article-viewer.html?a=2026-04-30-toolkit-drafts-architect-judges" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-28-pricing-arckit-investor-hero.png" alt="Pricing ArcKit for an investor — financial vs strategic valuation">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
-                            <span class="app-article-teaser__date">28 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">Pricing the ArcKit Project: What Would an Investor Actually Pay?</h3>
-                        <p class="app-article-teaser__summary">A defensible valuation range today: ~£20m financial floor, ~£80m strategic central, with the comparables maths shown in full.</p>
-                        <a href="article-viewer.html?a=2026-04-28-pricing-arckit-investor" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-27-mckinsey-decks-from-arckit-hero.png" alt="ArcKit artifacts transformed into McKinsey-style infographics">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
-                            <span class="app-article-teaser__date">27 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">From ArcKit to McKinsey-Style Infographics in an Afternoon</h3>
-                        <p class="app-article-teaser__summary">AntV Infographic and the end of the £200k visual wrap: ArcKit artifacts become action-titled, Pyramid-Principle decks without the partner-rate consulting layer.</p>
-                        <a href="article-viewer.html?a=2026-04-27-mckinsey-decks-from-arckit" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-22-wardley-commands-walkthrough-hero.png" alt="Five Wardley commands pipeline hero">
-                    </a>
-                    <div class="app-article-teaser__body">
-                        <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--guide">Guide</span>
-                            <span class="app-article-teaser__date">22 April 2026</span>
-                        </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">The Five Wardley Commands in ArcKit</h3>
-                        <p class="app-article-teaser__summary">A command-by-command walkthrough of ArcKit's Wardley Mapping suite: value-chain, wardley, doctrine, climate, and gameplay.</p>
-                        <a href="article-viewer.html?a=2026-04-22-wardley-commands-walkthrough" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
-                    </div>
-                </article>
-                <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-22-v490-wardley-mapping-hero.png" alt="ArcKit 4.9.0 Wardley Maps render natively hero">
+                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-24-v510-us-federal-civilian-overlay">
+                        <img src="articles/2026-05-24-v510-us-federal-civilian-overlay-hero.png" alt="ArcKit v5.1 US Federal Civilian Overlay launch hero — the Stars and Stripes flag and ten US federal civilian regulatory command names">
                     </a>
                     <div class="app-article-teaser__body">
                         <div class="app-article-teaser__meta">
                             <span class="app-article-teaser__tag app-article-teaser__tag--release">Release</span>
-                            <span class="app-article-teaser__date">22 April 2026</span>
+                            <span class="app-article-teaser__date">24 May 2026</span>
                         </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit 4.9.0: Wardley Maps Render Natively</h3>
-                        <p class="app-article-teaser__summary">Mermaid 11.14.0 brings wardley-beta. ArcKit adopts it everywhere with 100% conversion fidelity across 147 real-world maps.</p>
-                        <a href="article-viewer.html?a=2026-04-22-v490-wardley-mapping-support" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                        <h3 class="govuk-heading-s app-article-teaser__title">ArcKit v5.1: 10 US Federal Civilian Commands, Community Overlay</h3>
+                        <p class="app-article-teaser__summary"><code>arckit-us</code>, the eighth marketplace plugin, ships ten commands covering the US federal civilian stack: FedRAMP SSP and Readiness, FISMA / NIST SP 800-53 Rev 5, CISA Zero Trust, OMB M-19-17 ICAM, the NIST AI RMF plus OMB M-24-10 / M-25-21 assurance chain, the E-Gov Act &sect;208 PIA, and EO 14028 SBOM attestation. Recipe <code>us-federal</code>, five waves.</p>
+                        <a href="article-viewer.html?a=2026-05-24-v510-us-federal-civilian-overlay" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
                     </div>
                 </article>
                 <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-20-consulting-deliverable-is-dead-hero.png" alt="ArcKit displacing Big 4 consulting deliverables">
+                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-22-tidy-wardley-labels">
+                        <img src="articles/2026-05-22-tidy-wardley-labels-hero.png" alt="Tidy Wardley labels hero — a salmon BEFORE card with clustered overlapping component labels next to a green AFTER card with the same labels cleanly placed">
                     </a>
                     <div class="app-article-teaser__body">
                         <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Essay</span>
-                            <span class="app-article-teaser__date">20 April 2026</span>
+                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Technical</span>
+                            <span class="app-article-teaser__date">22 May 2026</span>
                         </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">How ArcKit Is Quietly Destroying a Billion-Pound Consulting Business</h3>
-                        <p class="app-article-teaser__summary">UK public-sector transformation has run on a Big 4 engine shipping a £250k–£2m PDF six months later. ArcKit makes that pipeline unnecessary.</p>
-                        <a href="article-viewer.html?a=2026-04-20-consulting-deliverable-is-dead" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                        <h3 class="govuk-heading-s app-article-teaser__title">How ArcKit tidies Wardley Map labels: a deterministic placement engine, stepped through</h3>
+                        <p class="app-article-teaser__summary">Mermaid draws every <code>wardley-beta</code> component label at the same offset, so clustered components on a real map land on top of each other. ArcKit fixes this with a PostToolUse hook: a pure, deterministic engine that projects the map to pixels, generates 32 candidate slots per label, scores collisions, places the most-constrained labels first, and converges to an idempotent result.</p>
+                        <a href="article-viewer.html?a=2026-05-22-tidy-wardley-labels" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
                     </div>
                 </article>
                 <article class="app-article-teaser">
-                    <a class="app-article-teaser__media" href="articles.html">
-                        <img src="articles/2026-04-20-v480-austrian-overlay-hero.png" alt="Austrian regulatory overlay hero">
+                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-20-plugin-split-token-budget">
+                        <img src="articles/2026-05-20-plugin-split-token-budget-hero.png" alt="Plugin split token budget hero — an arckit core card feeding six opt-in community overlay chips, with the saving of 5,249 always-on tokens highlighted">
                     </a>
                     <div class="app-article-teaser__body">
                         <div class="app-article-teaser__meta">
-                            <span class="app-article-teaser__tag app-article-teaser__tag--release">Release</span>
-                            <span class="app-article-teaser__date">20 April 2026</span>
+                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Technical</span>
+                            <span class="app-article-teaser__date">20 May 2026</span>
                         </div>
-                        <h3 class="govuk-heading-s app-article-teaser__title">What You Can Now Do in Austria with ArcKit v4.8</h3>
-                        <p class="app-article-teaser__summary">Three Austrian regulatory commands: DSG/DSGVO, NISG (NIS2), and BVergG 2018 procurement — a community-maintained overlay.</p>
-                        <a href="article-viewer.html?a=2026-04-20-v480-austrian-overlay" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                        <h3 class="govuk-heading-s app-article-teaser__title">The token budget behind ArcKit's plugin split, and how to split a plugin of your own</h3>
+                        <p class="app-article-teaser__summary">The old single-plugin ArcKit added roughly 15,000 tokens to every session before the user typed anything &mdash; a third of it jurisdictional compliance for countries they would never work in. This reads the receipt in full and shows how splitting into seven marketplace plugins cut a single-jurisdiction user's always-on footprint by about 34 percent, with an eight-step guide to splitting your own.</p>
+                        <a href="article-viewer.html?a=2026-05-20-plugin-split-token-budget" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
+                    </div>
+                </article>
+                <article class="app-article-teaser">
+                    <a class="app-article-teaser__media" href="article-viewer.html?a=2026-05-19-leaf-node-problem">
+                        <img src="articles/2026-05-19-leaf-node-problem-hero.png" alt="The Leaf Node Problem hero — an AI deployed at a leaf node trapped low under three inertia chips, with a gold LIFT arrow up to a strategic AI guidance target on the enterprise chain">
+                    </a>
+                    <div class="app-article-teaser__body">
+                        <div class="app-article-teaser__meta">
+                            <span class="app-article-teaser__tag app-article-teaser__tag--technical">Technical</span>
+                            <span class="app-article-teaser__date">19 May 2026</span>
+                        </div>
+                        <h3 class="govuk-heading-s app-article-teaser__title">The Leaf Node Problem: why your AI pilot is optimising the wrong thing</h3>
+                        <p class="app-article-teaser__summary">Most AI pilots in large organisations are funded by a team and accountable to a team &mdash; so they show local improvement while the enterprise outcome never moves. AI tooling deployed along the org chart inherits the org chart's gravity, with three points of inertia pulling every pilot downward. Mapped on a Wardley Map, the lift is visible, and so is the cost.</p>
+                        <a href="article-viewer.html?a=2026-05-19-leaf-node-problem" class="govuk-link app-article-teaser__link">Read article &rarr;</a>
                     </div>
                 </article>
             </div>


### PR DESCRIPTION
## Summary

The homepage `docs/index.html` **Latest writing** grid was stale — its newest card was **3 May 2026** and most cards linked to the generic `articles.html` rather than the article viewer.

This replaces the grid with the **6 most recent articles** (6 May → 28 May 2026), newest first, each using the `article-viewer.html?a=…` deep link. Titles, summaries, dates, and tags are taken from the canonical `articles.html`.

New cards:

1. 28 May — ArcKit v5.4: NHS Clinical Safety, the Second Sector Overlay
2. 27 May — ArcKit v5.3: The First Sector Overlay, for UK Payments
3. 24 May — ArcKit v5.1: 10 US Federal Civilian Commands
4. 22 May — How ArcKit tidies Wardley Map labels
5. 20 May — The token budget behind ArcKit's plugin split
6. 19 May — The Leaf Node Problem

"View all articles →" still links to the full `articles.html` list (unchanged). Older cards remain available there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)