### PR TITLE
[codex] publish claude plugin mirror

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -17,8 +17,8 @@
       "author": {
         "name": "TractorJuice"
       },
-      "homepage": "https://github.com/tractorjuice/arc-kit",
-      "repository": "https://github.com/tractorjuice/arc-kit",
+      "homepage": "https://github.com/tractorjuice/arckit-claude",
+      "repository": "https://github.com/tractorjuice/arckit-claude",
       "license": "MIT",
       "keywords": [
         "architecture",

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: release
-description: "Cut a new ArcKit release — bump versions in lockstep, regenerate non-Claude formats, validate plugin/marketplace agreement, tag, and push to extension repos. Use when the user says 'cut a release', 'release ArcKit', 'ship vX.Y.Z', 'bump the version and release', 'do the release flow', 'tag and publish', or 'push the extensions'. This is a manual, high-consequence workflow: it never runs automatically."
+description: "Cut a new ArcKit release — bump versions in lockstep, regenerate non-Claude formats, validate plugin/marketplace agreement, tag, and push to standalone repos. Use when the user says 'cut a release', 'release ArcKit', 'ship vX.Y.Z', 'bump the version and release', 'do the release flow', 'tag and publish', or 'push the extensions'. This is a manual, high-consequence workflow: it never runs automatically."
 disable-model-invocation: true
 argument-hint: "[X.Y.Z]"
 ---
@@ -84,15 +84,15 @@ git push && git push --tags
 #    Auto-discovers plugins; idempotent (skips existing tags):
 ./scripts/tag-plugins.sh X.Y.Z
 
-# 11. Push each extension to its standalone GitHub repo
-#     (tractorjuice/arckit-gemini, arckit-codex, …). This also creates or
-#     preserves each extension repo's vX.Y.Z tag and GitHub Release:
+# 11. Push each distribution to its standalone GitHub repo
+#     (tractorjuice/arckit-claude, arckit-gemini, arckit-codex, …).
+#     This also creates or preserves each repo's vX.Y.Z tag and GitHub Release:
 ./scripts/push-extensions.sh
 ```
 
 After step 11, confirm the GitHub Release was created (the `release.yml` workflow runs on the
-`vX.Y.Z` tag push). Also confirm every standalone extension repo has a `vX.Y.Z` tag and GitHub
-Release, then report the release URLs and which extension repos were pushed.
+`vX.Y.Z` tag push). Also confirm every standalone repo has a `vX.Y.Z` tag and GitHub
+Release, then report the release URLs and which standalone repos were pushed.
 
 ## Common Gotchas
 
@@ -125,7 +125,7 @@ The highest-signal failures — collected from real releases. Read these before 
   the same number by design; don't try to skew them.
 - **`push-extensions.sh` needs `GH_TOKEN`** and skips repos that don't yet exist on GitHub — a
   "skipped" line is not an error for a brand-new extension, but double-check it's not skipping a
-  repo that *should* exist. It now creates/preserves standalone extension `vX.Y.Z` tags and
+  repo that *should* exist. It now creates/preserves standalone repo `vX.Y.Z` tags and
   GitHub Releases; use `ARCKIT_SKIP_EXTENSION_RELEASES=1` only when intentionally doing a
   commit-only sync.
 - **Do not put release numbers in extension READMEs.** Extension release identity lives in
@@ -141,5 +141,5 @@ The highest-signal failures — collected from real releases. Read these before 
 - `scripts/bump-version.sh` — version bump across all files
 - `scripts/generate-release-notes.sh` — changelog preview from git log
 - `scripts/tag-plugins.sh` — native per-plugin tags (auto-discovers)
-- `scripts/push-extensions.sh` — pushes extension dirs to standalone repos
+- `scripts/push-extensions.sh` — pushes distribution dirs to standalone repos
 - `.github/workflows/release.yml` — creates the GitHub Release on `v*` tag push

--- a/README.md
+++ b/README.md
@@ -56,25 +56,35 @@ claude install latest
 Then in Claude Code:
 
 ```text
-/plugin marketplace add tractorjuice/arc-kit
+/plugin marketplace add tractorjuice/arckit-claude
 ```
 
-Then install from the Discover tab. The marketplace ships **13 plugins** — install only the jurisdictions you need:
+Then install from the Discover tab, or via CLI:
 
 ```bash
 # Core (75 commands — UK Government civilian + generic enterprise)
-claude plugin install arckit
+claude plugin install arckit@arckit-claude
+```
 
-# UK + UAE federal
+Use the umbrella ArcKit marketplace when you want the core plugin plus regional, sector, or tooling overlays:
+
+```text
+/plugin marketplace add tractorjuice/arc-kit
+```
+
+Then install only the overlays you need:
+
+```bash
+# Core + UAE federal
 claude plugin install arckit arckit-uae
 
-# Everything (150 commands across UK + UAE + FR + CA + EU + AT + AU + US + UK-NHS + UK-GCloud)
+# Broad overlay set (UK + UAE + FR + CA + EU + AT + AU + US + UK-NHS + UK-GCloud)
 claude plugin install arckit arckit-{uae,fr,ca,eu,at,au,us,uk-nhs,uk-gcloud}
 ```
 
-All 13 plugins come from the same `tractorjuice/arc-kit` marketplace. The 11 community plugins (`arckit-uae`, `arckit-fr`, `arckit-ca`, `arckit-eu`, `arckit-at`, `arckit-au`, `arckit-au-energy`, `arckit-us`, `arckit-uk-finance`, `arckit-uk-nhs`, `arckit-uk-gcloud`) require the `arckit` core plugin. `arckit-au-energy` (sector) additionally requires `arckit-au` (jurisdiction), which it composes — install with `claude plugin install arckit arckit-au arckit-au-energy`. `arckit-uk-gcloud` is a **proprietary, Claude Code only** supplier-side G-Cloud bid-authoring overlay — it is not distributed to the non-Claude extension formats. One **tooling plugin** — `arckit-fde` — is a lean, Claude Code only plugin with one command, `/arckit-fde:create`, that generates a brandable (white-label) Forward Deploy Engineering consulting website into `docs/` (GitHub Pages ready), with UK Public Sector and Generic market presets; no dependencies, not converted to non-Claude formats, no governance doc-types.
+The standalone `tractorjuice/arckit-claude` marketplace hosts the core plugin. The `tractorjuice/arc-kit` marketplace hosts the core plugin plus overlays. The 11 community plugins (`arckit-uae`, `arckit-fr`, `arckit-ca`, `arckit-eu`, `arckit-at`, `arckit-au`, `arckit-au-energy`, `arckit-us`, `arckit-uk-finance`, `arckit-uk-nhs`, `arckit-uk-gcloud`) require the `arckit` core plugin. `arckit-au-energy` (sector) additionally requires `arckit-au` (jurisdiction), which it composes — install with `claude plugin install arckit arckit-au arckit-au-energy`. `arckit-uk-gcloud` is a **proprietary, Claude Code only** supplier-side G-Cloud bid-authoring overlay — it is not distributed to the non-Claude extension formats. One **tooling plugin** — `arckit-fde` — is a lean, Claude Code only plugin with one command, `/arckit-fde:create`, that generates a brandable (white-label) Forward Deploy Engineering consulting website into `docs/` (GitHub Pages ready), with UK Public Sector and Generic market presets; no dependencies, not converted to non-Claude formats, no governance doc-types.
 
-> **Tip: lighter marketplace clone.** The command above clones the full arc-kit monorepo (~100 MB) because it hosts five other AI-assistant distributions, 147 vendored Wardley maps, and research docs you don't need. To fetch just the plugin's directories, add the marketplace via the CLI with `--sparse`:
+> **Tip: lighter overlay marketplace clone.** The standalone `tractorjuice/arckit-claude` repo is the lightweight core install path. If you use the umbrella marketplace for overlays but want to skip the other AI-assistant distributions in the monorepo, add it via the CLI with `--sparse`:
 >
 > ```bash
 > claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude
@@ -1832,8 +1842,8 @@ If you see: `API Error: Claude's response exceeded the 32000 output token maximu
 # For Codex, check if skills directory exists
 ls .agents/skills/arckit-principles/SKILL.md
 
-# For Claude Code, install the ArcKit plugin:
-# /plugin marketplace add tractorjuice/arc-kit
+# For Claude Code, install the ArcKit core plugin:
+# /plugin marketplace add tractorjuice/arckit-claude
 
 # For Gemini CLI, install the ArcKit extension:
 # gemini extensions install https://github.com/tractorjuice/arckit-gemini

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -6,7 +6,7 @@ This document covers version management, the release flow, and the helper script
 
 ## Version Files
 
-ArcKit ships in seven formats, each with its own version file. They are all bumped in lockstep by `scripts/bump-version.sh`.
+ArcKit ships in multiple formats, each with its own version file. They are all bumped in lockstep by `scripts/bump-version.sh`.
 
 **CLI version** (independent from the plugin):
 
@@ -25,7 +25,7 @@ ArcKit ships in seven formats, each with its own version file. They are all bump
 - `extensions/arckit-codex/VERSION`
 - `extensions/arckit-copilot/VERSION`
 
-`scripts/bump-version.sh <version>` updates all 15 version-bearing locations (VERSION files, manifests, README badges, docs, plugin.json) in one go.
+`scripts/bump-version.sh <version>` updates all version-bearing locations (VERSION files, manifests, README badges, docs, plugin.json, and standalone marketplace metadata) in one go.
 
 ## Release Helpers
 
@@ -33,7 +33,7 @@ ArcKit ships in seven formats, each with its own version file. They are all bump
 |--------|---------|
 | `scripts/bump-version.sh <version>` | Updates all version files in one pass |
 | `scripts/generate-release-notes.sh [prev-tag]` | Parses `git log` between tags into Keep a Changelog markdown (Added / Fixed / Changed / Breaking Changes), filters out `chore: bump version` commits, auto-detects previous tag if omitted |
-| `scripts/push-extensions.sh [name...]` | Pushes extension dirs to their separate GitHub repos (`tractorjuice/arckit-gemini`, `tractorjuice/arckit-codex`, etc.), then creates or preserves each repo's `vX.Y.Z` tag and GitHub Release. Uses `GH_TOKEN`. Skips repos that don't yet exist on GitHub. Set `ARCKIT_SKIP_EXTENSION_RELEASES=1` only for a commit-only sync |
+| `scripts/push-extensions.sh [name...]` | Pushes standalone distribution dirs to their separate GitHub repos (`tractorjuice/arckit-claude`, `tractorjuice/arckit-gemini`, `tractorjuice/arckit-codex`, etc.), then creates or preserves each repo's `vX.Y.Z` tag and GitHub Release. Uses `GH_TOKEN`. Skips repos that don't yet exist on GitHub. Set `ARCKIT_SKIP_EXTENSION_RELEASES=1` only for a commit-only sync |
 | `.github/workflows/release.yml` | Creates the GitHub Release automatically on `v*` tag push (tag-push triggered, does not commit back to main) |
 
 ## Development Workflow
@@ -94,14 +94,18 @@ claude plugin prune --dry-run
 git tag -a vX.Y.Z -m "vX.Y.Z"
 git push && git push --tags
 
-# 11. Push to extension repos (Gemini, Codex, etc.).
-#     This also publishes each extension repo's vX.Y.Z tag and GitHub Release.
+# 11. Push to standalone repos (Claude, Gemini, Codex, etc.).
+#     This also publishes each standalone repo's vX.Y.Z tag and GitHub Release.
 ./scripts/push-extensions.sh
 ```
 
-After step 11, verify the umbrella GitHub Release and every extension GitHub Release exists:
+Use `./scripts/push-extensions.sh claude` when you intentionally need to publish only the
+standalone Claude mirror.
+
+After step 11, verify the umbrella GitHub Release and every standalone GitHub Release exists:
 
 - `tractorjuice/arc-kit`
+- `tractorjuice/arckit-claude`
 - `tractorjuice/arckit-gemini`
 - `tractorjuice/arckit-codex`
 - `tractorjuice/arckit-opencode`

--- a/docs/getting-started.html
+++ b/docs/getting-started.html
@@ -398,25 +398,26 @@
                 <div class="app-step">
                     <span class="app-step__number">2</span>
                     <h2 class="govuk-heading-m app-step__title">Install ArcKit Plugins</h2>
-                    <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
-                    <p class="govuk-body govuk-!-margin-top-3">As of v5.1.0 the marketplace ships <strong>8 plugins</strong> &mdash; install only the jurisdictions you need:</p>
+                    <div class="app-code-block">/plugin marketplace add tractorjuice/arckit-claude</div>
+                    <p class="govuk-body govuk-!-margin-top-3">Install the core Claude Code plugin from Discover, or via CLI:</p>
                     <div class="app-code-block"><pre><code># Core (UK Government civilian + generic enterprise)
-claude plugin install arckit
-
-# UK + one community overlay (e.g. UAE federal)
+claude plugin install arckit@arckit-claude</code></pre></div>
+                    <p class="govuk-body govuk-!-margin-top-3">For regional, sector, and tooling overlays, add the umbrella ArcKit marketplace and install only the plugins you need:</p>
+                    <div class="app-code-block">/plugin marketplace add tractorjuice/arc-kit</div>
+                    <div class="app-code-block govuk-!-margin-top-3"><pre><code># Core + UAE overlay
 claude plugin install arckit arckit-uae
 
-# Everything (UK + UAE + FR + CA + EU + AT + AU + US)
-claude plugin install arckit arckit-{uae,fr,ca,eu,at,au,us}</code></pre></div>
-                    <p class="govuk-body govuk-!-margin-top-3">The 7 community plugins (<code>arckit-uae</code>, <code>arckit-fr</code>, <code>arckit-ca</code>, <code>arckit-eu</code>, <code>arckit-at</code>, <code>arckit-au</code>, <code>arckit-us</code>) auto-install the <code>arckit</code> core plugin as a declared dependency. Updates are automatic via the marketplace.</p>
-                    <p class="govuk-body govuk-!-margin-top-2"><strong>Lighter clone:</strong> to skip the other AI-assistant distributions in the monorepo (~100&nbsp;MB), add the marketplace with sparse-checkout. Each plugin directory you want to install is listed explicitly:</p>
+# Broad overlay set
+claude plugin install arckit arckit-{uae,fr,ca,eu,at,au,us,uk-nhs,uk-gcloud}</code></pre></div>
+                    <p class="govuk-body govuk-!-margin-top-3">The community overlay plugins auto-install the <code>arckit</code> core plugin as a declared dependency. Updates are automatic via the marketplace.</p>
+                    <p class="govuk-body govuk-!-margin-top-2"><strong>Lighter overlay clone:</strong> the standalone <code>tractorjuice/arckit-claude</code> repo is the lightweight core path. To use the umbrella marketplace while skipping the other AI-assistant distributions in the monorepo, add it with sparse-checkout. Each plugin directory you want to install is listed explicitly:</p>
                     <div class="app-code-block"><pre><code># Core only
 claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude
 
 # Core + UAE overlay
 claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude arckit-uae
 
-# All 8 plugins
+# Core + common overlays
 claude plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin \
   arckit-claude arckit-uae arckit-fr arckit-ca arckit-eu arckit-at arckit-au arckit-us</code></pre></div>
                 </div>

--- a/docs/index.html
+++ b/docs/index.html
@@ -453,7 +453,7 @@
                         "name": "How do I install ArcKit?",
                         "acceptedAnswer": {
                             "@type": "Answer",
-                            "text": "For Claude Code, run \"/plugin marketplace add tractorjuice/arc-kit\" then \"/plugin install arckit-claude\". For Gemini CLI, run \"gemini extensions install tractorjuice/arckit-gemini\". For Codex CLI, OpenCode CLI, or GitHub Copilot, install the Python CLI with \"pip install arckit\" and run \"arckit init --ai codex|opencode|copilot\" inside your project."
+                            "text": "For Claude Code, run \"/plugin marketplace add tractorjuice/arckit-claude\" then install arckit. For Gemini CLI, run \"gemini extensions install tractorjuice/arckit-gemini\". For Codex CLI, OpenCode CLI, or GitHub Copilot, install the Python CLI with \"pip install arckit\" and run \"arckit init --ai codex|opencode|copilot\" inside your project."
                         }
                     },
                     {
@@ -768,7 +768,7 @@
                     <h3 class="govuk-heading-s">Claude Code</h3>
                     <strong class="govuk-tag govuk-tag--green">Premier</strong>
                     <p class="govuk-body-s govuk-!-margin-top-2">Full experience with agents, hooks, MCP servers, and output validation.</p>
-                    <code>/plugin marketplace add tractorjuice/arc-kit</code>
+                    <code>/plugin marketplace add tractorjuice/arckit-claude</code>
                 </div>
                 <div class="app-ai-compact-card">
                     <h3 class="govuk-heading-s">Gemini CLI</h3>

--- a/docs/llms.txt
+++ b/docs/llms.txt
@@ -272,9 +272,9 @@ The full table of public test repos is in [CLAUDE.md](https://github.com/tractor
 
 ## Source code and distributions
 
-- [Main repository](https://github.com/tractorjuice/arc-kit): Monorepo containing all six distributions.
+- [Main repository](https://github.com/tractorjuice/arc-kit): Monorepo containing ArcKit source, generated distributions, and release tooling.
 - [CLAUDE.md (project guide)](https://github.com/tractorjuice/arc-kit/blob/main/CLAUDE.md): Architecture overview and conventions for contributors.
-- [Claude Code plugin](https://github.com/tractorjuice/arc-kit/tree/main/arckit-claude): `/plugin marketplace add tractorjuice/arc-kit`.
+- [Claude Code plugin](https://github.com/tractorjuice/arckit-claude): `/plugin marketplace add tractorjuice/arckit-claude`.
 - [Gemini CLI extension](https://github.com/tractorjuice/arckit-gemini): `gemini extensions install tractorjuice/arckit-gemini`.
 - [Codex CLI extension](https://github.com/tractorjuice/arckit-codex): Skills, agents, MCP servers for Codex.
 - [OpenCode CLI extension](https://github.com/tractorjuice/arc-kit/tree/main/extensions/arckit-opencode): Commands for OpenCode.

--- a/docs/plans/2026-06-30-claude-plugin-standalone-repo.md
+++ b/docs/plans/2026-06-30-claude-plugin-standalone-repo.md
@@ -1,0 +1,440 @@
+# Claude Plugin Standalone Repo Migration Plan
+
+> **For agentic workers:** Implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking. Keep unrelated dirty files, generated session memory, and local health output out of commits.
+
+**Goal:** Publish the Claude Code core ArcKit plugin to its own standalone repository, `tractorjuice/arckit-claude`, matching the standalone distribution pattern used by `arckit-codex`, `arckit-gemini`, `arckit-opencode`, `arckit-copilot`, `arckit-paperclip`, and `arckit-vibe`.
+
+**Architecture:** Use a two-stage migration. First, keep `plugins/arckit-claude/` as the canonical source inside `tractorjuice/arc-kit` and mirror that directory into a standalone public repo during release. This matches the existing extension repo model and avoids breaking the converter, tests, Claude marketplace overlays, and release tooling. Second, only after the mirror is stable, decide whether to make `tractorjuice/arckit-claude` the source of truth and have `arc-kit` consume it through a controlled vendor sync, subtree, or submodule.
+
+**Tech Stack:** Bash release scripts, Claude Code plugin manifests, Claude marketplace metadata, GitHub CLI, Python and Node test suites, `scripts/converter.py`, release documentation, and install docs.
+
+**Branch:** `feat/claude-standalone-repo`.
+
+---
+
+## Current State
+
+- `plugins/arckit-claude/` is the core Claude Code plugin source.
+- `scripts/converter.py` hard-codes `plugins/arckit-claude` as the core source for agents, scripts, guides, config, schemas, skills, references, and fallback copies into generated non-Claude extensions.
+- The existing standalone repo publisher is `scripts/push-extensions.sh`; it currently maps only `gemini`, `codex`, `opencode`, `copilot`, `paperclip`, and `vibe`.
+- `scripts/bump-version.sh` updates `plugins/arckit-claude/VERSION`, `plugins/arckit-claude/.claude-plugin/plugin.json`, `.claude-plugin/marketplace.json`, and generated extension version files in lockstep.
+- `.claude-plugin/marketplace.json` currently serves the Claude marketplace from `tractorjuice/arc-kit` and points the core plugin entry at `./plugins/arckit-claude`.
+- `.agents/plugins/marketplace.json` already points Codex users at `https://github.com/tractorjuice/arckit-codex`; this is the distribution shape to mirror for Claude.
+
+---
+
+## Target Shape
+
+### Stage 1: Standalone Mirror
+
+`tractorjuice/arc-kit` remains the development source of truth. Release tooling copies `plugins/arckit-claude/` into `tractorjuice/arckit-claude` and publishes the same `vX.Y.Z` tag and GitHub Release as the other standalone repos.
+
+The standalone `arckit-claude` repo root contains:
+
+| Path | Source | Purpose |
+|---|---|---|
+| `.claude-plugin/plugin.json` | `plugins/arckit-claude/.claude-plugin/plugin.json` | Claude plugin manifest |
+| `.claude-plugin/marketplace.json` | new generated or maintained file | Standalone marketplace entry with `source: "."` |
+| `.mcp.json` | `plugins/arckit-claude/.mcp.json` | Bundled MCP server config |
+| `commands/`, `agents/`, `hooks/`, `skills/`, `templates/`, `scripts/`, `docs/`, `config/`, `schemas/`, `references/` | `plugins/arckit-claude/` | Runtime plugin content |
+| `README.md`, `CHANGELOG.md`, `VERSION`, `LICENSE` | `plugins/arckit-claude/` | Standalone repo metadata |
+
+### Stage 2: Optional Source Split
+
+If the standalone mirror is stable for at least one release, choose whether the canonical source should move to `tractorjuice/arckit-claude`. If yes, keep a vendored copy in `plugins/arckit-claude/` for converter and tests, refreshed by an explicit sync script. Do not delete or submodule the core path until converter and CI are taught to handle the new source boundary.
+
+---
+
+## Non-Goals
+
+- Do not split the community Claude overlay plugins in this change.
+- Do not change `/arckit:*` command names or generated non-Claude command names.
+- Do not remove `plugins/arckit-claude/` from `arc-kit` during Stage 1.
+- Do not move proprietary `arckit-uk-gcloud` content into generated public extension repos.
+- Do not break the existing `tractorjuice/arc-kit` Claude marketplace during the transition.
+
+---
+
+## File Map
+
+| Path | Action | Purpose |
+|---|---|---|
+| `plugins/arckit-claude/.claude-plugin/marketplace.json` | create | Standalone Claude marketplace metadata copied into `arckit-claude` repo |
+| `plugins/arckit-claude/.claude-plugin/plugin.json` | modify | Change `repository` to `https://github.com/tractorjuice/arckit-claude`; verify version count text |
+| `.claude-plugin/marketplace.json` | modify | Keep old marketplace working; optionally update core plugin repository/homepage to standalone repo |
+| `scripts/push-extensions.sh` | modify | Add `claude` target mapping `plugins/arckit-claude:arckit-claude` |
+| `tests/plugin/test_release_process.py` | modify | Assert the Claude standalone repo is named in the publisher and release docs |
+| `docs/RELEASING.md` | modify | Add `arckit-claude` to standalone publish and verification steps |
+| `.claude/skills/release/SKILL.md` | modify | Keep guided release flow aligned with `docs/RELEASING.md` |
+| `plugins/arckit-claude/README.md` | modify | Add standalone marketplace install path |
+| `docs/getting-started.html` | modify | Prefer standalone core install, keep umbrella marketplace instructions for overlays |
+| `README.md`, `docs/index.html`, `docs/llms.txt`, `docs/PLATFORM-COMPARISON.md` | audit/modify | Update links and install wording that point at the old in-repo path |
+| `scripts/converter.py` | no Stage 1 change | Continue reading `plugins/arckit-claude` as the core source |
+| `tests/extension_helpers.py`, `tests/codex/test_codex_extension.py` | no Stage 1 change | Continue mirroring converter source inventory |
+
+---
+
+## Task 0: Preflight and Repo Inventory
+
+- [ ] **Step 1: Confirm current source and version state**
+
+```bash
+git status --short
+cat VERSION
+cat plugins/arckit-claude/VERSION
+jq -r '.version, .repository' plugins/arckit-claude/.claude-plugin/plugin.json
+```
+
+Expected:
+- Unrelated dirty files are identified and not swept into this work.
+- Root and Claude plugin versions match.
+- The current plugin repository still points at `tractorjuice/arc-kit` before the migration.
+
+- [ ] **Step 2: Confirm the new remote does not already exist, or read its state if it does**
+
+```bash
+gh repo view tractorjuice/arckit-claude --json name,visibility,description,homepageUrl,defaultBranchRef,repositoryTopics
+```
+
+If it does not exist, create it in Task 4. If it already exists, treat its current contents as user-owned state and inspect before overwriting.
+
+- [ ] **Step 3: Capture the current publisher inventory**
+
+```bash
+grep -n 'declare -A EXTENSIONS' -A12 scripts/push-extensions.sh
+pytest tests/plugin/test_release_process.py
+```
+
+Expected: tests pass before changes, and the publisher currently lists six standalone non-Claude repos.
+
+---
+
+## Task 1: Add Standalone Claude Marketplace Metadata
+
+**Files:**
+- Create: `plugins/arckit-claude/.claude-plugin/marketplace.json`
+- Modify: `plugins/arckit-claude/.claude-plugin/plugin.json`
+- Modify: `.claude-plugin/marketplace.json`
+
+- [ ] **Step 1: Add standalone marketplace metadata**
+
+Create `plugins/arckit-claude/.claude-plugin/marketplace.json`:
+
+```json
+{
+  "name": "arckit-claude",
+  "owner": {
+    "name": "TractorJuice",
+    "email": "tractorjuice@users.noreply.github.com"
+  },
+  "metadata": {
+    "description": "The Enterprise Architecture Governance Harness for Claude Code",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "arckit",
+      "source": ".",
+      "description": "ArcKit core for Claude Code: architecture governance, procurement, research, delivery, and assurance workflows",
+      "version": "<current plugin version>",
+      "author": {
+        "name": "TractorJuice"
+      },
+      "homepage": "https://github.com/tractorjuice/arckit-claude",
+      "repository": "https://github.com/tractorjuice/arckit-claude",
+      "license": "MIT",
+      "keywords": [
+        "architecture",
+        "governance",
+        "enterprise",
+        "procurement",
+        "vendor-evaluation",
+        "claude-code"
+      ],
+      "category": "productivity"
+    }
+  ]
+}
+```
+
+Use `jq --arg v "$(cat plugins/arckit-claude/VERSION)"` or a small checked-in generator if manual version drift becomes a concern.
+
+- [ ] **Step 2: Update the core plugin manifest repository field**
+
+Set `plugins/arckit-claude/.claude-plugin/plugin.json`:
+
+```json
+"repository": "https://github.com/tractorjuice/arckit-claude"
+```
+
+Keep `name: "arckit"` unchanged. The plugin name is user-facing and should not become `arckit-claude`.
+
+- [ ] **Step 3: Keep the umbrella marketplace compatible**
+
+In `.claude-plugin/marketplace.json`, keep:
+
+```json
+"source": "./plugins/arckit-claude"
+```
+
+Update only metadata fields such as `repository` or `homepage` if desired. Keeping the source path unchanged preserves installs through `tractorjuice/arc-kit`, especially for users installing overlays from the umbrella marketplace.
+
+- [ ] **Step 4: Add version drift coverage**
+
+Extend `scripts/bump-version.sh` so it also updates:
+
+```text
+plugins/arckit-claude/.claude-plugin/marketplace.json .plugins[].version
+```
+
+Extend `tests/plugin/test_release_process.py` with a check that:
+- the standalone Claude marketplace file exists,
+- its only plugin is named `arckit`,
+- its source is `.`,
+- its version matches `plugins/arckit-claude/VERSION`.
+
+---
+
+## Task 2: Teach the Publisher About `arckit-claude`
+
+**Files:**
+- Modify: `scripts/push-extensions.sh`
+- Modify: `tests/plugin/test_release_process.py`
+- Optional later rename: `scripts/push-extensions.sh` to `scripts/push-standalone-repos.sh`
+
+- [ ] **Step 1: Add a Claude target to the existing publisher**
+
+Update the extension map:
+
+```bash
+[claude]="plugins/arckit-claude:arckit-claude"
+```
+
+Update default targets:
+
+```bash
+TARGETS=("claude" "gemini" "codex" "opencode" "copilot" "paperclip" "vibe")
+```
+
+Keep the script name for the first PR to minimize blast radius. The behavior already matches what is needed: clone standalone repo, replace contents, commit, push, tag, and create a GitHub Release.
+
+- [ ] **Step 2: Make publish messaging accurate**
+
+Update comments and release docs from "extension repos" to "standalone repos" where the Claude repo is included. Avoid a broad rename in the same PR unless every docs/test reference is updated.
+
+- [ ] **Step 3: Update release process tests**
+
+Add `claude` to `EXPECTED_EXTENSIONS` or rename that fixture to `EXPECTED_STANDALONE_REPOS`:
+
+```python
+"claude": ("plugins/arckit-claude", "arckit-claude"),
+```
+
+Adjust README-version tests if needed. The Claude README may mention minimum Claude Code versions, but it should not pin the current ArcKit release number outside `VERSION`, manifests, tags, and releases.
+
+- [ ] **Step 4: Add a focused test for standalone release artifact behavior**
+
+Extend `test_push_extensions_publishes_tags_and_github_releases` so the same tag and GitHub Release assertions apply after adding `claude`.
+
+---
+
+## Task 3: Update Release Documentation and Install Docs
+
+**Files:**
+- Modify: `docs/RELEASING.md`
+- Modify: `.claude/skills/release/SKILL.md`
+- Modify: `plugins/arckit-claude/README.md`
+- Modify: `docs/getting-started.html`
+- Audit/modify: `README.md`, `docs/index.html`, `docs/llms.txt`, `docs/PLATFORM-COMPARISON.md`, `scripts/README.md`
+
+- [ ] **Step 1: Update release docs**
+
+In `docs/RELEASING.md`:
+- add `tractorjuice/arckit-claude` to the standalone repo verification list,
+- change "Push to extension repos" to "Push to standalone repos",
+- note that `scripts/push-extensions.sh claude` can publish just the Claude mirror,
+- keep `plugins/arckit-claude/` as the source path for versioning and converter generation.
+
+- [ ] **Step 2: Update the release skill**
+
+In `.claude/skills/release/SKILL.md`:
+- mirror the same standalone repo language,
+- update gotchas to mention the Claude standalone mirror,
+- keep the hard gate for public publishing.
+
+- [ ] **Step 3: Update Claude install docs**
+
+Preferred core install path after the standalone repo is live:
+
+```text
+/plugin marketplace add tractorjuice/arckit-claude
+/plugin
+```
+
+Keep umbrella marketplace guidance for overlays:
+
+```text
+/plugin marketplace add tractorjuice/arc-kit --sparse .claude-plugin arckit-claude arckit-uae arckit-fr arckit-ca arckit-eu arckit-at arckit-au arckit-us
+```
+
+Do not remove old instructions in the first release. Mark the standalone repo as the preferred core path and the umbrella repo as the overlay/multi-plugin path.
+
+- [ ] **Step 4: Fix stale links**
+
+Search and update links that imply the Claude plugin root is a top-level `arckit-claude/` directory in the `arc-kit` repo. Prefer:
+
+```text
+https://github.com/tractorjuice/arckit-claude
+```
+
+for public user-facing install links, and keep:
+
+```text
+plugins/arckit-claude/
+```
+
+for contributor docs describing the source tree inside `arc-kit`.
+
+---
+
+## Task 4: Create and Seed the Standalone Repo
+
+**Requires:** GitHub write access and `GH_TOKEN` or authenticated `gh`.
+
+- [ ] **Step 1: Create the repo if missing**
+
+```bash
+gh repo create tractorjuice/arckit-claude \
+  --public \
+  --description "ArcKit plugin for Claude Code" \
+  --homepage "https://arckit.org"
+```
+
+- [ ] **Step 2: Add repo topics**
+
+Use `gh api` to set topics, then verify by reading them back:
+
+```bash
+gh api repos/tractorjuice/arckit-claude/topics \
+  -X PUT \
+  -H 'Accept: application/vnd.github+json' \
+  -f names[]='arckit' \
+  -f names[]='claude-code' \
+  -f names[]='claude-code-plugin' \
+  -f names[]='enterprise-architecture' \
+  -f names[]='governance' \
+  -f names[]='model-context-protocol' \
+  -f names[]='public-sector'
+```
+
+- [ ] **Step 3: Publish the initial mirror**
+
+After Task 1 and Task 2 are merged to `main`, run:
+
+```bash
+./scripts/push-extensions.sh claude
+```
+
+Expected:
+- files from `plugins/arckit-claude/` are copied to the standalone repo root,
+- the repo gets a sync commit,
+- the repo gets `vX.Y.Z`,
+- the repo gets a GitHub Release for `vX.Y.Z`.
+
+- [ ] **Step 4: Verify install behavior**
+
+From a clean temporary project:
+
+```bash
+claude plugin marketplace add tractorjuice/arckit-claude
+claude plugin install arckit
+claude plugin list
+```
+
+Also verify the legacy umbrella marketplace path still works:
+
+```bash
+claude plugin marketplace add tractorjuice/arc-kit
+claude plugin install arckit@arc-kit
+```
+
+---
+
+## Task 5: Validation Before Merge
+
+Run focused validation before opening the PR:
+
+```bash
+python scripts/converter.py
+pytest tests/plugin/test_release_process.py
+pytest tests/codex/test_codex_extension.py tests/gemini tests/opencode tests/copilot tests/vibe/test_vibe_extension.py tests/paperclip/test_commands_json.py
+node tests/plugin/test_graph_inject.mjs
+claude plugin tag plugins/arckit-claude --dry-run
+```
+
+Expected:
+- converter output is unchanged except for expected generated metadata changes,
+- release process tests include the new Claude standalone repo,
+- Codex and other generated extension parity tests still pass,
+- Claude plugin tag validation still cross-checks the umbrella marketplace entry,
+- no unrelated `.arckit/memory/*`, `docs/health.json`, or autoresearch trace files are committed.
+
+---
+
+## Task 6: Optional Stage 2 Source-of-Truth Split
+
+Do this only after at least one release has successfully published `tractorjuice/arckit-claude` as a mirror.
+
+- [ ] **Step 1: Choose the source ownership model**
+
+Recommended order:
+
+| Option | Recommendation | Reason |
+|---|---|---|
+| Keep mirror only | Preferred unless repo size or contribution flow demands a split | Lowest release risk; matches current generated extension pattern |
+| Git subtree | Best if standalone repo becomes canonical but umbrella still needs a full vendored copy | Explicit sync commits; no submodule checkout footguns |
+| Git submodule | Avoid unless contributors are comfortable with submodule workflows | Easy to break converter/tests in fresh checkouts |
+| Runtime clone during converter | Avoid | Network dependency in generation and CI |
+
+- [ ] **Step 2: If splitting source, add a sync script**
+
+Create a script such as `scripts/sync-claude-plugin.sh` that:
+- verifies the target ref in `tractorjuice/arckit-claude`,
+- copies or subtree-pulls into `plugins/arckit-claude/`,
+- preserves ignored local project files,
+- refuses to run with a dirty target path,
+- records the source commit in a checked-in file such as `plugins/arckit-claude/SOURCE_COMMIT`.
+
+- [ ] **Step 3: Update contributor docs**
+
+If source moves out:
+- new Claude plugin changes start in `tractorjuice/arckit-claude`,
+- `arc-kit` PRs consume synced plugin snapshots,
+- converter and release PRs happen in `arc-kit`,
+- emergency fixes may land in both repos only through the sync script.
+
+- [ ] **Step 4: Add source-sync CI**
+
+Add a test that fails when `plugins/arckit-claude/SOURCE_COMMIT` does not match the expected standalone repo ref, unless the PR intentionally updates the vendored copy.
+
+---
+
+## Acceptance Criteria
+
+- `tractorjuice/arckit-claude` exists, is public, has appropriate topics, and contains the root-level Claude plugin mirror.
+- `claude plugin marketplace add tractorjuice/arckit-claude` can discover and install `arckit`.
+- `tractorjuice/arc-kit` marketplace installs still work for existing users and overlay installs.
+- `scripts/push-extensions.sh claude` publishes the Claude standalone repo with `vX.Y.Z` tag and GitHub Release.
+- `docs/RELEASING.md` and `.claude/skills/release/SKILL.md` both name `tractorjuice/arckit-claude` in release verification.
+- Release process tests cover the Claude standalone repo alongside Codex, Gemini, OpenCode, Copilot, Paperclip, and Vibe.
+- `scripts/converter.py` and generated extension tests still use `plugins/arckit-claude/` as the core source during Stage 1.
+- Public docs clearly distinguish the preferred standalone core install from the umbrella overlay marketplace path.
+
+---
+
+## Cutover Notes
+
+- Keep both marketplace paths live for at least one minor release.
+- Announce the standalone repo as a distribution mirror, not a source split, until Stage 2 is explicitly approved.
+- If a future release removes the umbrella core marketplace entry, do it in a separate PR with a deprecation note and install-doc update.
+- The first release after this change should explicitly verify all standalone repos: `arckit-claude`, `arckit-gemini`, `arckit-codex`, `arckit-opencode`, `arckit-copilot`, `arckit-paperclip`, and `arckit-vibe`.

--- a/plugins/arckit-claude/.claude-plugin/marketplace.json
+++ b/plugins/arckit-claude/.claude-plugin/marketplace.json
@@ -1,0 +1,34 @@
+{
+  "name": "arckit-claude",
+  "owner": {
+    "name": "TractorJuice",
+    "email": "tractorjuice@users.noreply.github.com"
+  },
+  "metadata": {
+    "description": "The Enterprise Architecture Governance Harness for Claude Code",
+    "version": "1.0.0"
+  },
+  "plugins": [
+    {
+      "name": "arckit",
+      "source": ".",
+      "description": "ArcKit core for Claude Code: architecture governance, procurement, research, delivery, and assurance workflows",
+      "version": "5.15.2",
+      "author": {
+        "name": "TractorJuice"
+      },
+      "homepage": "https://github.com/tractorjuice/arckit-claude",
+      "repository": "https://github.com/tractorjuice/arckit-claude",
+      "license": "MIT",
+      "keywords": [
+        "architecture",
+        "governance",
+        "enterprise",
+        "procurement",
+        "vendor-evaluation",
+        "claude-code"
+      ],
+      "category": "productivity"
+    }
+  ]
+}

--- a/plugins/arckit-claude/.claude-plugin/plugin.json
+++ b/plugins/arckit-claude/.claude-plugin/plugin.json
@@ -7,7 +7,7 @@
     "name": "TractorJuice",
     "url": "https://github.com/tractorjuice"
   },
-  "repository": "https://github.com/tractorjuice/arc-kit",
+  "repository": "https://github.com/tractorjuice/arckit-claude",
   "license": "MIT",
   "mcpServers": "./.mcp.json",
   "experimental": {

--- a/plugins/arckit-claude/README.md
+++ b/plugins/arckit-claude/README.md
@@ -23,7 +23,7 @@ claude --version
 In Claude Code, run:
 
 ```text
-/plugin marketplace add tractorjuice/arc-kit
+/plugin marketplace add tractorjuice/arckit-claude
 ```
 
 ### Step 2: Install the plugin
@@ -35,13 +35,23 @@ In Claude Code, run:
 Go to the **Discover** tab, find **arckit**, and install it. Or via CLI:
 
 ```bash
-claude plugin install arckit@arc-kit
+claude plugin install arckit@arckit-claude
+```
+
+### Installing with ArcKit overlay plugins
+
+The umbrella ArcKit marketplace still hosts the core plugin plus regional and sector overlays.
+Use it when you want `arckit` together with plugins such as `arckit-uae`, `arckit-fr`, or
+`arckit-au`:
+
+```text
+/plugin marketplace add tractorjuice/arc-kit
 ```
 
 ### Alternative: Load for a single session
 
 ```bash
-claude --plugin-dir /path/to/arc-kit/arckit-claude
+claude --plugin-dir /path/to/arckit-claude
 ```
 
 ## Prerequisites
@@ -287,9 +297,9 @@ This plugin is for Claude Code. For other AI assistants:
 
 ## Links
 
-- [Repository](https://github.com/tractorjuice/arc-kit)
+- [Repository](https://github.com/tractorjuice/arckit-claude)
 - [Documentation](https://tractorjuice.github.io/arc-kit)
-- [Changelog](https://github.com/tractorjuice/arc-kit/blob/main/CHANGELOG.md)
+- [Changelog](https://github.com/tractorjuice/arckit-claude/blob/main/CHANGELOG.md)
 
 ## License
 

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -127,16 +127,25 @@ jq --arg v "$NEW_VERSION" '.version = $v' plugins/arckit-claude/.claude-plugin/p
 mv plugins/arckit-claude/.claude-plugin/plugin.json.tmp plugins/arckit-claude/.claude-plugin/plugin.json
 update_file "plugins/arckit-claude/.claude-plugin/plugin.json" ".version"
 
-# ── 8. .claude-plugin/marketplace.json (all 6 plugin entries) ──────────────
+# ── 8. plugins/arckit-claude/.claude-plugin/marketplace.json ───────────────
 #
-# All 6 plugins (arckit core + 5 community: uae, fr, ca, eu, at) share one
-# version per the v5.0.0 split design. metadata.version stays at 1.0.0.
+# Standalone Claude distribution repo metadata. The plugin source is "." once
+# plugins/arckit-claude/ is mirrored to tractorjuice/arckit-claude.
+
+jq --arg v "$NEW_VERSION" '.plugins |= map(.version = $v)' plugins/arckit-claude/.claude-plugin/marketplace.json > plugins/arckit-claude/.claude-plugin/marketplace.json.tmp
+mv plugins/arckit-claude/.claude-plugin/marketplace.json.tmp plugins/arckit-claude/.claude-plugin/marketplace.json
+update_file "plugins/arckit-claude/.claude-plugin/marketplace.json" "all .plugins[].version (metadata.version unchanged)"
+
+# ── 9. .claude-plugin/marketplace.json (all Claude plugin entries) ─────────
+#
+# All Claude plugins share one version per the v5.0.0 split design.
+# metadata.version stays at 1.0.0.
 
 jq --arg v "$NEW_VERSION" '.plugins |= map(.version = $v)' .claude-plugin/marketplace.json > .claude-plugin/marketplace.json.tmp
 mv .claude-plugin/marketplace.json.tmp .claude-plugin/marketplace.json
 update_file ".claude-plugin/marketplace.json" "all .plugins[].version (metadata.version unchanged)"
 
-# ── 8a–8f. Community plugin manifests + VERSION files ─────────────────────
+# ── 9a–9f. Community plugin manifests + VERSION files ─────────────────────
 #
 # Each community plugin pins its `arckit` dependency to the current core
 # version with an exact (`=`) semver constraint. bump-version.sh keeps
@@ -249,6 +258,10 @@ echo ""
 echo "marketplace.json:"
 echo "  metadata.version:   $(jq -r '.metadata.version' .claude-plugin/marketplace.json)  (should be 1.0.0)"
 jq -r '.plugins[] | "  \(.name): \(.version)"' .claude-plugin/marketplace.json | sed 's/^/  /'
+echo ""
+echo "standalone Claude marketplace.json:"
+echo "  metadata.version:   $(jq -r '.metadata.version' plugins/arckit-claude/.claude-plugin/marketplace.json)  (should be 1.0.0)"
+jq -r '.plugins[] | "  \(.name): \(.version)"' plugins/arckit-claude/.claude-plugin/marketplace.json | sed 's/^/  /'
 echo ""
 
 # Lint check

--- a/scripts/push-extensions.sh
+++ b/scripts/push-extensions.sh
@@ -1,16 +1,16 @@
 #!/usr/bin/env bash
 set -uo pipefail
 
-# push-extensions.sh — Publish extension directories to their separate GitHub repos.
-# Usage: ./scripts/push-extensions.sh [extension...]
+# push-extensions.sh — Publish ArcKit distributions to separate GitHub repos.
+# Usage: ./scripts/push-extensions.sh [distribution...]
 #
 # Examples:
-#   ./scripts/push-extensions.sh              # Push all extensions
-#   ./scripts/push-extensions.sh gemini codex # Push only gemini and codex
+#   ./scripts/push-extensions.sh              # Push all standalone distributions
+#   ./scripts/push-extensions.sh claude codex # Push only Claude and Codex
 #
 # Requires: GH_TOKEN with repo scope, or gh CLI authenticated with push access.
 # By default this also creates/preserves a vX.Y.Z tag and GitHub Release in
-# each extension repo. Set ARCKIT_SKIP_EXTENSION_RELEASES=1 for a commit-only
+# each standalone repo. Set ARCKIT_SKIP_EXTENSION_RELEASES=1 for a commit-only
 # sync.
 
 REPO_OWNER="tractorjuice"
@@ -22,9 +22,10 @@ ROOT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 WORK_DIR=$(mktemp -d)
 trap 'rm -rf "$WORK_DIR"' EXIT
 
-# ── Extension config ──────────────────────────────────────────────────────────
+# ── Standalone repo config ────────────────────────────────────────────────────
 # Format: local_dir:repo_name
 declare -A EXTENSIONS=(
+  [claude]="plugins/arckit-claude:arckit-claude"
   [gemini]="extensions/arckit-gemini:arckit-gemini"
   [codex]="extensions/arckit-codex:arckit-codex"
   [opencode]="extensions/arckit-opencode:arckit-opencode"
@@ -33,11 +34,11 @@ declare -A EXTENSIONS=(
   [vibe]="extensions/arckit-vibe:arckit-vibe"
 )
 
-# ── Determine which extensions to push ────────────────────────────────────────
+# ── Determine which distributions to push ─────────────────────────────────────
 if [[ $# -gt 0 ]]; then
   TARGETS=("$@")
 else
-  TARGETS=("gemini" "codex" "opencode" "copilot" "paperclip" "vibe")
+  TARGETS=("claude" "gemini" "codex" "opencode" "copilot" "paperclip" "vibe")
 fi
 
 # ── Read version from root VERSION file ───────────────────────────────────────
@@ -110,7 +111,7 @@ publish_release_artifacts() {
   local release_notes
 
   if [[ "$SKIP_RELEASES" == "1" ]]; then
-    yellow "  Extension release publishing disabled by ARCKIT_SKIP_EXTENSION_RELEASES=1"
+    yellow "  Standalone repo release publishing disabled by ARCKIT_SKIP_EXTENSION_RELEASES=1"
     return 0
   fi
 
@@ -168,7 +169,7 @@ FAILED=0
 
 for target in "${TARGETS[@]}"; do
   if [[ ! ${EXTENSIONS[$target]+_} ]]; then
-    red "  Unknown extension: $target"
+    red "  Unknown distribution: $target"
     echo "  Valid: ${!EXTENSIONS[*]}"
     ((FAILED++))
     continue

--- a/tests/plugin/test_release_process.py
+++ b/tests/plugin/test_release_process.py
@@ -10,7 +10,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 PUSH_EXTENSIONS = REPO_ROOT / "scripts" / "push-extensions.sh"
 RELEASING_DOC = REPO_ROOT / "docs" / "RELEASING.md"
 ROOT_VERSION = REPO_ROOT / "VERSION"
-EXPECTED_EXTENSIONS = {
+EXPECTED_STANDALONE_REPOS = {
+    "claude": ("plugins/arckit-claude", "arckit-claude"),
     "gemini": ("extensions/arckit-gemini", "arckit-gemini"),
     "codex": ("extensions/arckit-codex", "arckit-codex"),
     "opencode": ("extensions/arckit-opencode", "arckit-opencode"),
@@ -27,55 +28,82 @@ PINNED_README_VERSION_PATTERNS = [
 ]
 
 
-def extension_path(extension_key: str) -> Path:
-    local_dir, _repo_name = EXPECTED_EXTENSIONS[extension_key]
+def standalone_path(distribution_key: str) -> Path:
+    local_dir, _repo_name = EXPECTED_STANDALONE_REPOS[distribution_key]
     return REPO_ROOT / local_dir
 
 
-def test_extension_readmes_do_not_pin_release_versions():
+def test_standalone_readmes_do_not_pin_release_versions():
     failures = []
 
-    for extension_key in EXPECTED_EXTENSIONS:
-        readme = extension_path(extension_key) / "README.md"
+    for distribution_key in EXPECTED_STANDALONE_REPOS:
+        readme = standalone_path(distribution_key) / "README.md"
         text = readme.read_text(encoding="utf-8")
         for pattern in PINNED_README_VERSION_PATTERNS:
             if pattern.search(text):
                 failures.append(f"{readme.relative_to(REPO_ROOT)} matches {pattern.pattern}")
 
-    assert not failures, "Pinned extension README versions found:\n" + "\n".join(failures)
+    assert not failures, "Pinned standalone README versions found:\n" + "\n".join(failures)
 
 
-def test_release_process_names_every_standalone_extension():
+def test_release_process_names_every_standalone_repo():
     script = PUSH_EXTENSIONS.read_text(encoding="utf-8")
     release_doc = RELEASING_DOC.read_text(encoding="utf-8")
 
-    for extension_key, (local_dir, repo_name) in EXPECTED_EXTENSIONS.items():
-        assert f'[{extension_key}]="{local_dir}:{repo_name}"' in script
+    for distribution_key, (local_dir, repo_name) in EXPECTED_STANDALONE_REPOS.items():
+        assert f'[{distribution_key}]="{local_dir}:{repo_name}"' in script
         assert f"tractorjuice/{repo_name}" in release_doc
         assert (REPO_ROOT / local_dir / "README.md").is_file()
         assert (REPO_ROOT / local_dir / "VERSION").is_file()
 
 
-def test_extension_version_files_match_root_version():
+def test_standalone_version_files_match_root_version():
     root_version = ROOT_VERSION.read_text(encoding="utf-8").strip()
 
-    for extension_key in EXPECTED_EXTENSIONS:
-        version_file = extension_path(extension_key) / "VERSION"
+    for distribution_key in EXPECTED_STANDALONE_REPOS:
+        version_file = standalone_path(distribution_key) / "VERSION"
         assert version_file.read_text(encoding="utf-8").strip() == root_version
 
     gemini_manifest = json.loads(
-        (extension_path("gemini") / "gemini-extension.json").read_text(encoding="utf-8")
+        (standalone_path("gemini") / "gemini-extension.json").read_text(encoding="utf-8")
     )
     assert gemini_manifest["version"] == root_version
 
     paperclip_manifest = json.loads(
-        (extension_path("paperclip") / "package.json").read_text(encoding="utf-8")
+        (standalone_path("paperclip") / "package.json").read_text(encoding="utf-8")
     )
     assert paperclip_manifest["version"] == root_version
 
-    with (extension_path("vibe") / "vibe-config.toml").open("rb") as f:
+    with (standalone_path("vibe") / "vibe-config.toml").open("rb") as f:
         vibe_config = tomllib.load(f)
     assert vibe_config["extension"]["version"] == root_version
+
+
+def test_claude_standalone_marketplace_matches_plugin_version():
+    plugin_version = (standalone_path("claude") / "VERSION").read_text(encoding="utf-8").strip()
+    plugin_manifest = json.loads(
+        (standalone_path("claude") / ".claude-plugin" / "plugin.json").read_text(
+            encoding="utf-8"
+        )
+    )
+    marketplace = json.loads(
+        (standalone_path("claude") / ".claude-plugin" / "marketplace.json").read_text(
+            encoding="utf-8"
+        )
+    )
+
+    assert plugin_manifest["name"] == "arckit"
+    assert plugin_manifest["version"] == plugin_version
+    assert plugin_manifest["repository"] == "https://github.com/tractorjuice/arckit-claude"
+    assert marketplace["name"] == "arckit-claude"
+    assert marketplace["metadata"]["version"] == "1.0.0"
+    assert len(marketplace["plugins"]) == 1
+
+    plugin = marketplace["plugins"][0]
+    assert plugin["name"] == "arckit"
+    assert plugin["source"] == "."
+    assert plugin["version"] == plugin_version
+    assert plugin["repository"] == "https://github.com/tractorjuice/arckit-claude"
 
 
 def test_push_extensions_publishes_tags_and_github_releases():


### PR DESCRIPTION
## Summary

- add a standalone Claude distribution target that mirrors `plugins/arckit-claude/` to `tractorjuice/arckit-claude`
- add standalone Claude marketplace metadata and keep version bump/release guardrails in sync
- update install and release docs to prefer `tractorjuice/arckit-claude` for core installs while preserving the umbrella marketplace for overlays
- add the implementation plan under `docs/plans/`

## Validation

- `pytest tests/plugin/test_release_process.py`
- `python scripts/converter.py`
- `pytest tests/codex/test_codex_extension.py tests/gemini tests/opencode tests/copilot tests/vibe/test_vibe_extension.py tests/paperclip/test_commands_json.py`
- `npx markdownlint-cli2 README.md docs/RELEASING.md docs/llms.txt plugins/arckit-claude/README.md .claude/skills/release/SKILL.md docs/plans/2026-06-30-claude-plugin-standalone-repo.md`
- `git diff --check`

## Notes

Created `tractorjuice/arckit-claude` as a public GitHub repo and set repository topics. The mirror contents should be published after this PR merges to `main` by running `./scripts/push-extensions.sh claude`.

`node tests/plugin/test_graph_inject.mjs` was attempted but hung silently in this environment and was interrupted after about 90 seconds.
