### PR TITLE
fix(cli): stop shipping confidential docs in the pip package + fix wheel build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,12 @@ packages = ["src/arckit_cli"]
 [tool.hatch.build.targets.wheel.shared-data]
 "scripts" = "share/arckit/scripts"
 ".arckit" = "share/arckit/.arckit"
-"docs" = "share/arckit/docs"
+# Distribute only the docs the CLI scaffolds (guides + the three named files),
+# NOT the whole docs/ tree — mapping the directory shipped BUSINESS-PLAN.md,
+# INVESTOR-REPORT.md, proposals/, articles/ and superpowers/ into the public
+# package, and also double-mapped DEPENDENCY-MATRIX.md (breaking the wheel build).
+"docs/guides" = "share/arckit/docs/guides"
+"docs/README.md" = "share/arckit/docs/README.md"
 "docs/DEPENDENCY-MATRIX.md" = "share/arckit/docs/DEPENDENCY-MATRIX.md"
 "docs/WORKFLOW-DIAGRAMS.md" = "share/arckit/docs/WORKFLOW-DIAGRAMS.md"
 "VERSION" = "share/arckit/VERSION"


### PR DESCRIPTION
## Summary

A pre-existing CLI packaging bug surfaced during the #556 review. The hatchling shared-data config maps the **entire `docs/` directory** into the pip wheel (`"docs" = "share/arckit/docs"`), which:

1. **Breaks the wheel build.** `docs/DEPENDENCY-MATRIX.md` is mapped both by the whole-directory line and by an explicit line, and current hatchling rejects the duplicate (`A second file is being added to the wheel archive at the same path`). This is the `codex-plugin` CI failure showing up on open PRs.
2. **Would publish confidential docs to PyPI.** The whole-`docs/` mapping pulls in `BUSINESS-PLAN.md`, `INVESTOR-REPORT.md`, `docs/proposals/*` (partner pitch/proposal), `docs/articles/*` (incl. investor + internal-memo drafts), a cabinet framework doc, and the `docs/superpowers/specs|plans/` design docs.

The failing build has, somewhat fortunately, been *preventing* (2) from shipping recently.

## Fix

Distribute only the docs the CLI actually scaffolds — `docs/guides/` plus `README.md` / `DEPENDENCY-MATRIX.md` / `WORKFLOW-DIAGRAMS.md` — matching what `CLAUDE.md` documents as the package data. The whole-`docs/` mapping is removed.

## Verification

Built the wheel locally (`pip wheel . --no-deps`):

- ✅ **builds** — the duplicate-path error is gone
- ✅ **confidential docs excluded** — no `BUSINESS-PLAN` / `INVESTOR-REPORT` / `proposals/` / `articles/` / `superpowers/` in the wheel
- ✅ **intended docs present** — `docs/guides/`, `DEPENDENCY-MATRIX.md`

This is independent of #556 (the tenders/competitors feature PR); it unblocks the `codex-plugin` check there once merged + rebased.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
