### PR TITLE
docs: update Claude Code platform guidance

### DIFF
--- a/.arckit/templates/architecture-repository-template.md
+++ b/.arckit/templates/architecture-repository-template.md
@@ -103,5 +103,5 @@ templateVersion: "1.0"
 **Generated on**: `[DATE] [TIME] GMT`
 **ArcKit Version**: `{ARCKIT_VERSION}`
 **Project**: Global Repository (Project 000)
-**AI Model**: `[Use actual model name, e.g., "claude-sonnet-4-5-20250929"]`
+**AI Model**: `[Use actual model name, e.g., "Claude Sonnet 5 (session default)"]`
 **Generation Context**: `[Brief note about source documents and projects synthesised]`

--- a/.arckit/templates/au-ai-assurance-template.md
+++ b/.arckit/templates/au-ai-assurance-template.md
@@ -160,7 +160,7 @@ National AI Centre (NAIC) operational practices for safe and responsible AI adop
 | Aspect | Detail |
 |--------|--------|
 | **Vendor Name** | [E.g., Anthropic / OpenAI / Google] |
-| **Model + Version** | [E.g., Claude Opus 4.7] |
+| **Model + Version** | [E.g., Claude Sonnet 5 (session default)] |
 | **Vendor AI Policy Compliance** | [Vendor's published AI policy alignment] |
 | **Training-Data Provenance** | [Disclosed / Partially disclosed / Not disclosed] |
 | **Inference Region** | [AU / US / EU / global] |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   latest v2.1.200 floor for project-scoped plugin loading from git worktrees,
   `claude agents --plugin-dir` agent/skill visibility, and the recent
   background-subagent reliability and hook diagnostics fixes tracked in #580.
+- **Claude Code v2.1.200 documentation backlog (#580).** Added managed model
+  governance, OTEL assistant-response, MCP auth, safe-mode troubleshooting,
+  plugin branch-testing, and ArcKit skill-layout guidance; refreshed stale
+  Claude model examples for Sonnet 5-era defaults.
 
 ## [6.1.7] — 2026-07-03
 

--- a/docs/guides/custom-commands.md
+++ b/docs/guides/custom-commands.md
@@ -24,6 +24,12 @@ You write **one** source file in `plugins/arckit-claude/commands/<n>.md`. The co
 
 The first row is the file you edit by hand; the converter generates all others. You do not edit the generated files directly. The converter handles argument-placeholder rewriting, path rewriting for the Gemini sandbox, frontmatter stripping for Claude-only fields, and extension-file copying.
 
+ArcKit does not use a root-level `SKILL.md` for plugin behaviour. Reusable
+Claude Code skills live in `plugins/arckit-claude/skills/<skill-name>/SKILL.md`;
+Codex skill outputs live under `extensions/arckit-codex/skills/`. Keep command
+authoring guidance in this guide unless Claude Code's plugin layout explicitly
+adds root-level skill support.
+
 ---
 
 ## The Source File

--- a/docs/guides/enterprise-scale.md
+++ b/docs/guides/enterprise-scale.md
@@ -236,6 +236,19 @@ Claude Code then **refuses to start** outside the range and directs the user to 
 
 For an **individual** user or repo that just wants to avoid drifting *below* the floor, the softer, user-scoped `minimumVersion` in `.claude/settings.json` blocks auto-update/`claude update` from going below it (it doesn't refuse startup). ArcKit pins this in its own repos and the below-floor warning recommends it.
 
+### Govern available models
+
+Managed settings can also govern which models are available to a fleet. Use
+your organisation defaults and model restrictions together, and enable
+`enforceAvailableModels` when you need project settings, subagents, or manual
+model overrides to stay inside the approved list.
+
+ArcKit does not pin a model in its commands. Commands inherit the Claude Code
+session default, so a centrally managed model policy is the right control point
+for regulated deployments. The current ArcKit guidance assumes Claude Sonnet 5
+as the normal default; allow Claude Fable 5 only where the tenant exposes it and
+the work justifies the higher tier.
+
 ### Allowlist the ArcKit marketplace
 
 `pluginSuggestionMarketplaces` lets admins allowlist org marketplaces whose plugins may surface in context-aware tips. Allowlisting `tractorjuice/arckit-claude` means Claude Code can suggest ArcKit when a user opens a directory with a `projects/` tree or `ARC-*` artefacts — useful for driving adoption across many teams without a manual rollout. Pair with `strictKnownMarketplaces` / `blockedMarketplaces` if you want to *restrict* installs to only the marketplaces you've vetted.
@@ -249,6 +262,18 @@ export OTEL_RESOURCE_ATTRIBUTES="repo=arc-kit,team=enterprise-architecture,proje
 ```
 
 You can then slice token/cost usage by team, repo, or project — a natural complement to the per-artefact Document Control headers and `provenance-stamp` ArcKit already produces. **Privacy caveat:** these labels are emitted as-is, so don't put project identifiers in them for OFFICIAL-SENSITIVE / SECRET work where the label itself would be sensitive.
+
+If you export prompt telemetry but must not export generated response text,
+leave assistant-response logging disabled:
+
+```bash
+export OTEL_LOG_ASSISTANT_RESPONSES=0
+```
+
+Only set `OTEL_LOG_ASSISTANT_RESPONSES=1` in environments where response
+content is approved for the telemetry backend. Treat ArcKit artefact drafts,
+policy decisions, and evidence summaries as sensitive until your data-handling
+rules say otherwise.
 
 ---
 

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -195,6 +195,27 @@ export DATA_COMMONS_API_KEY="your-api-key-here"
 
 > **Your keys stay hidden in `claude mcp` output.** Both keyed servers carry their key in an HTTP header (`X-Goog-Api-Key`, `X-API-Key`) via `${GOOGLE_API_KEY}` / `${DATA_COMMONS_API_KEY}`. As of Claude Code v2.1.161, `claude mcp list` / `get` / `add` no longer expand `${VAR}` references and redact credential headers and URL secrets — so inspecting your MCP config (or screen-sharing it) won't leak the keys. Relevant for OFFICIAL-SENSITIVE / regulated deployments. The other four bundled servers are keyless, so there's nothing to redact.
 
+### Managing MCP authentication
+
+For OAuth-backed or interactive MCP servers, use Claude Code's MCP auth
+commands instead of editing token files by hand:
+
+```bash
+claude mcp login <server-name>
+claude mcp logout <server-name>
+```
+
+ArcKit's bundled keyed servers still use environment variables, but the same
+`claude mcp` workflow is useful when you add third-party MCP servers alongside
+ArcKit. Recent Claude Code releases improved OAuth retries and headless login
+flows, so stale browser hand-offs are less likely to leave a server half
+configured.
+
+Servers that use a `headersHelper` can also refresh credentials after 401/403
+responses. If a helper-backed server works once and then starts failing after a
+token expiry, run `claude mcp login <server-name>` again before changing the
+ArcKit configuration.
+
 ---
 
 ## Troubleshooting

--- a/docs/guides/start.md
+++ b/docs/guides/start.md
@@ -99,7 +99,7 @@ If you want to skip the decision tree and let ArcKit do the heavy lifting, this 
 
 - **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
 - **Existing projects** with artifacts already on disk — run `/arckit:navigator` first to see what is missing rather than regenerating.
-- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.7 or 4.8 with the `max` or `xhigh` effort levels.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use the Claude Code session default, normally Claude Sonnet 5, and move to Claude Fable 5 only where your tenant exposes it and the work justifies the higher tier.
 
 ### Tips For Vibe Start
 

--- a/docs/guides/testing-plugin-branches.md
+++ b/docs/guides/testing-plugin-branches.md
@@ -31,6 +31,11 @@ cd your-test-project
 claude
 ```
 
+> **Claude Code v2.1.200+ recommended:** project-scoped plugin loading from
+> git worktrees is reliable from this floor. Earlier clients can fail to pick up
+> the expected branch, which makes `/arckit:health` look like the branch test is
+> passing against the marketplace copy.
+
 ## Source fields
 
 | Field | Required | Description |
@@ -48,6 +53,23 @@ To test from a local checkout without pushing:
 ```bash
 claude --plugin-dir /path/to/arc-kit/plugins/arckit-claude
 ```
+
+On Claude Code v2.1.200+, `claude agents --plugin-dir
+/path/to/arc-kit/plugins/arckit-claude` also shows the plugin's agents and
+skills. Use it when you are testing agent/skill visibility before opening a PR.
+
+## Validate local source
+
+Run local validation before relying on a branch test:
+
+```bash
+claude plugin validate /path/to/arc-kit/plugins/arckit-claude
+```
+
+Claude Code v2.1.200+ handles local `source: "."` plugin metadata correctly and
+reports all validation errors instead of stopping at the first one. It also
+honours local folder and git marketplace dependency pins, which matters when an
+overlay branch depends on an unmerged ArcKit core branch.
 
 ## Verifying the correct branch loaded
 

--- a/docs/guides/upgrading.md
+++ b/docs/guides/upgrading.md
@@ -121,6 +121,22 @@ arckit init . --ai codex
 
 Make sure you upgraded the CLI first (Step 1), then re-ran init (Step 2). The init command copies the latest commands from the installed package.
 
+### Claude Code plugin or hook issue
+
+Start Claude Code in safe mode before changing ArcKit files:
+
+```bash
+claude --safe-mode
+```
+
+You can also set `CLAUDE_CODE_SAFE_MODE=1` for the session. Safe mode is the
+fastest way to isolate whether an ArcKit hook, command, skill, or installed
+plugin is involved.
+
+`disableBundledSkills` disables Claude Code's bundled skills; it does not
+disable ArcKit plugin skills. To remove ArcKit from the test path, use safe
+mode, disable the plugin in `/plugin`, or uninstall the plugin.
+
 ### Custom templates lost
 
 Custom templates in `.arckit/templates-custom/` are preserved across upgrades. Only default templates in `.arckit/templates/` are refreshed. If you edited files in `.arckit/templates/` directly (instead of `.arckit/templates-custom/`), those edits will be overwritten. Use `/arckit:customize` to set up the override workflow:

--- a/plugins/arckit-agent-architecture/commands/agent-design.md
+++ b/plugins/arckit-agent-architecture/commands/agent-design.md
@@ -103,7 +103,7 @@ Before generating the agent design, use the **AskUserQuestion** tool to gather k
 
 - **Architecture pattern**: Single / Chain / Multi-Agent / Hierarchical (from Question 1)
 - **Scope**: Task Automation / Knowledge Work / Creative / Decision Support (from Question 2)
-- **LLM model**: Primary model (e.g., "claude-sonnet-4-5-20250929")
+- **LLM model**: Primary model (e.g., "Claude Sonnet 5 (session default)")
 - **Hosting**: Local / Cloud / Hybrid
 
 **Tool inventory** (minimum 3 tools):

--- a/plugins/arckit-agent-architecture/commands/agent-governance.md
+++ b/plugins/arckit-agent-architecture/commands/agent-governance.md
@@ -196,7 +196,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-agent-architecture/commands/agent-maturity.md
+++ b/plugins/arckit-agent-architecture/commands/agent-maturity.md
@@ -312,7 +312,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-agent-architecture/commands/agent-security.md
+++ b/plugins/arckit-agent-architecture/commands/agent-security.md
@@ -232,7 +232,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-au/templates/au-ai-assurance-template.md
+++ b/plugins/arckit-au/templates/au-ai-assurance-template.md
@@ -160,7 +160,7 @@ National AI Centre (NAIC) operational practices for safe and responsible AI adop
 | Aspect | Detail |
 |--------|--------|
 | **Vendor Name** | [E.g., Anthropic / OpenAI / Google] |
-| **Model + Version** | [E.g., Claude Opus 4.7] |
+| **Model + Version** | [E.g., Claude Sonnet 5 (session default)] |
 | **Vendor AI Policy Compliance** | [Vendor's published AI policy alignment] |
 | **Training-Data Provenance** | [Disclosed / Partially disclosed / Not disclosed] |
 | **Inference Region** | [AU / US / EU / global] |

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   latest v2.1.200 floor for project-scoped plugin loading from git worktrees,
   `claude agents --plugin-dir` agent/skill visibility, and the recent
   background-subagent reliability and hook diagnostics fixes tracked in #580.
+- **Claude Code v2.1.200 documentation backlog (#580).** Added managed model
+  governance, OTEL assistant-response, MCP auth, safe-mode troubleshooting,
+  plugin branch-testing, and ArcKit skill-layout guidance; refreshed stale
+  Claude model examples for Sonnet 5-era defaults.
 
 ## [6.1.7] — 2026-07-03
 

--- a/plugins/arckit-claude/commands/adr.md
+++ b/plugins/arckit-claude/commands/adr.md
@@ -375,7 +375,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/ai-playbook.md
+++ b/plugins/arckit-claude/commands/ai-playbook.md
@@ -413,7 +413,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/analyze.md
+++ b/plugins/arckit-claude/commands/analyze.md
@@ -1384,7 +1384,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/atrs.md
+++ b/plugins/arckit-claude/commands/atrs.md
@@ -305,7 +305,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/backlog.md
+++ b/plugins/arckit-claude/commands/backlog.md
@@ -1530,7 +1530,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/data-mesh-contract.md
+++ b/plugins/arckit-claude/commands/data-mesh-contract.md
@@ -399,7 +399,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/diagram.md
+++ b/plugins/arckit-claude/commands/diagram.md
@@ -827,7 +827,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/dld-review.md
+++ b/plugins/arckit-claude/commands/dld-review.md
@@ -227,7 +227,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/dos.md
+++ b/plugins/arckit-claude/commands/dos.md
@@ -133,7 +133,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/evaluate.md
+++ b/plugins/arckit-claude/commands/evaluate.md
@@ -160,7 +160,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/gcloud-clarify.md
+++ b/plugins/arckit-claude/commands/gcloud-clarify.md
@@ -246,7 +246,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/gcloud-search.md
+++ b/plugins/arckit-claude/commands/gcloud-search.md
@@ -130,7 +130,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/glossary.md
+++ b/plugins/arckit-claude/commands/glossary.md
@@ -217,7 +217,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/hld-review.md
+++ b/plugins/arckit-claude/commands/hld-review.md
@@ -216,7 +216,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/maturity-model.md
+++ b/plugins/arckit-claude/commands/maturity-model.md
@@ -256,7 +256,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/mod-secure.md
+++ b/plugins/arckit-claude/commands/mod-secure.md
@@ -284,7 +284,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/plan.md
+++ b/plugins/arckit-claude/commands/plan.md
@@ -448,7 +448,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/presentation.md
+++ b/plugins/arckit-claude/commands/presentation.md
@@ -252,7 +252,7 @@ Before generating the document ID, check if a previous version exists:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/requirements.md
+++ b/plugins/arckit-claude/commands/requirements.md
@@ -215,7 +215,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/roadmap.md
+++ b/plugins/arckit-claude/commands/roadmap.md
@@ -361,7 +361,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/secure.md
+++ b/plugins/arckit-claude/commands/secure.md
@@ -251,7 +251,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/sow.md
+++ b/plugins/arckit-claude/commands/sow.md
@@ -230,7 +230,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/strategy.md
+++ b/plugins/arckit-claude/commands/strategy.md
@@ -267,7 +267,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/tcop.md
+++ b/plugins/arckit-claude/commands/tcop.md
@@ -155,7 +155,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/traceability.md
+++ b/plugins/arckit-claude/commands/traceability.md
@@ -223,7 +223,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/wardley.climate.md
+++ b/plugins/arckit-claude/commands/wardley.climate.md
@@ -407,7 +407,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used — WARD, REQ, RSCH, etc.]
 ```
 

--- a/plugins/arckit-claude/commands/wardley.doctrine.md
+++ b/plugins/arckit-claude/commands/wardley.doctrine.md
@@ -302,7 +302,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used, e.g., "PRIN, WARD, STKE artifacts; user input"]
 ```
 

--- a/plugins/arckit-claude/commands/wardley.gameplay.md
+++ b/plugins/arckit-claude/commands/wardley.gameplay.md
@@ -412,7 +412,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used — WARD, WCLM, WDOC, etc.]
 ```
 

--- a/plugins/arckit-claude/commands/wardley.md
+++ b/plugins/arckit-claude/commands/wardley.md
@@ -482,7 +482,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/commands/wardley.value-chain.md
+++ b/plugins/arckit-claude/commands/wardley.value-chain.md
@@ -300,7 +300,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/docs/guides/custom-commands.md
+++ b/plugins/arckit-claude/docs/guides/custom-commands.md
@@ -24,6 +24,12 @@ You write **one** source file in `arckit-claude/commands/<n>.md`. The converter 
 
 The first row is the file you edit by hand; the converter generates all others. You do not edit the generated files directly. The converter handles argument-placeholder rewriting, path rewriting for the Gemini sandbox, frontmatter stripping for Claude-only fields, and extension-file copying.
 
+ArcKit does not use a root-level `SKILL.md` for plugin behaviour. Reusable
+Claude Code skills live in `plugins/arckit-claude/skills/<skill-name>/SKILL.md`;
+Codex skill outputs live under `extensions/arckit-codex/skills/`. Keep command
+authoring guidance in this guide unless Claude Code's plugin layout explicitly
+adds root-level skill support.
+
 ---
 
 ## The Source File

--- a/plugins/arckit-claude/docs/guides/enterprise-scale.md
+++ b/plugins/arckit-claude/docs/guides/enterprise-scale.md
@@ -215,6 +215,98 @@ We're looking for a real-world enterprise case study to anchor this guide — id
 
 ---
 
+## Fleet & Version Governance (managed settings)
+
+At enterprise scale you usually want to govern *which* Claude Code versions run
+ArcKit, *which* models are available, and *which* plugins teams may install —
+centrally, not repo by repo. Claude Code's
+[managed settings](https://code.claude.com/docs/en/permissions#managed-settings)
+(admin-deployed policy that users cannot override) give you the control point
+ArcKit benefits from.
+
+### Pin a version range across the fleet
+
+ArcKit ships a soft floor: the `version-check.mjs` SessionStart hook *warns*
+anyone running below the supported Claude Code version. To *enforce* it, an
+admin can set the native managed settings (Claude Code v2.1.163+):
+
+```json
+{
+  "requiredMinimumVersion": "2.1.200",
+  "requiredMaximumVersion": "2.1.999"
+}
+```
+
+Claude Code then **refuses to start** outside the range and directs the user to
+an approved version. Use `requiredMinimumVersion` to guarantee everyone has the
+features ArcKit relies on; use `requiredMaximumVersion` as a known-good ceiling
+so a regulated fleet doesn't auto-adopt a release before you've validated it.
+These are *managed-settings only* — a plugin or repo cannot set them.
+
+> **Run v2.1.166+ for reliable enforcement.** On earlier versions a single
+> invalid entry anywhere in the managed-settings file could silently disable
+> enforcement of the remaining valid policies. v2.1.166 fixes this and also
+> fixes `allowedMcpServers` / `deniedMcpServers` predicates that use `${VAR}`
+> references not matching.
+
+For an **individual** user or repo that just wants to avoid drifting *below*
+the floor, the softer, user-scoped `minimumVersion` in `.claude/settings.json`
+blocks auto-update/`claude update` from going below it. ArcKit pins this in its
+own repos and the below-floor warning recommends it.
+
+### Govern available models
+
+Managed settings can also govern which models are available to a fleet. Use
+your organisation defaults and model restrictions together, and enable
+`enforceAvailableModels` when you need project settings, subagents, or manual
+model overrides to stay inside the approved list.
+
+ArcKit does not pin a model in its commands. Commands inherit the Claude Code
+session default, so a centrally managed model policy is the right control point
+for regulated deployments. The current ArcKit guidance assumes Claude Sonnet 5
+as the normal default; allow Claude Fable 5 only where the tenant exposes it and
+the work justifies the higher tier.
+
+### Allowlist the ArcKit marketplace
+
+`pluginSuggestionMarketplaces` lets admins allowlist org marketplaces whose
+plugins may surface in context-aware tips. Allowlisting
+`tractorjuice/arckit-claude` means Claude Code can suggest ArcKit when a user
+opens a directory with a `projects/` tree or `ARC-*` artefacts — useful for
+driving adoption across many teams without a manual rollout. Pair with
+`strictKnownMarketplaces` / `blockedMarketplaces` if you want to *restrict*
+installs to only the marketplaces you've vetted.
+
+### Slice usage/cost metrics by project
+
+If you run Claude Code's OpenTelemetry export, set
+`OTEL_RESOURCE_ATTRIBUTES` (Claude Code v2.1.161+) to attach custom labels to
+every metric datapoint:
+
+```bash
+export OTEL_RESOURCE_ATTRIBUTES="repo=arc-kit,team=enterprise-architecture,project=042-identity-service"
+```
+
+You can then slice token/cost usage by team, repo, or project — a natural
+complement to the per-artefact Document Control headers and `provenance-stamp`
+ArcKit already produces. **Privacy caveat:** these labels are emitted as-is, so
+don't put project identifiers in them for OFFICIAL-SENSITIVE / SECRET work
+where the label itself would be sensitive.
+
+If you export prompt telemetry but must not export generated response text,
+leave assistant-response logging disabled:
+
+```bash
+export OTEL_LOG_ASSISTANT_RESPONSES=0
+```
+
+Only set `OTEL_LOG_ASSISTANT_RESPONSES=1` in environments where response
+content is approved for the telemetry backend. Treat ArcKit artefact drafts,
+policy decisions, and evidence summaries as sensitive until your data-handling
+rules say otherwise.
+
+---
+
 ## Related Guides
 
 - [ArcKit Init](init.md) — bootstrapping a new repo

--- a/plugins/arckit-claude/docs/guides/mcp-servers.md
+++ b/plugins/arckit-claude/docs/guides/mcp-servers.md
@@ -175,6 +175,36 @@ export DATA_COMMONS_API_KEY="your-api-key-here"
 
 3. Restart Claude Code
 
+> **Your keys stay hidden in `claude mcp` output.** Both keyed servers carry
+> their key in an HTTP header (`X-Goog-Api-Key`, `X-API-Key`) via
+> `${GOOGLE_API_KEY}` / `${DATA_COMMONS_API_KEY}`. As of Claude Code v2.1.161,
+> `claude mcp list` / `get` / `add` no longer expand `${VAR}` references and
+> redact credential headers and URL secrets, so inspecting your MCP config or
+> screen-sharing it will not leak the keys. Relevant for OFFICIAL-SENSITIVE /
+> regulated deployments. The other four bundled servers are keyless, so there's
+> nothing to redact.
+
+### Managing MCP authentication
+
+For OAuth-backed or interactive MCP servers, use Claude Code's MCP auth
+commands instead of editing token files by hand:
+
+```bash
+claude mcp login <server-name>
+claude mcp logout <server-name>
+```
+
+ArcKit's bundled keyed servers still use environment variables, but the same
+`claude mcp` workflow is useful when you add third-party MCP servers alongside
+ArcKit. Recent Claude Code releases improved OAuth retries and headless login
+flows, so stale browser hand-offs are less likely to leave a server half
+configured.
+
+Servers that use a `headersHelper` can also refresh credentials after 401/403
+responses. If a helper-backed server works once and then starts failing after a
+token expiry, run `claude mcp login <server-name>` again before changing the
+ArcKit configuration.
+
 ---
 
 ## Troubleshooting

--- a/plugins/arckit-claude/docs/guides/start.md
+++ b/plugins/arckit-claude/docs/guides/start.md
@@ -99,7 +99,7 @@ If you want to skip the decision tree and let ArcKit do the heavy lifting, this 
 
 - **Heavily regulated work** (UK Gov Secure by Design, MOD, EU AI Act) where each artifact needs reviewer sign-off before the next is generated.
 - **Existing projects** with artifacts already on disk — run `/arckit:navigator` first to see what is missing rather than regenerating.
-- **Token-constrained sessions** — the full chain can run dozens of commands. Use Opus 4.7 or 4.8 with the `max` or `xhigh` effort levels.
+- **Token-constrained sessions** — the full chain can run dozens of commands. Use the Claude Code session default, normally Claude Sonnet 5, and move to Claude Fable 5 only where your tenant exposes it and the work justifies the higher tier.
 
 ### Tips For Vibe Start
 

--- a/plugins/arckit-claude/docs/guides/upgrading.md
+++ b/plugins/arckit-claude/docs/guides/upgrading.md
@@ -121,6 +121,22 @@ arckit init . --ai codex
 
 Make sure you upgraded the CLI first (Step 1), then re-ran init (Step 2). The init command copies the latest commands from the installed package.
 
+### Claude Code plugin or hook issue
+
+Start Claude Code in safe mode before changing ArcKit files:
+
+```bash
+claude --safe-mode
+```
+
+You can also set `CLAUDE_CODE_SAFE_MODE=1` for the session. Safe mode is the
+fastest way to isolate whether an ArcKit hook, command, skill, or installed
+plugin is involved.
+
+`disableBundledSkills` disables Claude Code's bundled skills; it does not
+disable ArcKit plugin skills. To remove ArcKit from the test path, use safe
+mode, disable the plugin in `/plugin`, or uninstall the plugin.
+
 ### Custom templates lost
 
 Custom templates in `.arckit/templates-custom/` are preserved across upgrades. Only default templates in `.arckit/templates/` are refreshed. If you edited files in `.arckit/templates/` directly (instead of `.arckit/templates-custom/`), those edits will be overwritten. Use `/arckit:customize` to set up the override workflow:

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-design.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-design.md
@@ -103,7 +103,7 @@ Before generating the agent design, use the **AskUserQuestion** tool to gather k
 
 - **Architecture pattern**: Single / Chain / Multi-Agent / Hierarchical (from Question 1)
 - **Scope**: Task Automation / Knowledge Work / Creative / Decision Support (from Question 2)
-- **LLM model**: Primary model (e.g., "claude-sonnet-4-5-20250929")
+- **LLM model**: Primary model (e.g., "Claude Sonnet 5 (session default)")
 - **Hosting**: Local / Cloud / Hybrid
 
 **Tool inventory** (minimum 3 tools):

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-governance.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-governance.md
@@ -196,7 +196,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-maturity.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-maturity.md
@@ -312,7 +312,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-security.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-security.md
@@ -232,7 +232,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/plugins/au/templates/au-ai-assurance-template.md
+++ b/plugins/arckit-claude/plugins/au/templates/au-ai-assurance-template.md
@@ -160,7 +160,7 @@ National AI Centre (NAIC) operational practices for safe and responsible AI adop
 | Aspect | Detail |
 |--------|--------|
 | **Vendor Name** | [E.g., Anthropic / OpenAI / Google] |
-| **Model + Version** | [E.g., Claude Opus 4.7] |
+| **Model + Version** | [E.g., Claude Sonnet 5 (session default)] |
 | **Vendor AI Policy Compliance** | [Vendor's published AI policy alignment] |
 | **Training-Data Provenance** | [Disclosed / Partially disclosed / Not disclosed] |
 | **Inference Region** | [AU / US / EU / global] |

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/application-rationalization.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/application-rationalization.md
@@ -201,7 +201,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {P})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-board.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-board.md
@@ -238,7 +238,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-repository.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-repository.md
@@ -366,7 +366,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: Global Repository (Project 000)
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents and projects synthesised]
 ```
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-repository-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-repository-template.md
@@ -103,5 +103,5 @@ templateVersion: "1.0"
 **Generated on**: `[DATE] [TIME] GMT`
 **ArcKit Version**: `{ARCKIT_VERSION}`
 **Project**: Global Repository (Project 000)
-**AI Model**: `[Use actual model name, e.g., "claude-sonnet-4-5-20250929"]`
+**AI Model**: `[Use actual model name, e.g., "Claude Sonnet 5 (session default)"]`
 **Generation Context**: `[Brief note about source documents and projects synthesised]`

--- a/plugins/arckit-claude/skills/arckit-build/SKILL.md
+++ b/plugins/arckit-claude/skills/arckit-build/SKILL.md
@@ -310,7 +310,7 @@ Build wave {N}: {targets joined} via arckit-build
 
 {One-line per target with line count and headline result}
 
-Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+Co-Authored-By: Claude Code <noreply@anthropic.com>
 EOF
 )"
 ```

--- a/plugins/arckit-togaf-adm/commands/application-rationalization.md
+++ b/plugins/arckit-togaf-adm/commands/application-rationalization.md
@@ -201,7 +201,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {P})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-togaf-adm/commands/architecture-board.md
+++ b/plugins/arckit-togaf-adm/commands/architecture-board.md
@@ -238,7 +238,7 @@ The footer should be populated with:
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: {PROJECT_NAME} (Project {PROJECT_ID})
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents used]
 ```
 

--- a/plugins/arckit-togaf-adm/commands/architecture-repository.md
+++ b/plugins/arckit-togaf-adm/commands/architecture-repository.md
@@ -366,7 +366,7 @@ Before completing the document, populate ALL document control fields in the head
 **Generated on**: {DATE} {TIME} GMT
 **ArcKit Version**: {ARCKIT_VERSION}
 **Project**: Global Repository (Project 000)
-**AI Model**: [Use actual model name, e.g., "claude-sonnet-4-5-20250929"]
+**AI Model**: [Use actual model name, e.g., "Claude Sonnet 5 (session default)"]
 **Generation Context**: [Brief note about source documents and projects synthesised]
 ```
 

--- a/plugins/arckit-togaf-adm/templates/architecture-repository-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-repository-template.md
@@ -103,5 +103,5 @@ templateVersion: "1.0"
 **Generated on**: `[DATE] [TIME] GMT`
 **ArcKit Version**: `{ARCKIT_VERSION}`
 **Project**: Global Repository (Project 000)
-**AI Model**: `[Use actual model name, e.g., "claude-sonnet-4-5-20250929"]`
+**AI Model**: `[Use actual model name, e.g., "Claude Sonnet 5 (session default)"]`
 **Generation Context**: `[Brief note about source documents and projects synthesised]`

--- a/scripts/autoresearch/fixtures/000-global/ARC-000-PRIN-v1.0.md
+++ b/scripts/autoresearch/fixtures/000-global/ARC-000-PRIN-v1.0.md
@@ -117,4 +117,4 @@
 **Generated on:** 2026-03-20
 **ArcKit Version:** 4.4.0
 **Project:** Global (Project 000)
-**Model:** claude-sonnet-4-5-20250929
+**Model:** Claude Sonnet 5 (session default)

--- a/scripts/autoresearch/fixtures/001-test-project/ARC-001-STKE-v1.0.md
+++ b/scripts/autoresearch/fixtures/001-test-project/ARC-001-STKE-v1.0.md
@@ -97,4 +97,4 @@ Low Power  │                       │ Lead Architect
 **Generated on:** 2026-03-20
 **ArcKit Version:** 4.4.0
 **Project:** Digital Appointment Booking Service (Project 001)
-**Model:** claude-sonnet-4-5-20250929
+**Model:** Claude Sonnet 5 (session default)


### PR DESCRIPTION
Refs #580

## Summary
- Document the still-recommended Claude Code v2.1.200+ guidance for managed model governance, OTEL assistant-response logging, MCP auth, safe-mode troubleshooting, plugin branch testing, and ArcKit skill layout.
- Refresh stale model examples in command/template output guidance for Sonnet 5-era defaults and make generated Codex wording platform-neutral.
- Keep build/reader-pattern and Notification hook behavior docs deferred until runtime verification.

## Validation
- python scripts/converter.py
- git diff --check
- npx markdownlint-cli2 $(git diff --name-only -- '*.md' ':!.arckit/memory/sessions.md')
- pytest tests/codex/test_codex_extension.py
- pytest tests/plugin/test_template_consistency.py