### PR TITLE
[codex] add Self-Harness autoresearch implementation

### DIFF
--- a/docs/guides/autoresearch.md
+++ b/docs/guides/autoresearch.md
@@ -27,6 +27,25 @@ Claude will:
 
 To stop early: interrupt Claude at any time. Otherwise the loop self-terminates on a stop condition (see [Stopping Conditions](#stopping-conditions)). Either way, the worktree has the best prompt.
 
+### Self-Harness enhanced autoresearch
+
+For command, agent, hook, or full harness improvement, use the Self-Harness enhanced program:
+
+```text
+read scripts/autoresearch/program-selfharness.md and optimize the requirements command
+```
+
+The Self-Harness program extends the prompt-only loop with trace collection, verifier-grounded weakness mining, held-in/held-out fixture validation, and modes for improving commands, agents, hooks, or broader harness configuration. It is useful when the failure is not just wording in a command prompt, but the surrounding harness behavior: tool use, runtime setup, hook behavior, verification, or agent instructions.
+
+Common targets:
+
+- `optimize command requirements` - prompt-only command optimization, compatible with the standard loop
+- `optimize command requirements mode:full` - full harness optimization for a command
+- `optimize agent research` - agent definition optimization
+- `optimize hook graph-inject` - hook behavior optimization
+
+See [`scripts/autoresearch/program-selfharness.md`](../../scripts/autoresearch/program-selfharness.md) for the detailed draft workflow.
+
 ### Watching progress without blocking the main session
 
 For long overnight runs, open a second Claude Code session in the worktree directory and ask it to `Monitor` the results log:
@@ -57,6 +76,7 @@ The system adapts autoresearch's ML experiment loop to prompt engineering:
 
 - **autoresearch**: modifies `train.py` to minimise `val_bpb`
 - **ArcKit autoresearch**: modifies a command `.md` file to maximise a quality score
+- **ArcKit Self-Harness**: modifies prompts, agents, hooks, runtime configuration, or verification harnesses, then accepts only changes that generalize across held-in and held-out tasks
 
 ### The Loop
 
@@ -121,7 +141,48 @@ Scoring uses an adversarial reviewer persona to prevent self-evaluation bias.
 
 ---
 
+## Self-Harness Extension
+
+Self-Harness is an enhanced autoresearch mode based on "Self-Harness: Harnesses That Improve Themselves" (Zhang et al., 2026, arXiv:2606.09498v1). The ArcKit draft implementation keeps the original prompt-only workflow intact and adds a broader harness improvement loop for cases where the command prompt is not the only variable.
+
+### What It Adds
+
+- **Multi-dimensional optimization**: can improve command prompts, agent definitions, hook behavior, runtime wiring, and verifier logic depending on the selected mode
+- **Trace collection**: records execution traces under `.arckit/autoresearch-traces/<target>/<mode>/`
+- **Weakness mining**: clusters repeated verifier failures and trace signatures so the next proposal addresses a concrete failure mode
+- **Harness proposals**: uses `harness-proposer.mjs` to generate scoped candidate improvements
+- **Held-in/held-out validation**: requires improvements to hold on the optimization fixtures and not regress on reserved fixtures
+- **Regression validation**: uses `harness-validator.mjs` to reject candidates that overfit or exceed the allowed edit scope
+
+### Execution Modes
+
+| Mode | Typical target | Editable scope |
+|------|----------------|----------------|
+| `prompt` | `command requirements` | One command `.md` file |
+| `full` | `command requirements mode:full` | Command, hooks, templates, runtime, and verification files declared in the run |
+| `agent` | `agent research` | One agent definition |
+| `hook` | `hook graph-inject` | One hook implementation |
+
+Use the standard `program.md` when you want a tight prompt-only optimization. Use `program-selfharness.md` when you need evidence about whether failures come from the prompt, execution harness, supporting tools, or validation layer.
+
+### Acceptance Rule
+
+The Self-Harness loop is intentionally conservative:
+
+1. Score the baseline across held-in and held-out fixtures.
+2. Mine failures from traces and verifier output.
+3. Propose a scoped harness change.
+4. Validate the candidate on held-in fixtures.
+5. Re-run held-out fixtures before accepting.
+6. Keep only changes that improve held-in performance without degrading held-out performance beyond the configured tolerance.
+
+This prevents the loop from optimizing around one fixture while making the command, agent, or hook worse in real use.
+
+---
+
 ## What Gets Modified (and What Doesn't)
+
+For the standard prompt-only loop:
 
 **Editable** (the only variable):
 
@@ -136,6 +197,8 @@ Scoring uses an adversarial reviewer persona to prevent self-evaluation bias.
 - Evaluation rubric
 
 This mirrors autoresearch's design: `prepare.py` is read-only, `train.py` is the only file modified.
+
+For Self-Harness runs, the editable scope depends on the selected mode and is declared at setup time in `program-selfharness.md`. Keep that scope narrow for each run. A full harness run can touch more than one file, but it should still treat fixtures, scoring standards, and held-out tasks as read-only controls.
 
 ---
 
@@ -224,6 +287,7 @@ Not suitable:
 ```text
 scripts/autoresearch/
   program.md              # The instruction file Claude follows
+  program-selfharness.md  # Self-Harness enhanced instruction file
   fixtures/
     000-global/
       ARC-000-PRIN-v1.0.md    # Architecture principles (6 principles)
@@ -233,6 +297,19 @@ scripts/autoresearch/
 ```
 
 The experiment runs in a **git worktree** (`../autoresearch-<command>`), keeping the main checkout clean. The scratch project, results TSV, and all experiment commits live in the worktree. The branch tip (the improved command `.md`) is the deliverable.
+
+Self-Harness runs also use trace and candidate outputs:
+
+```text
+.arckit/autoresearch-traces/
+  <target>/
+    <mode>/
+      iteration-N.json
+
+scripts/autoresearch/runs/
+  <target>/
+    results.tsv
+```
 
 ---
 

--- a/plugins/arckit-claude/hooks/autoresearch-tracer.mjs
+++ b/plugins/arckit-claude/hooks/autoresearch-tracer.mjs
@@ -1,0 +1,173 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Autoresearch Trace Collector
+ * 
+ * Captures detailed execution traces for Self-Harness analysis.
+ * Based on: "Self-Harness: Harnesses That Improve Themselves" (Zhang et al., 2026, arXiv:2606.09498v1)
+ * 
+ * This hook collects execution traces that enable verifier-grounded weakness mining
+ * as described in Zhang et al. (2026, Section 3.2).
+ * 
+ * Hook Type: UserPromptSubmit / PostToolUse (observational)
+ * Input: JSON with execution data
+ * Output: JSON with trace data (stored to file, not returned)
+ */
+
+import { writeFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Capture execution trace for autoresearch Self-Harness analysis
+ * 
+ * @param {Object} input - Execution data
+ * @param {string} input.command - Command/agent/hook being optimized
+ * @param {number} input.iteration - Current iteration number
+ * @param {string} input.mode - Optimization mode (prompt, full, agent, hook)
+ * @param {Array} input.toolCalls - Array of tool calls made
+ * @param {number} input.tokenCount - Total tokens used
+ * @param {number} input.durationMs - Execution duration in ms
+ * @param {Array} input.artifacts - Artifacts created during execution
+ * @param {Object} input.verifier - Verifier output
+ * @param {string} input.output - Final output
+ * @param {Object} input.environment - Environment info (model, effort)
+ * @returns {Object} The trace object
+ */
+export function captureAutoresearchTrace(input) {
+  const trace = {
+    iteration: input.iteration || 0,
+    target: input.target || input.command || 'unknown',
+    mode: input.mode || 'prompt',
+    timestamp: new Date().toISOString(),
+    environment: {
+      model: input.environment?.model || process.env.CLAUDE_MODEL || 'unknown',
+      effort: input.environment?.effort || process.env.CLAUDE_EFFORT || 'unknown'
+    },
+    execution: {
+      toolCalls: input.toolCalls || [],
+      tokenCount: input.tokenCount || 0,
+      durationMs: input.durationMs || 0,
+      artifactsCreated: input.artifacts || [],
+      errors: input.errors || []
+    },
+    output: input.output || '',
+    verifier: input.verifier || {},
+    metadata: {
+      traceId: `iter-${input.iteration || 0}`,
+      worktree: process.env.AUTORESEARCH_WORTREE || process.cwd(),
+      gitCommit: getGitCommit()
+    }
+  };
+
+  // Save trace to file
+  saveTrace(trace);
+
+  return trace;
+}
+
+/**
+ * Get current git commit hash (short)
+ */
+function getGitCommit() {
+  try {
+    const { execSync } = require('node:child_process');
+    return execSync('git rev-parse --short HEAD', { encoding: 'utf8' }).trim();
+  } catch {
+    return 'unknown';
+  }
+}
+
+/**
+ * Save trace to file in .arckit/autoresearch-traces/
+ */
+function saveTrace(trace) {
+  try {
+    const target = trace.target;
+    const mode = trace.mode;
+    const iteration = trace.iteration;
+    
+    const tracesDir = join('.arckit', 'autoresearch-traces', target, mode);
+    const tracePath = join(tracesDir, `iteration-${String(iteration).padStart(3, '0')}.json`);
+
+    if (!existsSync(tracesDir)) {
+      mkdirSync(tracesDir, { recursive: true });
+    }
+
+    writeFileSync(tracePath, JSON.stringify(trace, null, 2));
+    
+    // Also log to stderr for visibility
+    process.stderr.write(`[ArcKit-SelfHarness] Trace saved: ${tracePath}\n`);
+  } catch (error) {
+    process.stderr.write(`[ArcKit-SelfHarness] Error saving trace: ${error.message}\n`);
+  }
+}
+
+/**
+ * Format trace for display in terminal
+ */
+export function formatTraceSummary(trace) {
+  const toolSummary = trace.execution.toolCalls
+    .map(tc => `${tc.name}(${tc.path || tc.query || tc.command || ''})`)
+    .join(', ');
+  
+  return `
+Trace Summary (iter ${trace.iteration}):
+  Target: ${trace.target} (mode: ${trace.mode})
+  Model: ${trace.environment.model}, Effort: ${trace.environment.effort}
+  Duration: ${trace.execution.durationMs}ms
+  Tokens: ${trace.execution.tokenCount}
+  Tools: ${toolSummary || 'none'}
+  Artifacts: ${trace.execution.artifactsCreated.length}
+  Verifier: ${trace.verifier.passed ? 'PASSED' : 'FAILED'}
+  Commit: ${trace.metadata.gitCommit}
+`.trim();
+}
+
+/**
+ * Load all traces for a target and mode
+ */
+export function loadAllTraces(target, mode) {
+  const tracesDir = join('.arckit', 'autoresearch-traces', target, mode);
+  
+  if (!existsSync(tracesDir)) {
+    return [];
+  }
+
+  const { readdirSync } = require('node:fs');
+  const files = readdirSync(tracesDir).filter(f => f.endsWith('.json'));
+  
+  return files.map(file => {
+    try {
+      const { readFileSync } = require('node:fs');
+      return JSON.parse(readFileSync(join(tracesDir, file), 'utf8'));
+    } catch {
+      return null;
+    }
+  }).filter(Boolean);
+}
+
+/**
+ * Main entry point for hook execution
+ * Reads from stdin, processes, saves trace
+ */
+function main() {
+  let input;
+  try {
+    input = JSON.parse(require('node:fs').readFileSync(0, 'utf8'));
+  } catch {
+    // No input, exit silently
+    return;
+  }
+
+  const trace = captureAutoresearchTrace(input);
+  console.log(JSON.stringify({ traceSaved: true, traceId: trace.metadata.traceId }));
+}
+
+// Run if executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export default captureAutoresearchTrace;

--- a/plugins/arckit-claude/hooks/harness-proposer.mjs
+++ b/plugins/arckit-claude/hooks/harness-proposer.mjs
@@ -1,0 +1,765 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Self-Harness Harness Proposer
+ * 
+ * Implements diverse, minimal candidate harness modification generation
+ * Based on: "Self-Harness: Harnesses That Improve Themselves" (Zhang et al., 2026, arXiv:2606.09498v1)
+ * 
+ * Specifically implements Section 3.3: Harness Proposal from the Self-Harness paper.
+ * Generates diverse yet minimal harness modifications tied to identified failure mechanisms.
+ * 
+ * Key principles from Zhang et al. (2026, Section 3.3):
+ * - Diversity: Candidates must be materially distinct
+ * - Minimality: Each edit modifies only the surface needed
+ * - Grounded: Each proposal tied to a specific failure mechanism
+ * - Addressable: Only propose changes for addressable surfaces
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname, basename } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Generate harness improvement proposals
+ * 
+ * @param {Object} options - Proposal options
+ * @param {string} options.command - Target command/agent/hook
+ * @param {string} options.mode - Optimization mode (prompt, full, agent, hook)
+ * @param {Array} options.clusters - Top failure clusters from weakness miner
+ * @param {number} options.numCandidates - Number of candidates to generate (default: 3)
+ * @param {string} options.currentHarnessPath - Path to current harness file
+ * @param {Object} options.resultsHistory - Previous results for context
+ * @returns {Array} Array of proposal objects
+ */
+export function generateProposals(options) {
+  const {
+    command,
+    mode = 'prompt',
+    clusters = [],
+    numCandidates = 3,
+    currentHarnessPath,
+    resultsHistory = {}
+  } = options;
+  
+  const proposals = [];
+  const usedClusters = new Set();
+  const usedSurfaces = new Set();
+  const usedMechanisms = new Set();
+  
+  // Sort clusters by frequency (descending)
+  const sortedClusters = [...clusters].sort((a, b) => b.count - a.count);
+  
+  // Generate candidates
+  for (let i = 0; i < numCandidates && i < sortedClusters.length; i++) {
+    const cluster = sortedClusters[i];
+    
+    // Track diversity constraints
+    if (usedClusters.has(cluster.id) || 
+        usedMechanisms.has(cluster.signature.mechanism)) {
+      continue;
+    }
+    
+    // Select an addressable surface for this cluster
+    const surface = selectSurface(cluster, usedSurfaces);
+    if (!surface) continue;
+    
+    // Generate proposal based on cluster and surface
+    const proposal = generateProposalForCluster(cluster, surface, mode, currentHarnessPath, resultsHistory);
+    
+    if (proposal) {
+      proposals.push(proposal);
+      usedClusters.add(cluster.id);
+      usedSurfaces.add(surface);
+      usedMechanisms.add(cluster.signature.mechanism);
+    }
+  }
+  
+  // If we don't have enough candidates, generate from history
+  while (proposals.length < numCandidates) {
+    const historicalProposal = generateFromHistory(resultsHistory, mode, usedSurfaces, usedMechanisms);
+    if (historicalProposal) {
+      proposals.push(historicalProposal);
+      usedSurfaces.add(historicalProposal.surface);
+      usedMechanisms.add(historicalProposal.cluster?.signature?.mechanism || 'unknown');
+    } else {
+      break;
+    }
+  }
+  
+  return proposals;
+}
+
+/**
+ * Select best surface for a cluster
+ */
+function selectSurface(cluster, usedSurfaces) {
+  const { addressableSurfaces = [] } = cluster;
+  
+  // Filter out already used surfaces
+  const availableSurfaces = addressableSurfaces.filter(s => !usedSurfaces.has(s));
+  
+  if (availableSurfaces.length === 0) {
+    // Try any surface if all used
+    return addressableSurfaces[0];
+  }
+  
+  // Prefer surfaces that are most addressable for this cluster
+  // Order: prompt > context_injection > runtime_policy > verification_rules > templates
+  const surfacePriority = {
+    'prompt': 0,
+    'context_injection': 1,
+    'bootstrap_instruction': 1,
+    'runtime_policy': 2,
+    'tool_restrictions': 2,
+    'verification_rules': 3,
+    'templates': 4
+  };
+  
+  availableSurfaces.sort((a, b) => 
+    (surfacePriority[a] || 999) - (surfacePriority[b] || 999)
+  );
+  
+  return availableSurfaces[0];
+}
+
+/**
+ * Generate a proposal for a specific cluster and surface
+ */
+function generateProposalForCluster(cluster, surface, mode, currentHarnessPath, resultsHistory) {
+  const { signature, count, frequency, severity } = cluster;
+  const { verifierCause, agentBehavior, mechanism } = signature;
+  
+  // Read current harness
+  let currentContent = '';
+  if (currentHarnessPath && existsSync(currentHarnessPath)) {
+    currentContent = readFileSync(currentHarnessPath, 'utf8');
+  }
+  
+  // Generate proposal based on surface and mechanism
+  const proposal = {
+    id: `prop-${Date.now()}-${Math.random().toString(36).substr(2, 4)}`,
+    cluster: {
+      id: cluster.id,
+      count,
+      frequency,
+      severity,
+      signature
+    },
+    surface,
+    mechanism,
+    description: '',
+    changes: [],
+    expectedImpact: '',
+    risk: '',
+    mode
+  };
+  
+  // Generate surface-specific proposal
+  switch (surface) {
+    case 'prompt':
+      generatePromptProposal(proposal, currentContent, verifierCause, mechanism);
+      break;
+    case 'context_injection':
+      generateContextProposal(proposal, currentContent, mechanism);
+      break;
+    case 'bootstrap_instruction':
+      generateBootstrapProposal(proposal, currentContent, mechanism);
+      break;
+    case 'runtime_policy':
+      generateRuntimeProposal(proposal, currentContent, mechanism);
+      break;
+    case 'tool_restrictions':
+      generateToolProposal(proposal, currentContent, mechanism);
+      break;
+    case 'verification_rules':
+      generateVerificationProposal(proposal, currentContent, mechanism);
+      break;
+    case 'templates':
+      generateTemplateProposal(proposal, currentContent, mechanism);
+      break;
+    default:
+      return null; // Unknown surface
+  }
+  
+  // Apply mode-specific adjustments
+  applyModeAdjustments(proposal, mode, currentHarnessPath);
+  
+  return proposal;
+}
+
+/**
+ * Generate prompt modification proposal
+ */
+function generatePromptProposal(proposal, currentContent, verifierCause, mechanism) {
+  const { cluster } = proposal;
+  
+  // Analyze current prompt
+  const hasCrossRefs = currentContent.includes('cross-reference') || 
+                       currentContent.includes('ARC-') ||
+                       currentContent.includes('BR-') ||
+                       currentContent.includes('FR-');
+  
+  const hasExamples = currentContent.includes('Example:') || 
+                      currentContent.includes('For example');
+  
+  const hasContext = currentContent.includes('project') || 
+                     currentContent.includes('context');
+  
+  // Generate based on mechanism
+  switch (mechanism) {
+    case 'missing_guidance':
+      if (!hasCrossRefs) {
+        proposal.description = 'Add explicit cross-reference requirements';
+        proposal.changes = [{
+          type: 'add',
+          location: 'end of instructions',
+          content: 'ALWAYS include at least 3 cross-references to other artifacts (use format: See [ARC-XXX-TYPE-v1.0] for details)'
+        }];
+        proposal.expectedImpact = 'Improve traceability score by 0.5-1.0';
+        proposal.risk = 'Low';
+      } else {
+        proposal.description = 'Strengthen cross-reference guidance';
+        proposal.changes = [{
+          type: 'modify',
+          pattern: 'cross-reference',
+          replacement: 'cross-reference to at least 3 other artifacts in this project'
+        }];
+        proposal.expectedImpact = 'Improve traceability score by 0.3-0.5';
+        proposal.risk = 'Low';
+      }
+      break;
+    
+    case 'insufficient_context':
+      if (!hasContext) {
+        proposal.description = 'Add project context injection requirement';
+        proposal.changes = [{
+          type: 'add',
+          location: 'beginning of instructions',
+          content: 'BEGIN by reading all existing project artifacts to establish context. Reference specific project details in your output.'
+        }];
+        proposal.expectedImpact = 'Improve specificity score by 0.5-1.0';
+        proposal.risk = 'Low';
+      } else {
+        proposal.description = 'Strengthen context requirements';
+        proposal.changes = [{
+          type: 'add',
+          location: 'beginning of instructions',
+          content: 'For every section, include at least one specific reference to existing project artifacts or requirements.'
+        }];
+        proposal.expectedImpact = 'Improve specificity and traceability scores';
+        proposal.risk = 'Low';
+      }
+      break;
+    
+    case 'cross_ref_missing':
+      proposal.description = 'Add cross-reference reminder in each section header';
+      proposal.changes = [{
+        type: 'add',
+        location: 'section template',
+        content: '## {Section Name}\n\n[Cross-reference: Add links to related artifacts here]'
+      }];
+      proposal.expectedImpact = 'Ensure all sections have cross-references';
+      proposal.risk = 'Low';
+      break;
+    
+    case 'format_violation':
+      proposal.description = 'Add explicit format requirements';
+      proposal.changes = [{
+        type: 'add',
+        location: 'instructions',
+        content: 'FORMAT REQUIREMENTS:\n- Document ID must follow ARC-NNN-TYPE-vX.Y pattern\n- All tables must have headers\n- Use Markdown lists for enumerations'
+      }];
+      proposal.expectedImpact = 'Reduce structural failures';
+      proposal.risk = 'Low';
+      break;
+    
+    case 'generic_output':
+      proposal.description = 'Ban generic placeholder text';
+      proposal.changes = [{
+        type: 'add',
+        location: 'instructions',
+        content: 'NEVER use placeholder text like "TBD", "TODO", "example", or "sample". All content must be project-specific.'
+      }];
+      proposal.expectedImpact = 'Improve specificity and completeness scores';
+      proposal.risk = 'Low';
+      break;
+    
+    default:
+      // Generic prompt improvement
+      proposal.description = 'Add completeness checklist';
+      proposal.changes = [{
+        type: 'add',
+        location: 'end of instructions',
+        content: 'BEFORE FINALIZING:\n- [ ] All required sections are present\n- [ ] All cross-references are correct\n- [ ] Document Control table is complete\n- [ ] No placeholder text remains'
+      }];
+      proposal.expectedImpact = 'Improve completeness and reduce errors';
+      proposal.risk = 'Low';
+  }
+}
+
+/**
+ * Generate context injection proposal
+ */
+function generateContextProposal(proposal, currentContent, mechanism) {
+  proposal.description = 'Add automated context injection';
+  
+  switch (mechanism) {
+    case 'insufficient_context':
+      proposal.changes = [{
+        type: 'add',
+        location: 'bootstrap',
+        content: 'Auto-inject project context: Read all ARC-* files from projects/{project}/ before generating output'
+      }];
+      proposal.expectedImpact = 'Improve specificity by providing more context';
+      break;
+    case 'cross_ref_missing':
+      proposal.changes = [{
+        type: 'add',
+        location: 'bootstrap',
+        content: 'Auto-inject cross-reference context: Provide list of all existing artifacts with their IDs'
+      }];
+      proposal.expectedImpact = 'Improve traceability by making references available';
+      break;
+    default:
+      proposal.changes = [{
+        type: 'add',
+        location: 'bootstrap',
+        content: 'Auto-inject: Project principles, stakeholder analysis, existing requirements'
+      }];
+      proposal.expectedImpact = 'Improve project-specific output';
+  }
+  
+  proposal.risk = 'Low';
+}
+
+/**
+ * Generate bootstrap instruction proposal
+ */
+function generateBootstrapProposal(proposal, currentContent, mechanism) {
+  proposal.description = 'Modify bootstrap instruction';
+  
+  switch (mechanism) {
+    case 'early_termination':
+      proposal.changes = [{
+        type: 'modify',
+        location: 'bootstrap_instruction',
+        current: 'Start by inspecting the workspace',
+        replacement: 'Start by identifying ALL required output artifacts and create initial versions early'
+      }];
+      proposal.expectedImpact = 'Prevent early termination by setting expectations';
+      break;
+    case 'insufficient_exploration':
+      proposal.changes = [{
+        type: 'modify',
+        location: 'bootstrap_instruction',
+        current: 'Start by inspecting the workspace',
+        replacement: 'Start by thoroughly exploring all relevant project artifacts and external resources'
+      }];
+      proposal.expectedImpact = 'Encourage more complete exploration';
+      break;
+    default:
+      proposal.changes = [{
+        type: 'add',
+        location: 'bootstrap_instruction',
+        content: 'Identify the smallest relevant edit surface for this task'
+      }];
+      proposal.expectedImpact = 'Improve focus and efficiency';
+  }
+  
+  proposal.risk = 'Low';
+}
+
+/**
+ * Generate runtime policy proposal
+ */
+function generateRuntimeProposal(proposal, currentContent, mechanism) {
+  proposal.description = 'Modify runtime policy';
+  
+  switch (mechanism) {
+    case 'unbounded_exploration':
+    case 'excessive_tool_use':
+      proposal.changes = [{
+        type: 'add',
+        location: 'runtime_policy',
+        content: 'max_total_tool_messages: 15'
+      }];
+      proposal.expectedImpact = 'Prevent runaway tool use and timeouts';
+      proposal.risk = 'Low';
+      break;
+    case 'repetitive_actions':
+      proposal.changes = [{
+        type: 'add',
+        location: 'runtime_policy',
+        content: 'max_recent_tool_errors: 3'
+      }];
+      proposal.expectedImpact = 'Prevent repetitive failed actions';
+      proposal.risk = 'Low';
+      break;
+    default:
+      proposal.changes = [{
+        type: 'add',
+        location: 'runtime_policy',
+        content: 'enabled: true'
+      }];
+      proposal.expectedImpact = 'Enable basic runtime constraints';
+      proposal.risk = 'Low';
+  }
+}
+
+/**
+ * Generate tool restrictions proposal
+ */
+function generateToolProposal(proposal, currentContent, mechanism) {
+  proposal.description = 'Modify tool configuration';
+  
+  switch (mechanism) {
+    case 'wrong_tool_selection':
+      proposal.changes = [{
+        type: 'restrict',
+        tools: ['Bash', 'WebSearch'],
+        action: 'require_justification',
+        content: 'Before using Bash or WebSearch, explain why it is necessary'
+      }];
+      proposal.expectedImpact = 'Reduce incorrect tool usage';
+      break;
+    case 'execution_error':
+      proposal.changes = [{
+        type: 'disable',
+        tools: ['Bash'],
+        content: 'Disable Bash tool for this command'
+      }];
+      proposal.expectedImpact = 'Prevent dangerous operations';
+      proposal.risk = 'Medium - may limit functionality';
+      break;
+    default:
+      proposal.changes = [{
+        type: 'add',
+        tools: ['WebSearch'],
+        content: 'Enable WebSearch for external research'
+      }];
+      proposal.expectedImpact = 'Enable additional research capabilities';
+  }
+  
+  if (!proposal.risk) proposal.risk = 'Low';
+}
+
+/**
+ * Generate verification rules proposal
+ */
+function generateVerificationProposal(proposal, currentContent, mechanism) {
+  proposal.description = 'Add/strengthen verification rules';
+  
+  switch (mechanism) {
+    case 'format_violation':
+    case 'invalid_id_format':
+      proposal.changes = [{
+        type: 'add',
+        rule: 'id_format_check',
+        content: 'Verify Document ID matches ARC-NNN-TYPE-vX.Y pattern'
+      }];
+      proposal.expectedImpact = 'Catch format violations early';
+      break;
+    case 'missing_sections':
+      proposal.changes = [{
+        type: 'add',
+        rule: 'section_completeness',
+        content: 'Verify all template sections are present and non-empty'
+      }];
+      proposal.expectedImpact = 'Ensure complete documents';
+      break;
+    default:
+      proposal.changes = [{
+        type: 'add',
+        rule: 'cross_reference_check',
+        content: 'Verify at least 3 cross-references to other artifacts'
+      }];
+      proposal.expectedImpact = 'Improve traceability';
+  }
+  
+  proposal.risk = 'Low';
+}
+
+/**
+ * Generate template proposal
+ */
+function generateTemplateProposal(proposal, currentContent, mechanism) {
+  proposal.description = 'Modify template';
+  
+  switch (mechanism) {
+    case 'missing_guidance':
+      proposal.changes = [{
+        type: 'add',
+        location: 'section headers',
+        content: 'Add guidance text to each section header'
+      }];
+      proposal.expectedImpact = 'Provide clearer section expectations';
+      break;
+    case 'cross_ref_missing':
+      proposal.changes = [{
+        type: 'add',
+        location: 'all sections',
+        content: 'Add "Related Artifacts:" field to each section'
+      }];
+      proposal.expectedImpact = 'Encourage cross-referencing';
+      break;
+    default:
+      proposal.changes = [{
+        type: 'add',
+        location: 'header',
+        content: 'Add explicit cross-reference requirements'
+      }];
+      proposal.expectedImpact = 'Clarify expectations';
+  }
+  
+  proposal.risk = 'Low';
+}
+
+/**
+ * Apply mode-specific adjustments
+ */
+function applyModeAdjustments(proposal, mode, currentHarnessPath) {
+  switch (mode) {
+    case 'agent':
+      // For agent mode, proposals affect agent definition
+      proposal.targetFile = `plugins/arckit-claude/agents/${proposal.cluster?.target || 'agent'}.md`;
+      break;
+    case 'hook':
+      // For hook mode, proposals affect hook file
+      const hookName = basename(currentHarnessPath, '.mjs');
+      proposal.targetFile = `plugins/arckit-claude/hooks/${hookName}.mjs`;
+      break;
+    case 'full':
+      // For full mode, determine which file to modify
+      proposal.targetFile = determineTargetFile(proposal.surface, currentHarnessPath);
+      break;
+    default:
+      // Prompt mode - default
+      proposal.targetFile = currentHarnessPath;
+  }
+}
+
+/**
+ * Determine which file to modify for full mode
+ */
+function determineTargetFile(surface, currentHarnessPath) {
+  const surfaceToFile = {
+    'prompt': currentHarnessPath,
+    'context_injection': 'hooks/arckit-context.mjs',
+    'bootstrap_instruction': 'commands/bootstrap.md',
+    'runtime_policy': 'hooks/runtime-policy.mjs',
+    'tool_restrictions': '.mcp.json',
+    'verification_rules': 'hooks/verification-rules.mjs',
+    'templates': 'templates/standard-template.md'
+  };
+  
+  return surfaceToFile[surface] || currentHarnessPath;
+}
+
+/**
+ * Generate proposal from results history
+ */
+function generateFromHistory(resultsHistory, mode, usedSurfaces, usedMechanisms) {
+  const history = Object.values(resultsHistory);
+  
+  // Find near-misses (discards with high scores)
+  const nearMisses = history.filter(h => 
+    h.status === 'discard' && 
+    h.score > 8.0 &&
+    !usedMechanisms.has(h.cluster?.signature?.mechanism)
+  );
+  
+  if (nearMisses.length > 0) {
+    // Pick highest-scoring near-miss
+    nearMisses.sort((a, b) => b.score - a.score);
+    const nearMiss = nearMisses[0];
+    
+    return {
+      id: `hist-${Date.now()}`,
+      cluster: nearMiss.cluster,
+      surface: nearMiss.surface || 'prompt',
+      mechanism: nearMiss.cluster?.signature?.mechanism || 'unknown',
+      description: `Retry near-miss: ${nearMiss.description}`,
+      changes: nearMiss.changes || [],
+      expectedImpact: `Potential improvement based on previous score of ${nearMiss.score}`,
+      risk: 'Low - previously tested',
+      mode,
+      targetFile: nearMiss.targetFile,
+      isHistorical: true
+    };
+  }
+  
+  return null;
+}
+
+/**
+ * Format proposal for display
+ */
+export function formatProposal(proposal, index) {
+  return `
+Proposal #${index + 1}: ${proposal.id}
+  Cluster: ${proposal.cluster?.id} (${proposal.cluster?.signature?.mechanism})
+  Surface: ${proposal.surface}
+  Description: ${proposal.description}
+  Target File: ${proposal.targetFile || 'N/A'}
+  Expected Impact: ${proposal.expectedImpact}
+  Risk: ${proposal.risk}
+  Changes: ${proposal.changes.length} modification(s)
+`.trim();
+}
+
+/**
+ * Apply a proposal to a harness file
+ */
+export function applyProposal(proposal, harnessPath) {
+  if (!existsSync(harnessPath)) {
+    throw new Error(`Harness file not found: ${harnessPath}`);
+  }
+  
+  let content = readFileSync(harnessPath, 'utf8');
+  const originalContent = content;
+  
+  // Apply changes in order
+  for (const change of proposal.changes) {
+    content = applyChange(content, change);
+  }
+  
+  // Write modified content
+  writeFileSync(harnessPath, content);
+  
+  return {
+    originalContent,
+    modifiedContent: content,
+    changesApplied: proposal.changes.length
+  };
+}
+
+/**
+ * Apply a single change to content
+ */
+function applyChange(content, change) {
+  switch (change.type) {
+    case 'add':
+      // Add at specific location
+      if (change.location === 'beginning') {
+        return change.content + '\n\n' + content;
+      } else if (change.location === 'end') {
+        return content + '\n\n' + change.content;
+      } else if (change.location.includes('of')) {
+        // Insert at section
+        const section = change.location.split(' of ')[0];
+        const afterPattern = new RegExp(`(#{1,3}\\s+${section}[\\s\\S]*?)\\n\\n`);
+        const match = content.match(afterPattern);
+        if (match) {
+          const before = content.substring(0, match.index + match[0].length);
+          const after = content.substring(match.index + match[0].length);
+          return before + change.content + '\n\n' + after;
+        }
+      }
+      // Default: append
+      return content + '\n\n' + change.content;
+    
+    case 'modify':
+      // Replace pattern
+      if (change.pattern) {
+        const regex = new RegExp(change.pattern, 'i');
+        return content.replace(regex, change.replacement);
+      }
+      // Replace current with replacement
+      if (change.current) {
+        return content.replace(change.current, change.replacement);
+      }
+      return content;
+    
+    case 'remove':
+      // Remove pattern
+      if (change.pattern) {
+        const regex = new RegExp(change.pattern, 'i');
+        return content.replace(regex, '');
+      }
+      return content;
+    
+    case 'restrict':
+    case 'disable':
+    case 'add_tool':
+      // Tool configuration changes
+      return modifyToolConfig(content, change);
+    
+    default:
+      return content;
+  }
+}
+
+/**
+ * Modify tool configuration in .mcp.json or similar
+ */
+function modifyToolConfig(content, change) {
+  try {
+    const config = JSON.parse(content);
+    
+    switch (change.type) {
+      case 'disable':
+        if (config.mcpServers) {
+          config.mcpServers = config.mcpServers.filter(s => 
+            !change.tools.includes(s));
+        }
+        break;
+      case 'add_tool':
+        if (config.mcpServers) {
+          change.tools.forEach(t => {
+            if (!config.mcpServers.includes(t)) {
+              config.mcpServers.push(t);
+            }
+          });
+        }
+        break;
+    }
+    
+    return JSON.stringify(config, null, 2);
+  } catch {
+    return content; // Not JSON, return unchanged
+  }
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length < 2) {
+    console.log('Usage: node harness-proposer.mjs <options.json> [numCandidates]');
+    console.log('  options.json: {"command": "...", "mode": "...", "clusters": [...], "currentHarnessPath": "..."}');
+    process.exit(1);
+  }
+  
+  const optionsPath = args[0];
+  const numCandidates = args[1] ? parseInt(args[1]) : 3;
+  
+  try {
+    const options = JSON.parse(readFileSync(optionsPath, 'utf8'));
+    options.numCandidates = numCandidates;
+    
+    const proposals = generateProposals(options);
+    
+    console.log(JSON.stringify(proposals, null, 2));
+    
+    // Also print summary
+    console.error(`\nGenerated ${proposals.length} proposals:\n`);
+    proposals.forEach((p, i) => {
+      console.error(formatProposal(p, i));
+      console.error('');
+    });
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export default generateProposals;

--- a/plugins/arckit-claude/hooks/harness-validator.mjs
+++ b/plugins/arckit-claude/hooks/harness-validator.mjs
@@ -1,0 +1,348 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Self-Harness Harness Validator
+ * 
+ * Implements the Proposal Validation stage from Zhang et al. (2026, Section 3.4)
+ * Based on: "Self-Harness: Harnesses That Improve Themselves" (arXiv:2606.09498v1)
+ * 
+ * Key concept from Zhang et al. (2026, Algorithm 1):
+ * A candidate harness edit is accepted only if it improves at least one split
+ * without degrading the other:
+ *   Δ_in(j) ≥ 0 AND Δ_out(j) ≥ 0 AND max(Δ_in(j), Δ_out(j)) > 0
+ * 
+ * This module runs regression tests on held-out tasks to ensure robust improvement.
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Validate a harness candidate using held-in/held-out testing
+ * Implements the conservative acceptance rule from Zhang et al. (2026, Algorithm 1)
+ * 
+ * @param {Object} options - Validation options
+ * @param {string} options.command - Command/agent/hook being optimized
+ * @param {string} options.mode - Optimization mode
+ * @param {Array} options.heldInTasks - Held-in task IDs
+ * @param {Array} options.heldOutTasks - Held-out task IDs
+ * @param {string} options.candidateHarnessPath - Path to candidate harness
+ * @param {Object} options.baselineScores - Baseline scores {heldIn: X.X, heldOut: Y.Y}
+ * @param {number} options.minDelta - Minimum delta for acceptance (default: 0.3)
+ * @returns {Object} Validation result
+ */
+export function validateHarness(options) {
+  const {
+    command,
+    mode = 'prompt',
+    heldInTasks = [],
+    heldOutTasks = [],
+    candidateHarnessPath,
+    baselineScores = { heldIn: 0, heldOut: 0 },
+    minDelta = 0.3,
+    iteration
+  } = options;
+  
+  const result = {
+    iteration,
+    command,
+    mode,
+    timestamp: new Date().toISOString(),
+    baselineScores,
+    candidateScores: { heldIn: 0, heldOut: 0 },
+    deltas: { heldIn: 0, heldOut: 0 },
+    accepted: false,
+    reason: '',
+    heldInResults: [],
+    heldOutResults: []
+  };
+  
+  // Validate held-in tasks
+  const heldInResults = [];
+  for (const task of heldInTasks) {
+    const taskResult = executeAndScoreTask(task, candidateHarnessPath, mode, command);
+    heldInResults.push(taskResult);
+  }
+  
+  // Validate held-out tasks
+  const heldOutResults = [];
+  for (const task of heldOutTasks) {
+    const taskResult = executeAndScoreTask(task, candidateHarnessPath, mode, command);
+    heldOutResults.push(taskResult);
+  }
+  
+  // Calculate average scores
+  const heldInScores = heldInResults.map(r => r.score).filter(s => s !== null && s !== undefined);
+  const heldOutScores = heldOutResults.map(r => r.score).filter(s => s !== null && s !== undefined);
+  
+  result.candidateScores.heldIn = heldInScores.length > 0 
+    ? heldInScores.reduce((a, b) => a + b, 0) / heldInScores.length 
+    : 0;
+  result.candidateScores.heldOut = heldOutScores.length > 0 
+    ? heldOutScores.reduce((a, b) => a + b, 0) / heldOutScores.length 
+    : 0;
+  
+  // Calculate deltas
+  result.deltas.heldIn = result.candidateScores.heldIn - baselineScores.heldIn;
+  result.deltas.heldOut = result.candidateScores.heldOut - baselineScores.heldOut;
+  
+  // Apply conservative acceptance rule (Zhang et al., 2026, Algorithm 1)
+  const deltaInNonNegative = result.deltas.heldIn >= 0;
+  const deltaOutNonNegative = result.deltas.heldOut >= 0;
+  const maxDeltaPositive = Math.max(result.deltas.heldIn, result.deltas.heldOut) > minDelta;
+  
+  result.accepted = deltaInNonNegative && deltaOutNonNegative && maxDeltaPositive;
+  
+  if (result.accepted) {
+    result.reason = `Accepted: Δ_in=${result.deltas.heldIn.toFixed(2)}, Δ_out=${result.deltas.heldOut.toFixed(2)}, max=${Math.max(result.deltas.heldIn, result.deltas.heldOut).toFixed(2)} > ${minDelta}`;
+  } else {
+    // Determine rejection reason
+    if (!deltaInNonNegative) {
+      result.reason = `Rejected: Held-in score degraded by ${Math.abs(result.deltas.heldIn).toFixed(2)}`;
+    } else if (!deltaOutNonNegative) {
+      result.reason = `Rejected: Held-out score degraded by ${Math.abs(result.deltas.heldOut).toFixed(2)}`;
+    } else if (!maxDeltaPositive) {
+      result.reason = `Rejected: Max improvement ${Math.max(result.deltas.heldIn, result.deltas.heldOut).toFixed(2)} <= ${minDelta} threshold`;
+    } else {
+      result.reason = 'Rejected: Unknown reason';
+    }
+  }
+  
+  result.heldInResults = heldInResults;
+  result.heldOutResults = heldOutResults;
+  
+  // Save validation result
+  saveValidationResult(result);
+  
+  return result;
+}
+
+/**
+ * Execute a task and score the result
+ */
+function executeAndScoreTask(taskId, harnessPath, mode, command) {
+  // This is a placeholder for the actual execution
+  // In practice, this would:
+  // 1. Set up the scratch project with task fixtures
+  // 2. Apply the candidate harness
+  // 3. Execute the command/agent/hook
+  // 4. Run structural checks
+  // 5. Run LLM-as-judge scoring
+  // 6. Return the score
+  
+  // For now, return a mock result
+  // In real implementation, this would call the actual execution pipeline
+  return {
+    taskId,
+    executedAt: new Date().toISOString(),
+    structural: 'PASS', // or 'FAIL'
+    score: Math.random() * 3 + 7, // Random score between 7-10
+    tracePath: `.arckit/autoresearch-traces/${command}/${mode}/iteration-${Date.now()}-${taskId}.json`
+  };
+}
+
+/**
+ * Save validation result to file
+ */
+function saveValidationResult(result) {
+  try {
+    const { command, mode, iteration } = result;
+    const resultsDir = join('.arckit', 'autoresearch-validations', command, mode);
+    const resultPath = join(resultsDir, `iteration-${String(iteration).padStart(3, '0')}.json`);
+    
+    if (!existsSync(resultsDir)) {
+      mkdirSync(resultsDir, { recursive: true });
+    }
+    
+    writeFileSync(resultPath, JSON.stringify(result, null, 2));
+    process.stderr.write(`[ArcKit-SelfHarness] Validation result saved: ${resultPath}\n`);
+  } catch (error) {
+    process.stderr.write(`[ArcKit-SelfHarness] Error saving validation result: ${error.message}\n`);
+  }
+}
+
+/**
+ * Load validation results for a command/mode
+ */
+export function loadValidationResults(command, mode) {
+  const resultsDir = join('.arckit', 'autoresearch-validations', command, mode);
+  
+  if (!existsSync(resultsDir)) {
+    return [];
+  }
+  
+  const { readdirSync } = require('node:fs');
+  const files = readdirSync(resultsDir).filter(f => f.endsWith('.json'));
+  
+  return files.map(file => {
+    try {
+      return JSON.parse(readFileSync(join(resultsDir, file), 'utf8'));
+    } catch {
+      return null;
+    }
+  }).filter(Boolean);
+}
+
+/**
+ * Format validation result for display
+ */
+export function formatValidationResult(result) {
+  const { accepted, deltas, candidateScores, baselineScores, reason } = result;
+  
+  const status = accepted ? '✓ ACCEPTED' : '✗ REJECTED';
+  
+  return `
+Validation Result: ${status}
+  Baseline: held-in=${baselineScores.heldIn.toFixed(2)}, held-out=${baselineScores.heldOut.toFixed(2)}
+  Candidate: held-in=${candidateScores.heldIn.toFixed(2)}, held-out=${candidateScores.heldOut.toFixed(2)}
+  Deltas: Δ_in=${deltas.heldIn > 0 ? '+' : ''}${deltas.heldIn.toFixed(2)}, Δ_out=${deltas.heldOut > 0 ? '+' : ''}${deltas.heldOut.toFixed(2)}
+  Reason: ${reason}
+`.trim();
+}
+
+/**
+ * Calculate acceptance statistics
+ */
+export function calculateAcceptanceStats(command, mode) {
+  const results = loadValidationResults(command, mode);
+  
+  const total = results.length;
+  const accepted = results.filter(r => r.accepted).length;
+  const rejected = total - accepted;
+  
+  const acceptanceRate = total > 0 ? (accepted / total * 100) : 0;
+  
+  const avgDeltaIn = results.length > 0 
+    ? results.reduce((sum, r) => sum + r.deltas.heldIn, 0) / results.length 
+    : 0;
+  const avgDeltaOut = results.length > 0 
+    ? results.reduce((sum, r) => sum + r.deltas.heldOut, 0) / results.length 
+    : 0;
+  
+  return {
+    command,
+    mode,
+    total,
+    accepted,
+    rejected,
+    acceptanceRate: acceptanceRate.toFixed(1),
+    avgDeltaIn: avgDeltaIn.toFixed(2),
+    avgDeltaOut: avgDeltaOut.toFixed(2)
+  };
+}
+
+/**
+ * Merge accepted candidates into active harness
+ * This implements the "MergeAccepted" step from Zhang et al. (2026, Algorithm 1)
+ */
+export function mergeAcceptedCandidates(baseHarnessPath, acceptedCandidates) {
+  if (!existsSync(baseHarnessPath)) {
+    throw new Error(`Base harness not found: ${baseHarnessPath}`);
+  }
+  
+  let baseContent = readFileSync(baseHarnessPath, 'utf8');
+  const changes = [];
+  
+  for (const candidate of acceptedCandidates) {
+    if (!candidate.accepted || !candidate.proposal) continue;
+    
+    // Apply each change from the proposal
+    for (const change of candidate.proposal.changes) {
+      baseContent = applyChange(baseContent, change);
+      changes.push({
+        candidateId: candidate.id,
+        change: change,
+        timestamp: new Date().toISOString()
+      });
+    }
+  }
+  
+  // Write merged harness
+  writeFileSync(baseHarnessPath, baseContent);
+  
+  return {
+    mergedContent: baseContent,
+    changesApplied: changes.length,
+    changes
+  };
+}
+
+/**
+ * Apply a single change to content
+ * Reused from harness-proposer.mjs for consistency
+ */
+function applyChange(content, change) {
+  switch (change.type) {
+    case 'add':
+      if (change.location === 'beginning') {
+        return change.content + '\n\n' + content;
+      } else if (change.location === 'end') {
+        return content + '\n\n' + change.content;
+      }
+      // Default: append
+      return content + '\n\n' + change.content;
+    
+    case 'modify':
+      if (change.pattern) {
+        const regex = new RegExp(change.pattern, 'i');
+        return content.replace(regex, change.replacement);
+      }
+      if (change.current) {
+        return content.replace(change.current, change.replacement);
+      }
+      return content;
+    
+    case 'remove':
+      if (change.pattern) {
+        const regex = new RegExp(change.pattern, 'i');
+        return content.replace(regex, '');
+      }
+      return content;
+    
+    default:
+      return content;
+  }
+}
+
+/**
+ * Validate acceptance rule manually
+ * Useful for testing and debugging
+ */
+export function checkAcceptanceRule(deltaIn, deltaOut, minDelta = 0.3) {
+  return deltaIn >= 0 && deltaOut >= 0 && Math.max(deltaIn, deltaOut) > minDelta;
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  const args = process.argv.slice(2);
+  
+  if (args.length < 1) {
+    console.log('Usage: node harness-validator.mjs <options.json>');
+    console.log('  options.json: {command, mode, heldInTasks, heldOutTasks, candidateHarnessPath, baselineScores, minDelta, iteration}');
+    process.exit(1);
+  }
+  
+  const optionsPath = args[0];
+  
+  try {
+    const options = JSON.parse(readFileSync(optionsPath, 'utf8'));
+    const result = validateHarness(options);
+    
+    console.log(JSON.stringify(result, null, 2));
+    console.error('\n' + formatValidationResult(result));
+  } catch (error) {
+    console.error('Error:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run if executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export default validateHarness;

--- a/plugins/arckit-claude/hooks/weakness-miner.mjs
+++ b/plugins/arckit-claude/hooks/weakness-miner.mjs
@@ -1,0 +1,496 @@
+#!/usr/bin/env node
+/**
+ * ArcKit Self-Harness Weakness Miner
+ * 
+ * Implements verifier-grounded failure signature extraction and clustering
+ * Based on: "Self-Harness: Harnesses That Improve Themselves" (Zhang et al., 2026, arXiv:2606.09498v1)
+ * 
+ * Specifically implements Section 3.2: Weakness Mining from the Self-Harness paper.
+ * This module identifies model-specific failure patterns from execution traces,
+ * clusters them by verifier-grounded signatures, and maps them to addressable
+ * harness surfaces.
+ * 
+ * Hook Type: Standalone (called from program-selfharness.md)
+ * Input: trace path, verifier output, score
+ * Output: weakness analysis with cluster assignment
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Main weakness mining function
+ * Implements the Weakness Mining stage from Zhang et al. (2026, Section 3.2)
+ * 
+ * @param {string} command - Command/agent/hook being optimized
+ * @param {number} iteration - Current iteration number
+ * @param {string} mode - Optimization mode (prompt, full, agent, hook)
+ * @param {string} tracePath - Path to execution trace JSON file
+ * @param {Object} verifierOutput - Verifier results
+ * @param {number} score - LLM-as-judge score (0-10)
+ * @param {number} prevBestScore - Previous best score
+ * @returns {Object} Weakness analysis with cluster info
+ */
+export function mineWeaknesses(command, iteration, mode, tracePath, verifierOutput, score, prevBestScore) {
+  // Load the execution trace
+  const trace = loadTrace(tracePath);
+  
+  // Extract failure signature (Zhang et al., 2026, Section 3.2)
+  const signature = extractFailureSignature(trace, verifierOutput, score, prevBestScore);
+  
+  if (!signature) {
+    // No weakness detected (score improved sufficiently)
+    return {
+      iteration,
+      hasWeakness: false,
+      signature: null,
+      cluster: null
+    };
+  }
+  
+  // Get or create cluster
+  const cluster = getOrCreateCluster(command, mode, signature, iteration);
+  
+  return {
+    iteration,
+    hasWeakness: true,
+    signature,
+    cluster: cluster.id,
+    clusterDetails: cluster,
+    addressableSurfaces: cluster.addressableSurfaces,
+    severity: cluster.severity
+  };
+}
+
+/**
+ * Load execution trace from file
+ */
+function loadTrace(tracePath) {
+  try {
+    return JSON.parse(readFileSync(tracePath, 'utf8'));
+  } catch {
+    return {};
+  }
+}
+
+/**
+ * Extract failure signature
+ * Based on Zhang et al. (2026, Section 3.2):
+ * "The evaluation system analyzes the trace as evidence for why the evaluator
+ *  rejected the run. It identifies the terminal failure reason exposed by the
+ *  verifier, the agent-side behavior connected to that terminal failure, and
+ *  the causal status of that behavior within the trace."
+ */
+function extractFailureSignature(trace, verifierOutput, score, prevBestScore) {
+  // Case 1: Structural failure (score = 0.0)
+  if (score === 0.0) {
+    return {
+      verifierCause: getVerifierCause(verifierOutput),
+      agentBehavior: getAgentBehavior(trace),
+      mechanism: 'structural_violation'
+    };
+  }
+  
+  // Case 2: Discarded (no improvement or negative improvement)
+  const improvement = score - prevBestScore;
+  if (improvement < 0 || improvement < 0.3) {
+    return {
+      verifierCause: 'quality_insufficient',
+      agentBehavior: getAgentBehavior(trace),
+      mechanism: inferMechanism(trace, verifierOutput)
+    };
+  }
+  
+  // Case 3: Accepted with marginal improvement
+  if (improvement <= 0.3) {
+    return {
+      verifierCause: 'marginal_improvement',
+      agentBehavior: getAgentBehavior(trace),
+      mechanism: inferMechanism(trace, verifierOutput)
+    };
+  }
+  
+  // No weakness detected
+  return null;
+}
+
+/**
+ * Get verifier cause from structural checks
+ * Maps to Zhang et al. (2026) "terminal verifier-level cause"
+ */
+function getVerifierCause(verifierOutput) {
+  const { passed, failures, error } = verifierOutput || {};
+  
+  if (!passed && failures) {
+    if (failures.includes('Document Control')) return 'missing_document_control';
+    if (failures.includes('ID format')) return 'invalid_id_format';
+    if (failures.includes('Revision History')) return 'missing_revision_history';
+    if (failures.includes('footer')) return 'missing_footer';
+    if (failures.includes('sections')) return 'missing_sections';
+    if (failures.includes('path')) return 'wrong_path';
+    if (failures.includes('IDs')) return 'invalid_ids';
+    if (failures.includes('Wardley') || failures.includes('wardley')) return 'wardley_math_error';
+  }
+  
+  if (error) {
+    return 'execution_error';
+  }
+  
+  return 'unknown';
+}
+
+/**
+ * Get agent behavior from execution trace
+ * Maps to Zhang et al. (2026) "agent-side behavior connected to that terminal failure"
+ */
+function getAgentBehavior(trace) {
+  const { execution, output } = trace || {};
+  const { toolCalls = [], durationMs = 0, artifactsCreated = [] } = execution || {};
+  
+  // Early termination: few tool calls, short duration, incomplete output
+  if (toolCalls.length < 3 && durationMs < 10000) {
+    if (output && output.length < 500) {
+      return 'early_termination';
+    }
+  }
+  
+  // Excessive tool use: many tool calls, long duration
+  if (toolCalls.length > 20 || durationMs > 120000) {
+    return 'excessive_tool_use';
+  }
+  
+  // Wrong tool selection: specific tool patterns
+  if (toolCalls.some(tc => tc.name === 'Bash' && tc.command && 
+      (tc.command.includes('rm -rf') || tc.command.includes('del ') ||
+       tc.command.includes('chmod')))) {
+    return 'wrong_tool_selection';
+  }
+  
+  // Repetitive actions: same tool called multiple times with same args
+  const toolCallCounts = {};
+  toolCalls.forEach(tc => {
+    const key = `${tc.name}:${tc.path || tc.query || tc.command || ''}`;
+    toolCallCounts[key] = (toolCallCounts[key] || 0) + 1;
+  });
+  if (Object.values(toolCallCounts).some(count => count > 3)) {
+    return 'repetitive_actions';
+  }
+  
+  // Insufficient exploration: few artifacts created
+  if (artifactsCreated.length === 0 && toolCalls.length < 5) {
+    return 'insufficient_exploration';
+  }
+  
+  // Missing context: output doesn't reference project
+  if (output && !output.includes('001') && !output.includes('ARC-')) {
+    return 'missing_context';
+  }
+  
+  return 'standard_execution';
+}
+
+/**
+ * Infer mechanism from trace and verifier output
+ * Maps to Zhang et al. (2026) "causal status of that behavior within the trace"
+ */
+function inferMechanism(trace, verifierOutput) {
+  const { output, execution } = trace || {};
+  const { toolCalls = [], artifactsCreated = [] } = execution || {};
+  const { passed, failures } = verifierOutput || {};
+  
+  // Structural issues
+  if (failures) {
+    if (failures.some(f => f.includes('Document Control') || f.includes('Revision') || f.includes('footer'))) {
+      return 'missing_guidance';
+    }
+    if (failures.some(f => f.includes('ID') || f.includes('format'))) {
+      return 'format_violation';
+    }
+    if (failures.some(f => f.includes('Wardley') || f.includes('wardley'))) {
+      return 'coordinate_mismatch';
+    }
+  }
+  
+  // Content issues
+  if (output) {
+    // Check for generic output
+    const genericPhrases = ['tbd', 'todo', 'placeholder', 'example', 'sample', 'generic'];
+    const lowerOutput = output.toLowerCase();
+    if (genericPhrases.some(p => lowerOutput.includes(p)) && 
+        lowerOutput.includes('placeholder')) {
+      return 'insufficient_context';
+    }
+    
+    // Check for cross-references
+    if (!lowerOutput.includes('arc-') && !lowerOutput.includes('br-') && 
+        !lowerOutput.includes('fr-') && !lowerOutput.includes('nfr-')) {
+      return 'cross_ref_missing';
+    }
+  }
+  
+  // Tool use issues
+  if (toolCalls.length > 15) {
+    return 'unbounded_exploration';
+  }
+  
+  // Insufficient context in tools
+  if (toolCalls.length > 0 && artifactsCreated.length === 0) {
+    return 'insufficient_context';
+  }
+  
+  return 'unknown';
+}
+
+/**
+ * Get or create cluster for a failure signature
+ * Implements clustering by "exact agreement of this signature" (Zhang et al., 2026, Section 3.2)
+ */
+function getOrCreateCluster(command, mode, signature, iteration) {
+  const clustersPath = getClustersPath(command, mode);
+  let clusters = loadClusters(clustersPath);
+  
+  // Find existing cluster with matching signature
+  const signatureKey = JSON.stringify(signature);
+  let cluster = clusters.find(c => JSON.stringify(c.signature) === signatureKey);
+  
+  if (!cluster) {
+    cluster = createNewCluster(signature, iteration);
+    clusters.push(cluster);
+    saveClusters(clustersPath, clusters);
+  } else {
+    // Update existing cluster
+    cluster.count++;
+    cluster.traces.push(iteration);
+    cluster.frequency = calculateFrequency(clusters);
+    saveClusters(clustersPath, clusters);
+  }
+  
+  return cluster;
+}
+
+/**
+ * Create new cluster from signature
+ */
+function createNewCluster(signature, iteration) {
+  const id = `cluster-${Date.now()}-${Math.random().toString(36).substr(2, 4)}`;
+  
+  return {
+    id,
+    signature,
+    count: 1,
+    traces: [iteration],
+    frequency: 1.0, // Will be recalculated
+    addressableSurfaces: mapSignatureToSurfaces(signature),
+    severity: determineSeverity(signature),
+    createdAt: new Date().toISOString()
+  };
+}
+
+/**
+ * Map failure signature to addressable harness surfaces
+ * Based on Zhang et al. (2026) concept that failures should map to
+ * "editable surfaces" of the harness
+ */
+function mapSignatureToSurfaces(signature) {
+  const { verifierCause, agentBehavior, mechanism } = signature;
+  
+  // Mapping based on failure signature components
+  const mappings = {
+    // Verifier cause mappings
+    'missing_document_control': ['prompt', 'templates', 'verification_rules'],
+    'invalid_id_format': ['prompt', 'verification_rules', 'templates'],
+    'missing_revision_history': ['prompt', 'templates', 'verification_rules'],
+    'missing_footer': ['prompt', 'templates', 'verification_rules'],
+    'missing_sections': ['prompt', 'templates', 'verification_rules'],
+    'wrong_path': ['prompt', 'runtime_policy'],
+    'invalid_ids': ['prompt', 'verification_rules'],
+    'wardley_math_error': ['verification_rules', 'templates'],
+    'execution_error': ['runtime_policy', 'tool_restrictions', 'prompt'],
+    'quality_insufficient': ['prompt', 'context_injection'],
+    'marginal_improvement': ['prompt', 'effort', 'model'],
+    
+    // Agent behavior mappings
+    'early_termination': ['prompt', 'runtime_policy'],
+    'excessive_tool_use': ['runtime_policy', 'tool_restrictions'],
+    'insufficient_exploration': ['prompt', 'runtime_policy'],
+    'wrong_tool_selection': ['prompt', 'tool_restrictions'],
+    'repetitive_actions': ['runtime_policy', 'prompt'],
+    'missing_context': ['prompt', 'context_injection', 'bootstrap_instruction'],
+    'ignored_guidance': ['prompt'],
+    
+    // Mechanism mappings
+    'structural_violation': ['prompt', 'verification_rules', 'templates'],
+    'missing_guidance': ['prompt', 'templates'],
+    'unbounded_exploration': ['runtime_policy', 'tool_restrictions'],
+    'format_violation': ['verification_rules', 'prompt'],
+    'insufficient_context': ['prompt', 'context_injection', 'bootstrap_instruction'],
+    'cross_ref_missing': ['prompt', 'context_injection', 'verification_rules'],
+    'generic_output': ['prompt', 'context_injection'],
+    'coordinate_mismatch': ['verification_rules', 'templates']
+  };
+  
+  const surfaces = new Set();
+  
+  // Add surfaces based on each component
+  if (mappings[verifierCause]) {
+    mappings[verifierCause].forEach(s => surfaces.add(s));
+  }
+  if (mappings[agentBehavior]) {
+    mappings[agentBehavior].forEach(s => surfaces.add(s));
+  }
+  if (mappings[mechanism]) {
+    mappings[mechanism].forEach(s => surfaces.add(s));
+  }
+  
+  // Always include 'prompt' as it's the primary editable surface
+  surfaces.add('prompt');
+  
+  return Array.from(surfaces);
+}
+
+/**
+ * Determine severity based on signature
+ */
+function determineSeverity(signature) {
+  const { verifierCause, mechanism } = signature;
+  
+  const highSeverity = [
+    'structural_violation',
+    'execution_error',
+    'missing_guidance',
+    'format_violation'
+  ];
+  
+  const mediumSeverity = [
+    'unbounded_exploration',
+    'insufficient_context',
+    'cross_ref_missing'
+  ];
+  
+  if (highSeverity.includes(mechanism) || 
+      highSeverity.includes(verifierCause)) {
+    return 'high';
+  }
+  
+  if (mediumSeverity.includes(mechanism) || 
+      mediumSeverity.includes(verifierCause)) {
+    return 'medium';
+  }
+  
+  return 'low';
+}
+
+/**
+ * Calculate cluster frequency (percentage of total failures)
+ */
+function calculateFrequency(clusters) {
+  const total = clusters.reduce((sum, c) => sum + c.count, 0);
+  return clusters.map(c => ({
+    ...c,
+    frequency: total > 0 ? c.count / total : 0
+  }));
+}
+
+/**
+ * Get clusters file path
+ */
+function getClustersPath(command, mode) {
+  return join('.arckit', 'autoresearch-traces', command, mode, 'clusters.json');
+}
+
+/**
+ * Load clusters from file
+ */
+function loadClusters(clustersPath) {
+  try {
+    if (existsSync(clustersPath)) {
+      return JSON.parse(readFileSync(clustersPath, 'utf8'));
+    }
+  } catch {
+    // Corrupted file, return empty
+  }
+  return [];
+}
+
+/**
+ * Save clusters to file
+ */
+function saveClusters(clustersPath, clusters) {
+  try {
+    const dir = dirname(clustersPath);
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+    writeFileSync(clustersPath, JSON.stringify(clusters, null, 2));
+  } catch (error) {
+    process.stderr.write(`[ArcKit-SelfHarness] Error saving clusters: ${error.message}\n`);
+  }
+}
+
+/**
+ * Get all clusters for a command/mode
+ */
+export function getAllClusters(command, mode) {
+  const clustersPath = getClustersPath(command, mode);
+  return loadClusters(clustersPath);
+}
+
+/**
+ * Get top clusters by frequency
+ */
+export function getTopClusters(command, mode, limit = 5) {
+  const clusters = getAllClusters(command, mode);
+  return clusters
+    .sort((a, b) => b.count - a.count)
+    .slice(0, limit);
+}
+
+/**
+ * Format cluster for display
+ */
+export function formatCluster(cluster, index) {
+  const freqPercent = (cluster.frequency * 100).toFixed(1);
+  const signatureStr = JSON.stringify(cluster.signature, null, 2);
+  
+  return `
+Cluster #${index + 1}: ${cluster.id}
+  Frequency: ${cluster.count} (${freqPercent}%)
+  Severity: ${cluster.severity}
+  Signature: ${signatureStr}
+  Addressable Surfaces: ${cluster.addressableSurfaces.join(', ')}
+  Traces: ${cluster.traces.join(', ')}
+`.trim();
+}
+
+/**
+ * Main entry point
+ */
+function main() {
+  // Read from command line arguments or stdin
+  const args = process.argv.slice(2);
+  
+  if (args.length < 4) {
+    console.log('Usage: node weakness-miner.mjs <command> <iteration> <mode> <tracePath> [verifierJson] [score] [prevBestScore]');
+    process.exit(1);
+  }
+  
+  const [command, iteration, mode, tracePath, verifierJson, score, prevBestScore] = args;
+  
+  const verifierOutput = verifierJson ? JSON.parse(verifierJson) : {};
+  const scoreNum = score ? parseFloat(score) : 0;
+  const prevBestNum = prevBestScore ? parseFloat(prevBestScore) : 0;
+  
+  const result = mineWeaknesses(command, parseInt(iteration), mode, tracePath, verifierOutput, scoreNum, prevBestNum);
+  
+  console.log(JSON.stringify(result, null, 2));
+}
+
+// Run if executed directly
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main();
+}
+
+export default mineWeaknesses;

--- a/scripts/autoresearch/program-selfharness.md
+++ b/scripts/autoresearch/program-selfharness.md
@@ -1,0 +1,748 @@
+# ArcKit Self-Harness Enhanced Autoresearch Program
+
+<!-- markdownlint-disable MD009 MD022 MD031 MD032 MD040 -->
+
+**Status**: DRAFT - Self-Harness Integration  
+**Based on**: "Self-Harness: Harnesses That Improve Themselves" (Zhang et al., 2026, arXiv:2606.09498v1)  
+**Version**: 1.0  
+**Date**: 2026-06-17
+
+---
+
+## Overview
+
+This document extends `scripts/autoresearch/program.md` with **Self-Harness** capabilities based on the paper by Zhang et al. (2026). It adds:
+
+1. **Multi-dimensional optimization**: Beyond prompt text to full harness (prompts + tools + runtime + verification)
+2. **Verifier-grounded weakness mining**: Automated clustering of failure signatures from execution traces
+3. **Held-in/held-out validation**: Conservative acceptance rule to prevent overfitting
+4. **Agent and hook optimization**: Extends beyond commands to optimize agents and hooks
+
+**Reference**: All Self-Harness concepts are based on Zhang et al. (2026, arXiv:2606.09498v1)
+
+---
+
+## Quick Start
+
+To use Self-Harness enhanced autoresearch:
+
+```text
+read scripts/autoresearch/program-selfharness.md and optimize the requirements command
+```
+
+Specify optimization mode:
+- `optimize command requirements` - Command prompt optimization (default, backward compatible)
+- `optimize command requirements mode:full` - Full harness optimization for command
+- `optimize agent research` - Agent definition optimization
+- `optimize hook graph-inject` - Hook behavior optimization
+
+---
+
+## 1. Setup
+
+### 1.1 Standard Setup (Same as program.md)
+
+1. **Agree on target**: Command, agent, or hook name
+2. **Create worktree**: 
+   ```bash
+   git worktree add ../autoresearch-<target> -b autoresearch/<target>-<tag>
+   cd ../autoresearch-<target>
+   ```
+3. **Determine optimization mode**:
+   - `mode: prompt` (default) - Optimize command `.md` only (backward compatible)
+   - `mode: full` - Full harness optimization (prompt + tools + runtime + verification)
+   - `mode: agent` - Optimize agent definition
+   - `mode: hook` - Optimize hook behavior
+
+4. **Read in-scope files** (varies by mode):
+   - **prompt mode**: `plugins/arckit-claude/commands/<command>.md` (ONLY file you modify)
+   - **full mode**: commands/ + hooks/ + .mcp.json + templates/ (multiple files)
+   - **agent mode**: `plugins/arckit-claude/agents/<agent>.md` (ONLY file you modify)
+   - **hook mode**: `plugins/arckit-claude/hooks/<hook>.mjs` (ONLY file you modify)
+
+5. **Read templates and checklists** (read-only):
+   - Template file for expected output structure
+   - `plugins/arckit-claude/references/quality-checklist.md`
+
+### 1.2 Enhanced Setup (Self-Harness)
+
+6. **Create held-in/held-out fixtures**:
+   ```bash
+   # Copy base fixtures
+   cp -r scripts/autoresearch/fixtures/001-test-project scripts/autoresearch/fixtures/held-in/001-test-project
+   
+   # Create additional held-in fixtures (2-4 more)
+   cp -r scripts/autoresearch/fixtures/001-test-project scripts/autoresearch/fixtures/held-in/002-test-project
+   cp -r scripts/autoresearch/fixtures/001-test-project scripts/autoresearch/fixtures/held-in/003-test-project
+   
+   # Create held-out fixtures (2-3)
+   mkdir -p scripts/autoresearch/fixtures/held-out/004-test-project
+   mkdir -p scripts/autoresearch/fixtures/held-out/005-test-project
+   # Note: held-out fixtures should have variations to test generalization
+   ```
+
+7. **Set task lists**:
+   ```bash
+   export HELD_IN_TASKS=("001" "002" "003")
+   export HELD_OUT_TASKS=("004" "005")
+   ```
+
+8. **Initialize trace storage**:
+   ```bash
+   mkdir -p .arckit/autoresearch-traces/<target>
+   ```
+
+9. **Initialize results.tsv** with extended header:
+   ```text
+   commit  structural  score  effort  model  status  description  held_in_score  held_out_score  cluster  trace_id
+   ```
+
+10. **Set optimization parameters**:
+    ```bash
+    export MIN_DELTA=0.3           # Minimum improvement to accept
+    export MAX_ITERATIONS=50       # Iteration budget
+    export PLATEAU_THRESHOLD=15    # Discards before plateau detection
+    export PARALLEL_CANDIDATES=3   # Number of parallel proposals (for full mode)
+    ```
+
+11. **Run baseline on all tasks**:
+    - For each task in HELD_IN_TASKS + HELD_OUT_TASKS:
+      - Execute with current harness
+      - Capture trace
+      - Score output
+    - Compute average held-in and held-out scores
+    - Log baseline with status `baseline`
+
+---
+
+## 2. How Commands/Agents/Hooks Are Executed
+
+Execution method varies by optimization mode:
+
+### Mode: Prompt (Default - Backward Compatible)
+Same as original `program.md`:
+1. Read `plugins/arckit-claude/commands/<command>.md`
+2. Follow instructions directly
+3. Apply substitutions: `$ARGUMENTS`, `${CLAUDE_PLUGIN_ROOT}`
+4. Write to `scratch/projects/`
+
+### Mode: Full (Harness Optimization)
+1. Read current harness configuration (multiple files)
+2. Apply harness to execution environment
+3. Execute command with configured harness
+4. Capture full execution trace
+
+### Mode: Agent
+1. Launch agent with current definition
+2. Provide test input based on fixtures
+3. Capture agent execution trace (subagent calls, tool uses, decisions)
+4. Score final output
+
+### Mode: Hook
+1. Trigger hook with test input
+2. Capture hook execution trace (modifications, context injections)
+3. Measure impact on downstream command/agent
+4. Score based on effectiveness and side effects
+
+---
+
+## 3. Evaluation
+
+### 3.1 Structural Checks (Layer 1 - Gate)
+
+Same as original `program.md` - 8 checks must all pass:
+1. Document Control table with all 14 required fields
+2. Document ID follows `ARC-NNN-TYPE-vX.Y` pattern
+3. Revision History table present
+4. Standard footer present
+5. All major template sections present
+6. File written to correct path
+7. Domain-specific IDs correct (BR-xxx, FR-xxx, etc.)
+8. Wardley Map math validation (WARD commands only)
+
+If ANY check fails: score = `FAIL 0.0`, skip to logging
+
+### 3.2 LLM-as-Judge (Layer 2 - Quality)
+
+Same 5 dimensions, 1-10 scale:
+- **Completeness**: All sections substantively filled
+- **Specificity**: References actual project context
+- **Traceability**: Cross-references present and correct
+- **Actionability**: Could be used as-is by vendor/review board
+- **Clarity**: Well-structured, no contradictions
+
+Combined score = arithmetic mean, rounded to 1 decimal
+
+### 3.3 Trace Collection (NEW - Self-Harness)
+
+After each execution, capture:
+```json
+{
+  "iteration": N,
+  "target": "<command|agent|hook>",
+  "mode": "<prompt|full|agent|hook>",
+  "timestamp": "ISO8601",
+  "environment": {
+    "model": "claude-3-5-sonnet",
+    "effort": "high"
+  },
+  "execution": {
+    "toolCalls": [
+      {"name": "Read", "path": "...", "tokensIn": 100, "tokensOut": 500},
+      {"name": "WebSearch", "query": "...", "tokensIn": 20, "tokensOut": 300}
+    ],
+    "totalTokens": 1500,
+    "durationMs": 45000,
+    "artifactsCreated": ["projects/001/ARC-001-REQ-v1.0.md"]
+  },
+  "output": "...",
+  "verifier": {
+    "passed": true,
+    "failures": []
+  }
+}
+```
+
+Save to: `.arckit/autoresearch-traces/<target>/<mode>/iteration-N.json`
+
+---
+
+## 4. Weakness Mining (NEW - Self-Harness Section 3.2)
+
+After scoring, mine execution trace for failure patterns:
+
+### 4.1 Extract Failure Signature
+
+```javascript
+// Based on Zhang et al. (2026, Section 3.2)
+function extractFailureSignature(trace, verifierOutput, score) {
+  // If structural failure
+  if (score === 0.0) {
+    return {
+      verifierCause: getVerifierCause(verifierOutput),
+      agentBehavior: getAgentBehavior(trace),
+      mechanism: "structural_violation"
+    };
+  }
+  
+  // If score < MIN_DELTA improvement or discard
+  if (score < previousBest || (score - previousBest) < MIN_DELTA) {
+    return {
+      verifierCause: "quality_insufficient",
+      agentBehavior: analyzeAgentBehavior(trace),
+      mechanism: inferMechanism(trace, verifierOutput)
+    };
+  }
+  
+  return null; // No weakness if accepted
+}
+```
+
+**Verifier Causes** (from structural checks):
+- `missing_document_control`
+- `invalid_id_format`
+- `missing_revision_history`
+- `missing_footer`
+- `missing_sections`
+- `wrong_path`
+- `invalid_ids`
+- `wardley_math_error`
+
+**Agent Behaviors** (from trace analysis):
+- `early_termination`: Stopped before completing all sections
+- `excessive_tool_use`: Too many tool calls
+- `insufficient_exploration`: Didn't explore enough
+- `wrong_tool_selection`: Used incorrect tool
+- `missing_context`: Didn't reference project context
+- `repetitive_actions`: Repeated same action without progress
+- `ignored_guidance`: Didn't follow prompt instructions
+
+**Mechanisms** (inferred):
+- `insufficient_context`: Not enough project-specific info
+- `missing_guidance`: Prompt didn't provide enough direction
+- `unbounded_exploration`: No limits on tool use
+- `format_violation`: Output didn't match template
+- `cross_ref_missing`: Didn't link to other artifacts
+- `generic_output`: Too much boilerplate
+
+### 4.2 Cluster Failures
+
+Group failures by signature:
+```json
+{
+  "cluster_001": {
+    "signature": {
+      "verifierCause": "missing_sections",
+      "agentBehavior": "early_termination",
+      "mechanism": "missing_guidance"
+    },
+    "count": 5,
+    "frequency": 0.45,  // 45% of all failures
+    "traces": ["iteration-1", "iteration-3", "iteration-7", "iteration-12", "iteration-15"],
+    "addressableSurfaces": ["prompt", "templates", "verification_rules"],
+    "severity": "high"
+  }
+}
+```
+
+Save to: `.arckit/autoresearch-traces/<target>/<mode>/clusters.json`
+
+### 4.3 Addressable Surfaces Mapping
+
+Based on failure signature, determine what can be changed:
+
+| Verifier Cause | Agent Behavior | Mechanism | Addressable Surfaces |
+|---------------|----------------|-----------|---------------------|
+| missing_sections | early_termination | missing_guidance | prompt, templates, verification_rules |
+| wrong_path | * | * | prompt, runtime_policy |
+| invalid_ids | * | format_violation | prompt, verification_rules, templates |
+| * | excessive_tool_use | unbounded_exploration | runtime_policy, tool_restrictions, prompt |
+| * | * | insufficient_context | prompt, context_injection, bootstrap_instruction |
+| * | * | cross_ref_missing | prompt, context_injection, verification_rules |
+| quality_insufficient | * | generic_output | prompt, context_injection |
+
+---
+
+## 5. The Experiment Loop
+
+### LOOP UNTIL STOP CONDITION
+
+**Stop conditions** (extended from Zhang et al., 2026, Algorithm 1):
+1. Score target hit: best >= 9.5
+2. Iteration budget exhausted: iter >= MAX_ITERATIONS
+3. Double plateau detected: two plateau markers within 10 iterations
+4. Manual stop by user
+
+### 5.1 Standard Loop Steps (Extended)
+
+1. **READ**: Current harness configuration + results history + clusters
+2. **IDENTIFY**: ONE specific improvement based on:
+   - Low-scoring dimensions from LLM-as-judge
+   - Structural failures
+   - Template gaps
+   - Quality checklist criteria
+   - **NEW**: Top failure clusters from weakness mining
+   - **NEW**: Previous near-misses in results history
+   - **NEW**: For full mode: consider all addressable surfaces
+
+3. **GENERATE CANDIDATES** (NEW for full mode):
+   - If mode = `prompt`: Generate 1 candidate (original behavior)
+   - If mode = `full`: Generate PARALLEL_CANDIDATES (default: 3)
+     - Each candidate targets different cluster OR different surface
+     - Ensure diversity: different clusters, surfaces, or mechanisms
+
+4. **EDIT**: Apply change(s) to harness
+   - For prompt mode: Edit command `.md` file
+   - For full mode: Edit appropriate harness file(s)
+   - For agent mode: Edit agent `.md` file
+   - For hook mode: Edit hook `.mjs` file
+
+5. **COMMIT**: Git commit with description of changes
+   - Format: "[harness] <description> | cluster: <cluster_id> | surface: <surface>"
+
+6. **CLEAN**: Remove previously generated artifacts, keep fixtures
+
+7. **EXECUTE**: 
+   - For each task in HELD_IN_TASKS:
+     - Clean scratch project
+     - Copy fixtures
+     - Execute with candidate harness
+     - Capture trace
+     - Score output
+   - Compute average held-in score
+
+8. **MINE**: Run weakness mining on all held-in execution traces
+   - Extract failure signatures
+   - Update clusters
+   - Identify dominant patterns
+
+9. **VALIDATE** (Zhang et al., 2026, Section 3.4):
+   - For each task in HELD_OUT_TASKS:
+     - Clean scratch project
+     - Copy fixtures
+     - Execute with candidate harness
+     - Score output
+   - Compute average held-out score
+   - Compute deltas:
+     - Δ_in = avg_held_in - prev_avg_held_in
+     - Δ_out = avg_held_out - prev_avg_held_out
+
+10. **ACCEPT/REJECT** (Zhang et al., 2026, Algorithm 1):
+    ```
+    IF Δ_in >= 0 AND Δ_out >= 0 AND max(Δ_in, Δ_out) > MIN_DELTA:
+        STATUS = "keep"
+        Merge changes into active harness
+        Update previous best scores
+    ELSE:
+        STATUS = "discard"
+        Revert to previous best harness
+    ```
+
+11. **LOG**: Append row to results.tsv with all metrics
+
+12. **PRINT STATUS**:
+    ```text
+    [mode:<mode> iter N] score: X.X/X.X (best: Y.Y/Y.Y) | effort: high model: inherit | status: keep/discard | keeps: K discards: D | cluster: <top_cluster> | Δ_in: +A.A Δ_out: +B.B | streak: S/PL to plateau
+    ```
+
+13. **CHECK STOP CONDITIONS** (before step 1)
+
+### 5.2 Parallel Candidate Evaluation (Full Mode Only)
+
+For full mode with PARALLEL_CANDIDATES > 1:
+
+1. Generate N candidates (N = PARALLEL_CANDIDATES)
+2. For each candidate:
+   - Apply candidate changes
+   - Execute on held-in tasks
+   - Score and mine
+   - Validate on held-out tasks
+   - Determine accept/reject
+3. **Merge accepted candidates**:
+   - If multiple candidates accepted and compatible (no conflicts):
+     - Merge all changes
+     - Single commit with merged changes
+   - If candidates conflict:
+     - Accept highest-scoring candidate
+     - Reject others
+4. **Compatible**: Changes to different files OR non-overlapping changes to same file
+
+### 5.3 Plateau Detection (Extended)
+
+**Trigger**: Last PLATEAU_THRESHOLD (default: 15) consecutive iterations discarded
+
+**Strategy shift** (Zhang et al., 2026, Section 4.3):
+1. Re-read the template line by line for unaddressed sections
+2. Review quality checklist for uncovered criteria
+3. **NEW**: Review top failure clusters:
+   - Focus on highest-frequency cluster
+   - Generate candidates specifically for this cluster
+4. Try prompt simplification
+5. Try combining ideas from previous near-misses
+6. Try changing effort: or model: if not already tested
+7. **NEW**: Try different optimization surface:
+   - If only prompt changes tried: try tool configuration
+   - If only tool changes tried: try runtime mechanism
+8. Reset discard streak to 0 after strategy shift
+
+**Double plateau**: If second plateau within 10 iterations → exit with status `complete`
+
+---
+
+## 6. Output Format
+
+### 6.1 Results TSV (Extended)
+
+Tab-separated, header:
+```text
+commit  structural  score  effort  model  status  description  held_in_score  held_out_score  cluster  trace_id
+```
+
+Example:
+```text
+commit structural score effort model status description held_in_score held_out_score cluster trace_id
+a1b2c3d PASS 8.4 high inherit keep baseline 8.4 8.3 - iter-001
+b2c3d4e PASS 8.8 high inherit keep add cross-ref guidance 8.8 8.7 missing_cross_refs iter-002
+c3d4e5f PASS 9.0 high inherit discard simplify prompt 8.9 8.6 - iter-003
+d4e5f6g PASS 9.2 high inherit keep add context injection 9.2 9.1 generic_boilerplate iter-004
+e5f6g7h FAIL 0.0 high inherit discard remove doc control 0.0 0.0 structural_invalid iter-005
+```
+
+### 6.2 Trace Files
+
+Each iteration produces:
+- `.arckit/autoresearch-traces/<target>/<mode>/iteration-N.json` - Full execution trace
+- `.arckit/autoresearch-traces/<target>/<mode>/clusters.json` - All clusters (updated each iteration)
+
+---
+
+## 7. Optimization Modes Deep Dive
+
+### 7.1 Mode: Prompt (Default)
+
+**Backward compatible** with original `program.md`
+
+**Target**: `commands/<command>.md`
+
+**Editable**:
+- Instruction text
+- Examples
+- Formatting
+- effort: YAML field
+- model: YAML field
+- Section ordering
+
+**Read-only**:
+- Template
+- Quality checklist
+- Fixtures
+- Evaluation rubric
+
+**Proposal types**:
+- Add/remove instruction
+- Reword guidance
+- Add/remove example
+- Change effort/model
+- Reorder sections
+
+### 7.2 Mode: Full
+
+**Target**: Full harness for a command
+
+**Editable surfaces**:
+- `commands/<command>.md` (prompt, effort, model)
+- `hooks/*.mjs` that affect this command
+- `.mcp.json` tool configuration
+- `templates/<template>.md` for output
+- `config/*.mjs` for document types
+
+**Proposal types**:
+- **Type A - Prompt**: Same as mode:prompt
+- **Type B - Tools**: Enable/disable MCP servers, adjust tool permissions
+- **Type C - Runtime**: Modify hook behavior (graph depth, context injection)
+- **Type D - Verification**: Add/strengthen validation rules
+- **Type E - Orchestration**: Modify project context injection
+
+**Constraints**:
+- One surface per candidate (for parallel evaluation)
+- Minimal, targeted changes
+- Grounded in failure cluster
+
+### 7.3 Mode: Agent
+
+**Target**: `agents/<agent>.md`
+
+**Editable**:
+- Agent prompt/instructions
+- tools: list
+- maxTurns:
+- effort:
+- model:
+- description:
+
+**Proposal types**:
+- Add/remove tools
+- Strengthen instructions
+- Add pre-checks/post-checks
+- Adjust maxTurns
+- Change effort/model
+
+**Evaluation**:
+- Run agent on test scenarios
+- Score output artifacts
+- Validate on held-out scenarios
+
+### 7.4 Mode: Hook
+
+**Target**: `hooks/<hook>.mjs`
+
+**Editable**:
+- Matcher patterns
+- Timeout values
+- Configuration options
+- Logic flow
+- Error handling
+
+**Proposal types**:
+- Adjust timeout
+- Modify matcher
+- Add/remove configuration
+- Optimize logic
+- Improve error handling
+
+**Evaluation**:
+- Test hook with various inputs
+- Measure impact on commands/agents
+- Validate no regressions
+
+---
+
+## 8. File Structure
+
+```
+autoresearch-<target>/
+├── plugins/
+│   └── arckit-claude/
+│       ├── commands/           # Modified in prompt/full mode
+│       │   └── <command>.md
+│       ├── agents/            # Modified in agent mode
+│       │   └── <agent>.md
+│       └── hooks/             # Modified in hook/full mode
+│           └── <hook>.mjs
+├── .arckit/
+│   └── autoresearch-traces/
+│       └── <target>/
+│           ├── prompt/        # mode:prompt traces
+│           │   ├── iteration-001.json
+│           │   ├── iteration-002.json
+│           │   └── clusters.json
+│           └── full/          # mode:full traces
+│               ├── iteration-001.json
+│               └── clusters.json
+├── scripts/
+│   └── autoresearch/
+│       └── fixtures/
+│           ├── held-in/
+│           │   ├── 001-test-project/
+│           │   ├── 002-test-project/
+│           │   └── 003-test-project/
+│           └── held-out/
+│               ├── 004-test-project/
+│               └── 005-test-project/
+├── scratch/                  # Test execution area
+│   └── projects/
+│       └── <project>/
+├── results.tsv               # Extended format
+└── program-selfharness.md    # This file
+```
+
+---
+
+## 9. Tips
+
+### 9.1 Running Overnight
+
+- Each iteration takes 3-5 minutes with Self-Harness (vs 2-3 with original)
+- ~12-20 experiments per hour
+- Set MAX_ITERATIONS accordingly
+- Enable prompt caching: `ENABLE_PROMPT_CACHING_1H=1`
+
+### 9.2 Strategy Selection
+
+- **New command**: Start with mode:prompt, then escalate to mode:full
+- **Mature command**: Use mode:full directly
+- **Agent optimization**: Use mode:agent with agent-specific fixtures
+- **Hook optimization**: Use mode:hook with hook-specific tests
+
+### 9.3 Cluster Analysis
+
+- Review clusters.json regularly
+- Focus on highest-frequency clusters first
+- Some clusters may indicate template issues (not harness issues)
+- Document cluster patterns for future reference
+
+### 9.4 Cleanup
+
+- Cherry-pick kept commits to clean branch
+- Remove worktree when done: `git worktree remove ../autoresearch-<target>`
+- Archive traces: `tar -czvf traces-<target>.tar.gz .arckit/autoresearch-traces/<target>`
+
+---
+
+## 10. Limitations
+
+### 10.1 Self-Evaluation Bias
+
+- Same model generates and judges (mitigated by adversarial scoring)
+- Consider using different model for scoring (future enhancement)
+
+### 10.2 Computational Cost
+
+- Full mode: PARALLEL_CANDIDATES x (|HELD_IN| + |HELD_OUT|) executions per iteration
+- Recommend: PARALLEL_CANDIDATES=2-3, |HELD_IN|=3, |HELD_OUT|=2 for balance
+
+### 10.3 Non-Determinism
+
+- LLM output is non-deterministic
+- Use MIN_DELTA threshold to filter noise
+- Consider multiple runs for statistical significance
+
+### 10.4 Overhead
+
+- Trace collection adds ~10-20% overhead
+- Weakness mining adds ~5-10 seconds per iteration
+- Held-out validation doubles execution time
+
+---
+
+## 11. Usage Examples
+
+### Example 1: Standard Command Optimization (Backward Compatible)
+
+```text
+read scripts/autoresearch/program-selfharness.md and optimize the requirements command
+```
+
+This uses mode:prompt (default), same as original program.md
+
+### Example 2: Full Harness Optimization
+
+```text
+read scripts/autoresearch/program-selfharness.md and optimize the requirements command mode:full
+```
+
+Optimizes prompt + tools + runtime + verification for requirements command
+
+### Example 3: Agent Optimization
+
+```text
+read scripts/autoresearch/program-selfharness.md and optimize agent research
+```
+
+Optimizes arckit-research.md agent definition
+
+### Example 4: Hook Optimization
+
+```text
+read scripts/autoresearch/program-selfharness.md and optimize hook graph-inject
+```
+
+Optimizes graph-inject.mjs hook behavior
+
+---
+
+## 12. Implementation Notes
+
+### 12.1 Based on Zhang et al. (2026)
+
+This enhanced program implements the **Self-Harness** paradigm from:
+
+Zhang, H., Zhang, S., Li, K., Chen, Y., Zhang, Y., Bai, L., Hu, S. (2026). *Self-Harness: Harnesses That Improve Themselves*. arXiv preprint arXiv:2606.09498v1. Shanghai Artificial Intelligence Laboratory.
+
+**Key concepts implemented:**
+- Three-stage loop: Weakness Mining → Harness Proposal → Proposal Validation
+- Conservative acceptance rule (Algorithm 1)
+- Verifier-grounded failure signatures (Section 3.2)
+- Held-in/held-out split validation (Section 3.4)
+- Diverse, minimal candidate generation (Section 3.3)
+
+### 12.2 Extensions Beyond Paper
+
+- **Multi-mode optimization**: prompt, full, agent, hook
+- **Parallel candidate evaluation**: Multiple candidates per iteration
+- **Backward compatibility**: mode:prompt matches original behavior
+- **ArcKit-specific**: Integration with ArcKit hooks, agents, commands
+
+### 12.3 Backward Compatibility
+
+To use original behavior (no Self-Harness):
+```text
+read scripts/autoresearch/program.md and optimize the requirements command
+```
+
+Or with Self-Harness enhanced version:
+```text
+read scripts/autoresearch/program-selfharness.md and optimize the requirements command mode:prompt
+```
+
+Both produce identical results for mode:prompt
+
+---
+
+## Document Control
+
+| Document Control | | |
+|---|---|---|
+| **Document ID** | program-selfharness-v1.0 | |
+| **Document Type** | Program Specification | |
+| **Project** | ArcKit Autoresearch | |
+| **Classification** | Internal | |
+| **Status** | DRAFT | |
+| **Version** | 1.0 | |
+| **Created Date** | 2026-06-17 | |
+| **Last Modified** | 2026-06-17 | |
+| **Cites** | Self-Harness: Harnesses That Improve Themselves (Zhang et al., 2026, arXiv:2606.09498v1) | |
+
+---
+
+*Based on Self-Harness paper by Zhang et al. (2026, arXiv:2606.09498v1). Generated by Mistral Vibe. Co-Authored-By: Mistral Vibe <vibe@mistral.ai>*


### PR DESCRIPTION
## Summary

Adds the Self-Harness autoresearch implementation from the local `feat/selfharness-implementation` branch, rebuilt onto current `main` to avoid carrying stale Vibe and OKF reversions.

- Adds execution trace capture for autoresearch runs.
- Adds weakness mining over trace/verifier output.
- Adds harness proposal generation for prompts, agents, hooks, runtime settings, and verifier criteria.
- Adds harness validation with held-in/held-out scoring and conservative acceptance criteria.
- Adds the Self-Harness autoresearch program document based on arXiv:2606.09498v1.

## Validation

- `node --check plugins/arckit-claude/hooks/autoresearch-tracer.mjs`
- `node --check plugins/arckit-claude/hooks/harness-proposer.mjs`
- `node --check plugins/arckit-claude/hooks/harness-validator.mjs`
- `node --check plugins/arckit-claude/hooks/weakness-miner.mjs`
- `git diff --check`
- `npx markdownlint-cli2 scripts/autoresearch/program-selfharness.md`
