### PR TITLE
fix: handle codex pages namespaced invocation

### DIFF
--- a/extensions/arckit-codex/hooks/arckit-codex-hook.mjs
+++ b/extensions/arckit-codex/hooks/arckit-codex-hook.mjs
@@ -271,7 +271,7 @@ function hookAdditionalContext(output) {
 
 function promptMatchesCommand(prompt, command) {
   const escaped = command.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
-  return new RegExp(`(?:^|\\s)(?:\\$arckit-${escaped}|/arckit[.:]${escaped})\\b`, "i").test(prompt);
+  return new RegExp(`(?:^|\\s)(?:\\$arckit-${escaped}|\\$arckit-codex:arckit-${escaped}|/arckit[.:]${escaped})\\b`, "i").test(prompt);
 }
 
 function detectSecrets(text) {

--- a/extensions/arckit-codex/hooks/sync-guides.mjs
+++ b/extensions/arckit-codex/hooks/sync-guides.mjs
@@ -877,7 +877,7 @@ export function runSyncGuidesHook(data = {}) {
 // OR the Skill-expanded body (unique description/heading).
 // No ^ anchors — Skill tool may wrap the expanded body in XML tags.
 const userPrompt = data.prompt || '';
-const isRawCommand = /^\s*(?:\/arckit[.:]+|\$arckit-)pages\b/i.test(userPrompt);
+const isRawCommand = /^\s*(?:\/arckit[.:]+pages\b|\$arckit-pages\b|\$arckit-codex:arckit-pages\b)/i.test(userPrompt);
 const isExpandedBody = /description:\s*Generate documentation site/i.test(userPrompt)
   || /#\s*ArcKit:\s*Documentation Site Generator/i.test(userPrompt);
 if (!isRawCommand && !isExpandedBody) return null;

--- a/tests/codex/test_codex_extension.py
+++ b/tests/codex/test_codex_extension.py
@@ -607,6 +607,31 @@ def test_codex_hook_runs_pages_preprocessor(tmp_path):
     assert (tmp_path / "docs" / "index.html").is_file()
 
 
+def test_codex_hook_runs_pages_preprocessor_for_namespaced_invocation(tmp_path):
+    project_dir = tmp_path / "projects" / "001-demo"
+    project_dir.mkdir(parents=True)
+    artifact = project_dir / "ARC-001-REQ-v1.0.md"
+    artifact.write_text(
+        "# Requirements\n\n| Field | Value |\n|-------|-------|\n| Status | Draft |\n\nBR-001 user need\n",
+        encoding="utf-8",
+    )
+
+    output = run_codex_hook(
+        "UserPromptSubmit",
+        {
+            "hook_event_name": "UserPromptSubmit",
+            "cwd": str(tmp_path),
+            "prompt": "$arckit-codex:arckit-pages",
+        },
+    )
+
+    context = output["hookSpecificOutput"]["additionalContext"]
+    assert "Pages Pre-processor Complete (hook)" in context
+    assert "DOCUMENT STATS" in context
+    assert (tmp_path / "docs" / "manifest.json").is_file()
+    assert (tmp_path / "docs" / "index.html").is_file()
+
+
 def test_codex_hook_updates_manifest_and_stamps_provenance(tmp_path):
     project_dir = tmp_path / "projects" / "001-demo"
     project_dir.mkdir(parents=True)


### PR DESCRIPTION
## Summary

- Fixes the Codex pages hook matcher so `$arckit-codex:arckit-pages` triggers the Pages preprocessor.
- Updates the sync-guides raw command guard to accept the same namespaced invocation.
- Adds regression coverage proving the hook context includes Pages document stats for the namespaced command.

## Root Cause

The outer Codex hook and inner sync-guides hook only recognized `$arckit-pages` and slash-style `/arckit:pages` forms. When Codex invoked the skill as `$arckit-codex:arckit-pages`, the assistant received generic ArcKit context but not the Pages preprocessor statistics required by the command instructions.

## Validation

- `python scripts/converter.py`
- `pytest tests/codex/test_codex_extension.py`

Fixes #631
