### PR TITLE
chore: note wardley-lsp is now its own repo in .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,9 +93,13 @@ docs/INVESTOR-REPORT-hero.*
 tests/*/output/
 
 # Local experiments — not part of the published toolkit
-tools/wardley-lsp/
 tests/mermaid-wardley/
 .claude/scheduled_tasks.lock
+
+# tools/wardley-lsp/ is a clone of the separate (private) tractorjuice/wardley-lsp
+# repo (the OnlineWardleyMaps Language Server). Same convention as
+# arckit-consulting below: changes belong in that repo, not here.
+tools/wardley-lsp/
 
 # Ignyte scraper - captured session token (never commit)
 docs/auth.txt


### PR DESCRIPTION
Follow-up to extracting `tools/wardley-lsp/` into the separate private repo **tractorjuice/wardley-lsp** (the OnlineWardleyMaps Language Server).

Updates the `.gitignore` comment so it matches the `arckit-consulting` convention — a clone of a separate repo whose changes belong there — instead of labelling it a "local experiment". The path stays ignored (no behavioural change); this is comment accuracy only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)