### PR TITLE
[codex] update llms and sitemap article indexes

### DIFF
--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -195,16 +195,55 @@ French government (apply on top of EU baseline):
 
 ## Articles and essays
 
-- [Articles index](https://arckit.org/articles.html): Long-form essays on ArcKit's design, the GDS / G-Cloud / UN Global Platform context, and platform-by-platform comparisons.
-- [Why ArcKit needed a build harness](https://arckit.org/article-viewer.html?a=2026-05-03-build-harness-parallel-architecture-generation): v4.13.0 launch piece for `/arckit:build` (The GDS Harness) — orchestration model, recipes, live-run evidence.
-- [ArcKit v5.0.0: one toolkit, seven plugins](https://arckit.org/article-viewer.html?a=2026-05-18-arckit-v5-plugin-split): the v5.0.0 release piece — splitting ArcKit into a core plugin plus six community overlays, auto-install via the `dependencies` manifest field, three-tier recipe lookup, migration banner.
-- [The Leaf Node Problem](https://arckit.org/article-viewer.html?a=2026-05-19-leaf-node-problem): why AI pilots funded and measured by a single team optimise local KPIs instead of the enterprise outcome, mapped on a Wardley Map with three points of inertia.
-- [Your Wardley Maps belong in Git](https://arckit.org/article-viewer.html?a=2026-05-19-wardley-maps-mermaid-github): what Mermaid `wardley-beta` support changes — maps rendered natively in GitHub READMEs and Claude artifacts, 98% render success across 147 real maps.
-- [The token budget behind ArcKit's plugin split](https://arckit.org/article-viewer.html?a=2026-05-20-plugin-split-token-budget): why v5.0.0 split into seven marketplace plugins, grounded in real `claude plugin details` token data (core ~10,042 tokens always-on, six overlays ~5,249 combined, ~34% always-on cut for single-jurisdiction users); includes an eight-step guide to splitting a monolithic plugin.
-- [How ArcKit tidies Wardley Map labels](https://arckit.org/article-viewer.html?a=2026-05-22-tidy-wardley-labels): a step-by-step walkthrough of the deterministic label-placement engine behind the `tidy-wardley-labels` hook, covering the six-stage pipeline (parse, project, build obstacles, place, invert, rewrite), 32-candidate scoring, most-constrained-first ordering, manual-label preservation, and fixpoint convergence.
-- [ArcKit v5.1: 10 US Federal Civilian Commands, Community Overlay](https://arckit.org/article-viewer.html?a=2026-05-24-v510-us-federal-civilian-overlay): the v5.1.0 launch piece for `arckit-us` — ten commands covering FedRAMP (SSP, Readiness), FISMA / NIST SP 800-53 Rev 5, CISA Zero Trust Maturity Model, OMB M-19-17 ICAM, NIST AI RMF + OMB M-24-10 / M-25-21 AI assurance, E-Gov §208 PIA, EO 14028 secure software self-attestation; `us-federal` recipe (5 waves); community tier while a US federal civilian co-maintainer is recruited.
-- [ArcKit v5.3: The First Sector Overlay, for UK Payments](https://arckit.org/article-viewer.html?a=2026-05-27-v530-uk-finance-payments-overlay): the v5.3.0 launch piece for `arckit-uk-finance` — four commands covering UK PSD2 SCA-RTS exemption design, EMI/PI safeguarding (CRITICAL severity), FCA Consumer Duty board report, and the PS24/16 Critical Third Parties dependency assessment for established UK PSPs / EMIs / PIs. Introduces the sector-overlay shape as a sibling to the jurisdiction-overlay shape, ships EXPERIMENTAL while a UK FS domain co-maintainer is recruited.
-- [ArcKit v5.4: NHS Clinical Safety, the Second Sector Overlay](https://arckit.org/article-viewer.html?a=2026-05-28-v540-uk-nhs-clinical-safety-overlay): the v5.4.0 launch piece for `arckit-uk-nhs` — four commands covering NHS DCB0129 manufacturer clinical safety case, NHS DCB0160 deployer case, NHS DTAC v3 procurement assurance, and UK MDR 2002 / EU MDR 2017/745 SaMD classification. Adopts Dr Marcus Baw's `SAFETY.md` spec verbatim for filenames and YAML hazard-log schema (three-file output: `SAFETY.md`, `SAFETY-CASE.md`, `HAZARD-LOG.md`). Recipe: `uk-nhs-clinical-safety` (44 targets, 8 waves, composes with `uk-saas` baseline). Second sector overlay after UK Finance, ships EXPERIMENTAL with Marcus Baw invited as proposed domain co-maintainer.
+- [Articles index](https://arckit.org/articles.html): Complete published article catalogue for ArcKit release notes, AI-harness design notes, procurement analysis, regulatory overlays, Wardley Mapping, and delivery workflows.
+
+Published articles, newest first:
+
+- [ArcKit and OKF: knowledge interoperability without giving up governance](https://arckit.org/article-viewer.html?a=2026-06-19-okf-compatibility-workflows): Analysis / 19 June 2026.
+- [ArcKit Self-Harness: when the governance harness starts improving itself](https://arckit.org/article-viewer.html?a=2026-06-19-self-harness-autoresearch): Technical / 19 June 2026.
+- [ArcKit v5.14: Mistral Vibe joins the harness](https://arckit.org/article-viewer.html?a=2026-06-17-arckit-vibe-extension): Release / 17 June 2026.
+- [Don't Build an AI App. Build an AI CLI Harness.](https://arckit.org/article-viewer.html?a=2026-06-15-ai-cli-harness-not-ai-app): Analysis / 15 June 2026.
+- [The supplier side of G-Cloud: ArcKit's new bid-authoring overlay](https://arckit.org/article-viewer.html?a=2026-06-10-arckit-uk-gcloud-supplier-overlay): Release / 10 June 2026.
+- [ArcKit FDE is now a plugin: generate your own forward deploy site in one command](https://arckit.org/article-viewer.html?a=2026-06-09-arckit-fde-site-generator): Release / 9 June 2026.
+- [Britain's War on Consultants: What the Procurement Data Actually Shows](https://arckit.org/article-viewer.html?a=2026-06-03-uk-government-consulting-spend): Analysis / 3 June 2026.
+- [ArcKit v5.9.0: Procurement Market Intelligence from Real Award Data](https://arckit.org/article-viewer.html?a=2026-06-02-uk-tenders-procurement-intelligence): Release / 2 June 2026.
+- [ArcKit v5.4: NHS Clinical Safety, the Second Sector Overlay](https://arckit.org/article-viewer.html?a=2026-05-28-v540-uk-nhs-clinical-safety-overlay): Release / 28 May 2026.
+- [ArcKit v5.3: The First Sector Overlay, for UK Payments](https://arckit.org/article-viewer.html?a=2026-05-27-v530-uk-finance-payments-overlay): Release / 27 May 2026.
+- [ArcKit v5.1: 10 US Federal Civilian Commands, Community Overlay](https://arckit.org/article-viewer.html?a=2026-05-24-v510-us-federal-civilian-overlay): Release / 24 May 2026.
+- [How ArcKit tidies Wardley Map labels: a deterministic placement engine, stepped through](https://arckit.org/article-viewer.html?a=2026-05-22-tidy-wardley-labels): Technical / 22 May 2026.
+- [The token budget behind ArcKit's plugin split, and how to split a plugin of your own](https://arckit.org/article-viewer.html?a=2026-05-20-plugin-split-token-budget): Technical / 20 May 2026.
+- [The Leaf Node Problem: why your AI pilot is optimising the wrong thing](https://arckit.org/article-viewer.html?a=2026-05-19-leaf-node-problem): Technical / 19 May 2026.
+- [Your Wardley Maps belong in Git: what Mermaid support changes](https://arckit.org/article-viewer.html?a=2026-05-19-wardley-maps-mermaid-github): Technical / 19 May 2026.
+- [ArcKit v5.0.0: one toolkit, seven plugins, install only what you need](https://arckit.org/article-viewer.html?a=2026-05-18-arckit-v5-plugin-split): Release / 18 May 2026.
+- [We are launching ArcKit FDE: embedded architects for UK public sector](https://arckit.org/article-viewer.html?a=2026-05-12-arckit-fde-launch): Launch / 12 May 2026.
+- [Five patterns to steal from anthropics/financial-services](https://arckit.org/article-viewer.html?a=2026-05-06-anthropics-financial-services-architecture-lesson): Technical / 6 May 2026.
+- [Wanted: /arckit:build recipes for your jurisdiction](https://arckit.org/article-viewer.html?a=2026-05-03-community-recipes-wanted): Community / 3 May 2026.
+- [ArcKit v4.13.0: The Build Harness — Building a full architecture in one Claude Code session. AKA The GDS Harness](https://arckit.org/article-viewer.html?a=2026-05-03-build-harness-parallel-architecture-generation): Release / 3 May 2026.
+- [I have saved the UK economy £24 billion. ArcKit is the third time.](https://arckit.org/article-viewer.html?a=2026-05-03-how-open-source-saved-uk-economy-12bn): Essay / 3 May 2026.
+- [Internal Memo, Somewhere in a Big 4 Consulting Company](https://arckit.org/article-viewer.html?a=2026-05-01-consulting-internal-memo): Essay / 1 May 2026.
+- [ArcKit v4.10: 12 UAE Federal Commands, Community Overlay](https://arckit.org/article-viewer.html?a=2026-04-30-uae-overlay-launch): Release / 30 April 2026.
+- [How ArcKit v4.10 Accelerates the UAE's Federal Agentic Decree](https://arckit.org/article-viewer.html?a=2026-04-30-uae-agentic-decree-arckit-v4-10): Essay / 30 April 2026.
+- [The CAIO's First 90 Days: Delivering the UAE Cabinet Agentic AI Mandate](https://arckit.org/article-viewer.html?a=2026-04-30-uae-caio-first-90-days): Guide / 30 April 2026.
+- [The UAE Agentic Decree: A 90-Day ArcKit Playbook](https://arckit.org/article-viewer.html?a=2026-04-30-uae-agentic-decree-90-day-playbook): Guide / 30 April 2026.
+- [The Toolkit Drafts. The Architect Judges.](https://arckit.org/article-viewer.html?a=2026-04-30-toolkit-drafts-architect-judges): Essay / 30 April 2026.
+- [Pricing the ArcKit Project: What Would an Investor Actually Pay?](https://arckit.org/article-viewer.html?a=2026-04-28-pricing-arckit-investor): Essay / 28 April 2026.
+- [From ArcKit to McKinsey-Style Infographics in an Afternoon](https://arckit.org/article-viewer.html?a=2026-04-27-mckinsey-decks-from-arckit): Essay / 27 April 2026.
+- [The Five Wardley Commands in ArcKit](https://arckit.org/article-viewer.html?a=2026-04-22-wardley-commands-walkthrough): Guide / 22 April 2026.
+- [ArcKit 4.9.0: Wardley Maps Render Natively](https://arckit.org/article-viewer.html?a=2026-04-22-v490-wardley-mapping-support): Release / 22 April 2026.
+- [How ArcKit Is Quietly Destroying a Billion-Pound Consulting Business](https://arckit.org/article-viewer.html?a=2026-04-20-consulting-deliverable-is-dead): Essay / 20 April 2026.
+- [What You Can Now Do in Austria with ArcKit v4.8](https://arckit.org/article-viewer.html?a=2026-04-20-v480-austrian-overlay): Release / 20 April 2026.
+- [ArcKit v4.7: 18 EU and French Regulatory Commands](https://arckit.org/article-viewer.html?a=2026-04-19-v470-eu-french-regulatory): Release / 19 April 2026.
+- [Why an EA Toolkit is Trending on GitHub in 2026](https://arckit.org/article-viewer.html?a=2026-04-19-arckit-trending-on-github): Milestone / 19 April 2026.
+- [Finding UK Funding for Public Sector Projects](https://arckit.org/article-viewer.html?a=2026-04-07-v464-grants-command-for-companies): Release / 7 April 2026.
+- [Automated UK Funding Research with the Grants Command](https://arckit.org/article-viewer.html?a=2026-04-07-v464-grants-command-funding-research): Release / 7 April 2026.
+- [Discovering What Government Has Already Built](https://arckit.org/article-viewer.html?a=2026-03-23-government-code-discovery-commands): Release / 23 March 2026.
+- [Building ClaudeClaw: Autonomous Agents on Claude Code](https://arckit.org/article-viewer.html?a=2026-03-18-building-claudeclaw-autonomous-agents-on-claude-code): Technical / 18 March 2026.
+- [ArcKit v4.3.0: Complete Wardley Mapping Suite](https://arckit.org/article-viewer.html?a=2026-03-16-wardley-suite-strategic-mapping): Release / 16 March 2026.
+- [Your Architecture Documents Are Connected](https://arckit.org/article-viewer.html?a=2026-03-12-document-map-medium): Release / 12 March 2026.
+- [ArcKit v4.1.1: Copilot, Vendor Scoring, Blast Radius](https://arckit.org/article-viewer.html?a=2026-03-11-v411-copilot-vendor-scoring-impact): Release / 11 March 2026.
+- [ArcKit v4: First-Class Codex and Gemini Support](https://arckit.org/article-viewer.html?a=2026-03-08-v4-codex-gemini-support): Release / 8 March 2026.
+- [The People Behind ArcKit](https://arckit.org/article-viewer.html?a=2026-02-28-arckit-contributors-medium-post): Community / 28 February 2026.
+- [ArcKit Recommends Claude Code v2.1.63+](https://arckit.org/article-viewer.html?a=2026-02-28-arckit-v2163-linkedin-post): Release / 28 February 2026.
 
 ## Roles
 

--- a/docs/sitemap.xml
+++ b/docs/sitemap.xml
@@ -277,6 +277,30 @@
         <priority>0.6</priority>
     </url>
     <url>
+        <loc>https://arckit.org/article-viewer.html?a=2026-06-02-uk-tenders-procurement-intelligence</loc>
+        <lastmod>2026-06-02</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
+        <loc>https://arckit.org/article-viewer.html?a=2026-06-03-uk-government-consulting-spend</loc>
+        <lastmod>2026-06-03</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
+        <loc>https://arckit.org/article-viewer.html?a=2026-06-09-arckit-fde-site-generator</loc>
+        <lastmod>2026-06-09</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
+        <loc>https://arckit.org/article-viewer.html?a=2026-06-10-arckit-uk-gcloud-supplier-overlay</loc>
+        <lastmod>2026-06-10</lastmod>
+        <changefreq>monthly</changefreq>
+        <priority>0.6</priority>
+    </url>
+    <url>
         <loc>https://arckit.org/article-viewer.html?a=2026-06-15-ai-cli-harness-not-ai-app</loc>
         <lastmod>2026-06-15</lastmod>
         <changefreq>monthly</changefreq>
@@ -308,7 +332,7 @@
     </url>
     <url>
         <loc>https://arckit.org/llms.txt</loc>
-        <lastmod>2026-05-16</lastmod>
+        <lastmod>2026-06-19</lastmod>
         <changefreq>weekly</changefreq>
         <priority>0.5</priority>
     </url>


### PR DESCRIPTION
## Summary

- sync `docs/llms.txt` with the full published article list from `docs/articles.html`
- add the four missing June article URLs to `docs/sitemap.xml`
- update the `llms.txt` sitemap lastmod date because the file changed

## Validation

- parsed `docs/sitemap.xml` with Python `xml.etree.ElementTree`
- compared article slugs across `docs/articles.html`, `docs/llms.txt`, and `docs/sitemap.xml`: 45 published links, 45 llms links, 45 sitemap URLs, 0 missing, 0 extra
- `git diff --check -- docs/llms.txt docs/sitemap.xml`
- `npx markdownlint-cli2 docs/llms.txt`