### PR TITLE
Add Gotchas to wardley-mapping skill; document "grow your skills" practice

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,0 +1,128 @@
+---
+name: release
+description: "Cut a new ArcKit release — bump versions in lockstep, regenerate non-Claude formats, validate plugin/marketplace agreement, tag, and push to extension repos. Use when the user says 'cut a release', 'release ArcKit', 'ship vX.Y.Z', 'bump the version and release', 'do the release flow', 'tag and publish', or 'push the extensions'. This is a manual, high-consequence workflow: it never runs automatically."
+disable-model-invocation: true
+argument-hint: "[X.Y.Z]"
+---
+
+# Release ArcKit
+
+Drive the ArcKit release flow end to end. This skill is the executable companion to
+[`docs/RELEASING.md`](../../../docs/RELEASING.md) — that doc is the source of truth; if the two
+disagree, trust `RELEASING.md` and update this skill.
+
+The target version is `$ARGUMENTS` (e.g. `/release 5.10.0`). If no version was given, ask
+for it before doing anything — never guess a version.
+
+<HARD-GATE>
+This workflow tags and publishes to public GitHub repos. Do NOT run any step that pushes,
+tags, or publishes without the user confirming the version and that the PR is already merged
+to `main`. Show the plan and the computed version first, then proceed step by step.
+</HARD-GATE>
+
+## Preconditions
+
+Confirm all of these before touching version files:
+
+1. The feature PR is **merged to `main`** — releases are cut from `main`, never from a branch.
+2. Working tree is on `main` and clean: `git checkout main && git pull && git status`.
+3. The version `$ARGUMENTS` is valid semver (`X.Y.Z`) and **greater** than the current
+   plugin version (`cat arckit-claude/VERSION`) and CLI version (`cat VERSION`).
+4. `GH_TOKEN` is set in the environment (needed by `push-extensions.sh`).
+
+If any precondition fails, stop and surface it. Do not work around it.
+
+## Release flow
+
+Run these in order. Each script is idempotent or safe to re-run except the `git tag`/`git push`
+steps. Pause after step 5 (the commit) and after step 8 (validation) to let the user confirm.
+
+```bash
+# 1. Edit CHANGELOGs by hand — both of them:
+#    CHANGELOG.md (CLI) and arckit-claude/CHANGELOG.md (plugin).
+#    Preview what shipped since the last tag to seed the entries:
+./scripts/generate-release-notes.sh
+
+# 2. Bump every version file in lockstep (15 locations: VERSION files,
+#    manifests, README badges, docs, plugin.json):
+./scripts/bump-version.sh X.Y.Z
+
+# 3. Regenerate Codex/OpenCode/Gemini/Copilot/Paperclip formats from the
+#    plugin source — MUST run after the bump so the extensions carry the
+#    new version:
+python scripts/converter.py
+
+# 4. Sanity-check the tree (no stray edits, counts/versions consistent):
+git status && git diff --stat
+
+# 5. Commit the bump — a clean tree is required for `claude plugin tag`:
+git add -A && git commit -m "chore: bump version to X.Y.Z"
+
+# 6. Validate EVERY plugin manifest against the marketplace entry.
+#    Discover plugins dynamically — do NOT hardcode the list (it grows):
+for manifest in $(find . -maxdepth 3 -path '*/.claude-plugin/plugin.json' -not -path '*/node_modules/*' | sort); do
+  p=$(python3 -c "import json;print(json.load(open('$manifest'))['name'])")
+  claude plugin tag "$p" --dry-run || { echo "VERSION DRIFT: $p"; exit 1; }
+done
+
+# 7. (optional) Prune orphaned plugin deps:
+claude plugin prune --dry-run
+
+# 8. Tag the umbrella release and push — this triggers
+#    .github/workflows/release.yml, which creates the GitHub Release:
+git tag -a vX.Y.Z -m "vX.Y.Z"
+git push && git push --tags
+
+# 9. Create native per-plugin tags (arckit--vX.Y.Z, arckit-uae--vX.Y.Z, …).
+#    Auto-discovers plugins; idempotent (skips existing tags):
+./scripts/tag-plugins.sh X.Y.Z
+
+# 10. Push each extension to its standalone GitHub repo
+#     (tractorjuice/arckit-gemini, arckit-codex, …):
+./scripts/push-extensions.sh
+```
+
+After step 10, confirm the GitHub Release was created (the `release.yml` workflow runs on the
+`vX.Y.Z` tag push) and report the release URL and which extension repos were pushed.
+
+## Common Gotchas
+
+The highest-signal failures — collected from real releases. Read these before running anything.
+
+- **Releasing from a feature branch.** Releases are cut from `main` after the PR is merged.
+  Tagging a branch ships an unmerged tree. Always `git checkout main && git pull` first.
+- **Forgetting the converter (step 3).** `bump-version.sh` updates the plugin source, but the
+  Codex/OpenCode/Gemini/Copilot/Paperclip copies are *generated*. Skip `converter.py` and the
+  extensions ship the **old** version. The converter must run *after* the bump and *before* the
+  commit, so the regenerated files are included.
+- **Hardcoding the plugin list.** The marketplace now ships 11 plugins (core + 10 overlays) and
+  keeps growing. The `--dry-run` validation loop in older `RELEASING.md` examples lists only 7 —
+  that silently skips newer plugins. Discover plugins dynamically (step 6) — this is the exact
+  bug that shipped `arckit-uk-nhs` untagged mid-v5.4.0, which is why `tag-plugins.sh` now
+  auto-discovers. Never copy a static plugin array.
+- **`claude plugin tag` needs a clean tree.** Run it *after* the commit (step 5), not before, or
+  it errors on the dirty working tree.
+- **`claude plugin tag` is `--dry-run` only here.** It creates `name--vX.Y.Z` style tags that do
+  **not** match `release.yml`'s `v[0-9]+.[0-9]+.[0-9]+` trigger. We use it solely for its
+  validation side effect (cross-checking `plugin.json` vs `marketplace.json`). The real release
+  tag is the `git tag -a vX.Y.Z` in step 8.
+- **Two CHANGELOGs, not one.** `CHANGELOG.md` is the CLI changelog; `arckit-claude/CHANGELOG.md`
+  is the plugin changelog. Both need an entry. They are human-authored — `generate-release-notes.sh`
+  only *previews* what changed, it does not write them.
+- **CLI and plugin versions are independent but bumped together.** `bump-version.sh` moves both to
+  the same number by design; don't try to skew them.
+- **`push-extensions.sh` needs `GH_TOKEN`** and skips repos that don't yet exist on GitHub — a
+  "skipped" line is not an error for a brand-new extension, but double-check it's not skipping a
+  repo that *should* exist.
+- **Order is load-bearing.** bump → convert → commit → validate → tag → tag-plugins → push-extensions.
+  Re-running an earlier step after a later one (e.g. editing files after the commit) means the tag
+  no longer points at the released tree. If you edit after committing, redo from the commit.
+
+## Reference
+
+- [`docs/RELEASING.md`](../../../docs/RELEASING.md) — full release documentation and rationale
+- `scripts/bump-version.sh` — version bump across all files
+- `scripts/generate-release-notes.sh` — changelog preview from git log
+- `scripts/tag-plugins.sh` — native per-plugin tags (auto-discovers)
+- `scripts/push-extensions.sh` — pushes extension dirs to standalone repos
+- `.github/workflows/release.yml` — creates the GitHub Release on `v*` tag push

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -111,6 +111,8 @@ Skills live in `arckit-claude/skills/{name}/SKILL.md`. Frontmatter: `name`, `des
 | `wardley-mapping` | reference | Wardley Map syntax + gameplay/doctrine/climatic patterns |
 | `arckit-build` | orchestration | Bulk-build harness — parallel artefact generation, YAML-recipe-driven, resumable. Claude-only (parallel `Agent` dispatch). See `arckit-claude/skills/arckit-build/`. |
 
+**Skills are grown, not built.** The highest-signal content in a skill is its **Gotchas** section (`## Common Gotchas` / `## Common Syntax Gotchas`). When Claude is led into a repeatable mistake while a skill is active — a syntax footgun, a positioning error, a step done in the wrong order — capture it as a gotcha in that skill rather than only fixing it in the current chat. Keep the body concise (it stays in context across turns and costs recurring tokens), push detailed reference material into the skill's `references/` folder (progressive disclosure), and lead `description` with the key use case. See [the Claude Code skills guide](https://code.claude.com/docs/en/skills).
+
 ### Plugin User Configuration
 
 Plugin-level user config is declared in `arckit-claude/.claude-plugin/plugin.json` under `userConfig` (v2.1.83+). Per-field schema: `title`, `type` (`string`/`number`/`boolean`/`directory`/`file`), `description`, `sensitive: true` (stores in keychain). Current fields:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -109,7 +109,7 @@ Skills live in `arckit-claude/skills/{name}/SKILL.md`. Frontmatter: `name`, `des
 | `mermaid-syntax` | reference | Mermaid syntax for `/arckit:diagram` outputs |
 | `plantuml-syntax` | reference | PlantUML / C4 syntax |
 | `wardley-mapping` | reference | Wardley Map syntax + gameplay/doctrine/climatic patterns |
-| `arckit-build` | orchestration | Bulk-build harness — parallel artefact generation, YAML-recipe-driven, resumable. Claude-only (parallel `Agent` dispatch). See `arckit-claude/skills/arckit-build/`. |
+| `arckit-build` | orchestration | Bulk-build harness — parallel artefact generation, YAML-recipe-driven, resumable. Claude-only (parallel `Agent` dispatch) and **manual-invocation only** (`disable-model-invocation: true`) so a bulk build that commits code is never auto-triggered — run `/arckit:arckit-build`. See `arckit-claude/skills/arckit-build/`. |
 
 **Skills are grown, not built.** The highest-signal content in a skill is its **Gotchas** section (`## Common Gotchas` / `## Common Syntax Gotchas`). When Claude is led into a repeatable mistake while a skill is active — a syntax footgun, a positioning error, a step done in the wrong order — capture it as a gotcha in that skill rather than only fixing it in the current chat. Keep the body concise (it stays in context across turns and costs recurring tokens), push detailed reference material into the skill's `references/` folder (progressive disclosure), and lead `description` with the key use case. See [the Claude Code skills guide](https://code.claude.com/docs/en/skills).
 

