### PR TITLE
fix(hooks): gate findRepoRoot on a numbered projects/ entry + Windows path fix

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -90,3 +90,6 @@ jobs:
 
       - name: OWM-to-Mermaid converter tests
         run: node --test tests/plugin/owm-to-mermaid.test.mjs
+
+      - name: Hook-utils findRepoRoot tests
+        run: node --test tests/plugin/test_hook_utils.mjs

--- a/arckit-claude/hooks/allow-plugin-internals.mjs
+++ b/arckit-claude/hooks/allow-plugin-internals.mjs
@@ -108,7 +108,7 @@ function commandTouchesPluginScripts(cmd) {
   // and ${CLAUDE_PLUGIN_ROOT} is a sentinel string the LLM only emits
   // when the prompt instructed it to use plugin-internal helpers.
   const PREFIXES = [
-    SCRIPTS_DIR + '/',
+    SCRIPTS_DIR.replaceAll('\\', '/') + '/',
     '${CLAUDE_PLUGIN_ROOT}/scripts/',
   ];
   let anyPrefixHit = false;

--- a/arckit-claude/hooks/hook-utils.mjs
+++ b/arckit-claude/hooks/hook-utils.mjs
@@ -40,12 +40,17 @@ export function mtimeMs(p) {
 export function findRepoRoot(cwd) {
   let current = resolve(cwd);
   while (true) {
-    if (isDir(join(current, 'projects'))) return current;
+    if (isArcKitProjectsDir(join(current, 'projects'))) return current;
     const parent = resolve(current, '..');
     if (parent === current) break;
     current = parent;
   }
   return null;
+}
+
+function isArcKitProjectsDir(projectsDir) {
+  if (!isDir(projectsDir)) return false;
+  return listDir(projectsDir).some((entry) => /^\d{3}(?:-|$)/.test(entry));
 }
 
 // ── Doc Type Extraction ──

--- a/arckit-codex/hooks/hook-utils.mjs
+++ b/arckit-codex/hooks/hook-utils.mjs
@@ -40,12 +40,17 @@ export function mtimeMs(p) {
 export function findRepoRoot(cwd) {
   let current = resolve(cwd);
   while (true) {
-    if (isDir(join(current, 'projects'))) return current;
+    if (isArcKitProjectsDir(join(current, 'projects'))) return current;
     const parent = resolve(current, '..');
     if (parent === current) break;
     current = parent;
   }
   return null;
+}
+
+function isArcKitProjectsDir(projectsDir) {
+  if (!isDir(projectsDir)) return false;
+  return listDir(projectsDir).some((entry) => /^\d{3}(?:-|$)/.test(entry));
 }
 
 // ── Doc Type Extraction ──

--- a/tests/plugin/test_hook_utils.mjs
+++ b/tests/plugin/test_hook_utils.mjs
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for arckit-claude/hooks/hook-utils.mjs :: findRepoRoot
+ *
+ * findRepoRoot walks up from `cwd` looking for an ArcKit repo root. A repo root
+ * is an ancestor that contains a `projects/` directory holding at least one
+ * numbered project entry (`NNN` or `NNN-...`, e.g. `000-global`, `001-foo`).
+ *
+ * The numbered-entry gate (isArcKitProjectsDir) exists so an unrelated
+ * `projects/` directory higher up the tree is not mistaken for the repo root.
+ *
+ * Run with:  node tests/plugin/test_hook_utils.mjs
+ */
+
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { findRepoRoot } from '../../arckit-claude/hooks/hook-utils.mjs';
+
+function makeRoot() {
+  return mkdtempSync(join(tmpdir(), 'arckit-hookutils-'));
+}
+
+test('finds the repo root when projects/ holds a numbered project', () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, 'projects', '001-example'), { recursive: true });
+    assert.equal(findRepoRoot(root), root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('recognises the bare 000-global numbered entry', () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, 'projects', '000-global'), { recursive: true });
+    assert.equal(findRepoRoot(root), root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('walks up the tree to find the repo root from a nested cwd', () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, 'projects', '002-foo'), { recursive: true });
+    const nested = join(root, 'projects', '002-foo', 'diagrams');
+    mkdirSync(nested, { recursive: true });
+    assert.equal(findRepoRoot(nested), root);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('returns null when projects/ exists but is empty', () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, 'projects'), { recursive: true });
+    assert.equal(findRepoRoot(root), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('returns null when projects/ holds only non-numbered entries', () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, 'projects', 'global'), { recursive: true });
+    writeFileSync(join(root, 'projects', 'README.md'), '# not a project\n');
+    assert.equal(findRepoRoot(root), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('does not treat an unrelated parent projects/ dir as the root', () => {
+  const root = makeRoot();
+  try {
+    // An unrelated `projects/` higher up (no numbered entries) must be ignored.
+    mkdirSync(join(root, 'projects', 'unrelated-app'), { recursive: true });
+    const work = join(root, 'work', 'sub');
+    mkdirSync(work, { recursive: true });
+    assert.equal(findRepoRoot(work), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('returns null when there is no projects/ directory at all', () => {
+  const root = makeRoot();
+  try {
+    mkdirSync(join(root, 'src'), { recursive: true });
+    assert.equal(findRepoRoot(join(root, 'src')), null);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Extracts two cross-platform hook-robustness fixes that were bundled into the AU Federal enrichment PR (#569). They change a **shared hook utility used by every hook**, so they deserve review on their own rather than riding an overlay PR (raised in my review of #569).

## What changed

- **`hook-utils.findRepoRoot`** now only treats an ancestor's `projects/` directory as the ArcKit repo root when it contains a numbered project entry (`NNN` / `NNN-...`, e.g. `000-global`, `001-foo`). Previously any `projects/` directory was enough, so an unrelated `projects/` higher up the tree (or an empty one) could be mistaken for the root and cause hooks to operate against the wrong directory.
- **`allow-plugin-internals`** normalises `SCRIPTS_DIR` separators to `/` before prefix matching, so the plugin-internals allowlist works on Windows.
- Mirrors the `hook-utils` change into the Codex extension (`arckit-codex/hooks/hook-utils.mjs`).
- Adds **`tests/plugin/test_hook_utils.mjs`** (7 cases: numbered, bare `000-global`, nested cwd, empty `projects/`, non-numbered entries, unrelated parent `projects/`, no `projects/`), wired into the `lint-markdown` workflow.

## Behaviour-change note

A brand-new repo whose `projects/` directory is empty (before the first project is created) will no longer be detected as a repo root, so project-context hooks no-op until a numbered project exists. That is the intended behaviour (nothing to act on yet), but calling it out explicitly for reviewers.

## Validation

- `node --test tests/plugin/test_hook_utils.mjs` -> 7 passed
- `node tests/plugin/test_graph_inject.mjs` -> 17 passed (exercises `findRepoRoot` indirectly)
- `python scripts/converter.py` -> zero drift
- `node --check` passes on all three changed `.mjs` files

🤖 Generated with [Claude Code](https://claude.com/claude-code)