### PR TITLE
fix(mcp): make all MCP-backed subagents reach their plugin MCP servers

### DIFF
--- a/arckit-claude/.mcp.json
+++ b/arckit-claude/.mcp.json
@@ -15,18 +15,21 @@
       "url": "https://developerknowledge.googleapis.com/mcp",
       "headers": {
         "X-Goog-Api-Key": "${user_config.GOOGLE_API_KEY}"
-      }
+      },
+      "alwaysLoad": true
     },
     "datacommons-mcp": {
       "type": "http",
       "url": "https://api.datacommons.org/mcp",
       "headers": {
         "X-API-Key": "${user_config.DATA_COMMONS_API_KEY}"
-      }
+      },
+      "alwaysLoad": true
     },
     "govreposcrape": {
       "type": "http",
-      "url": "https://govreposcrape-api-1060386346356.us-central1.run.app/mcp"
+      "url": "https://govreposcrape-api-1060386346356.us-central1.run.app/mcp",
+      "alwaysLoad": true
     },
     "uk-tenders": {
       "type": "http",

--- a/arckit-claude/agents/arckit-aws-research.md
+++ b/arckit-claude/agents/arckit-aws-research.md
@@ -10,12 +10,12 @@ tools:
   - TodoWrite
   - WebSearch
   - WebFetch
-  - mcp__aws-knowledge__aws___search_documentation
-  - mcp__aws-knowledge__aws___read_documentation
-  - mcp__aws-knowledge__aws___recommend
-  - mcp__aws-knowledge__aws___get_regional_availability
-  - mcp__aws-knowledge__aws___list_regions
-  - mcp__aws-knowledge__aws___retrieve_skill
+  - mcp__plugin_arckit_aws-knowledge__aws___search_documentation
+  - mcp__plugin_arckit_aws-knowledge__aws___read_documentation
+  - mcp__plugin_arckit_aws-knowledge__aws___recommend
+  - mcp__plugin_arckit_aws-knowledge__aws___get_regional_availability
+  - mcp__plugin_arckit_aws-knowledge__aws___list_regions
+  - mcp__plugin_arckit_aws-knowledge__aws___retrieve_skill
 effort: high
 description: |
   Use this agent when the user needs AWS-specific technology research using the AWS Knowledge MCP server to match project requirements to AWS services, architecture patterns, Well-Architected guidance, and Security Hub controls. Examples:

--- a/arckit-claude/agents/arckit-azure-research.md
+++ b/arckit-claude/agents/arckit-azure-research.md
@@ -10,9 +10,9 @@ tools:
   - TodoWrite
   - WebSearch
   - WebFetch
-  - mcp__microsoft-learn__microsoft_docs_search
-  - mcp__microsoft-learn__microsoft_docs_fetch
-  - mcp__microsoft-learn__microsoft_code_sample_search
+  - mcp__plugin_arckit_microsoft-learn__microsoft_docs_search
+  - mcp__plugin_arckit_microsoft-learn__microsoft_docs_fetch
+  - mcp__plugin_arckit_microsoft-learn__microsoft_code_sample_search
 effort: high
 description: |
   Use this agent when the user needs Azure-specific technology research using the Microsoft Learn MCP server to match project requirements to Azure services, architecture patterns, Well-Architected guidance, and Security Benchmark controls. Examples:

--- a/arckit-claude/agents/arckit-datascout-reader.md
+++ b/arckit-claude/agents/arckit-datascout-reader.md
@@ -2,7 +2,7 @@
 name: arckit-datascout-reader
 subagent: true
 maxTurns: 30
-tools: ["Read", "Glob", "Grep", "WebSearch", "WebFetch", "TodoWrite", "mcp__govreposcrape__search_uk_gov_code", "mcp__datacommons-mcp__search_indicators", "mcp__datacommons-mcp__get_observations"]
+tools: ["Read", "Glob", "Grep", "WebSearch", "WebFetch", "TodoWrite", "mcp__plugin_arckit_govreposcrape__search_uk_gov_code", "mcp__plugin_arckit_datacommons-mcp__search_indicators", "mcp__plugin_arckit_datacommons-mcp__get_observations"]
 effort: high
 description: |
   Reader subagent invoked by arckit-datascout (orchestrator). Fetches and
@@ -51,7 +51,7 @@ The orchestrator passes you a JSON object in its Agent prompt with these fields:
    - For `source_type: "uk-gov"`: WebFetch `https://www.api.gov.uk/`, run `WebSearch` on each query with `site:gov.uk` filter, follow links to department developer hubs.
    - For `source_type: "commercial"`: `WebSearch` on each query, fetch top vendor pages.
    - For `source_type: "free"`: `WebSearch` on each query plus public-API list patterns. (Sources with `pricing_model: "freemium"` are still emitted under `source_type: "free"` — pricing model is per-source, not a discovery bucket.)
-   - For `source_type: "oss"`: use `mcp__govreposcrape__search_uk_gov_code` with the search queries; for statistical data, use `mcp__datacommons-mcp__search_indicators` with `places: ["country/GBR"]`.
+   - For `source_type: "oss"`: use `mcp__plugin_arckit_govreposcrape__search_uk_gov_code` with the search queries; for statistical data, use `mcp__plugin_arckit_datacommons-mcp__search_indicators` with `places: ["country/GBR"]`.
    - For each pre-supplied `candidate_urls` entry, `WebFetch` it directly.
 
 3. **For each candidate, extract Evidence fields.** WebFetch the candidate's documentation / developer / pricing / licence pages. Extract only the fields the schema allows, only from the page contents. For each candidate, build one `SourceRecord` with:

--- a/arckit-claude/agents/arckit-gcp-research.md
+++ b/arckit-claude/agents/arckit-gcp-research.md
@@ -10,9 +10,9 @@ tools:
   - TodoWrite
   - WebSearch
   - WebFetch
-  - mcp__google-developer-knowledge__search_documents
-  - mcp__google-developer-knowledge__get_document
-  - mcp__google-developer-knowledge__batch_get_documents
+  - mcp__plugin_arckit_google-developer-knowledge__search_documents
+  - mcp__plugin_arckit_google-developer-knowledge__get_document
+  - mcp__plugin_arckit_google-developer-knowledge__batch_get_documents
 effort: high
 description: |
   Use this agent when the user needs Google Cloud-specific technology research using the Google Developer Knowledge MCP server to match project requirements to Google Cloud services, architecture patterns, Architecture Framework guidance, and Security Command Center controls. Examples:

--- a/arckit-claude/agents/arckit-gov-code-search.md
+++ b/arckit-claude/agents/arckit-gov-code-search.md
@@ -9,7 +9,7 @@ tools:
   - Bash
   - TodoWrite
   - WebFetch
-  - mcp__govreposcrape__search_uk_gov_code
+  - mcp__plugin_arckit_govreposcrape__search_uk_gov_code
 effort: high
 description: |
   Use this agent when the user wants to search UK government repositories using natural language queries. This agent provides general-purpose semantic search across 24,500+ government repos via govreposcrape. Examples:

--- a/arckit-claude/agents/arckit-gov-landscape.md
+++ b/arckit-claude/agents/arckit-gov-landscape.md
@@ -9,8 +9,8 @@ tools:
   - Bash
   - TodoWrite
   - WebFetch
-  - mcp__govreposcrape__search_uk_gov_code
-  - mcp__govreposcrape__vulnerability_exposure
+  - mcp__plugin_arckit_govreposcrape__search_uk_gov_code
+  - mcp__plugin_arckit_govreposcrape__vulnerability_exposure
 effort: max
 description: |
   Use this agent when the user wants to understand what UK government has built in a domain — mapping organisations, technology patterns, standards, and maturity levels. Examples:

--- a/arckit-claude/agents/arckit-gov-reuse-reader.md
+++ b/arckit-claude/agents/arckit-gov-reuse-reader.md
@@ -2,7 +2,7 @@
 name: arckit-gov-reuse-reader
 subagent: true
 maxTurns: 30
-tools: ["Read", "Glob", "Grep", "WebFetch", "TodoWrite", "mcp__govreposcrape__search_uk_gov_code", "mcp__govreposcrape__dependency_compare"]
+tools: ["Read", "Glob", "Grep", "WebFetch", "TodoWrite", "mcp__plugin_arckit_govreposcrape__search_uk_gov_code", "mcp__plugin_arckit_govreposcrape__dependency_compare"]
 effort: high
 description: |
   Reader subagent invoked by /arckit:gov-reuse (orchestrator). Searches
@@ -39,7 +39,7 @@ orchestrator parses your entire final message as JSON.
 The orchestrator passes you a JSON object in its Agent prompt:
 
 - `capability` — descriptive name of the capability you're searching for, e.g. `"gov.uk-style frontend components and templates"` or `"appointment booking system for NHS patients"`
-- `search_queries` — array of natural-language strings to drive `mcp__govreposcrape__search_uk_gov_code` (3-5 variations, descriptive, 3-500 chars each)
+- `search_queries` — array of natural-language strings to drive `mcp__plugin_arckit_govreposcrape__search_uk_gov_code` (3-5 variations, descriptive, 3-500 chars each)
 - `candidate_urls` — optional array of pre-supplied GitHub URLs to fetch directly
 - `evidence_fields_required` — array of Evidence field names the orchestrator most needs (helps you prioritise fetch effort)
 - `project_profile` — context only, **not** evidence: `{ preferred_languages, framework_hints, sectors }`. Use it to focus searches; never copy its values into evidence fields.
@@ -48,7 +48,7 @@ The orchestrator passes you a JSON object in its Agent prompt:
 
 1. **Read the schema.** Open `${CLAUDE_PLUGIN_ROOT}/schemas/gov-reuse-handoff.schema.json` so you know the exact shape your output must take and which enum values are accepted.
 
-2. **Discover candidates via govreposcrape.** For each `search_queries` entry, call `mcp__govreposcrape__search_uk_gov_code` with `resultMode: "snippets"` and `limit: 10`. Collect distinct `org/repo` pairs across all queries. Then for the top 3-5 most relevant results across queries (not per query — total budget), fetch deeper signal via WebFetch.
+2. **Discover candidates via govreposcrape.** For each `search_queries` entry, call `mcp__plugin_arckit_govreposcrape__search_uk_gov_code` with `resultMode: "snippets"` and `limit: 10`. Collect distinct `org/repo` pairs across all queries. Then for the top 3-5 most relevant results across queries (not per query — total budget), fetch deeper signal via WebFetch.
 
 3. **For each candidate repo, extract Evidence fields.** WebFetch the GitHub repository's main page and `LICENSE` file. Extract:
    - `org` and `repo` from the URL (e.g. `https://github.com/alphagov/govuk-frontend` → `org: "alphagov"`, `repo: "govuk-frontend"`)
@@ -73,7 +73,7 @@ The orchestrator passes you a JSON object in its Agent prompt:
 
 5. **Special handling for `archived`.** Always check for the GitHub "Archived" or "Public archive" badge on the repo's main page. Archived repos are valid evidence but the orchestrator will heavily downweight them.
 
-6. **Quantify dependency overlap between candidates (when 2+ repos share a capability).** If your candidate set for this capability contains two or more repos, call `mcp__govreposcrape__dependency_compare` on the most-similar-looking pairs (same language/framework, or names suggesting a fork relationship — e.g. `alphagov/govuk-frontend` vs `hmrc/hmrc-frontend`). Pass the `org/repo` slug for each side. For each comparison, emit one `dependency_comparisons` entry with `repo_a`, `repo_b` (both as `org/repo` slugs), `overlap_pct`, and the `shared_count` / `unique_a_count` / `unique_b_count` if the tool returns them. Set `citation_id` to a token like `DEPCMP-1`. This is **extract-only**: report the overlap numbers, never judge which repo is "better" or whether one is redundant — that is the orchestrator's job. Skip silently if only one candidate exists, or if the tool returns no SBOM data for a repo (record an `errors[]` entry).
+6. **Quantify dependency overlap between candidates (when 2+ repos share a capability).** If your candidate set for this capability contains two or more repos, call `mcp__plugin_arckit_govreposcrape__dependency_compare` on the most-similar-looking pairs (same language/framework, or names suggesting a fork relationship — e.g. `alphagov/govuk-frontend` vs `hmrc/hmrc-frontend`). Pass the `org/repo` slug for each side. For each comparison, emit one `dependency_comparisons` entry with `repo_a`, `repo_b` (both as `org/repo` slugs), `overlap_pct`, and the `shared_count` / `unique_a_count` / `unique_b_count` if the tool returns them. Set `citation_id` to a token like `DEPCMP-1`. This is **extract-only**: report the overlap numbers, never judge which repo is "better" or whether one is redundant — that is the orchestrator's job. Skip silently if only one candidate exists, or if the tool returns no SBOM data for a repo (record an `errors[]` entry).
 
 7. **Record failures honestly.**
    - If a govreposcrape result's URL was discovered but you could not WebFetch it, add it to `unfetched_urls`.


### PR DESCRIPTION
## Summary

Generalises the #564 `uk-tenders` fix to **every** MCP-backed agent. After #564 fixed `/arckit:tenders` + `/arckit:competitors`, the same two root causes were confirmed (against the Claude Code docs) to affect all the other MCP-backed subagents — they silently degrade on a clean plugin install.

Two root causes, both required:

1. **Tool-name prefix.** Plugin-bundled MCP tools surface at runtime as `mcp__plugin_arckit_<server>__<tool>`, but the agents' `tools:` allowlists used the bare `mcp__<server>__` form, which matches nothing in a subagent allowlist. Prefixed all entries in 7 agents:
   - `arckit-aws-research`, `arckit-azure-research`, `arckit-gcp-research`
   - `arckit-gov-code-search`, `arckit-gov-landscape`
   - `arckit-gov-reuse-reader`, `arckit-datascout-reader`
2. **Deferred servers don't reach subagents.** Per the docs, deferred plugin MCP servers are not injected into subagent context — only the main agent can load them on demand. A subagent needs `alwaysLoad: true` for the server to be present. Added `alwaysLoad` to the three deferred servers: `govreposcrape`, `google-developer-knowledge`, `datacommons-mcp` (`aws-knowledge` / `microsoft-learn` / `uk-tenders` already had it).

## Why it was hidden

The dev workspace masks the govreposcrape half because it has a **user-level** `govreposcrape` registration in `~/.claude.json` (surfacing it bare, `mcp__govreposcrape__*`). End users installing only the plugin get `mcp__plugin_arckit_govreposcrape__*`, so the bare allowlists matched nothing for them.

## Keyed-server note

`alwaysLoad` on the two **keyed** servers (`google-developer-knowledge`, `datacommons-mcp`) means a keyless user's session attempts the connection at startup. Per [the docs](https://code.claude.com/docs/en/mcp.md): an auth failure marks the server **failed** and the session **continues** (graceful), bounded by the 5s connect timeout. Not a startup crash.

## Verification

- `pytest tests/codex/` — 28 passed
- `scripts/converter.py` — regenerates 888 files, **zero** extension changes (`tools:` and `alwaysLoad` are Claude-only, stripped for non-Claude targets)
- `scripts/sync-shared-assets.py --check` — all shared assets present
- `scripts/check_references.py` — no broken references
- `markdownlint-cli2` on changed agents — 0 errors

Final runtime confirmation (that subagents now call the MCP rather than degrading) requires a fresh session after the next plugin release, same as #564.

Docs: https://code.claude.com/docs/en/mcp.md (`alwaysLoad`, deferred tool-search, initial-connection failure handling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)