### PR TITLE
fix(codex): sync sync-guides.mjs drift — NHS clinical-safety block + {{REPO_OWNER}}

### DIFF
--- a/arckit-codex/hooks/sync-guides.mjs
+++ b/arckit-codex/hooks/sync-guides.mjs
@@ -441,6 +441,31 @@ function scanProject(repoRoot, projectName) {
     }
   }
 
+  // Clinical safety (NHS DCB0129 + DCB0160 — Marcus Baw SAFETY.md spec)
+  // These files deliberately do NOT carry the ARC- prefix (verbatim filenames
+  // are part of the spec), so they slip through the ARC-* glob above. Scan
+  // clinical-safety/ and clinical-safety/deployment/ explicitly and surface
+  // their contents under the project documents list with category
+  // "Clinical Safety" so the manifest, dashboard, and search index pick them
+  // up. Title is the file's first heading, falling back to the basename.
+  for (const dirRel of ['clinical-safety', 'clinical-safety/deployment']) {
+    const safetyDir = join(projectDir, dirRel);
+    if (!isDir(safetyDir)) continue;
+    for (const f of listDir(safetyDir)) {
+      if (f === 'README.md' || f.startsWith('.')) continue;
+      const fp = join(safetyDir, f);
+      if (!isFile(fp) || !f.endsWith('.md')) continue;
+      const heading = extractFirstHeading(fp) || basename(f, '.md');
+      project.documents.push({
+        path: `${projectPath}/${dirRel}/${f}`,
+        title: heading,
+        category: 'Clinical Safety',
+        documentId: basename(f, '.md'),
+        extension: '.md',
+      });
+    }
+  }
+
   // Vendors
   const vendorsDir = join(projectDir, 'vendors');
   if (isDir(vendorsDir)) {
@@ -947,6 +972,7 @@ function escapeHtml(str) {
 if (templatePath) {
   let html = readFileSync(templatePath, 'utf8');
   html = html.replace(/\{\{REPO\}\}/g, escapeHtml(repoInfo.repo));
+  html = html.replace(/\{\{REPO_OWNER\}\}/g, escapeHtml(repoInfo.owner));
   html = html.replace(/\{\{REPO_URL\}\}/g, escapeHtml(repoInfo.repoUrl));
   html = html.replace(/\{\{CONTENT_BASE_URL\}\}/g, escapeHtml(repoInfo.contentBaseUrl));
   html = html.replace(/\{\{VERSION\}\}/g, escapeHtml(version));


### PR DESCRIPTION
## What

Syncs the hand-maintained `arckit-codex/hooks/sync-guides.mjs` with its `arckit-claude` source, fixing two stale drifts found during the SEO pass (#561).

`sync-guides.mjs` (the hook powering `/arckit:pages`) is **not** propagated by `converter.py` — it's maintained separately in `arckit-claude/hooks/` and `arckit-codex/hooks/`, so the Codex copy drifted.

## Fixes

1. **NHS clinical-safety block** — the Codex copy was missing the scan of `clinical-safety/` + `clinical-safety/deployment/` (NHS DCB0129/0160 Marcus Baw `SAFETY.md` spec files, which deliberately carry no `ARC-` prefix). So Codex `/arckit:pages` did not surface `SAFETY.md` / `SAFETY-CASE.md` / `HAZARD-LOG.md` in the dashboard, manifest, or search index. Claude did.
2. **`{{REPO_OWNER}}` substitution** — also missing in the Codex copy, so Codex-generated sites rendered a literal `{{REPO_OWNER}}` in `<meta name="author">` and the JSON-LD `Organization` `name`/`url`. (Spotted while auditing the substitution block in #561.)

Both ported verbatim from `arckit-claude/hooks/sync-guides.mjs`.

## Preserved (intentional Codex adaptations, untouched)

Exported `runSyncGuidesHook(data)`, `return null` instead of `process.exit(0)`, `CODEX_PLUGIN_ROOT` env, `.arckit/templates-custom/` path + legacy fallback, `$arckit-` skill-invocation regex, and the `main()` / `import.meta` runner guard. After this PR the only `arckit-claude` ↔ `arckit-codex` hook differences are those intentional adaptations.

## Verification

- `node --check` passes; `tests/codex` 28 passed.
- Confirmed `project.documents` (the NHS block's push target) and all helpers (`isDir`/`isFile`/`listDir`/`extractFirstHeading`/`join`/`basename`) are in scope in the Codex hook.
- Single file, +26 lines.

Independent of #561 (different region of the file) — should merge cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
