### PR TITLE
[codex] complete OKF documentation coverage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `ARCKIT_OKF_FRONTMATTER=1` or `.arckit/config.json` containing
   `{ "okfFrontmatter": true }`. Stamping is off by default and idempotent.
 
+### Changed
+
+- **OKF documentation coverage.** Updated remaining extension READMEs, getting
+  started docs, guide index, remote-control docs, MCP setup docs, and copied
+  dependency matrices so all current documentation surfaces mention the OKF
+  import/export workflow consistently.
+
 ## [5.14.0] — 2026-06-17
 
 ### Added

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -494,7 +494,7 @@ gemini</code></pre></div>
 [features]
 hooks = true
 plugin_hooks = true</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">Restart Codex, run <code>/plugins</code>, choose <strong>ArcKit Plugins</strong>, then install and enable <strong>ArcKit</strong>. The plugin bundles 120 skills, 10 agent configs, MCP config, templates, schemas, scripts, and <code>hooks/hooks.json</code>.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">Restart Codex, run <code>/plugins</code>, choose <strong>ArcKit Plugins</strong>, then install and enable <strong>ArcKit</strong>. The plugin bundles ArcKit command skills, reference skills, agent configs, MCP config, templates, schemas, scripts, and <code>hooks/hooks.json</code>.</p>
                     <p class="govuk-body govuk-!-margin-top-2">Prefer a project-scoped copy instead? Use <code>arckit init my-project --ai codex</code> from the ArcKit CLI.</p>
                 </div>
 
@@ -591,7 +591,7 @@ uv tool install arckit-cli --from git+https://github.com/tractorjuice/arc-kit.gi
 
 # Initialize project
 arckit init my-project --ai copilot</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">This scaffolds 67 prompt files, 9 research agents, templates, and scripts into your project.</p>
+                    <p class="govuk-body govuk-!-margin-top-3">This scaffolds ArcKit prompt files, research agents, templates, and scripts into your project.</p>
                 </div>
 
                 <div class="app-step">

--- a/docs/guides.html
+++ b/docs/guides.html
@@ -287,7 +287,7 @@
         <div class="govuk-width-container app-page-hero__content">
             <span class="app-page-hero__stat">Enterprise Architecture Playbooks</span>
             <h1 class="app-page-hero__title">ArcKit Guides</h1>
-            <p class="app-page-hero__description">Step-by-step command playbooks for setup, discovery, architecture design, Wardley mapping, procurement, assurance, and community compliance overlays.</p>
+            <p class="app-page-hero__description">Step-by-step command playbooks for setup, discovery, architecture design, Wardley mapping, procurement, assurance, interoperability, and community compliance overlays.</p>
         </div>
     </div>
 
@@ -719,6 +719,19 @@
             </div>
 
             <!-- Integrations -->
+            <div class="app-guide-category">
+                <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
+                    <span class="app-guide-category__toggle">&#9662;</span> Interoperability
+                    <span class="app-guide-category__count">2 guides</span>
+                </h2>
+                <div class="app-guide-category__body">
+                    <ul class="app-guide-list">
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=export-okf" class="govuk-link">Open Knowledge Format Export</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Export ArcKit artifacts as an OKF-compatible Markdown bundle</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=import-okf" class="govuk-link">Open Knowledge Format Import</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Import OKF bundles as reviewable ArcKit research notes</span></li>
+                    </ul>
+                </div>
+            </div>
+
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Integrations

--- a/docs/guides/remote-control.md
+++ b/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 67 ArcKit commands and 9 research agents remain fully available
+- All 75 ArcKit commands and research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync

--- a/extensions/arckit-codex/README.md
+++ b/extensions/arckit-codex/README.md
@@ -36,7 +36,7 @@ That's it -- no environment variables, no config files. Codex auto-discovers ski
 
 This creates a project with:
 
-- `.agents/skills/` -- 120 skills (116 commands + 4 reference skills, auto-discovered by Codex)
+- `.agents/skills/` -- ArcKit command skills plus 4 reference skills, auto-discovered by Codex
 - `.codex/agents/` -- 10 agent configs (research, datascout, gov reuse, grants, cloud providers, framework)
 - `.codex/hooks/` -- ArcKit lifecycle hooks for context injection, secret checks, file guardrails, and MCP approval policy
 - `.codex/config.toml` -- 5 MCP servers, agent roles, and hook wiring
