### PR TITLE
docs(start): correct workflow-trigger note for v2.1.160 ultracode rename (#522 item 59)

### DIFF
--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -67,7 +67,7 @@ $arckit-init
 $arckit-principles
 ```
 
-> **Claude Code users — the word "workflow" can trigger dynamic workflows.** From Claude Code v2.1.157, typing the word *workflow* in a free-text prompt may trigger the built-in dynamic-workflows feature, which fans work out across many agents. That is unrelated to the ArcKit command sequences this guide also calls "workflows". The trigger fires only on free-text prompts — invoking a slash command (`/arckit.start`) or the `architecture-workflow` skill is never affected. If a workflow request appears when you did not want it, press `alt+w` or backspace immediately after the keyword to dismiss it. To turn the keyword trigger off for the session, run `/config` and disable **Workflow keyword trigger**. Other platforms (Codex, Gemini, OpenCode, Copilot) have no equivalent trigger.
+> **Claude Code users — ArcKit "workflows" are unrelated to Claude Code's dynamic-workflows feature.** Throughout this guide, "workflow" means an ArcKit command sequence. Claude Code's built-in dynamic workflows (which fan work out across many agents) are a separate feature; as of Claude Code v2.1.160 their free-text trigger keyword is `ultracode` — the word *workflow* no longer starts one — so the term is safe to type here. ArcKit ships no `ultracode` content, and running a slash command (`/arckit.start`) or the `architecture-workflow` skill never starts a dynamic workflow. Other platforms (Codex, Gemini, OpenCode, Copilot) have no equivalent feature.
 
 ---
 


### PR DESCRIPTION
## What

Corrects the Claude Code "workflow" keyword-trigger note in `docs/guides/start.md` (added in #552 for v2.1.157).

## Why

Claude Code **v2.1.160** renamed the dynamic-workflow free-text trigger keyword from `workflow` → `ultracode`:

> Renamed the dynamic-workflow trigger keyword from `workflow` to `ultracode`. The word "workflow" no longer triggers a run; asking for one in your own words still works.

#552 shipped its note one day earlier (for v2.1.157). As of v2.1.160 two of its claims are stale:

- "the word *workflow* … may trigger the built-in dynamic-workflows feature" — no longer true
- "run `/config` and disable **Workflow keyword trigger**" — moot (and the setting label is unverified after the rename)

Verified ArcKit uses the new keyword `ultracode` in **zero** files, so the accidental-trigger surface that motivated #522 item 54 is gone.

## Change

Reframes the callout from a warning into a brief disambiguation: ArcKit "workflows" are command sequences, unrelated to Claude Code's dynamic-workflows feature; the word "workflow" is safe to type. Drops the now-false trigger claim and the moot `/config` instruction; keeps the useful "these are different things" clarification and the cross-platform line.

## Scope notes

- Single-file docs change. The note lives only in root `docs/guides/start.md` — it is Claude-Code-specific ("other platforms have no equivalent"), and the converter source `arckit-claude/docs/guides/start.md` never carried it, so there is nothing to propagate to the plugin or extension copies.
- `markdownlint-cli2` clean. No floor bump.

Tracking: #522 (item 59, v2.1.160 triage — https://github.com/tractorjuice/arc-kit/issues/522#issuecomment-4603868190).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
