### PR TITLE
feat(telemetry): attribute tool/MCP activity by agent (#522 items 33/52/63)

### DIFF
--- a/.arckit/templates/pages-template.html
+++ b/.arckit/templates/pages-template.html
@@ -3087,6 +3087,13 @@
                         const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
                         parts.push(`${total} MCP`);
                     }
+                    if (Array.isArray(t.byAgent)) {
+                        const topAgent = t.byAgent.find(a => a.agent !== 'main');
+                        if (topAgent) {
+                            const calls = (topAgent.toolCalls || 0) + (topAgent.mcpCalls || 0);
+                            parts.push(`top agent: ${topAgent.agent} (${calls})`);
+                        }
+                    }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
                     const effortChip = (typeof s.effort === 'string' && s.effort)

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -99,3 +99,6 @@ jobs:
 
       - name: Session-nudge rule-engine tests
         run: node --test tests/plugin/session-nudge.test.mjs
+
+      - name: Telemetry rollup tests
+        run: node --test tests/plugin/telemetry-rollup.test.mjs

--- a/arckit-claude/hooks/README.md
+++ b/arckit-claude/hooks/README.md
@@ -62,18 +62,22 @@ Lightweight telemetry recorder registered for three events:
 
 Every record also carries an **`effort`** field (Claude Code v2.1.133+) when the harness supplies one — read from hookInput `effort.level` or the `$CLAUDE_EFFORT` env var. Omitted on older clients or when no explicit effort was set. The effort tag enables comparing e.g. p95 latency at `xhigh` vs `max` for the same tool, and supports the Phase 5 audit of which `effort: max` commands could be downgraded.
 
+Latency (`hook_duration`) and MCP (`mcp_call`) records additionally carry **`agent_type`** and **`agent_id`** (Claude Code v2.1.145+) when the call ran *inside a subagent* — e.g. a `WebFetch` made by `arckit-research`. Main-thread calls omit them. This lets `session-learner.mjs` attribute tool activity **by agent** (see below). Note: hook input exposes `agent_id`/`agent_type` but **not** `parent_agent_id`, so we can attribute work to an agent but cannot reconstruct the orchestrator→reader/writer dispatch tree.
+
 The session-level effort is also surfaced in `.arckit/memory/sessions.md` (one extra line per entry) and in the `docs/telemetry.json` per-session record (top-level `effort` field), so the dashboard "Recent Sessions" panel can colour-code sessions by effort tier.
 
 Events are appended to `.arckit/memory/.telemetry.jsonl` during the session. `session-learner.mjs` reads, summarises, and truncates the file at Stop / StopFailure, adding a single line to each session entry, e.g.:
 
 ```text
 - **Effort:** high
-- **Telemetry:** 47 tool calls (p50=12ms, p95=4200ms) | 3 agents (arckit-research×2, arckit-datascout) | MCP: govreposcrape×8
+- **Telemetry:** 47 tool calls (p50=12ms, p95=4200ms) | 3 agents (arckit-research×2, arckit-datascout) | MCP: govreposcrape×8 | by agent: arckit-research(12 calls, p95=4200ms), main(35 calls, p95=300ms)
 ```
+
+The summarisation/rollup logic lives in the pure, unit-tested `telemetry-rollup.mjs` (`summariseTelemetry` / `rollupTelemetry`), imported by `session-learner.mjs`. The "by agent" segment appears only when a subagent did tool work.
 
 Telemetry is best-effort — any failure (write error, malformed line, missing field) is swallowed silently so it never breaks a session.
 
