### PR TITLE
docs: add community footer to articles

### DIFF
--- a/docs/articles/2026-03-08-v4-codex-gemini-support.md
+++ b/docs/articles/2026-03-08-v4-codex-gemini-support.md
@@ -148,10 +148,6 @@ ArcKit is open source and available on GitHub. For Claude Code users, it's a mar
 
 That's what first-class support means. Not a translation. Not a compatibility layer. A native experience, built for each platform, from a single source of truth.
 
-## Join the Community
-
-ArcKit now has dedicated spaces for architects and developers using the toolkit. The [ArcKit LinkedIn Group](https://www.linkedin.com/groups/17641034/) is the place for announcements, case studies, and discussion around enterprise architecture governance across all five supported platforms. If you prefer real-time conversation, the [ArcKit Discord](https://discord.gg/UsfzrZmr) is where you'll find help with commands, share what you're building, and connect with other users working across Claude Code, Gemini CLI, Codex CLI, and OpenCode. Whether you're generating your first requirements document or running multi-platform governance across a programme, come say hello.
-
 <!-- arckit:related-articles -->
 ## Related Articles
 
@@ -160,3 +156,9 @@ ArcKit now has dedicated spaces for architects and developers using the toolkit.
 - [The Token Budget Behind ArcKit's Plugin Split](article-viewer.html?a=2026-05-20-plugin-split-token-budget)
 - [Your Architecture Documents Are Connected — Now You Can See How](article-viewer.html?a=2026-03-12-document-map-medium)
 
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-03-16-wardley-suite-strategic-mapping.md
+++ b/docs/articles/2026-03-16-wardley-suite-strategic-mapping.md
@@ -68,10 +68,6 @@ The suite doesn't replace strategic thinking. It makes the structured parts of s
 
 ArcKit v4.3.0 is available now. Update via the Claude Code marketplace, `gemini extensions update arckit`, or pull the latest from GitHub. The four new commands are tagged as Experimental while they accumulate test coverage across ArcKit's 22 test repositories. The reference material, templates, and guides are stable.
 
-## Join the Community
-
-ArcKit is open source at [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit). Join the [ArcKit LinkedIn Group](https://www.linkedin.com/groups/17641034/) for announcements, case studies, and discussion around enterprise architecture governance. For real-time conversation, help with commands, and sharing what you're building, join the [ArcKit Discord](https://discord.gg/UsfzrZmr).
-
 <!-- arckit:related-articles -->
 ## Related Articles
 
@@ -80,3 +76,9 @@ ArcKit is open source at [github.com/tractorjuice/arc-kit](https://github.com/tr
 - [Your Wardley Maps Belong in Git: What Mermaid Support Changes](article-viewer.html?a=2026-05-19-wardley-maps-mermaid-github)
 - [How ArcKit Tidies Wardley Map Labels: A Deterministic Placement Engine](article-viewer.html?a=2026-05-22-tidy-wardley-labels)
 
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-02-uk-tenders-procurement-intelligence.md
+++ b/docs/articles/2026-06-02-uk-tenders-procurement-intelligence.md
@@ -70,3 +70,10 @@ Both commands are part of ArcKit and need no API key. Run `/arckit:tenders` on y
 The shift is small to describe and large in practice. Architectural decisions that used to rest on estimates can now rest on the public record, with a citation on every figure and an honest note on what that figure does and does not mean.
 
 Find ArcKit, and the rest of the governance harness, at [arckit.org](https://arckit.org).
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-09-arckit-fde-site-generator.md
+++ b/docs/articles/2026-06-09-arckit-fde-site-generator.md
@@ -29,3 +29,10 @@ Install it with `/plugin marketplace add tractorjuice/arc-kit` then `/plugin ins
 ## About ArcKit
 
 [ArcKit](https://arckit.org) is the enterprise architecture governance harness for AI coding assistants. It generates strategy, architecture, delivery and assurance artefacts on Claude Code, Codex, Gemini, OpenCode and Copilot, turning architecture governance from scattered documents into a systematic, template-driven process.
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-10-arckit-uk-gcloud-supplier-overlay.md
+++ b/docs/articles/2026-06-10-arckit-uk-gcloud-supplier-overlay.md
@@ -79,3 +79,10 @@ ArcKit has spent its life making the buyer's governance legible. This overlay ex
 ---
 
 *`arckit-uk-gcloud` is the 13th ArcKit marketplace plugin. It requires the `arckit` core plugin, is proprietary (not covered by the repository's MIT licence), and is available for Claude Code.*
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-15-ai-cli-harness-not-ai-app.md
+++ b/docs/articles/2026-06-15-ai-cli-harness-not-ai-app.md
@@ -117,3 +117,10 @@ That is the bet behind ArcKit.
 ---
 
 Sources: SemiAnalysis' [original X thread](https://x.com/SemiAnalysis_/status/2064815042374074396), the [subscription-plan data post](https://x.com/SemiAnalysis_/status/2064815044085318040), the [subscription-margin post](https://x.com/SemiAnalysis_/status/2064815045767213400), and the [unrolled thread data](https://api.fxtwitter.com/2/thread/2064815042374074396).
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-17-arckit-vibe-extension.md
+++ b/docs/articles/2026-06-17-arckit-vibe-extension.md
@@ -87,3 +87,10 @@ For architecture teams, that is the point. The assistant may change. The artifac
 - Pull request: [#598 — feat: add Mistral Vibe CLI extension support](https://github.com/tractorjuice/arc-kit/pull/598)
 - Extension repo: [tractorjuice/arckit-vibe](https://github.com/tractorjuice/arckit-vibe)
 - Issue: [#597 — Add support for Mistral Vibe](https://github.com/tractorjuice/arc-kit/issues/597)
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-19-okf-compatibility-workflows.md
+++ b/docs/articles/2026-06-19-okf-compatibility-workflows.md
@@ -85,3 +85,10 @@ OKF gives ArcKit a bridge to the wider AI knowledge ecosystem. ArcKit gives OKF 
 - Pull request: [#603 -- add OKF compatibility workflows](https://github.com/tractorjuice/arc-kit/pull/603)
 - Follow-up docs: [#605 -- complete OKF documentation coverage](https://github.com/tractorjuice/arc-kit/pull/605)
 - Issue: [#604 -- OKF compatibility](https://github.com/tractorjuice/arc-kit/issues/604)
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)

--- a/docs/articles/2026-06-19-self-harness-autoresearch.md
+++ b/docs/articles/2026-06-19-self-harness-autoresearch.md
@@ -102,3 +102,10 @@ That is the right kind of self-improvement for a governance tool: explicit, boun
 - Pull request: [#606 -- add Self-Harness autoresearch implementation](https://github.com/tractorjuice/arc-kit/pull/606)
 - Program: [`scripts/autoresearch/program-selfharness.md`](https://github.com/tractorjuice/arc-kit/blob/main/scripts/autoresearch/program-selfharness.md)
 - Guide: [`docs/guides/autoresearch.md`](https://github.com/tractorjuice/arc-kit/blob/main/docs/guides/autoresearch.md)
+
+<!-- arckit:community-block -->
+## Join the ArcKit Community
+
+- **Discord** — real-time conversation, help with commands, and what people are building: [discord.gg/UsfzrZmr](https://discord.gg/UsfzrZmr)
+- **LinkedIn Group** — announcements, case studies, and longer-form discussion: [linkedin.com/groups/17641034](https://www.linkedin.com/groups/17641034/)
+- **GitHub** — code, issues, and contributions: [github.com/tractorjuice/arc-kit](https://github.com/tractorjuice/arc-kit)


### PR DESCRIPTION
## Summary
- add the canonical ArcKit community footer to the remaining article markdown files
- normalize two older community sections so the same footer appears at the actual end of every article

## Validation
- verified 47/47 article markdown files include the community block
- verified every article ends with the GitHub footer line
- ran git diff --check -- docs/articles