@@ -81,7 +81,7 @@ cp -r /path/to/arckit-codex/skills/* .agents/skills/
 cp -r /path/to/arckit-codex/skills/* ~/.agents/skills/
 ```
 
-This makes all 116 ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
+This makes ArcKit commands available as `$arckit-*` skills plus 4 reference skills.
 
 **Step 2: MCP Servers and Agents**
 
@@ -134,7 +134,7 @@ MCP servers require no API keys except for Google Developer Knowledge (`GOOGLE_A
 
 ## Skills
 
-All 116 commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
+ArcKit commands are available as skills, invoked with `$arckit-<command>` in Codex CLI. Additionally, 4 reference skills provide domain knowledge.
 
 ### Reference Skills
 
@@ -231,6 +231,13 @@ $arckit-story                  # Programme story for governance reporting
 $arckit-customize              # Template customization
 ```
 
+#### OKF Interoperability
+
+```bash
+$arckit-export-okf  # Export ArcKit artifacts as an OKF-compatible Markdown bundle
+$arckit-import-okf  # Import OKF bundles as reviewable research notes
+```
+
 ## Agents (Experimental)
 
 Agents run as autonomous sub-processes to handle research-intensive tasks. They require the Codex multi-agent feature flag to be enabled.
@@ -291,18 +298,18 @@ arckit-codex/
 ├── hooks/
 │   ├── hooks.json         # Codex plugin lifecycle configuration
 │   └── arckit-codex-hook.mjs
-├── skills/                # 120 skills (116 commands + 4 reference)
+├── skills/                # ArcKit command skills + 4 reference skills
 │   ├── arckit-requirements/
 │   │   ├── SKILL.md       # Command prompt with frontmatter
 │   │   └── agents/
 │   │       └── openai.yaml  # allow_implicit_invocation: false
 │   ├── arckit-principles/
-│   ├── ...                # 108 more command skills
+│   ├── ...                # More command skills
 │   ├── architecture-workflow/  # Reference skill
 │   ├── mermaid-syntax/         # Reference skill
 │   ├── plantuml-syntax/        # Reference skill
 │   └── wardley-mapping/        # Reference skill
-├── prompts/               # 116 prompts (deprecated, use skills instead)
+├── prompts/               # Command prompts (deprecated, use skills instead)
 ├── agents/                # 10 agent configs + system prompts
 │   ├── arckit-research.md
 │   ├── arckit-research.toml
@@ -317,7 +324,7 @@ arckit-codex/
 
 ## Version
 
-**Current Release: v4.20.0 (116 commands, 4 reference skills)**
+**Current Release: v5.14.0**
 
 ---
 

--- a/extensions/arckit-codex/docs/DEPENDENCY-MATRIX.md
+++ b/extensions/arckit-codex/docs/DEPENDENCY-MATRIX.md
@@ -357,7 +357,7 @@ principles-compliance → conformance → analyze → service-assessment → sto
 - **Matrix Date**: 2026-02-25
 - **Commands Documented**: 60
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit:customize`, `/arckit:template-builder`, `/arckit:health`, `/arckit:search`, `/arckit:impact`, `/arckit:init`, and `/arckit:start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit:customize`, `/arckit:template-builder`, `/arckit:health`, `/arckit:search`, `/arckit:impact`, `/arckit:navigator`, `/arckit:graph-report`, `/arckit:init`, `/arckit:start`, `/arckit:export-okf`, and `/arckit:import-okf` are utility/interoperability/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
 

--- a/extensions/arckit-copilot/README.md
+++ b/extensions/arckit-copilot/README.md
@@ -1,14 +1,14 @@
 # ArcKit for GitHub Copilot
 
 GitHub Copilot prompt and agent bundle for ArcKit — The Enterprise Architecture
-Governance Harness (strategy, architecture, delivery, and assurance).
+Governance Harness (strategy, architecture, delivery, assurance, and interoperability).
 
 This repository is generated from the main ArcKit source repository:
 https://github.com/tractorjuice/arc-kit
 
 ## What Is Included
 
-- 116 reusable Copilot prompts under `prompts/`
+- Reusable ArcKit Copilot prompts under `prompts/`
 - 10 custom agent definitions under `agents/`
 - Project instructions in `copilot-instructions.md`
 - 112 document templates under `templates/`
@@ -48,7 +48,13 @@ arckit-risk
 arckit-sow
 arckit-evaluate
 arckit-health
+arckit-export-okf
+arckit-import-okf
 ```
+
+## OKF Interoperability
+
+Use `arckit-export-okf` to export ArcKit artifacts as an OKF-compatible Markdown bundle. Use `arckit-import-okf` to import OKF bundles as reviewable ArcKit research notes.
 
 ## Updating
 

--- a/extensions/arckit-copilot/docs/DEPENDENCY-MATRIX.md
+++ b/extensions/arckit-copilot/docs/DEPENDENCY-MATRIX.md
@@ -357,7 +357,7 @@ principles-compliance → conformance → analyze → service-assessment → sto
 - **Matrix Date**: 2026-02-25
 - **Commands Documented**: 60
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit:customize`, `/arckit:template-builder`, `/arckit:health`, `/arckit:search`, `/arckit:impact`, `/arckit:init`, and `/arckit:start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit:customize`, `/arckit:template-builder`, `/arckit:health`, `/arckit:search`, `/arckit:impact`, `/arckit:navigator`, `/arckit:graph-report`, `/arckit:init`, `/arckit:start`, `/arckit:export-okf`, and `/arckit:import-okf` are utility/interoperability/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
 

--- a/extensions/arckit-gemini/GEMINI.md
+++ b/extensions/arckit-gemini/GEMINI.md
@@ -1,6 +1,6 @@
 # ArcKit - Gemini Extension Context
 
-ArcKit is **The Enterprise Architecture Governance Harness**, providing 70 slash commands across strategy, architecture, delivery, and assurance. It transforms architecture governance from scattered documents into a systematic, template-driven process.
+ArcKit is **The Enterprise Architecture Governance Harness**, providing 75 slash commands across strategy, architecture, delivery, assurance, and interoperability. It transforms architecture governance from scattered documents into a systematic, template-driven process.
 
 ## Extension File Locations
 

--- a/extensions/arckit-opencode/README.md
+++ b/extensions/arckit-opencode/README.md
@@ -1,14 +1,14 @@
 # ArcKit for OpenCode
 
-OpenCode extension for ArcKit, an enterprise architecture governance and vendor
-procurement toolkit.
+OpenCode extension for ArcKit, an enterprise architecture governance,
+interoperability, and vendor procurement toolkit.
 
 This repository is generated from the main ArcKit source repository:
 https://github.com/tractorjuice/arc-kit
 
 ## What Is Included
 
-- 116 ArcKit commands under `commands/`
+- ArcKit commands under `commands/`
 - 10 research and specialist agents under `agents/`
 - 112 document templates under `templates/`
 - Handoff schemas and scoring rubrics under `schemas/`
@@ -45,7 +45,13 @@ ArcKit commands are available in OpenCode with `/arckit.<command>`:
 /arckit:sow
 /arckit:evaluate
 /arckit:health
+/arckit:export-okf
+/arckit:import-okf
 ```
+
+## OKF Interoperability
+
+Use `/arckit:export-okf` to export ArcKit artifacts as an OKF-compatible Markdown bundle. Use `/arckit:import-okf` to import OKF bundles as reviewable ArcKit research notes.
 
 ## Updating
 

--- a/extensions/arckit-opencode/docs/DEPENDENCY-MATRIX.md
+++ b/extensions/arckit-opencode/docs/DEPENDENCY-MATRIX.md
@@ -357,7 +357,7 @@ principles-compliance → conformance → analyze → service-assessment → sto
 - **Matrix Date**: 2026-02-25
 - **Commands Documented**: 60
 - **Matrix Rows**: 54 (52 document-generating commands + 2 external documents)
-- **Note**: `/arckit:customize`, `/arckit:template-builder`, `/arckit:health`, `/arckit:search`, `/arckit:impact`, `/arckit:init`, and `/arckit:start` are utility/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
+- **Note**: `/arckit:customize`, `/arckit:template-builder`, `/arckit:health`, `/arckit:search`, `/arckit:impact`, `/arckit:navigator`, `/arckit:graph-report`, `/arckit:init`, `/arckit:start`, `/arckit:export-okf`, and `/arckit:import-okf` are utility/interoperability/diagnostic commands not in the matrix — they have no dependencies and produce no outputs consumed by other commands
 
 ## Changelog
 

--- a/extensions/arckit-paperclip/README.md
+++ b/extensions/arckit-paperclip/README.md
@@ -1,14 +1,14 @@
 # ArcKit for Paperclip
 
-Paperclip plugin for ArcKit, an enterprise architecture governance and vendor
-procurement toolkit.
+Paperclip plugin for ArcKit, an enterprise architecture governance,
+interoperability, and vendor procurement toolkit.
 
 This repository is generated from the main ArcKit source repository:
 https://github.com/tractorjuice/arc-kit
 
 ## What Is Included
 
-- 116 ArcKit command tools from `src/data/commands.json`
+- ArcKit command tools from `src/data/commands.json`
 - 5 utility tools for project setup, document IDs, prerequisites, project lists,
   and plugin health checks
 - 109 document templates under `templates/`
@@ -68,7 +68,13 @@ arckit-risk
 arckit-sow
 arckit-evaluate
 arckit-health
+arckit-export-okf
+arckit-import-okf
 ```
+
+## OKF Interoperability
+
+Use `arckit-export-okf` to export ArcKit artifacts as an OKF-compatible Markdown bundle. Use `arckit-import-okf` to import OKF bundles as reviewable ArcKit research notes.
 
 Utility tools include:
 

--- a/extensions/arckit-vibe/README.md
+++ b/extensions/arckit-vibe/README.md
@@ -121,6 +121,12 @@ vibe /arckit-data-model Design data model for customer management
 
 # Build vs buy analysis
 vibe /arckit-build Analyze build vs buy for authentication system
+
+# OKF export
+vibe /arckit-export-okf --project 001 --out okf/001
+
+# OKF import
+vibe /arckit-import-okf --bundle okf/001 --project 002
 ```
 
 ### Agents
@@ -202,6 +208,13 @@ vibe --agent arckit-gcp-research "Evaluate BigQuery vs Snowflake for analytics"
 | `/arckit-azure-research` | Azure-specific research |
 | `/arckit-gcp-research` | GCP-specific research |
 | `/arckit-gov-code-search` | Government code search |
+
+### Interoperability
+
+| Skill | Description |
+|-------|-------------|
+| `/arckit-export-okf` | Export ArcKit artifacts as an OKF-compatible Markdown bundle |
+| `/arckit-import-okf` | Import OKF bundles as reviewable research notes |
 
 ### Vendor Management
 

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   frontmatter into native ARC artifacts only when explicitly opted in through
   `ARCKIT_OKF_FRONTMATTER=1` or `.arckit/config.json`.
 
+### Changed
+
+- **OKF documentation coverage.** Updated plugin guide references and copied
+  extension documentation so OKF import/export and opt-in frontmatter behavior
+  are consistently discoverable.
+
 ## [5.14.0] — 2026-06-17
 
 ### Added

--- a/plugins/arckit-claude/docs/guides/mcp-servers.md
+++ b/plugins/arckit-claude/docs/guides/mcp-servers.md
@@ -63,8 +63,8 @@ The plugin loads MCP servers and hooks at startup. **A restart is required** aft
 
 After restart, open the plugin manager (`/plugin`) and navigate to **Installed**. You should see:
 
-- **Commands**: 70 slash commands
-- **Agents**: 6 autonomous research agents
+- **Commands**: 75 slash commands
+- **Agents**: Autonomous research and specialist agents
 - **Skills**: 1 (Wardley Mapping)
 - **Hooks**: SessionStart, UserPromptSubmit, PreToolUse, PermissionRequest
 

--- a/plugins/arckit-claude/docs/guides/remote-control.md
+++ b/plugins/arckit-claude/docs/guides/remote-control.md
@@ -17,7 +17,7 @@ The key distinction: **your session never leaves your machine**. Claude Code con
 This means:
 
 - Your `projects/` directory, templates, and generated artifacts stay local
-- All 67 ArcKit commands and 9 research agents remain fully available
+- All 75 ArcKit commands and research agents remain fully available
 - MCP servers for cloud research (AWS, Azure, GCP) keep working
 - Automation hooks (session init, project context injection, filename enforcement) continue to fire
 - You can send messages from terminal, browser, and phone interchangeably — the conversation stays in sync


### PR DESCRIPTION
## Summary

Follow-up documentation pass for the OKF compatibility work merged in #603.

- Adds OKF import/export entries to the static guide index.
- Updates getting-started, remote-control, MCP setup, and copied dependency-matrix docs.
- Updates Codex, Copilot, OpenCode, Paperclip, Gemini, and Vibe extension documentation so OKF commands are discoverable across target formats.
- Removes brittle stale generated-command counts from extension READMEs where generated content is not tracked in this repo.

## Validation

- `git diff --check`
- `npx markdownlint-cli2 "**/*.md"`