-When `docs/` exists (i.e. the project has run `/arckit:pages`), `session-learner.mjs` also writes a structured rollup to `docs/telemetry.json` (newer-first, capped at 50 sessions) so the dashboard can render a "Session Telemetry" + "Recent Sessions" panel. Each record contains `{ ts, type, isFailure, effort?, commits, filesChanged, artifacts, telemetry: { toolCalls, p50, p95, agents, mcp } }`. The dashboard fetches `telemetry.json` with the same graceful-fallback pattern as `health.json` — projects without a `docs/` directory render the dashboard exactly as before.
+When `docs/` exists (i.e. the project has run `/arckit:pages`), `session-learner.mjs` also writes a structured rollup to `docs/telemetry.json` (newer-first, capped at 50 sessions) so the dashboard can render a "Session Telemetry" + "Recent Sessions" panel. Each record contains `{ ts, type, isFailure, effort?, commits, filesChanged, artifacts, telemetry: { toolCalls, p50, p95, agents, mcp, byAgent? } }`, where `byAgent` (present only when a subagent did tool work) is `[{ agent, toolCalls, p50?, p95?, mcpCalls }]` sorted by activity. The dashboard fetches `telemetry.json` with the same graceful-fallback pattern as `health.json` — projects without a `docs/` directory render the dashboard exactly as before, and older `telemetry.json` files without `byAgent` render unchanged (the "Recent Sessions" panel surfaces the busiest subagent when present).
 
 > **Note on `type: "mcp_tool"` (v2.1.118)**: This Claude Code feature lets a hook *invoke* an MCP tool as its action (alternative to `type: "command"` / `type: "prompt"`). It does **not** filter hooks to fire only on MCP tool calls. ArcKit logs `govreposcrape` calls via the existing tool-name matcher pattern (`mcp__govreposcrape__.*`); no `type: "mcp_tool"` registration is needed for telemetry.
 

--- a/arckit-claude/hooks/session-learner.mjs
+++ b/arckit-claude/hooks/session-learner.mjs
@@ -23,6 +23,7 @@ import { execFileSync } from 'node:child_process';
 import { isDir, isFile, readText, parseHookInput, parseVersion, compareVersions } from './hook-utils.mjs';
 import { DOC_TYPES } from '../config/doc-types.mjs';
 import { selectNudge } from './session-nudge.mjs';
+import { summariseTelemetry, rollupTelemetry } from './telemetry-rollup.mjs';
 
 const data = parseHookInput();
 const cwd = data.cwd || '.';
@@ -361,115 +362,6 @@ function scanProjectDiskCodes(baseCwd, projNum) {
   };
   walk(projectDir);
   return found;
