### PR TITLE
[codex] fix issue 601 manifest dedupe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.13.2] — 2026-06-17
+
+### Fixed
+
+- **Manifest auto-update tolerates legacy entries without `documentId` (#601).**
+  `hooks/update-manifest.mjs` now deduplicates existing manifest entries by
+  `documentId` when present and falls back to the entry path basename when
+  older `docs/manifest.json` rows omit `documentId`, avoiding non-blocking
+  PostToolUse warnings after `/arckit:principles` writes global artifacts.
+
 ## [5.13.1] — 2026-06-11
 
 ### Changed

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.13.2] — 2026-06-17
+
+### Fixed
+
+- **Manifest auto-update tolerates legacy entries without `documentId` (#601).**
+  `hooks/update-manifest.mjs` now deduplicates existing manifest entries by
+  `documentId` when present and falls back to the entry path basename when
+  older `docs/manifest.json` rows omit `documentId`, avoiding non-blocking
+  PostToolUse warnings after `/arckit:principles` writes global artifacts.
+
 ## [5.13.1] — 2026-06-11
 
 ### Changed

--- a/plugins/arckit-claude/hooks/update-manifest.mjs
+++ b/plugins/arckit-claude/hooks/update-manifest.mjs
@@ -70,7 +70,19 @@ function extractDocId(filename) {
 
 /** Strip version to get base ID for dedup: ARC-001-REQ-v1.0 → ARC-001-REQ */
 function baseId(documentId) {
+  if (typeof documentId !== 'string' || documentId.length === 0) return null;
   return documentId.replace(/-v\d+(\.\d+)?$/, '');
+}
+
+function entryBaseId(entry) {
+  if (!entry || typeof entry !== 'object') return null;
+  if (typeof entry.documentId === 'string' && entry.documentId.length > 0) {
+    return baseId(entry.documentId);
+  }
+  if (typeof entry.path === 'string' && entry.path.length > 0) {
+    return baseId(extractDocId(basename(entry.path)));
+  }
+  return null;
 }
 
 /** Extract first # heading from markdown content */
@@ -153,7 +165,7 @@ if (projectDirName === '000-global') {
   if (!Array.isArray(manifest.global)) manifest.global = [];
 
   // Dedup: remove any existing entry with same base ID
-  manifest.global = manifest.global.filter(e => baseId(e.documentId) !== newBaseId);
+  manifest.global = manifest.global.filter(e => entryBaseId(e) !== newBaseId);
   manifest.global.push(newEntry);
 
   // Update defaultDocument if this is a PRIN doc
@@ -210,7 +222,7 @@ if (targetKey === 'documents') {
 }
 
 // Dedup: remove any existing entry with same base ID
-project[targetKey] = project[targetKey].filter(e => baseId(e.documentId) !== newBaseId);
+project[targetKey] = project[targetKey].filter(e => entryBaseId(e) !== newBaseId);
 project[targetKey].push(newEntry);
 
 // Update timestamp and write

--- a/tests/plugin/test_update_manifest.mjs
+++ b/tests/plugin/test_update_manifest.mjs
@@ -1,0 +1,123 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for plugins/arckit-claude/hooks/update-manifest.mjs.
+ *
+ * Run with: node tests/plugin/test_update_manifest.mjs
+ */
+
+import { closeSync, mkdtempSync, mkdirSync, openSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+const repoRoot = resolve(import.meta.dirname, '..', '..');
+const HOOK = join(repoRoot, 'plugins', 'arckit-claude', 'hooks', 'update-manifest.mjs');
+
+function writePayload(root, filePath, payloadName = 'payload.json') {
+  const payloadPath = join(root, payloadName);
+  writeFileSync(
+    payloadPath,
+    JSON.stringify({
+      cwd: root,
+      tool_name: 'Write',
+      tool_input: {
+        file_path: filePath,
+        content: readFileSync(filePath, 'utf8'),
+      },
+    })
+  );
+  return payloadPath;
+}
+
+function runHook(payloadPath) {
+  const stdin = openSync(payloadPath, 'r');
+  try {
+    const result = spawnSync('node', [HOOK], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      stdio: [stdin, 'pipe', 'pipe'],
+    });
+    assert.equal(result.status, 0, result.stderr);
+    return result.stdout;
+  } finally {
+    closeSync(stdin);
+  }
+}
+
+test('update-manifest tolerates global manifest entries missing documentId', () => {
+  const root = mkdtempSync(join(tmpdir(), 'arckit-manifest-global-'));
+  try {
+    const globalDir = join(root, 'projects', '000-global');
+    const docsDir = join(root, 'docs');
+    mkdirSync(globalDir, { recursive: true });
+    mkdirSync(docsDir, { recursive: true });
+
+    const artifactPath = join(globalDir, 'ARC-000-PRIN-v1.1.md');
+    writeFileSync(artifactPath, '# Principles\n');
+    writeFileSync(
+      join(docsDir, 'manifest.json'),
+      JSON.stringify({
+        generated: '2026-01-01T00:00:00.000Z',
+        global: [
+          {
+            path: 'projects/000-global/ARC-000-PRIN-v1.0.md',
+            title: 'Legacy principles entry',
+          },
+        ],
+        projects: [],
+      })
+    );
+
+    runHook(writePayload(root, artifactPath));
+
+    const manifest = JSON.parse(readFileSync(join(docsDir, 'manifest.json'), 'utf8'));
+    assert.equal(manifest.global.length, 1);
+    assert.equal(manifest.global[0].documentId, 'ARC-000-PRIN-v1.1');
+    assert.equal(manifest.defaultDocument, 'projects/000-global/ARC-000-PRIN-v1.1.md');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('update-manifest tolerates project manifest entries missing documentId', () => {
+  const root = mkdtempSync(join(tmpdir(), 'arckit-manifest-project-'));
+  try {
+    const projectDir = join(root, 'projects', '001-demo');
+    const docsDir = join(root, 'docs');
+    mkdirSync(projectDir, { recursive: true });
+    mkdirSync(docsDir, { recursive: true });
+
+    const artifactPath = join(projectDir, 'ARC-001-REQ-v1.1.md');
+    writeFileSync(artifactPath, '# Requirements\n');
+    writeFileSync(
+      join(docsDir, 'manifest.json'),
+      JSON.stringify({
+        generated: '2026-01-01T00:00:00.000Z',
+        projects: [
+          {
+            id: '001-demo',
+            name: 'Demo',
+            documents: [
+              {
+                path: 'projects/001-demo/ARC-001-REQ-v1.0.md',
+                title: 'Legacy requirements entry',
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    runHook(writePayload(root, artifactPath));
+
+    const manifest = JSON.parse(readFileSync(join(docsDir, 'manifest.json'), 'utf8'));
+    const project = manifest.projects.find(p => p.id === '001-demo');
+    assert.equal(project.documents.length, 1);
+    assert.equal(project.documents[0].documentId, 'ARC-001-REQ-v1.1');
+    assert.equal(project.documents[0].path, 'projects/001-demo/ARC-001-REQ-v1.1.md');
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

Fixes #601 by hardening the Claude `update-manifest.mjs` hook against legacy `docs/manifest.json` entries that omit `documentId`.

## Root Cause

The manifest dedupe path assumed every existing manifest entry had a string `documentId`, then called `.replace()` while computing the base document ID. Older or partial manifest rows can contain only `path` and `title`, which made the PostToolUse Write hook throw after `/arckit:principles` wrote a global artifact.

## Changes

- Guard `baseId()` against missing or non-string values.
- Add `entryBaseId()` so dedupe uses `documentId` when present and falls back to the entry path basename for legacy rows.
- Add Node regression tests for global and project manifest entries missing `documentId`.
- Update root and Claude plugin changelogs for #601.

## Validation

- `node tests/plugin/test_update_manifest.mjs`
- `node tests/plugin/test_hook_utils.mjs`
- `git diff --check HEAD~1 HEAD`