### PR TITLE
docs(nhs): correct DCB0129 severity/likelihood numbering caveat (Orange Book / inversion claim)

### DIFF
--- a/.arckit/templates/uk-nhs-dcb0129-case-template.md
+++ b/.arckit/templates/uk-nhs-dcb0129-case-template.md
@@ -39,7 +39,7 @@
 **Risk levels**: `unacceptable` · `high` · `medium` · `low`
 **Hazard status**: `open` · `mitigated` · `accepted` · `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. Read carefully when cross-referencing project risk registers.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so these ordinals run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing project risk registers.
 
 ---
 

--- a/.arckit/templates/uk-nhs-dcb0129-hazard-template.md
+++ b/.arckit/templates/uk-nhs-dcb0129-hazard-template.md
@@ -157,7 +157,7 @@ controls:
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. The numbers above carry the opposite meaning from the project risk register.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing the project risk register.
 
 ---
 

--- a/.arckit/templates/uk-nhs-dcb0160-deployment-hazard-template.md
+++ b/.arckit/templates/uk-nhs-dcb0160-deployment-hazard-template.md
@@ -232,7 +232,7 @@ controls:
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129/0160 inverts the usual Orange Book convention. The numbers above carry the opposite meaning from the project risk register.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129/0160).** ArcKit numbers the DCB0129/0160 labels 1 (worst) to 5 (least) purely to store them. The standard itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in DCB0129/0160 are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and the standard's own risk classes. Take care when cross-referencing the project risk register.
 
 ---
 

--- a/docs/guides/uk-nhs-dcb0129.md
+++ b/docs/guides/uk-nhs-dcb0129.md
@@ -27,7 +27,7 @@ The 3 files together implement the four DCB0129 deliverables — Clinical Risk M
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. Templates carry the legend prominently.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled; the only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction). So these ordinals run opposite to both the usual risk-register convention and DCB0129's own risk classes. The templates carry this legend prominently.
 
 ## When to use
 

--- a/plugins/arckit-claude/docs/guides/uk-nhs-dcb0129.md
+++ b/plugins/arckit-claude/docs/guides/uk-nhs-dcb0129.md
@@ -27,7 +27,7 @@ The 3 files together implement the four DCB0129 deliverables — Clinical Risk M
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. Templates carry the legend prominently.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled; the only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction). So these ordinals run opposite to both the usual risk-register convention and DCB0129's own risk classes. The templates carry this legend prominently.
 
 ## When to use
 

--- a/plugins/arckit-claude/plugins/uk/nhs/commands/uk-nhs-dcb0129.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/commands/uk-nhs-dcb0129.md
@@ -52,7 +52,7 @@ NHS DCB0129 ("Clinical Risk Management: its Application in the Manufacture of He
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> Note: the DCB0129 scale inverts the usual ArcKit / Orange Book convention where 5 = highest. We follow DCB0129 because that is what CSOs sign off against. Templates carry the legend prominently.
+> Note: ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) to store them; DCB0129 itself puts no numbers on the severity/likelihood axes (word-labelled), and its only numbers are the Risk Class cells (1-5, 5 = unacceptable/highest, the conventional direction). ArcKit keeps the DCB0129 label order because that is what CSOs sign off against; templates carry the legend prominently.
 
 ## Process
 

--- a/plugins/arckit-claude/plugins/uk/nhs/templates/uk-nhs-dcb0129-case-template.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/templates/uk-nhs-dcb0129-case-template.md
@@ -39,7 +39,7 @@
 **Risk levels**: `unacceptable` · `high` · `medium` · `low`
 **Hazard status**: `open` · `mitigated` · `accepted` · `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. Read carefully when cross-referencing project risk registers.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so these ordinals run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing project risk registers.
 
 ---
 

--- a/plugins/arckit-claude/plugins/uk/nhs/templates/uk-nhs-dcb0129-hazard-template.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/templates/uk-nhs-dcb0129-hazard-template.md
@@ -157,7 +157,7 @@ controls:
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. The numbers above carry the opposite meaning from the project risk register.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing the project risk register.
 
 ---
 

--- a/plugins/arckit-claude/plugins/uk/nhs/templates/uk-nhs-dcb0160-deployment-hazard-template.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/templates/uk-nhs-dcb0160-deployment-hazard-template.md
@@ -232,7 +232,7 @@ controls:
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129/0160 inverts the usual Orange Book convention. The numbers above carry the opposite meaning from the project risk register.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129/0160).** ArcKit numbers the DCB0129/0160 labels 1 (worst) to 5 (least) purely to store them. The standard itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in DCB0129/0160 are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and the standard's own risk classes. Take care when cross-referencing the project risk register.
 
 ---
 

