### PR TITLE
docs: adopt Claude Code v2.1.161–163 capability notes (#522)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,9 +70,10 @@ Commands exist in multiple formats across the distribution. The plugin source is
 
 - `description` (required), `effort:` (override session effort: `low`, `medium`, `high`, `max` for Opus 4.6, `xhigh` for Opus 4.7 and Opus 4.8 — note Opus 4.8 defaults to `high`)
 - `keep-coding-instructions: true` (v2.1.94+) — persist instructions across `/compact` for long-running commands
+- `disallowed-tools:` (v2.1.152+) — remove tools from the model while the command/skill is active; available but **not yet used** in ArcKit (candidate hardening for read-only commands like `/arckit:search`, `/arckit:navigator`, `/arckit:health`)
 - `handoffs:` — list of `{command, description?, condition?}` entries; converter renders these as a "Suggested Next Steps" section for non-Claude targets
 
-Effort and `keep-coding-instructions` are stripped by the converter for non-Claude targets.
+Effort, `keep-coding-instructions`, and `disallowed-tools` are stripped by the converter for non-Claude targets.
 
 **Fast mode** (`/fast` toggle) runs the current Opus model with faster output — same model, no smaller-model downgrade. As of Claude Code v2.1.154 the default backing model for `/fast` is **Opus 4.8** (2x the standard rate for 2.5x the speed); it was Opus 4.7 on v2.1.142–v2.1.153 and Opus 4.6 before that. `/fast` is unrelated to the `effort:` frontmatter — the two compose: a command with `effort: xhigh` still benefits from `/fast` if the user has toggled it.
 
@@ -101,7 +102,7 @@ Agents are Claude Code only — Codex/OpenCode/Gemini equivalents inline the ful
 
 ### Plugin Skills
 
-Skills live in `arckit-claude/skills/{name}/SKILL.md`. Frontmatter: `name`, `description` (≤1,536 chars), optional `paths:` glob list (v2.1.84+) for auto-activation. The converter strips `paths:` for non-Claude targets.
+Skills live in `arckit-claude/skills/{name}/SKILL.md`. Frontmatter: `name`, `description` (≤1,536 chars), optional `paths:` glob list (v2.1.84+) for auto-activation, optional `disallowed-tools:` (v2.1.152+) to remove tools while the skill is active. The converter strips `paths:` and `disallowed-tools:` for non-Claude targets. During plugin development, `/reload-skills` (v2.1.152+) re-scans skill directories without restarting the session.
 
 | Skill | Type | Purpose |
 |-------|------|---------|
@@ -130,6 +131,8 @@ Substitution uses `${user_config.KEY}`. Sensitive values are never substituted i
 ### Plugin Hooks
 
 Hook handlers live in `arckit-claude/hooks/` and are registered in `arckit-claude/hooks/hooks.json`. All entries use the **exec form** (`command: "node"` + `args: ["${CLAUDE_PLUGIN_ROOT}/hooks/<name>.mjs"]`, v2.1.139+) so the harness execs the binary directly instead of parsing a shell-quoted command line. PostToolUse entries set `continueOnBlock: true` (v2.1.139+) so the observational `update-manifest`, `provenance-stamp`, and `telemetry` hooks can never derail the user's turn — block semantics are reserved for the genuine gates (`file-protection`, `secret-detection`, `validate-arc-filename`). The `PostCompact` event re-injects project context after `/compact` or auto-compaction (`postcompact-rehydrate.mjs`) so the dynamic filesystem-derived state (`projects/`, ARC artefacts, external policies) isn't lost in the summary — companion to `keep-coding-instructions: true` which preserves static command bodies. Individual hook entries also support an `if:` field (v2.1.85+) using permission rule syntax (e.g. `"Write(/projects/**)"`) to narrow triggering and avoid unnecessary Node spawns.
+
+Platform hook capabilities available but **not yet used** by ArcKit (flagged for future adoption, tracked on #522): `SessionStart` hooks can return `hookSpecificOutput.sessionTitle` to name the session and `reloadSkills: true` to re-scan skill directories (v2.1.152+); `Stop`/`SubagentStop` hooks can return `hookSpecificOutput.additionalContext` to feed the model an end-of-turn nudge without erroring (v2.1.163+ — candidate for `session-learner.mjs`); and the `MessageDisplay` event (v2.1.152+) can transform or hide assistant text as it is displayed (speculative classification-aware redaction for OFFICIAL-SENSITIVE work).
 
 Notable hooks: provenance stamping, manifest auto-update, session telemetry, secret detection, requirement-graph injection. **For full details on each hook, see [`arckit-claude/hooks/README.md`](arckit-claude/hooks/README.md).**
 

--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -240,6 +240,7 @@ The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping
 
 - **Run overnight** -- each iteration takes 2-3 minutes, so you get 20-30 experiments per hour
 - **Extend the prompt cache TTL for overnight runs** -- set `ENABLE_PROMPT_CACHING_1H=1` (Claude Code v2.1.108+) before launching Claude. The default 5-minute prompt cache expires between iterations once Claude pauses to think, score, and write `results.tsv`; the 1-hour TTL keeps the template, fixtures, and accumulated `results.tsv` warm across the full overnight run, materially reducing token cost. Pair with `ANTHROPIC_API_KEY` billing dashboards to confirm cache-read rates climb.
+- **Configure a fallback model** -- launch with `--fallback-model <model>` so that if the primary model is briefly unavailable mid-run (e.g. Opus overloaded), Claude Code switches to the fallback for the rest of the session instead of failing every request (Claude Code v2.1.152+). Keeps an unattended overnight loop alive through a transient capacity blip rather than stalling on iteration 7.
 - **Review the results.tsv** -- the discard history tells you what didn't work, which is as valuable as what did
 - **Check against standards** -- before starting a run, review relevant external standards (e.g., UK Gov ADR Framework for ADRs, GDS Service Standard for assessments) to prime the system with specific gaps to target
 - **Create a PR for the prompt change only** -- the experiment branch has noise (scratch files, results, reverts); cherry-pick the kept commits onto a clean branch

--- a/docs/guides/custom-commands.md
+++ b/docs/guides/custom-commands.md
@@ -81,6 +81,8 @@ Always include a `## User Input` section with a fenced `text` block containing `
 
 Do not hand-write target-specific placeholders — use `$ARGUMENTS` and let the converter do the work.
 
+> **Need a literal `$` before a digit?** Claude Code treats `$1`, `$2`, … as positional argument placeholders in command/skill bodies. To write a literal dollar-then-digit (e.g. a price like `$5`, or a regex like `$1`), escape it as `\$` (Claude Code v2.1.163+) — `\$5`, `\$1`. ArcKit commands rarely need this since they use `$ARGUMENTS`, but it matters if you write a worked example containing currency or shell positional vars.
+
 > The Copilot placeholder currently hard-codes the `topic:` label regardless of what the command expects as input. If you need a command-specific label, it requires changes to `scripts/converter.py` — the converter is the right place to thread that customisation through.
 
 ### Reading Templates with User Overrides

--- a/docs/guides/enterprise-scale.md
+++ b/docs/guides/enterprise-scale.md
@@ -215,6 +215,41 @@ We're looking for a real-world enterprise case study to anchor this guide — id
 
 ---
 
+## Fleet & Version Governance (managed settings)
+
+At enterprise scale you usually want to govern *which* Claude Code versions run ArcKit and *which* plugins teams may install — centrally, not repo by repo. Claude Code's [managed settings](https://code.claude.com/docs/en/permissions#managed-settings) (admin-deployed policy that users cannot override) give you three levers ArcKit benefits from.
+
+### Pin a version range across the fleet
+
+ArcKit ships a soft floor: the `version-check.mjs` SessionStart hook *warns* anyone running below the supported Claude Code version. To *enforce* it, an admin can set the native managed settings (Claude Code v2.1.163+):
+
+```json
+{
+  "requiredMinimumVersion": "2.1.156",
+  "requiredMaximumVersion": "2.1.999"
+}
+```
+
+Claude Code then **refuses to start** outside the range and directs the user to an approved version. Use `requiredMinimumVersion` to guarantee everyone has the features ArcKit relies on; use `requiredMaximumVersion` as a known-good ceiling so a regulated fleet doesn't auto-adopt a release before you've validated it. These are *managed-settings only* — a plugin or repo cannot set them (by design: a hostile repo must not be able to lock you out of your own tooling).
+
+For an **individual** user or repo that just wants to avoid drifting *below* the floor, the softer, user-scoped `minimumVersion` in `.claude/settings.json` blocks auto-update/`claude update` from going below it (it doesn't refuse startup). ArcKit pins this in its own repos and the below-floor warning recommends it.
+
+### Allowlist the ArcKit marketplace
+
+`pluginSuggestionMarketplaces` lets admins allowlist org marketplaces whose plugins may surface in context-aware tips. Allowlisting `tractorjuice/arc-kit` means Claude Code can suggest ArcKit when a user opens a directory with a `projects/` tree or `ARC-*` artefacts — useful for driving adoption across many teams without a manual rollout. Pair with `strictKnownMarketplaces` / `blockedMarketplaces` if you want to *restrict* installs to only the marketplaces you've vetted.
+
+### Slice usage/cost metrics by project
+
+If you run Claude Code's OpenTelemetry export, set `OTEL_RESOURCE_ATTRIBUTES` (Claude Code v2.1.161+) to attach custom labels to every metric datapoint:
+
+```bash
+export OTEL_RESOURCE_ATTRIBUTES="repo=arc-kit,team=enterprise-architecture,project=042-identity-service"
+```
+
+You can then slice token/cost usage by team, repo, or project — a natural complement to the per-artefact Document Control headers and `provenance-stamp` ArcKit already produces. **Privacy caveat:** these labels are emitted as-is, so don't put project identifiers in them for OFFICIAL-SENSITIVE / SECRET work where the label itself would be sensitive.
+
+---
+
 ## Related Guides
 
 - [ArcKit Init](init.md) — bootstrapping a new repo

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -49,6 +49,8 @@ claude
 
 The value is milliseconds. Recommended for: corporate networks with TLS-inspecting proxies, VPN-tunnelled connections, and large-scope research prompts that trigger many `microsoft_docs_fetch` / `aws___read_documentation` / `get_document` calls in sequence. On a healthy direct connection the default is fine — only set this when you see timeout failures.
 
+> **Don't set a sub-second timeout.** As of Claude Code v2.1.162, a per-server `timeout` below `1000` ms is ignored (it falls back to `MCP_TOOL_TIMEOUT` or the default) rather than being floored to a 1-second watchdog that aborted every call. ArcKit ships no sub-1000 ms timeouts, so this is reassurance only — but if you hand-edit a server's `timeout`, keep it ≥ `1000`.
+
 ### Step 1: Add the marketplace
 
 In Claude Code, run:
@@ -83,6 +85,8 @@ After restart, open the plugin manager (`/plugin`) and navigate to **Installed**
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
 
 > **Tip**: You may see 2 MCP errors about missing API keys for Google and Data Commons. These are harmless — see [Servers Requiring API Keys](#servers-requiring-api-keys) below.
+
+> **Confirm what's enabled from the CLI** (Claude Code v2.1.163+): `/plugin list --enabled` lists the active plugins. Handy because the community overlays (`arckit-uae`, `arckit-fr`, `arckit-au`, …) ship `defaultEnabled: false` — if an overlay's `/arckit:*` commands aren't showing up, it's almost always because it wasn't enabled. Use `/plugin list --disabled` to see what's installed but off.
 
 ### Auto-enabling for team repos
 
@@ -188,6 +192,8 @@ export DATA_COMMONS_API_KEY="your-api-key-here"
 ```
 
 3. Restart Claude Code
+
+> **Your keys stay hidden in `claude mcp` output.** Both keyed servers carry their key in an HTTP header (`X-Goog-Api-Key`, `X-API-Key`) via `${GOOGLE_API_KEY}` / `${DATA_COMMONS_API_KEY}`. As of Claude Code v2.1.161, `claude mcp list` / `get` / `add` no longer expand `${VAR}` references and redact credential headers and URL secrets — so inspecting your MCP config (or screen-sharing it) won't leak the keys. Relevant for OFFICIAL-SENSITIVE / regulated deployments. The other four bundled servers are keyless, so there's nothing to redact.
 
 ---
 

--- a/docs/guides/security-hooks.md
+++ b/docs/guides/security-hooks.md
@@ -128,6 +128,27 @@ SKIP_PATTERNS = [
 ]
 ```
 
+## Restricting web access for research agents
+
+ArcKit's web-research agents (`research`, `datascout`, `aws-research`, `azure-research`, `gcp-research`, `gov-*`, `grants`) use `WebFetch`. For a regulated or OFFICIAL-SENSITIVE deployment you may want to confine that traffic to an approved set of domains. As of Claude Code v2.1.162, explicit `WebFetch(domain:...)` permission rules **take precedence over the built-in preapproved-host auto-allow** (previously the preapproved hosts leaked through), so a deny/allow policy now actually holds.
+
+Add rules to `.claude/settings.json` (or org managed settings for fleet-wide enforcement — see [Fleet & Version Governance](enterprise-scale.md#fleet--version-governance-managed-settings)):
+
+```json
+{
+  "permissions": {
+    "deny": ["WebFetch"],
+    "allow": [
+      "WebFetch(domain:*.gov.uk)",
+      "WebFetch(domain:*.service.gov.uk)",
+      "WebFetch(domain:docs.aws.amazon.com)"
+    ]
+  }
+}
+```
+
+This is a Claude Code permission policy, not an ArcKit hook — ArcKit ships no domain restrictions by default, leaving the choice to the deployment.
+
 ## Testing
 
 You can test each hook by piping JSON to stdin. All hooks handle empty input gracefully.


### PR DESCRIPTION
## Summary

Clears the open documentation tasks on the #522 Claude Code adoption tracker (v2.1.161–v2.1.163 triage + carried-forward CLAUDE.md mentions). Pure documentation — no code, no command/agent/hook/template change.

## Changes

| File | Task | What |
|------|------|------|
| `docs/guides/mcp-servers.md` | item 84 | Note that a per-server `timeout` < 1000 ms is now ignored (not floored to a 1s watchdog); keep hand-edited timeouts ≥ 1000 |
| `docs/guides/mcp-servers.md` | item 64 | `claude mcp list`/`get`/`add` now redact credential headers + stop expanding `${VAR}` — reassurance for the 2 keyed servers (`X-Goog-Api-Key`, `X-API-Key`) |
| `docs/guides/enterprise-scale.md` | items 69, 63 | New **Fleet & Version Governance (managed settings)** section: `requiredMinimumVersion`/`requiredMaximumVersion` (org enforcement) vs the user-scoped `minimumVersion` ArcKit already pins; `pluginSuggestionMarketplaces` allowlist; `OTEL_RESOURCE_ATTRIBUTES` per-project slicing with a privacy caveat |
| `docs/guides/autoresearch.md` | — | `--fallback-model` keeps unattended overnight loops alive through a transient capacity blip |
| `docs/guides/security-hooks.md` | item 68 | Scope research-agent `WebFetch` to approved domains now that explicit `WebFetch(domain:...)` rules take precedence over preapproved hosts |
| `docs/guides/custom-commands.md` | item 73 | `\$` escape for a literal `$` before a digit in command/skill bodies |
| `CLAUDE.md` | carried-forward | Mention `disallowed-tools` frontmatter, SessionStart `sessionTitle`/`reloadSkills`, Stop `additionalContext`, `MessageDisplay`, `/reload-skills` as available-but-not-yet-used |

## Verified separately (no edit)

The "confirm community overlays declare the `arckit` dependency" task is already satisfied — all 9 overlays' `plugin.json` declare `arckit` (and `arckit-au-energy` declares both `arckit` + `arckit-au`).

## Checks

- `python scripts/converter.py` — clean, **0 extension drift** (guide edits don't propagate to tracked extension files)
- `markdownlint-cli2` on all 6 changed files — **0 errors**

Tracker: #522 (items 63, 64, 68, 69, 71, 73, 84 + frontmatter/hook mentions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)