### PR TITLE
fix: simplify plugin.json to match official Anthropic plugin format

### DIFF
--- a/plugins/arckit-togaf-adm/.claude-plugin/plugin.json
+++ b/plugins/arckit-togaf-adm/.claude-plugin/plugin.json
@@ -1,26 +1,8 @@
 {
-  "$schema": "https://json.schemastore.org/claude-code-plugin-manifest.json",
   "name": "arckit-togaf-adm",
-  "version": "6.1.1",
   "description": "TOGAF ADM — Enterprise Architecture Development Method for AI-assisted governance. 9 commands covering all ADM phases (Preliminary through H) plus Architecture Repository.",
   "author": {
     "name": "ArcKit Contributors",
     "url": "https://github.com/tractorjuice/arckit-claude"
-  },
-  "repository": "https://github.com/tractorjuice/arckit-claude",
-  "license": "MIT",
-  "defaultEnabled": false,
-  "userConfig": {
-    "default_classification": {
-      "type": "string",
-      "default": "PUBLIC",
-      "description": "Default document classification (e.g. PUBLIC, OFFICIAL, OFFICIAL-SENSITIVE)"
-    }
-  },
-  "dependencies": [
-    {
-      "name": "arckit",
-      "version": "=6.1.1"
-    }
-  ]
+  }
 }


### PR DESCRIPTION
Simplify plugins/arckit-togaf-adm/.claude-plugin/plugin.json to match the official Anthropic Claude Code plugin manifest format.

**Before:**
- Included $schema, version, repository, license, defaultEnabled, userConfig, dependencies

**After:**
- Minimal manifest: name, description, author (matching commit-commands from claude-plugins-official)

**Fixes:**
- userConfig.default_classification.title validation error when installing via marketplace