--- a/arckit-claude/skills/arckit-build/SKILL.md
+++ b/arckit-claude/skills/arckit-build/SKILL.md
@@ -1,10 +1,7 @@
 ---
 name: arckit-build
-description: "This skill should be used when the user wants to bulk-build ArcKit artefacts in parallel rather than running individual /arckit:* commands one at a time. Load whenever the task sounds like 'kick off a build', 'build everything', 'generate all artefacts', 'run all the commands', 'rebuild this project from scratch', 'resume the build', 'pick up where we left off', 'refresh the artefacts', 'run the recipe', 'build the whole project end-to-end', or 'parallel build', or mentions `--plan`, `--resume`, `--target`, `--refresh`, `--recipe`, or `.arckit/state.json`. The skill orchestrates parallel /arckit:* generation using subagent isolation: reads project state, computes the artefact dependency DAG, dispatches one subagent per target per wave (each subagent invokes a /arckit:* skill in its own context), validates outputs, commits the wave, and persists progress to .arckit/state.json for resumability."
-paths:
-  - "projects/**/.arckit/state.json"
-  - "projects/**/ARC-*-*.md"
-  - ".arckit/recipes/*.yaml"
+description: "This skill should be used when the user wants to bulk-build ArcKit artefacts in parallel rather than running individual /arckit:* commands one at a time. Invoke manually with /arckit:arckit-build when the task sounds like 'kick off a build', 'build everything', 'generate all artefacts', 'run all the commands', 'rebuild this project from scratch', 'resume the build', 'pick up where we left off', 'refresh the artefacts', 'run the recipe', 'build the whole project end-to-end', or 'parallel build', or mentions `--plan`, `--resume`, `--target`, `--refresh`, `--recipe`, or `.arckit/state.json`. The skill orchestrates parallel /arckit:* generation using subagent isolation: reads project state, computes the artefact dependency DAG, dispatches one subagent per target per wave (each subagent invokes a /arckit:* skill in its own context), validates outputs, commits the wave, and persists progress to .arckit/state.json for resumability."
+disable-model-invocation: true
 ---
 
 # ArcKit Build Harness (v0.4)