-}
-
-/**
- * Roll up telemetry events from telemetry.mjs into a single line for
- * the session entry. Records:
- *   - hook_duration{tool, duration_ms}: per-tool latency histogram
- *   - mcp_call{server, tool, args}:     MCP call count (govreposcrape only)
- *   - agent_spawn{agent}:               agent spawn counts
- *
- * Returns a one-line string or null if nothing meaningful to report.
- */
-function summariseTelemetry(events) {
-  const durationsByTool = new Map(); // tool → array of duration_ms
-  const mcpCalls = new Map();        // server → count
-  const agentSpawns = new Map();     // agent → count
-
-  for (const ev of events) {
-    if (ev.kind === 'hook_duration' && ev.tool && typeof ev.duration_ms === 'number') {
-      if (!durationsByTool.has(ev.tool)) durationsByTool.set(ev.tool, []);
-      durationsByTool.get(ev.tool).push(ev.duration_ms);
-    } else if (ev.kind === 'mcp_call' && ev.server) {
-      mcpCalls.set(ev.server, (mcpCalls.get(ev.server) || 0) + 1);
-    } else if (ev.kind === 'agent_spawn' && ev.agent) {
-      agentSpawns.set(ev.agent, (agentSpawns.get(ev.agent) || 0) + 1);
-    }
-  }
-
-  const parts = [];
-
-  if (durationsByTool.size > 0) {
-    // Compute total tool calls and overall p50/p95
-    const all = [];
-    for (const arr of durationsByTool.values()) all.push(...arr);
-    all.sort((a, b) => a - b);
-    const p50 = all[Math.floor(all.length * 0.5)];
-    const p95 = all[Math.floor(all.length * 0.95)];
-    parts.push(`${all.length} tool calls (p50=${p50}ms, p95=${p95}ms)`);
-  }
-
-  if (agentSpawns.size > 0) {
-    const total = [...agentSpawns.values()].reduce((a, b) => a + b, 0);
-    const top = [...agentSpawns.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .slice(0, 3)
-      .map(([a, n]) => (n > 1 ? `${a}×${n}` : a))
-      .join(', ');
-    parts.push(`${total} agent${total === 1 ? '' : 's'} (${top})`);
-  }
-
-  if (mcpCalls.size > 0) {
-    const top = [...mcpCalls.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .map(([s, n]) => `${s}×${n}`)
-      .join(', ');
-    parts.push(`MCP: ${top}`);
-  }
-
-  return parts.length > 0 ? parts.join(' | ') : null;
-}
-
-/**
- * Same input as summariseTelemetry, but returns a structured object for
- * docs/telemetry.json. Shape matches what the pages dashboard renders:
- *
- *   {
- *     toolCalls: 47,
- *     p50: 12,
- *     p95: 4200,
- *     agents: [{name: "arckit-research", count: 2}, ...],
- *     mcp:    [{server: "govreposcrape", count: 8}, ...]
- *   }
- *
- * Returns null when there are no meaningful events.
- */
-function rollupTelemetry(events) {
-  const all = [];
-  const agents = new Map();
-  const mcp = new Map();
-
-  for (const ev of events) {
-    if (ev.kind === 'hook_duration' && typeof ev.duration_ms === 'number') {
-      all.push(ev.duration_ms);
-    } else if (ev.kind === 'mcp_call' && ev.server) {
-      mcp.set(ev.server, (mcp.get(ev.server) || 0) + 1);
-    } else if (ev.kind === 'agent_spawn' && ev.agent) {
-      agents.set(ev.agent, (agents.get(ev.agent) || 0) + 1);
-    }
-  }
-
-  if (all.length === 0 && agents.size === 0 && mcp.size === 0) return null;
-
-  const result = {};
-  if (all.length > 0) {
-    all.sort((a, b) => a - b);
-    result.toolCalls = all.length;
-    result.p50 = all[Math.floor(all.length * 0.5)];
-    result.p95 = all[Math.floor(all.length * 0.95)];
-  }
-  if (agents.size > 0) {
-    result.agents = [...agents.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .map(([name, count]) => ({ name, count }));
-  }
-  if (mcp.size > 0) {
-    result.mcp = [...mcp.entries()]
-      .sort((a, b) => b[1] - a[1])
-      .map(([server, count]) => ({ server, count }));
-  }
-  return result;
 }
 
 /**

--- a/arckit-claude/hooks/telemetry-rollup.mjs
+++ b/arckit-claude/hooks/telemetry-rollup.mjs
@@ -1,0 +1,181 @@
+/**
+ * ArcKit Telemetry Rollup — pure aggregation of the per-session telemetry
+ * events written by telemetry.mjs to `.arckit/memory/.telemetry.jsonl`.
+ *
+ * Two views over the same event list:
+ *   - summariseTelemetry(events) → one-line prose for the sessions.md entry
+ *   - rollupTelemetry(events)    → structured object for docs/telemetry.json
+ *
+ * Both group activity BY AGENT when subagent context is present: each
+ * hook_duration / mcp_call event may carry `agent_type` (the subagent the
+ * tool ran inside, e.g. "arckit-research"); events with no agent_type are
+ * main-thread work, bucketed under "main". This lets the dashboard and the
+ * session log show where the research agents spend tool time and MCP calls.
+ * (Hook input exposes agent_id/agent_type but NOT parent_agent_id, so we
+ * attribute by agent — we cannot reconstruct the dispatch tree.)
+ *
+ * Pure: no fs, no side effects on import. Imported by session-learner.mjs;
+ * unit-tested in tests/plugin/telemetry-rollup.test.mjs.
+ */
+
+const MAIN = 'main';
+
+/**
+ * Group hook_duration durations and mcp_call counts by agent bucket
+ * (agent_type, or "main" when absent).
+ *
+ * @returns {Map<string, { durations: number[], mcpCalls: number }>}
+ */
+function groupByAgent(events) {
+  const byAgent = new Map();
+  const bucket = (key) => {
+    if (!byAgent.has(key)) byAgent.set(key, { durations: [], mcpCalls: 0 });
+    return byAgent.get(key);
+  };
+  for (const ev of events) {
+    const agent = ev.agent_type || MAIN;
+    if (ev.kind === 'hook_duration' && typeof ev.duration_ms === 'number') {
+      bucket(agent).durations.push(ev.duration_ms);
+    } else if (ev.kind === 'mcp_call') {
+      bucket(agent).mcpCalls += 1;
+    }
+  }
+  return byAgent;
+}
+
+function pct(sorted, p) {
+  return sorted[Math.floor(sorted.length * p)];
+}
+
+/**
+ * Build the per-agent breakdown array, sorted by total activity descending.
+ * Returns null when the only bucket is "main" (no subagent work to attribute).
+ *
+ * @returns {Array<{ agent: string, toolCalls: number, p50?: number, p95?: number, mcpCalls: number }> | null}
+ */
+function buildByAgent(events) {
+  const grouped = groupByAgent(events);
+  const hasSubagent = [...grouped.keys()].some((k) => k !== MAIN);
+  if (!hasSubagent) return null;
+
+  const rows = [];
+  for (const [agent, { durations, mcpCalls }] of grouped) {
+    const sorted = [...durations].sort((a, b) => a - b);
+    const row = { agent, toolCalls: sorted.length, mcpCalls };
+    if (sorted.length > 0) {
+      row.p50 = pct(sorted, 0.5);
+      row.p95 = pct(sorted, 0.95);
+    }
+    rows.push(row);
+  }
+  rows.sort((a, b) => (b.toolCalls + b.mcpCalls) - (a.toolCalls + a.mcpCalls));
+  return rows;
+}
+
+/**
+ * One-line prose summary for the sessions.md entry. Returns null when there
+ * is nothing meaningful to report.
+ */
+export function summariseTelemetry(events) {
+  const durationsByTool = new Map();
+  const mcpCalls = new Map();
+  const agentSpawns = new Map();
+
+  for (const ev of events) {
+    if (ev.kind === 'hook_duration' && ev.tool && typeof ev.duration_ms === 'number') {
+      if (!durationsByTool.has(ev.tool)) durationsByTool.set(ev.tool, []);
+      durationsByTool.get(ev.tool).push(ev.duration_ms);
+    } else if (ev.kind === 'mcp_call' && ev.server) {
+      mcpCalls.set(ev.server, (mcpCalls.get(ev.server) || 0) + 1);
+    } else if (ev.kind === 'agent_spawn' && ev.agent) {
+      agentSpawns.set(ev.agent, (agentSpawns.get(ev.agent) || 0) + 1);
+    }
+  }
+
+  const parts = [];
+
+  if (durationsByTool.size > 0) {
+    const all = [];
+    for (const arr of durationsByTool.values()) all.push(...arr);
+    all.sort((a, b) => a - b);
+    parts.push(`${all.length} tool calls (p50=${pct(all, 0.5)}ms, p95=${pct(all, 0.95)}ms)`);
+  }
+
+  if (agentSpawns.size > 0) {
+    const total = [...agentSpawns.values()].reduce((a, b) => a + b, 0);
+    const top = [...agentSpawns.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 3)
+      .map(([a, n]) => (n > 1 ? `${a}×${n}` : a))
+      .join(', ');
+    parts.push(`${total} agent${total === 1 ? '' : 's'} (${top})`);
+  }
+
+  if (mcpCalls.size > 0) {
+    const top = [...mcpCalls.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([s, n]) => `${s}×${n}`)
+      .join(', ');
+    parts.push(`MCP: ${top}`);
+  }
+
+  // By-agent breakdown — only when a subagent did tool work.
+  const byAgent = buildByAgent(events);
+  if (byAgent) {
+    const top = byAgent
+      .slice(0, 3)
+      .map((a) => {
+        if (a.toolCalls > 0) return `${a.agent}(${a.toolCalls} call${a.toolCalls === 1 ? '' : 's'}, p95=${a.p95}ms)`;
+        return `${a.agent}(${a.mcpCalls} MCP)`;
+      })
+      .join(', ');
+    parts.push(`by agent: ${top}`);
+  }
+
+  return parts.length > 0 ? parts.join(' | ') : null;
+}
+
+/**
+ * Structured rollup for docs/telemetry.json. Returns null when there are no
+ * meaningful events.
+ */
+export function rollupTelemetry(events) {
+  const all = [];
+  const agents = new Map();
+  const mcp = new Map();
+
+  for (const ev of events) {
+    if (ev.kind === 'hook_duration' && typeof ev.duration_ms === 'number') {
+      all.push(ev.duration_ms);
+    } else if (ev.kind === 'mcp_call' && ev.server) {
+      mcp.set(ev.server, (mcp.get(ev.server) || 0) + 1);
+    } else if (ev.kind === 'agent_spawn' && ev.agent) {
+      agents.set(ev.agent, (agents.get(ev.agent) || 0) + 1);
+    }
+  }
+
+  if (all.length === 0 && agents.size === 0 && mcp.size === 0) return null;
+
+  const result = {};
+  if (all.length > 0) {
+    all.sort((a, b) => a - b);
+    result.toolCalls = all.length;
+    result.p50 = pct(all, 0.5);
+    result.p95 = pct(all, 0.95);
+  }
+  if (agents.size > 0) {
+    result.agents = [...agents.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, count]) => ({ name, count }));
+  }
+  if (mcp.size > 0) {
+    result.mcp = [...mcp.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([server, count]) => ({ server, count }));
+  }
+
+  const byAgent = buildByAgent(events);
+  if (byAgent) result.byAgent = byAgent;
+
+  return result;
+}

--- a/arckit-claude/hooks/telemetry.mjs
+++ b/arckit-claude/hooks/telemetry.mjs
@@ -61,6 +61,15 @@ const tool = data.tool_name || '';
 // vs `max` for the same tool.
 const effortLevel = (data.effort && typeof data.effort === 'object' ? data.effort.level : null) || process.env.CLAUDE_EFFORT || null;
 
+// Subagent context (Claude Code v2.1.145+): present only when the hook fires
+// inside a subagent call. `agent_type` is the subagent name (e.g.
+// "arckit-research"); `agent_id` is the unique instance. Attached to
+// latency/MCP records so session-learner can attribute tool activity by agent.
+// (Hook input exposes agent_id/agent_type but NOT parent_agent_id, so the
+// dispatch tree cannot be reconstructed — only per-agent attribution.)
+const agentType = data.agent_type || null;
+const agentId = data.agent_id || null;
+
 let record = null;
 const ts = new Date().toISOString();
 
@@ -95,6 +104,11 @@ if (event === 'TaskCreated' || tool === 'TaskCreate') {
 
 if (record) {
   if (effortLevel) record.effort = effortLevel;
+  // Attribute latency/MCP activity to the subagent it ran inside (if any).
+  if (record.kind === 'hook_duration' || record.kind === 'mcp_call') {
+    if (agentType) record.agent_type = agentType;
+    if (agentId) record.agent_id = agentId;
+  }
   const memoryDir = join(cwd, '.arckit', 'memory');
   try {
     mkdirSync(memoryDir, { recursive: true });

--- a/arckit-claude/templates/pages-template.html
+++ b/arckit-claude/templates/pages-template.html
@@ -3087,6 +3087,13 @@
                         const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
                         parts.push(`${total} MCP`);
                     }
+                    if (Array.isArray(t.byAgent)) {
+                        const topAgent = t.byAgent.find(a => a.agent !== 'main');
+                        if (topAgent) {
+                            const calls = (topAgent.toolCalls || 0) + (topAgent.mcpCalls || 0);
+                            parts.push(`top agent: ${topAgent.agent} (${calls})`);
+                        }
+                    }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
                     const effortChip = (typeof s.effort === 'string' && s.effort)

--- a/arckit-codex/templates/pages-template.html
+++ b/arckit-codex/templates/pages-template.html
@@ -3087,6 +3087,13 @@
                         const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
                         parts.push(`${total} MCP`);
                     }
+                    if (Array.isArray(t.byAgent)) {
+                        const topAgent = t.byAgent.find(a => a.agent !== 'main');
+                        if (topAgent) {
+                            const calls = (topAgent.toolCalls || 0) + (topAgent.mcpCalls || 0);
+                            parts.push(`top agent: ${topAgent.agent} (${calls})`);
+                        }
+                    }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
                     const effortChip = (typeof s.effort === 'string' && s.effort)

--- a/arckit-copilot/templates/pages-template.html
+++ b/arckit-copilot/templates/pages-template.html
@@ -3087,6 +3087,13 @@
                         const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
                         parts.push(`${total} MCP`);
                     }
+                    if (Array.isArray(t.byAgent)) {
+                        const topAgent = t.byAgent.find(a => a.agent !== 'main');
+                        if (topAgent) {
+                            const calls = (topAgent.toolCalls || 0) + (topAgent.mcpCalls || 0);
+                            parts.push(`top agent: ${topAgent.agent} (${calls})`);
+                        }
+                    }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
                     const effortChip = (typeof s.effort === 'string' && s.effort)

--- a/arckit-opencode/templates/pages-template.html
+++ b/arckit-opencode/templates/pages-template.html
@@ -3087,6 +3087,13 @@
                         const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
                         parts.push(`${total} MCP`);
                     }