--- a/plugins/arckit-uk-nhs/commands/uk-nhs-dcb0129.md
+++ b/plugins/arckit-uk-nhs/commands/uk-nhs-dcb0129.md
@@ -52,7 +52,7 @@ NHS DCB0129 ("Clinical Risk Management: its Application in the Manufacture of He
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> Note: the DCB0129 scale inverts the usual ArcKit / Orange Book convention where 5 = highest. We follow DCB0129 because that is what CSOs sign off against. Templates carry the legend prominently.
+> Note: ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) to store them; DCB0129 itself puts no numbers on the severity/likelihood axes (word-labelled), and its only numbers are the Risk Class cells (1-5, 5 = unacceptable/highest, the conventional direction). ArcKit keeps the DCB0129 label order because that is what CSOs sign off against; templates carry the legend prominently.
 
 ## Process
 

--- a/plugins/arckit-uk-nhs/templates/uk-nhs-dcb0129-case-template.md
+++ b/plugins/arckit-uk-nhs/templates/uk-nhs-dcb0129-case-template.md
@@ -39,7 +39,7 @@
 **Risk levels**: `unacceptable` · `high` · `medium` · `low`
 **Hazard status**: `open` · `mitigated` · `accepted` · `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. Read carefully when cross-referencing project risk registers.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so these ordinals run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing project risk registers.
 
 ---
 

--- a/plugins/arckit-uk-nhs/templates/uk-nhs-dcb0129-hazard-template.md
+++ b/plugins/arckit-uk-nhs/templates/uk-nhs-dcb0129-hazard-template.md
@@ -157,7 +157,7 @@ controls:
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest. The numbers above carry the opposite meaning from the project risk register.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing the project risk register.
 
 ---
 

--- a/plugins/arckit-uk-nhs/templates/uk-nhs-dcb0160-deployment-hazard-template.md
+++ b/plugins/arckit-uk-nhs/templates/uk-nhs-dcb0160-deployment-hazard-template.md
@@ -232,7 +232,7 @@ controls:
 - **Risk level**: `unacceptable` | `high` | `medium` | `low`
 - **Status**: `open` | `mitigated` | `accepted` | `closed`
 
-> ⚠️ DCB0129/0160 inverts the usual Orange Book convention. The numbers above carry the opposite meaning from the project risk register.
+> ⚠️ **Numbering note (ArcKit encoding, not DCB0129/0160).** ArcKit numbers the DCB0129/0160 labels 1 (worst) to 5 (least) purely to store them. The standard itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in DCB0129/0160 are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and the standard's own risk classes. Take care when cross-referencing the project risk register.
 
 ---
 


### PR DESCRIPTION
Closes #640.

## What

Rewords the DCB0129/0160 clinical-safety numbering caveat in all **13** places it appears (the `arckit-uk-nhs` overlay, its mirror under `plugins/arckit-claude/plugins/uk/nhs/`, the `.arckit/templates/` working copies, and the guide in both locations).

## Why

The old caveat -

> ⚠️ DCB0129 inverts the usual Orange Book convention where 5 = highest.

- is inaccurate on three counts:

1. **DCB0129 does not number its severity/likelihood axes.** The published DCB0129/0160 matrix labels both axes with words only (severity Minor -> Catastrophic, likelihood Very Low -> Very High). Its only numbers are the **Risk Class** cells (1-5), where **5 = unacceptable/highest** - the conventional direction. DCB0129 inverts nothing. (Confirmed against the NHS *Clinical Risk Management: Implementation Guidance* matrix, reproduced e.g. in [RCHT's DCB0129/0160 policy, Appendix 3](https://doclibrary-rcht.cornwall.nhs.uk/GET/d10359420).)
2. **The Orange Book prescribes no 1-5 scale.** HM Treasury's [*Management of Risk - Principles and Concepts* (May 2023)](https://www.gov.uk/government/publications/orange-book/the-orange-book-management-of-risk-principles-and-concepts) uses word scales and states there is no absolute standard for risk-matrix scales. "5 = highest" is common risk-register practice, not an Orange Book rule.
3. **The inversion is ArcKit's own encoding.** ArcKit stores the labels as `1 = Catastrophic ... 5 = Minor` (1 = worst), which runs opposite to both the usual risk-register convention and DCB0129's own Risk Class direction (5 = worst).

## Change

Caveat text only. The new wording attributes the ordinals to ArcKit's encoding, states the standard's axes are word-labelled, and notes the Risk Class runs 5 = highest. Example (hazard template):

> ⚠️ **Numbering note (ArcKit encoding, not DCB0129).** ArcKit numbers the DCB0129 labels 1 (worst) to 5 (least) purely to store them. DCB0129 itself puts no numbers on the severity/likelihood axes - they are word-labelled. The only numbers in the standard are the Risk Class cells (1-5, where 5 = unacceptable/highest, the conventional direction), so the ordinals above run opposite to both the usual risk-register convention and DCB0129's own risk classes. Take care when cross-referencing the project risk register.

**The stored ordinals are unchanged.** A possible follow-up (noted in #640) is to re-number so `5 = worst`, aligning ArcKit with both DCB0129's Risk Class and every UK risk register, which would remove the footgun rather than only documenting it.

## Notes

- No functional/scoring logic touched; docs-only.
- Converter-generated extension formats are gitignored and regenerate from source, so no changes there.
