### PR TITLE
[codex] add new articles to documentation index

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -8,7 +8,17 @@ Complete documentation for ArcKit — The Enterprise Architecture Governance Har
 
 - [Getting Started](../README.md#getting-started)
 - [Command Reference](../README.md#commands)
+- [Articles](articles.html)
 - [Token Limits Guide](TOKEN-LIMITS.md)
+
+---
+
+## Articles
+
+- [ArcKit and OKF: knowledge interoperability without giving up governance](article-viewer.html?a=2026-06-19-okf-compatibility-workflows)
+- [ArcKit Self-Harness: when the governance harness starts improving itself](article-viewer.html?a=2026-06-19-self-harness-autoresearch)
+
+See the [full articles index](articles.html) for all ArcKit release notes, analysis, and essays.
 
 ---
 


### PR DESCRIPTION
## Summary

- add an Articles quick link to the documentation index
- add the OKF and Self-Harness articles to `docs/README.md`
- link to the full articles index from the documentation index

## Validation

- `npx markdownlint-cli2 docs/README.md`
- `git diff --check -- docs/README.md`