--- a/arckit-claude/skills/wardley-mapping/SKILL.md
+++ b/arckit-claude/skills/wardley-mapping/SKILL.md
@@ -128,6 +128,34 @@ When the user asks for numeric precision, scoring, or data-driven positioning, a
 
 Present results as a table alongside the qualitative analysis — the numbers should confirm or challenge the intuitive positioning, not replace it.
 
+## Common Gotchas
+
+The highest-signal failures, collected from real maps. Check these before finalizing.
+
+### Positioning mistakes
+
+- **Positioning by age, not market maturity.** A 20-year-old internal system is not Commodity if the capability it provides is still bespoke across the market. Use *ubiquity + certainty*, never "how long we've had it." (See Step 3 and [references/evolution-stages.md](references/evolution-stages.md).)
+- **Confusing internal unfamiliarity with Genesis.** "New to us" ≠ "new to the world." If multiple vendors sell it, it is Product/Commodity even if your team has never used it. This is the single most common error.
+- **Treating the Y-axis as importance.** Visibility means *visibility to the user*, not business value or criticality. Power supply is invisible-but-critical → it belongs low on the map, not high.
+- **Floating components with no anchor.** Every value chain must trace upward to the user need. A component nothing depends on (directly or transitively) is either mis-placed or doesn't belong on this map.
+
+### OnlineWardleyMaps (OWM) syntax — for the `/arckit.wardley*` commands
+
+These produce OWM text for <https://create.wardleymaps.ai>. The renderer is strict:
+
+- **Coordinates are `[visibility, evolution]`, both 0–1, in that order** — `component Foo [0.9, 0.2]`. Authors routinely swap the pair or use 0–100; either silently mis-renders. Visibility first (Y), evolution second (X).
+- **Declare a component before linking it.** `A->B` referencing an undeclared `B` drops the link. Declare all `component` lines first, dependency lines after.
+- **`evolve` needs only the target X, and the component must already exist:** `evolve Foo 0.7`. Don't restate visibility; don't `evolve` a name you never declared.
+- **Names with spaces work in declarations but must match *exactly* in links** — `component Data Pipeline [..]` then `Kettle->Data Pipeline`, not `->DataPipeline`. Trailing whitespace breaks the match.
+- **Stage-boundary x-values:** Genesis `0.0–0.25`, Custom `0.25–0.50`, Product `0.50–0.75`, Commodity `0.75–1.0`. Keep positions inside the intended band so the visual reads correctly.
+- **One statement per line.** OWM is line-based; no semicolons, no inline comments after a statement.
+
+### Process mistakes
+
+- **Skipping the AskUserQuestion triage.** Inventing the user need, scope, or positioning instead of asking produces a confident-but-wrong map. When positioning is ambiguous for a key component, ask (Step 3) rather than guess.
+- **Listing only technology.** A value chain includes people, practices, and data — not just systems. Maps that are all boxes-of-software miss the inertia and doctrine insights that make the exercise worthwhile.
+- **Recommendations with no rationale.** Every strategic move must tie back to a position or movement on the map ("commoditize X because it sits Product-right with three vendors"), not generic advice.
+
 ## Analysis Checklist
 
 Apply this checklist to every completed map:

--- a/arckit-codex/skills/wardley-mapping/SKILL.md
+++ b/arckit-codex/skills/wardley-mapping/SKILL.md
@@ -127,6 +127,34 @@ When the user asks for numeric precision, scoring, or data-driven positioning, a
 
 Present results as a table alongside the qualitative analysis — the numbers should confirm or challenge the intuitive positioning, not replace it.
 
+## Common Gotchas
+
+The highest-signal failures, collected from real maps. Check these before finalizing.
+
+### Positioning mistakes
+
+- **Positioning by age, not market maturity.** A 20-year-old internal system is not Commodity if the capability it provides is still bespoke across the market. Use *ubiquity + certainty*, never "how long we've had it." (See Step 3 and [references/evolution-stages.md](references/evolution-stages.md).)
+- **Confusing internal unfamiliarity with Genesis.** "New to us" ≠ "new to the world." If multiple vendors sell it, it is Product/Commodity even if your team has never used it. This is the single most common error.
+- **Treating the Y-axis as importance.** Visibility means *visibility to the user*, not business value or criticality. Power supply is invisible-but-critical → it belongs low on the map, not high.
+- **Floating components with no anchor.** Every value chain must trace upward to the user need. A component nothing depends on (directly or transitively) is either mis-placed or doesn't belong on this map.
+
+### OnlineWardleyMaps (OWM) syntax — for the `$arckit-wardley*` commands
+
+These produce OWM text for <https://create.wardleymaps.ai>. The renderer is strict:
+
+- **Coordinates are `[visibility, evolution]`, both 0–1, in that order** — `component Foo [0.9, 0.2]`. Authors routinely swap the pair or use 0–100; either silently mis-renders. Visibility first (Y), evolution second (X).
+- **Declare a component before linking it.** `A->B` referencing an undeclared `B` drops the link. Declare all `component` lines first, dependency lines after.
+- **`evolve` needs only the target X, and the component must already exist:** `evolve Foo 0.7`. Don't restate visibility; don't `evolve` a name you never declared.
+- **Names with spaces work in declarations but must match *exactly* in links** — `component Data Pipeline [..]` then `Kettle->Data Pipeline`, not `->DataPipeline`. Trailing whitespace breaks the match.
+- **Stage-boundary x-values:** Genesis `0.0–0.25`, Custom `0.25–0.50`, Product `0.50–0.75`, Commodity `0.75–1.0`. Keep positions inside the intended band so the visual reads correctly.
+- **One statement per line.** OWM is line-based; no semicolons, no inline comments after a statement.
+
+### Process mistakes
+
+- **Skipping the direct user question triage.** Inventing the user need, scope, or positioning instead of asking produces a confident-but-wrong map. When positioning is ambiguous for a key component, ask (Step 3) rather than guess.
+- **Listing only technology.** A value chain includes people, practices, and data — not just systems. Maps that are all boxes-of-software miss the inertia and doctrine insights that make the exercise worthwhile.
+- **Recommendations with no rationale.** Every strategic move must tie back to a position or movement on the map ("commoditize X because it sits Product-right with three vendors"), not generic advice.
+
 ## Analysis Checklist
 
 Apply this checklist to every completed map:

--- a/arckit-copilot/skills/wardley-mapping/SKILL.md
+++ b/arckit-copilot/skills/wardley-mapping/SKILL.md
@@ -127,6 +127,34 @@ When the user asks for numeric precision, scoring, or data-driven positioning, a
 
 Present results as a table alongside the qualitative analysis — the numbers should confirm or challenge the intuitive positioning, not replace it.
 
+## Common Gotchas
+
+The highest-signal failures, collected from real maps. Check these before finalizing.
+
+### Positioning mistakes
+
+- **Positioning by age, not market maturity.** A 20-year-old internal system is not Commodity if the capability it provides is still bespoke across the market. Use *ubiquity + certainty*, never "how long we've had it." (See Step 3 and [references/evolution-stages.md](references/evolution-stages.md).)
+- **Confusing internal unfamiliarity with Genesis.** "New to us" ≠ "new to the world." If multiple vendors sell it, it is Product/Commodity even if your team has never used it. This is the single most common error.
+- **Treating the Y-axis as importance.** Visibility means *visibility to the user*, not business value or criticality. Power supply is invisible-but-critical → it belongs low on the map, not high.
+- **Floating components with no anchor.** Every value chain must trace upward to the user need. A component nothing depends on (directly or transitively) is either mis-placed or doesn't belong on this map.
+
+### OnlineWardleyMaps (OWM) syntax — for the `/arckit.wardley*` commands
+
+These produce OWM text for <https://create.wardleymaps.ai>. The renderer is strict:
+
+- **Coordinates are `[visibility, evolution]`, both 0–1, in that order** — `component Foo [0.9, 0.2]`. Authors routinely swap the pair or use 0–100; either silently mis-renders. Visibility first (Y), evolution second (X).
+- **Declare a component before linking it.** `A->B` referencing an undeclared `B` drops the link. Declare all `component` lines first, dependency lines after.
+- **`evolve` needs only the target X, and the component must already exist:** `evolve Foo 0.7`. Don't restate visibility; don't `evolve` a name you never declared.
+- **Names with spaces work in declarations but must match *exactly* in links** — `component Data Pipeline [..]` then `Kettle->Data Pipeline`, not `->DataPipeline`. Trailing whitespace breaks the match.
+- **Stage-boundary x-values:** Genesis `0.0–0.25`, Custom `0.25–0.50`, Product `0.50–0.75`, Commodity `0.75–1.0`. Keep positions inside the intended band so the visual reads correctly.
+- **One statement per line.** OWM is line-based; no semicolons, no inline comments after a statement.
+
+### Process mistakes
+
+- **Skipping the AskUserQuestion triage.** Inventing the user need, scope, or positioning instead of asking produces a confident-but-wrong map. When positioning is ambiguous for a key component, ask (Step 3) rather than guess.
+- **Listing only technology.** A value chain includes people, practices, and data — not just systems. Maps that are all boxes-of-software miss the inertia and doctrine insights that make the exercise worthwhile.
+- **Recommendations with no rationale.** Every strategic move must tie back to a position or movement on the map ("commoditize X because it sits Product-right with three vendors"), not generic advice.
+
 ## Analysis Checklist
 
 Apply this checklist to every completed map:

--- a/arckit-opencode/skills/wardley-mapping/SKILL.md
+++ b/arckit-opencode/skills/wardley-mapping/SKILL.md
@@ -127,6 +127,34 @@ When the user asks for numeric precision, scoring, or data-driven positioning, a
 
 Present results as a table alongside the qualitative analysis — the numbers should confirm or challenge the intuitive positioning, not replace it.
 
+## Common Gotchas
+
+The highest-signal failures, collected from real maps. Check these before finalizing.
+
+### Positioning mistakes
+
+- **Positioning by age, not market maturity.** A 20-year-old internal system is not Commodity if the capability it provides is still bespoke across the market. Use *ubiquity + certainty*, never "how long we've had it." (See Step 3 and [references/evolution-stages.md](references/evolution-stages.md).)
+- **Confusing internal unfamiliarity with Genesis.** "New to us" ≠ "new to the world." If multiple vendors sell it, it is Product/Commodity even if your team has never used it. This is the single most common error.
+- **Treating the Y-axis as importance.** Visibility means *visibility to the user*, not business value or criticality. Power supply is invisible-but-critical → it belongs low on the map, not high.
+- **Floating components with no anchor.** Every value chain must trace upward to the user need. A component nothing depends on (directly or transitively) is either mis-placed or doesn't belong on this map.
+
+### OnlineWardleyMaps (OWM) syntax — for the `/arckit.wardley*` commands
+
+These produce OWM text for <https://create.wardleymaps.ai>. The renderer is strict:
+
+- **Coordinates are `[visibility, evolution]`, both 0–1, in that order** — `component Foo [0.9, 0.2]`. Authors routinely swap the pair or use 0–100; either silently mis-renders. Visibility first (Y), evolution second (X).
+- **Declare a component before linking it.** `A->B` referencing an undeclared `B` drops the link. Declare all `component` lines first, dependency lines after.
+- **`evolve` needs only the target X, and the component must already exist:** `evolve Foo 0.7`. Don't restate visibility; don't `evolve` a name you never declared.
+- **Names with spaces work in declarations but must match *exactly* in links** — `component Data Pipeline [..]` then `Kettle->Data Pipeline`, not `->DataPipeline`. Trailing whitespace breaks the match.
+- **Stage-boundary x-values:** Genesis `0.0–0.25`, Custom `0.25–0.50`, Product `0.50–0.75`, Commodity `0.75–1.0`. Keep positions inside the intended band so the visual reads correctly.
+- **One statement per line.** OWM is line-based; no semicolons, no inline comments after a statement.
+
+### Process mistakes
+
+- **Skipping the AskUserQuestion triage.** Inventing the user need, scope, or positioning instead of asking produces a confident-but-wrong map. When positioning is ambiguous for a key component, ask (Step 3) rather than guess.
+- **Listing only technology.** A value chain includes people, practices, and data — not just systems. Maps that are all boxes-of-software miss the inertia and doctrine insights that make the exercise worthwhile.
+- **Recommendations with no rationale.** Every strategic move must tie back to a position or movement on the map ("commoditize X because it sits Product-right with three vendors"), not generic advice.
+
 ## Analysis Checklist
 
 Apply this checklist to every completed map:

--- a/arckit-paperclip/skills/wardley-mapping/SKILL.md
+++ b/arckit-paperclip/skills/wardley-mapping/SKILL.md
@@ -127,6 +127,34 @@ When the user asks for numeric precision, scoring, or data-driven positioning, a
 
 Present results as a table alongside the qualitative analysis — the numbers should confirm or challenge the intuitive positioning, not replace it.
 
+## Common Gotchas
+
+The highest-signal failures, collected from real maps. Check these before finalizing.
+
+### Positioning mistakes
+
+- **Positioning by age, not market maturity.** A 20-year-old internal system is not Commodity if the capability it provides is still bespoke across the market. Use *ubiquity + certainty*, never "how long we've had it." (See Step 3 and [references/evolution-stages.md](references/evolution-stages.md).)
+- **Confusing internal unfamiliarity with Genesis.** "New to us" ≠ "new to the world." If multiple vendors sell it, it is Product/Commodity even if your team has never used it. This is the single most common error.
+- **Treating the Y-axis as importance.** Visibility means *visibility to the user*, not business value or criticality. Power supply is invisible-but-critical → it belongs low on the map, not high.
+- **Floating components with no anchor.** Every value chain must trace upward to the user need. A component nothing depends on (directly or transitively) is either mis-placed or doesn't belong on this map.
+
+### OnlineWardleyMaps (OWM) syntax — for the `/arckit.wardley*` commands
+
+These produce OWM text for <https://create.wardleymaps.ai>. The renderer is strict:
+
+- **Coordinates are `[visibility, evolution]`, both 0–1, in that order** — `component Foo [0.9, 0.2]`. Authors routinely swap the pair or use 0–100; either silently mis-renders. Visibility first (Y), evolution second (X).
+- **Declare a component before linking it.** `A->B` referencing an undeclared `B` drops the link. Declare all `component` lines first, dependency lines after.
+- **`evolve` needs only the target X, and the component must already exist:** `evolve Foo 0.7`. Don't restate visibility; don't `evolve` a name you never declared.
+- **Names with spaces work in declarations but must match *exactly* in links** — `component Data Pipeline [..]` then `Kettle->Data Pipeline`, not `->DataPipeline`. Trailing whitespace breaks the match.
+- **Stage-boundary x-values:** Genesis `0.0–0.25`, Custom `0.25–0.50`, Product `0.50–0.75`, Commodity `0.75–1.0`. Keep positions inside the intended band so the visual reads correctly.
+- **One statement per line.** OWM is line-based; no semicolons, no inline comments after a statement.
+
+### Process mistakes
+
+- **Skipping the AskUserQuestion triage.** Inventing the user need, scope, or positioning instead of asking produces a confident-but-wrong map. When positioning is ambiguous for a key component, ask (Step 3) rather than guess.
+- **Listing only technology.** A value chain includes people, practices, and data — not just systems. Maps that are all boxes-of-software miss the inertia and doctrine insights that make the exercise worthwhile.
+- **Recommendations with no rationale.** Every strategic move must tie back to a position or movement on the map ("commoditize X because it sits Product-right with three vendors"), not generic advice.
+
 ## Analysis Checklist
 
 Apply this checklist to every completed map:

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -2,6 +2,8 @@
 
 This document covers version management, the release flow, and the helper scripts that automate it. For day-to-day development guidance, see `CLAUDE.md`.
 
+> **Driving a release with Claude Code?** Run `/release X.Y.Z` — the `.claude/skills/release/` skill turns the flow below into a guided, gotcha-aware checklist. It is manual-invocation only (`disable-model-invocation: true`) so a release is never triggered automatically. This document remains the source of truth; the skill defers to it.
+
 ## Version Files
 
 ArcKit ships in seven formats, each with its own version file. They are all bumped in lockstep by `scripts/bump-version.sh`.


### PR DESCRIPTION
Applies lessons from "How we use Claude Code skills":
- Add a Common Gotchas section to the wardley-mapping skill covering the
  highest-signal failures (positioning by age, internal-unfamiliarity vs
  Genesis, Y-axis as importance, OWM syntax footguns, process mistakes).
  It was the only skill missing the blog's highest-signal element.
- Document in CLAUDE.md that skills are grown not built: capture repeatable
  mistakes as gotchas, keep bodies concise, push detail into references/.
- Regenerate non-Claude skill copies via converter.

https://claude.ai/code/session_011hupaDrZB99RW5JXU4q57s