### PR TITLE
fix(mcp): make uk-tenders reachable from the tenders/competitors reader subagent

### DIFF
--- a/arckit-claude/.mcp.json
+++ b/arckit-claude/.mcp.json
@@ -30,7 +30,8 @@
     },
     "uk-tenders": {
       "type": "http",
-      "url": "https://tenders.run.cns.me/mcp"
+      "url": "https://tenders.run.cns.me/mcp",
+      "alwaysLoad": true
     }
   }
 }

--- a/arckit-claude/agents/arckit-tenders-reader.md
+++ b/arckit-claude/agents/arckit-tenders-reader.md
@@ -2,7 +2,7 @@
 name: arckit-tenders-reader
 subagent: true
 maxTurns: 25
-tools: ["Read", "Glob", "Grep", "TodoWrite", "mcp__uk-tenders__search_tenders", "mcp__uk-tenders__top_suppliers", "mcp__uk-tenders__awarded_value_by_buyer", "mcp__uk-tenders__aggregate_tenders", "mcp__uk-tenders__awards_over_time", "mcp__uk-tenders__get_tender", "mcp__uk-tenders__get_status"]
+tools: ["Read", "Glob", "Grep", "TodoWrite", "mcp__plugin_arckit_uk-tenders__search_tenders", "mcp__plugin_arckit_uk-tenders__top_suppliers", "mcp__plugin_arckit_uk-tenders__awarded_value_by_buyer", "mcp__plugin_arckit_uk-tenders__aggregate_tenders", "mcp__plugin_arckit_uk-tenders__awards_over_time", "mcp__plugin_arckit_uk-tenders__get_tender", "mcp__plugin_arckit_uk-tenders__get_status"]
 effort: high
 description: |
   Reader subagent invoked by the /arckit:tenders and /arckit:competitors


### PR DESCRIPTION
## Problem

`/arckit:tenders` and `/arckit:competitors` silently fell through to their empty degraded path because the `arckit-tenders-reader` subagent could not reach the UK Tenders MCP. Two independent causes, both required to fix:

1. **Deferred server invisible to subagents.** `uk-tenders` had no `alwaysLoad`, and deferred plugin MCP servers are not loaded into subagent context — only the main agent can load them via ToolSearch. The reader never saw the tools.
2. **Tool-name namespace mismatch.** The reader's `tools:` allowlist used the bare `mcp__uk-tenders__*` form, but plugin-bundled MCP tools surface at runtime as `mcp__plugin_arckit_uk-tenders__*`. The bare names matched nothing.

Verified empirically: a sibling subagent (`arckit-aws-research`) with a bare allowlist on the **alwaysLoad** `aws-knowledge` server *also* could not call its MCP tool — confirming the plugin prefix is not normalised in subagent allowlists.

## Fix

- `.mcp.json`: add `alwaysLoad: true` to `uk-tenders` (keyless HTTP; same as `aws-knowledge` / `microsoft-learn`).
- `arckit-tenders-reader.md`: prefix the 7 `uk-tenders` tool names with `plugin_arckit_`.

Low-risk: the failure mode is graceful (the reader degrades exactly as today), so there is no regression path.

## Needs runtime verification

`alwaysLoad` only takes effect at session start, so this could **not** be verified in the authoring session. Before relying on it: refresh the `arckit` plugin from this branch, restart, run `/arckit:competitors`, and confirm the reader calls the MCP instead of degrading.

## Follow-up (same root cause, not in this PR)

- `aws-knowledge` + `microsoft-learn`: `alwaysLoad` set but **bare allowlists** -> `/arckit:aws-research` + `/arckit:azure-research` have been falling back to WebSearch. Need the prefix fix.
- `govreposcrape`, `datacommons-mcp`, `google-developer-knowledge`: deferred **and** bare -> need both changes (the keyed servers carry an `alwaysLoad` startup-penalty tradeoff worth weighing).
- `CLAUDE.md` documents the convention as bare `mcp__<server>__<tool>` — should be updated to the `plugin_arckit_` form for plugin-bundled servers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
