### PR TITLE
[codex] clarify health JSON side effect

### DIFF
--- a/docs/guides/artifact-health.md
+++ b/docs/guides/artifact-health.md
@@ -8,7 +8,7 @@ The `/arckit:health` command scans your projects for governance artifacts that n
 
 Architecture governance artifacts have a shelf life. Research data goes stale, decisions get forgotten, review conditions go unresolved, and traceability links break as projects evolve. The health command performs a quick, non-destructive scan to surface these issues before they become problems.
 
-**Key principle**: The health check is a diagnostic tool, not a governance artifact. It outputs to the console and does not create files. Run it frequently — before governance gates, at the start of a sprint, or as part of your regular project hygiene.
+**Key principle**: The health check is a diagnostic tool, not a governance artifact. It outputs to the console and writes only `docs/health.json` for dashboard integration; it does not create project governance artifacts. Run it frequently — before governance gates, at the start of a sprint, or as part of your regular project hygiene.
 
 ---
 

--- a/docs/guides/health.md
+++ b/docs/guides/health.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-`/arckit:health` scans all ArcKit projects for stale research, forgotten ADRs, unresolved review conditions, orphaned artifacts, missing traceability, and version drift -- reporting findings to the console without creating a file.
+`/arckit:health` scans all ArcKit projects for stale research, forgotten ADRs, unresolved review conditions, orphaned artifacts, missing traceability, and version drift -- reporting findings to the console and writing `docs/health.json` for dashboard integration.
 
 ---
 
@@ -63,7 +63,7 @@ The `/arckit:health` command **performs a diagnostic scan** that:
 /arckit:health SINCE=2026-06-01
 ```
 
-Outputs: Console only (no file created). Also writes `docs/health.json` for dashboard integration.
+Outputs: Console report plus `docs/health.json` for dashboard integration. No project governance artifacts are created.
 
 ---
 

--- a/plugins/arckit-claude/commands/health.md
+++ b/plugins/arckit-claude/commands/health.md
@@ -8,7 +8,7 @@ tags: [health, quality, governance, staleness, maintenance, audit]
 
 You are performing a **diagnostic health check** across all ArcKit projects, identifying governance artifacts that need attention — stale data, forgotten decisions, unresolved conditions, broken traceability, and version drift.
 
-**This is a diagnostic command. Output goes to the console only — do NOT create a file.** The health report is a point-in-time scan, not a governance artifact.
+**This is a diagnostic command. Output goes to the console and the hook writes only `docs/health.json` for dashboard integration. Do NOT create project governance artifacts.** The health report is a point-in-time scan, not a governance artifact.
 
 ## User Input
 

--- a/plugins/arckit-claude/docs/guides/artifact-health.md
+++ b/plugins/arckit-claude/docs/guides/artifact-health.md
@@ -8,7 +8,7 @@ The `/arckit:health` command scans your projects for governance artifacts that n
 
 Architecture governance artifacts have a shelf life. Research data goes stale, decisions get forgotten, review conditions go unresolved, and traceability links break as projects evolve. The health command performs a quick, non-destructive scan to surface these issues before they become problems.
 
-**Key principle**: The health check is a diagnostic tool, not a governance artifact. It outputs to the console and does not create files. Run it frequently — before governance gates, at the start of a sprint, or as part of your regular project hygiene.
+**Key principle**: The health check is a diagnostic tool, not a governance artifact. It outputs to the console and writes only `docs/health.json` for dashboard integration; it does not create project governance artifacts. Run it frequently — before governance gates, at the start of a sprint, or as part of your regular project hygiene.
 
 ---
 

--- a/plugins/arckit-claude/docs/guides/health.md
+++ b/plugins/arckit-claude/docs/guides/health.md
@@ -2,7 +2,7 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-`/arckit:health` scans all ArcKit projects for stale research, forgotten ADRs, unresolved review conditions, orphaned artifacts, missing traceability, and version drift -- reporting findings to the console without creating a file.
+`/arckit:health` scans all ArcKit projects for stale research, forgotten ADRs, unresolved review conditions, orphaned artifacts, missing traceability, and version drift -- reporting findings to the console and writing `docs/health.json` for dashboard integration.
 
 ---
 
@@ -63,7 +63,7 @@ The `/arckit:health` command **performs a diagnostic scan** that:
 /arckit:health SINCE=2026-06-01
 ```
 
-Outputs: Console only (no file created). Also writes `docs/health.json` for dashboard integration.
+Outputs: Console report plus `docs/health.json` for dashboard integration. No project governance artifacts are created.
 
 ---
 


### PR DESCRIPTION
This updates the health command docs so they match the current implementation.\n\nWhat changed:\n- Clarified that /arckit:health is diagnostic and does not create project governance artifacts.\n- Documented the expected docs/health.json side effect for dashboard integration.\n- Aligned the public health guides with the plugin source wording.\n\nWhy:\n- The docs previously said the command created no files, which conflicted with the implemented docs/health.json side effect and caused user confusion.\n\nValidation:\n- npx markdownlint-cli2 docs/guides/health.md docs/guides/artifact-health.md plugins/arckit-claude/commands/health.md plugins/arckit-claude/docs/guides/health.md plugins/arckit-claude/docs/guides/artifact-health.md