+                    if (Array.isArray(t.byAgent)) {
+                        const topAgent = t.byAgent.find(a => a.agent !== 'main');
+                        if (topAgent) {
+                            const calls = (topAgent.toolCalls || 0) + (topAgent.mcpCalls || 0);
+                            parts.push(`top agent: ${topAgent.agent} (${calls})`);
+                        }
+                    }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
                     const effortChip = (typeof s.effort === 'string' && s.effort)

--- a/arckit-paperclip/templates/pages-template.html
+++ b/arckit-paperclip/templates/pages-template.html
@@ -3087,6 +3087,13 @@
                         const total = t.mcp.reduce((sum, m) => sum + (m.count || 0), 0);
                         parts.push(`${total} MCP`);
                     }
+                    if (Array.isArray(t.byAgent)) {
+                        const topAgent = t.byAgent.find(a => a.agent !== 'main');
+                        if (topAgent) {
+                            const calls = (topAgent.toolCalls || 0) + (topAgent.mcpCalls || 0);
+                            parts.push(`top agent: ${topAgent.agent} (${calls})`);
+                        }
+                    }
                     const summary = parts.length > 0 ? parts.join(' · ') : 'no telemetry';
                     const failureMark = s.isFailure ? ' <span style="color:#d4351c">⚠</span>' : '';
                     const effortChip = (typeof s.effort === 'string' && s.effort)

