### PR TITLE
feat(version-check): recommend and dogfood minimumVersion floor pin

### DIFF
--- a/.claude/commands/create-test-repo.md
+++ b/.claude/commands/create-test-repo.md
@@ -50,6 +50,7 @@ Use the **Write** tool to create each file inside `/tmp/arckit-test-setup/${REPO
 
 ```json
 {
+  "minimumVersion": "2.1.156",
   "extraKnownMarketplaces": {
     "arc-kit": {
       "source": {
@@ -63,6 +64,8 @@ Use the **Write** tool to create each file inside `/tmp/arckit-test-setup/${REPO
   }
 }
 ```
+
+> `minimumVersion` pins the test repo to ArcKit's current Claude Code floor (matches `MIN_CLAUDE_CODE_VERSION` in `arckit-claude/hooks/version-check.mjs`) so background auto-updates can't drop a Codespace below it. Bump this alongside the floor.
 
 ### 4b. `.devcontainer/devcontainer.json`
 

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,4 +1,5 @@
 {
+  "minimumVersion": "2.1.156",
   "permissions": {
     "allow": [
       "mcp__aws-knowledge__aws___get_regional_availability",

--- a/arckit-claude/hooks/version-check.mjs
+++ b/arckit-claude/hooks/version-check.mjs
@@ -60,7 +60,11 @@ if (clientVersion && compareVersions(clientVersion, MIN_CLAUDE_CODE_VERSION) < 0
     `- Skill tool headless permission fix — \`/arckit:*\` commands run via \`claude -p\` / CI failed with permission errors on v2.1.141–v2.1.143 (needs v2.1.144)\n` +
     `- Plugin \`defaultEnabled: false\` — ArcKit's 9 community overlays no longer auto-enable on marketplace install; users opt in to only the jurisdiction/sector they need (needs v2.1.154)\n` +
     `- Opus 4.8 thinking-block API-error fix — modified thinking blocks caused API errors on earlier clients; affects \`/arckit:*\` commands and research agents using extended thinking (needs v2.1.156)\n\n` +
-    `Update with: \`claude update\``
+    `Update with: \`claude update\`\n\n` +
+    `**Tip — stop drifting back below the floor:** after updating, add ` +
+    `\`"minimumVersion": "${MIN_CLAUDE_CODE_VERSION}"\` to your \`.claude/settings.json\`. ` +
+    `Claude Code then refuses to auto-update or \`claude update\` to anything below ArcKit's floor. ` +
+    `(This is a per-user/project setting — distinct from the org-only \`requiredMinimumVersion\` managed setting that hard-refuses startup fleet-wide.)`
   );
   process.stderr.write(`[ArcKit] Claude Code v${clientVersion} is below required v${MIN_CLAUDE_CODE_VERSION}\n`);
 }


### PR DESCRIPTION
## Summary

Follow-on from #522 item 69. While triaging the new v2.1.163 managed settings `requiredMinimumVersion` / `requiredMaximumVersion` (admin-only, hard-refuse-startup), confirmed there's a pre-existing **user/project-scoped** sibling — `minimumVersion` — valid in `.claude/settings.json`. It's softer (an update-floor: it stops background auto-updates and `claude update` from installing *below* the value; it does not refuse startup) but, unlike the managed key, it doesn't require an admin, so it's the version-pin ArcKit can actually reach individual users with.

There's no automatic "ship to everyone" path for either key — a plugin can't write to a user's `settings.json`, and `arckit init` only scaffolds Codex/OpenCode/Copilot projects (no `.claude/` files). So this PR uses the two levers that do work: the warning the plugin shows everyone, and dogfooding in repos we control.

## Changes

- **`arckit-claude/hooks/version-check.mjs`** — the below-floor SessionStart warning (reaches every below-floor user) now appends a tip to add `"minimumVersion": "<floor>"` to `.claude/settings.json`. Value interpolated from `MIN_CLAUDE_CODE_VERSION` so it stays in sync with the floor; explicitly distinguished from the org-only managed `requiredMinimumVersion`.
- **`.claude/settings.json`** — pinned `"minimumVersion": "2.1.156"` (dogfood).
- **`.claude/commands/create-test-repo.md`** — added `minimumVersion` to the scaffolded test-repo settings (step 4a) with a bump-alongside-the-floor note.

## Scope / risk

Claude-only: a hook + dev-repo config + the test-repo template. No converter run, no extension propagation, no doc-type/regime change. **Floor unchanged at v2.1.156.**

Minor maintenance note: the literal `2.1.156` now appears in the dev `.claude/settings.json` and the test-repo template in addition to `version-check.mjs`. Drift there is low-consequence (a stale pin just means a slightly lower update-floor), so it is not CI-guarded.

## Verification

- `.claude/settings.json` + scaffold JSON block both valid JSON
- `node --check arckit-claude/hooks/version-check.mjs` passes
- Simulated below-floor run (`CLAUDE_CODE_VERSION=2.1.100`) renders the new tip with the live floor value

Tracker: #522 (item 92)

🤖 Generated with [Claude Code](https://claude.com/claude-code)