--- a/tests/plugin/telemetry-rollup.test.mjs
+++ b/tests/plugin/telemetry-rollup.test.mjs
@@ -1,0 +1,72 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { resolve } from 'node:path';
+
+const { summariseTelemetry, rollupTelemetry } = await import(
+  resolve('arckit-claude/hooks/telemetry-rollup.mjs')
+);
+
+// hook_duration event helper
+const dur = (tool, ms, agent_type) => ({ kind: 'hook_duration', tool, duration_ms: ms, ...(agent_type ? { agent_type } : {}) });
+// mcp_call event helper
+const mcp = (server, agent_type) => ({ kind: 'mcp_call', server, tool: 't', ...(agent_type ? { agent_type } : {}) });
+
+test('rollup buckets tool durations by agent, main-thread calls under "main"', () => {
+  const events = [
+    dur('Write', 10),                 // main
+    dur('Bash', 20),                  // main
+    dur('WebFetch', 100, 'arckit-research'),
+    dur('WebFetch', 300, 'arckit-research'),
+  ];
+  const r = rollupTelemetry(events);
+  assert.ok(Array.isArray(r.byAgent));
+  const byName = Object.fromEntries(r.byAgent.map((a) => [a.agent, a]));
+  assert.equal(byName.main.toolCalls, 2);
+  assert.equal(byName['arckit-research'].toolCalls, 2);
+  assert.equal(typeof byName['arckit-research'].p95, 'number');
+});
+
+test('rollup attributes mcp calls to the agent that made them', () => {
+  const events = [
+    mcp('govreposcrape', 'arckit-gov-reuse-reader'),
+    mcp('govreposcrape', 'arckit-gov-reuse-reader'),
+    mcp('uk-tenders', 'arckit-tenders-reader'),
+  ];
+  const r = rollupTelemetry(events);
+  const byName = Object.fromEntries(r.byAgent.map((a) => [a.agent, a]));
+  assert.equal(byName['arckit-gov-reuse-reader'].mcpCalls, 2);
+  assert.equal(byName['arckit-tenders-reader'].mcpCalls, 1);
+});
+
+test('rollup preserves the existing top-line fields', () => {
+  const events = [dur('Write', 10), dur('Edit', 30), mcp('govreposcrape', 'arckit-research')];
+  const r = rollupTelemetry(events);
+  assert.equal(r.toolCalls, 2);
+  assert.equal(typeof r.p50, 'number');
+  assert.deepEqual(r.mcp, [{ server: 'govreposcrape', count: 1 }]);
+});
+
+test('rollup omits byAgent when all activity is main-thread only', () => {
+  const r = rollupTelemetry([dur('Write', 10), dur('Bash', 20)]);
+  assert.equal(r.byAgent, undefined);
+});
+
+test('rollup returns null for empty events', () => {
+  assert.equal(rollupTelemetry([]), null);
+});
+
+test('summary includes a by-agent segment when a subagent did work', () => {
+  const events = [
+    dur('Write', 10),
+    dur('WebFetch', 100, 'arckit-research'),
+    dur('WebFetch', 200, 'arckit-research'),
+  ];
+  const s = summariseTelemetry(events);
+  assert.match(s, /by agent/i);
+  assert.match(s, /arckit-research/);
+});
+
+test('summary omits the by-agent segment when only main-thread work', () => {
+  const s = summariseTelemetry([dur('Write', 10), dur('Bash', 20)]);
+  assert.doesNotMatch(s, /by agent/i);
+});


### PR DESCRIPTION
## Summary

Implements the feasible slice of the #522 telemetry-enrichment items. `telemetry.mjs` now stamps `agent_id`/`agent_type` (Claude Code v2.1.145+) onto `hook_duration` and `mcp_call` records when a tool runs **inside a subagent**, so `session-learner.mjs` can break activity down **by agent** — how many tool calls and what p95 latency `arckit-research` (or a reader subagent) spent vs the main thread.

## Re-scope (verified against the hooks reference first)

The tracker's headline goal — reconstruct which orchestrator dispatched which reader/writer — turned out to be **infeasible via hooks**: hook input exposes `agent_id` and `agent_type` but **not** `parent_agent_id` (docs state agent hierarchy isn't exposed). So we attribute work *to* an agent rather than rebuilding the dispatch tree. The other two items needed no code: **item 52** (`tool_parameters`) is already covered by the existing `tool_input` capture, and **item 63** (`OTEL_RESOURCE_ATTRIBUTES`) was documented in #576.

## Changes

- **`telemetry-rollup.mjs`** (new) — pure `summariseTelemetry` / `rollupTelemetry` moved out of `session-learner.mjs` (which executes on import, so the logic wasn't testable in place) and enriched with a `byAgent` breakdown. Unit-tested in `tests/plugin/telemetry-rollup.test.mjs`, wired into the `lint-markdown.yml` `node --test` step.
- **`telemetry.mjs`** — stamps `agent_type`/`agent_id` onto latency/MCP records; main-thread calls omit them.
- **`session-learner.mjs`** — imports the rollup module; `sessions.md` gains a `by agent: …` segment, `docs/telemetry.json` gains `telemetry.byAgent` = `[{ agent, toolCalls, p50?, p95?, mcpCalls }]`.
- **`pages-template.html`** — "Recent Sessions" panel surfaces the busiest subagent (propagated to all mirrors + `.arckit`; gemini copy gitignored). Older `telemetry.json` without `byAgent` renders unchanged (additive/graceful).

## Tests

TDD on the rollup (RED→GREEN). **56/56** plugin unit tests pass; integration smoke-tested end-to-end (agent-tagged events → `sessions.md` by-agent line + `telemetry.json` `byAgent`). markdownlint clean. Converter run propagates only the template mirrors — **0 hook drift**.

Tracker: #522 (items 33 / 52 / 63)

🤖 Generated with [Claude Code](https://claude.com/claude-code)