### PR TITLE
[codex] inject external context on file changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Reactive external-document context (#580).** Added Claude Code
+  `FileChanged` hook coverage for `projects/*/external/` directories so newly
+  added or changed evidence is injected into session context without waiting
+  for a restart, `/compact`, or another `/arckit:` command.
 - **Claude Code minimum-version floor raised to v2.1.200.** Updated the
   runtime version check, repo/test-repo settings, and docs to require the
   latest v2.1.200 floor for project-scoped plugin loading from git worktrees,

--- a/docs/guides/hooks.md
+++ b/docs/guides/hooks.md
@@ -2,19 +2,22 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-ArcKit's Claude Code plugin includes 17 automation hooks across 7 event types. Hooks run automatically — no manual configuration required.
+ArcKit's Claude Code plugin includes automation hooks across 10 event types. Hooks run automatically — no manual configuration required.
 
 ## Overview
 
 | Event | Hooks | When it fires |
 |-------|-------|---------------|
-| **SessionStart** | arckit-session, version-check | Session start, resume, clear, compact |
+| **SessionStart** | arckit-session, version-check, v5-migration-banner, notify-stale-artifacts | Session start, resume, clear, compact |
 | **Stop** | session-learner | Session ends normally |
 | **StopFailure** | session-learner | Session ends with error |
-| **UserPromptSubmit** | arckit-context, secret-detection, + 6 command-specific | Every user message |
-| **PreToolUse** | validate-arc-filename, score-validator, file-protection, secret-file-scanner | Before Write or Edit |
-| **PostToolUse** | update-manifest | After Write |
+| **UserPromptSubmit** | arckit-context, secret-detection, sync-guides, graph-inject | Every user message and matched ArcKit commands |
+| **PreToolUse** | allow-plugin-internals, inject-agent-context, validate-arc-filename, score-validator, validate-wardley-math, file-protection, secret-file-scanner | Before selected tool calls |
+| **PostToolUse** | update-manifest, provenance-stamp, tidy-wardley-labels, telemetry | After selected tool calls |
+| **TaskCreated** | telemetry | When an agent task is created |
 | **PermissionRequest** | allow-mcp-tools | MCP tool permission prompt |
+| **FileChanged** | external-context-watch | Watched external documents change |
+| **PostCompact** | postcompact-rehydrate | After context compaction |
 
 ## SessionStart Hooks
 
@@ -27,6 +30,7 @@ Also detects:
 - Whether a `projects/` directory exists
 - External files newer than the latest artifacts (prompts re-running commands)
 - Recent session history from `.arckit/memory/sessions.md`
+- `projects/*/external/` directories to watch for mid-session evidence changes
 
 ### version-check
 
@@ -37,6 +41,21 @@ Compares the local plugin version against the latest GitHub release tag. Shows a
 ### session-learner
 
 Fires when a session ends (both normal and failure). Records session activity — which projects were touched, what artifact types were created or modified — to `.arckit/memory/sessions.md` for context in future sessions.
+
+## FileChanged Hooks
+
+### external-context-watch
+
+`arckit-session` registers every existing `projects/*/external/` directory as a
+dynamic watch path at session start. `external-context-watch` injects refreshed
+project context when a watched external document is added, changed, or removed,
+and refreshes the watch list so newly created nested external directories are
+picked up after the next file-change event.
+
+This means a briefing, transcript, vendor pack, regulation, or architecture
+note dropped into `external/` mid-session is surfaced to Claude without waiting
+for a restart, `/compact`, or another `/arckit:` command. README files inside
+`external/` are ignored.
 
 ## UserPromptSubmit Hooks
 
@@ -95,11 +114,26 @@ After a file is written to `projects/`, updates `docs/manifest.json` with the ne
 
 After an ArcKit artifact is written or edited, stamps build provenance when the hook can derive build context or command effort. It can also add OKF-compatible frontmatter when explicitly enabled with `ARCKIT_OKF_FRONTMATTER=1` or `.arckit/config.json` containing `{ "okfFrontmatter": true }`.
 
+## TaskCreated Hooks
+
+### telemetry
+
+Records ArcKit agent spawns so session summaries can show which subagents ran
+and how much tool activity they performed.
+
+## PostCompact Hooks
+
+### postcompact-rehydrate
+
+Re-injects the same project inventory used by `arckit-context` after manual or
+automatic compaction so dynamic project state is not lost from the context
+window.
+
 ## PermissionRequest Hooks
 
 ### allow-mcp-tools
 
-Auto-allows MCP tool calls from ArcKit's bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, DataCommons, govreposcrape) so users don't need to approve each one manually.
+Auto-allows MCP tool calls from ArcKit's bundled MCP servers (AWS Knowledge, Microsoft Learn, Google Developer Knowledge, DataCommons, govreposcrape, uk-tenders) so users don't need to approve each one manually.
 
 ## Utility Files
 
@@ -108,6 +142,7 @@ These are shared libraries, not hooks themselves:
 | File | Purpose |
 |------|---------|
 | **hook-utils.mjs** | Shared utilities: `parseHookInput()`, `findRepoRoot()`, `extractDocType()`, file I/O helpers |
+| **external-context-utils.mjs** | Shared helpers for external-document watch paths and path filtering |
 | **graph-utils.mjs** | Dependency graph construction (nodes, edges, requirements, principles, risks, vendors, externals) |
 | **graph-rollups.mjs** | Shared health, coverage, and compliance computations: `tagNodeHealth()`, `computeAllProjectRollups()`, plus the canonical `ESSENTIAL_TYPES` / `HIGH_SEVERITY_TYPES` / `CONTEXTUAL_TYPES` / `STALE_THRESHOLD_DAYS` constants used by both `graph-inject` and `sync-guides` |
 | **hooks.json** | Hook registration — maps events and matchers to handler commands |

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Reactive external-document context (#580).** Added Claude Code
+  `FileChanged` hook coverage for `projects/*/external/` directories so newly
+  added or changed evidence is injected into session context without waiting
+  for a restart, `/compact`, or another `/arckit:` command.
 - **Claude Code minimum-version floor raised to v2.1.200.** Updated the
   runtime version check, repo/test-repo settings, and docs to require the
   latest v2.1.200 floor for project-scoped plugin loading from git worktrees,

--- a/plugins/arckit-claude/docs/guides/hooks.md
+++ b/plugins/arckit-claude/docs/guides/hooks.md
@@ -2,19 +2,22 @@
 
 > **Guide Origin**: Official | **ArcKit Version**: [VERSION]
 
-ArcKit's Claude Code plugin includes 17 automation hooks across 7 event types. Hooks run automatically — no manual configuration required.
+ArcKit's Claude Code plugin includes automation hooks across 10 event types. Hooks run automatically — no manual configuration required.
 
 ## Overview
 
 | Event | Hooks | When it fires |
 |-------|-------|---------------|
-| **SessionStart** | arckit-session, version-check | Session start, resume, clear, compact |
+| **SessionStart** | arckit-session, version-check, v5-migration-banner, notify-stale-artifacts | Session start, resume, clear, compact |
 | **Stop** | session-learner | Session ends normally |
 | **StopFailure** | session-learner | Session ends with error |
-| **UserPromptSubmit** | arckit-context, secret-detection, + 6 command-specific | Every user message |
-| **PreToolUse** | validate-arc-filename, score-validator, file-protection, secret-file-scanner | Before Write or Edit |
-| **PostToolUse** | update-manifest | After Write |
+| **UserPromptSubmit** | arckit-context, secret-detection, sync-guides, graph-inject | Every user message and matched ArcKit commands |
+| **PreToolUse** | allow-plugin-internals, inject-agent-context, validate-arc-filename, score-validator, validate-wardley-math, file-protection, secret-file-scanner | Before selected tool calls |
+| **PostToolUse** | update-manifest, provenance-stamp, tidy-wardley-labels, telemetry | After selected tool calls |
+| **TaskCreated** | telemetry | When an agent task is created |
 | **PermissionRequest** | allow-mcp-tools | MCP tool permission prompt |
+| **FileChanged** | external-context-watch | Watched external documents change |
+| **PostCompact** | postcompact-rehydrate | After context compaction |
 
 ## SessionStart Hooks
 
@@ -27,6 +30,7 @@ Also detects:
 - Whether a `projects/` directory exists
 - External files newer than the latest artifacts (prompts re-running commands)
 - Recent session history from `.arckit/memory/sessions.md`
+- `projects/*/external/` directories to watch for mid-session evidence changes
 
 ### version-check
 
@@ -37,6 +41,21 @@ Compares the local plugin version against the latest GitHub release tag. Shows a
 ### session-learner
 
 Fires when a session ends (both normal and failure). Records session activity — which projects were touched, what artifact types were created or modified — to `.arckit/memory/sessions.md` for context in future sessions.
+
+## FileChanged Hooks
+
+### external-context-watch
+
+`arckit-session` registers every existing `projects/*/external/` directory as a
+dynamic watch path at session start. `external-context-watch` injects refreshed
+project context when a watched external document is added, changed, or removed,
+and refreshes the watch list so newly created nested external directories are
+picked up after the next file-change event.
+
+This means a briefing, transcript, vendor pack, regulation, or architecture
+note dropped into `external/` mid-session is surfaced to Claude without waiting
+for a restart, `/compact`, or another `/arckit:` command. README files inside
+`external/` are ignored.
 
 ## UserPromptSubmit Hooks
 
@@ -95,6 +114,21 @@ After a file is written to `projects/`, updates `docs/manifest.json` with the ne
 
 After an ArcKit artifact is written or edited, stamps build provenance when the hook can derive build context or command effort. It can also add OKF-compatible frontmatter when explicitly enabled with `ARCKIT_OKF_FRONTMATTER=1` or `.arckit/config.json` containing `{ "okfFrontmatter": true }`.
 
+## TaskCreated Hooks
+
+### telemetry
+
+Records ArcKit agent spawns so session summaries can show which subagents ran
+and how much tool activity they performed.
+
+## PostCompact Hooks
+
+### postcompact-rehydrate
+
+Re-injects the same project inventory used by `arckit-context` after manual or
+automatic compaction so dynamic project state is not lost from the context
+window.
+
 ## PermissionRequest Hooks
 
 ### allow-mcp-tools
@@ -108,6 +142,7 @@ These are shared libraries, not hooks themselves:
 | File | Purpose |
 |------|---------|
 | **hook-utils.mjs** | Shared utilities: `parseHookInput()`, `findRepoRoot()`, `extractDocType()`, file I/O helpers |
+| **external-context-utils.mjs** | Shared helpers for external-document watch paths and path filtering |
 | **graph-utils.mjs** | Dependency graph construction (nodes, edges, requirements, principles, risks, vendors, externals) |
 | **graph-rollups.mjs** | Shared health, coverage, and compliance computations: `tagNodeHealth()`, `computeAllProjectRollups()`, plus the canonical `ESSENTIAL_TYPES` / `HIGH_SEVERITY_TYPES` / `CONTEXTUAL_TYPES` / `STALE_THRESHOLD_DAYS` constants used by both `graph-inject` and `sync-guides` |
 | **hooks.json** | Hook registration — maps events and matchers to handler commands |

--- a/plugins/arckit-claude/hooks/README.md
+++ b/plugins/arckit-claude/hooks/README.md
@@ -1,6 +1,6 @@
 # ArcKit Plugin Hooks
 
-Hook handlers live in this directory and are registered in `hooks.json`. Supported hook events include `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `StopFailure`, `PermissionRequest`, plus the newer `PostCompact` (v2.1.76), `FileChanged`/`CwdChanged`/`TaskCreated` (v2.1.83–84), `PermissionDenied` (v2.1.89), and `PreCompact` blocking (v2.1.105).
+Hook handlers live in this directory and are registered in `hooks.json`. Supported hook events include `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `StopFailure`, `PermissionRequest`, plus the newer `PostCompact` (v2.1.76), `FileChanged`/`CwdChanged`/`TaskCreated` (v2.1.83-84), `PermissionDenied` (v2.1.89), and `PreCompact` blocking (v2.1.105).
 
 ## `args:` Exec Form (v2.1.139+)
 
@@ -117,12 +117,35 @@ Companion to `keep-coding-instructions: true` (v2.1.94): that flag preserves the
 
 Reuses `buildProjectContext` from `project-context-builder.mjs` (same builder as `arckit-context.mjs` and `inject-agent-context.mjs`). No new marker-file convention — the filesystem (`projects/`, ARC artefact files, `external/`, `policies/`) is the source of truth, so the post-compact view is always consistent with the live repo state. Exits silently with `{}` when no `projects/` directory exists.
 
+## Reactive External Context (`external-context-watch.mjs`)
+
+SessionStart and FileChanged now cooperate to keep external document context
+live during a session:
+
+- `arckit-session.mjs` returns `hookSpecificOutput.watchPaths` for every
+  existing `projects/*/external/` directory, including nested subdirectories,
+  so Claude Code starts watching external evidence as soon as the plugin loads.
+- `external-context-watch.mjs` runs on `FileChanged`. When the changed path is
+  under a project `external/` directory and is not that directory's README, it
+  injects a compact "ArcKit External Document Update" notice plus refreshed
+  `buildProjectContext()` output via `hookSpecificOutput.additionalContext`.
+  It also returns the current `watchPaths` list so newly created nested
+  external directories can be watched after the next file-change event.
+
+This closes the gap where a user could drop a briefing, transcript, vendor
+pack, regulation, or architecture note into `external/` mid-session and the
+model would not see it until the next `/arckit:` command, `/compact`, or
+session restart. The hook is observational: it cannot block file changes, and
+it has no marker-file state. The filesystem remains the source of truth.
+
 ## All Registered Hooks
 
 See `hooks.json` for the full registration. Current handler files in this directory:
 
 - `allow-mcp-tools.mjs` — pre-approve specific MCP tool calls
 - `arckit-context.mjs` / `arckit-session.mjs` — session context + summary
+- `external-context-watch.mjs` / `external-context-utils.mjs` — reactive
+  external-document watch paths and FileChanged context injection
 - `file-protection.mjs` — guards critical files
 - `graph-inject.mjs` / `graph-rollups.mjs` / `graph-utils.mjs` — requirement-graph injection
 - `hook-utils.mjs` — shared helpers

--- a/plugins/arckit-claude/hooks/arckit-session.mjs
+++ b/plugins/arckit-claude/hooks/arckit-session.mjs
@@ -14,7 +14,8 @@
 import { readdirSync, appendFileSync } from 'node:fs';
 import { join, dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { isDir, isFile, listFilesRecursive, mtimeMs, readText, parseHookInput } from './hook-utils.mjs';
+import { isDir, isFile, listFilesRecursive, mtimeMs, readText, parseHookInput, findRepoRoot } from './hook-utils.mjs';
+import { collectExternalWatchPaths } from './external-context-utils.mjs';
 
 const data = parseHookInput();
 
@@ -129,6 +130,7 @@ const output = {
   hookSpecificOutput: {
     hookEventName: 'SessionStart',
     additionalContext: context,
+    watchPaths: collectExternalWatchPaths(findRepoRoot(cwd) || cwd),
   },
 };
 console.log(JSON.stringify(output));

--- a/plugins/arckit-claude/hooks/external-context-utils.mjs
+++ b/plugins/arckit-claude/hooks/external-context-utils.mjs
@@ -1,0 +1,59 @@
+import { readdirSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import { isDir } from './hook-utils.mjs';
+
+export function collectExternalWatchPaths(repoRoot) {
+  const projectsDir = join(repoRoot, 'projects');
+  if (!isDir(projectsDir)) return [];
+
+  const watchPaths = [];
+  for (const entry of readdirSync(projectsDir).sort()) {
+    const projectDir = join(projectsDir, entry);
+    if (!isDir(projectDir)) continue;
+
+    const externalDir = join(projectDir, 'external');
+    if (!isDir(externalDir)) continue;
+
+    collectDirs(externalDir, watchPaths);
+  }
+
+  return watchPaths;
+}
+
+function collectDirs(dir, out) {
+  out.push(dir);
+  for (const entry of readdirSync(dir).sort()) {
+    const path = join(dir, entry);
+    if (isDir(path)) collectDirs(path, out);
+  }
+}
+
+export function resolveEventPath(filePath, cwd) {
+  if (!filePath) return '';
+  return isAbsolute(filePath) ? resolve(filePath) : resolve(cwd || process.cwd(), filePath);
+}
+
+export function findExternalDocumentChange(repoRoot, filePath) {
+  const projectsDir = join(repoRoot, 'projects');
+  if (!isDir(projectsDir) || !filePath) return null;
+
+  for (const projectName of readdirSync(projectsDir).sort()) {
+    const projectDir = join(projectsDir, projectName);
+    if (!isDir(projectDir)) continue;
+
+    const externalDir = join(projectDir, 'external');
+    if (!isDir(externalDir)) continue;
+
+    const rel = relative(externalDir, filePath);
+    if (!rel || rel.startsWith('..') || isAbsolute(rel)) continue;
+    if (rel === 'README.md' || rel.endsWith('/README.md')) return null;
+
+    return {
+      projectName,
+      relativePath: rel.split('\\').join('/'),
+      projectRelativePath: relative(repoRoot, filePath).split('\\').join('/'),
+    };
+  }
+
+  return null;
+}

--- a/plugins/arckit-claude/hooks/external-context-watch.mjs
+++ b/plugins/arckit-claude/hooks/external-context-watch.mjs
@@ -1,0 +1,65 @@
+#!/usr/bin/env node
+/**
+ * ArcKit FileChanged Hook - external document context watcher.
+ *
+ * Refreshes project `external/` directory watch paths and injects refreshed
+ * ArcKit project context when a watched external document changes.
+ */
+
+import { dirname } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { findRepoRoot, parseHookInput } from './hook-utils.mjs';
+import { buildProjectContext } from './project-context-builder.mjs';
+import {
+  collectExternalWatchPaths,
+  findExternalDocumentChange,
+  resolveEventPath,
+} from './external-context-utils.mjs';
+
+export function runExternalContextWatch(data) {
+  const eventName = data.hook_event_name || data.hookEventName || 'FileChanged';
+  const eventPath = resolveEventPath(data.file_path || '', data.cwd || process.cwd());
+  const cwd = data.cwd || (eventPath ? dirname(eventPath) : process.cwd());
+  const repoRoot = findRepoRoot(cwd) || (eventPath ? findRepoRoot(dirname(eventPath)) : null);
+
+  const output = {
+    hookSpecificOutput: {
+      hookEventName: eventName,
+      watchPaths: repoRoot ? collectExternalWatchPaths(repoRoot) : [],
+    },
+  };
+
+  if (!repoRoot || !eventPath) return output;
+
+  const change = findExternalDocumentChange(repoRoot, eventPath);
+  if (!change) return output;
+
+  const contextText = buildProjectContext(repoRoot);
+  if (!contextText) return output;
+
+  const verbByEvent = {
+    add: 'added',
+    change: 'changed',
+    unlink: 'removed',
+  };
+  const event = data.event || 'change';
+  const verb = verbByEvent[event] || event;
+
+  output.hookSpecificOutput.additionalContext = [
+    '## ArcKit External Document Update',
+    '',
+    `A project external document was ${verb}:`,
+    `- Project: ${change.projectName}`,
+    `- Path: \`${change.projectRelativePath}\``,
+    '',
+    'Use the refreshed project context below when deciding whether existing artifacts should be updated.',
+    '',
+    contextText,
+  ].join('\n');
+
+  return output;
+}
+
+if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
+  console.log(JSON.stringify(runExternalContextWatch(parseHookInput())));
+}

--- a/plugins/arckit-claude/hooks/hooks.json
+++ b/plugins/arckit-claude/hooks/hooks.json
@@ -1,5 +1,5 @@
 {
-  "description": "ArcKit hooks: session init, version check, session learner (Stop + StopFailure), project context injection (UserPromptSubmit + PostCompact rehydrate), filename enforcement, MCP tool auto-allow, security protection (file protection, secret detection, secret file scanning), provenance stamping on artefact writes (PostToolUse Write|Edit), and telemetry recording (PostToolUse for hook duration_ms + govreposcrape MCP calls; TaskCreated for agent spawns). All entries use the `args: string[]` exec form (Claude Code v2.1.139+) to avoid shell-string parsing. PostToolUse entries set `continueOnBlock: true` (v2.1.139+) so a stamping / telemetry / manifest hook can never derail the user's turn — they are observational and must fail soft.",
+  "description": "ArcKit hooks: session init, version check, session learner (Stop + StopFailure), project context injection (UserPromptSubmit + PostCompact rehydrate + FileChanged external documents), filename enforcement, MCP tool auto-allow, security protection (file protection, secret detection, secret file scanning), provenance stamping on artefact writes (PostToolUse Write|Edit), and telemetry recording (PostToolUse for hook duration_ms + govreposcrape MCP calls; TaskCreated for agent spawns). All entries use the `args: string[]` exec form (Claude Code v2.1.139+) to avoid shell-string parsing. PostToolUse entries set `continueOnBlock: true` (v2.1.139+) so a stamping / telemetry / manifest hook can never derail the user's turn — they are observational and must fail soft.",
   "hooks": {
     "Stop": [
       {
@@ -317,6 +317,18 @@
             "type": "command",
             "command": "node",
             "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/allow-mcp-tools.mjs"],
+            "timeout": 5
+          }
+        ]
+      }
+    ],
+    "FileChanged": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "node",
+            "args": ["${CLAUDE_PLUGIN_ROOT}/hooks/external-context-watch.mjs"],
             "timeout": 5
           }
         ]

--- a/tests/plugin/external-context-watch.test.mjs
+++ b/tests/plugin/external-context-watch.test.mjs
@@ -1,0 +1,70 @@
+#!/usr/bin/env node
+/**
+ * Regression tests for external-context-watch.mjs.
+ *
+ * Run with: node tests/plugin/external-context-watch.test.mjs
+ */
+
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { runExternalContextWatch } from '../../plugins/arckit-claude/hooks/external-context-watch.mjs';
+
+function makeProject() {
+  const root = mkdtempSync(join(tmpdir(), 'arckit-external-watch-'));
+  const projectDir = join(root, 'projects', '001-demo');
+  const externalDir = join(projectDir, 'external');
+  const nestedDir = join(externalDir, 'nested');
+  mkdirSync(nestedDir, { recursive: true });
+  writeFileSync(join(projectDir, 'ARC-001-REQ-v1.0.md'), '# Requirements\n');
+  writeFileSync(join(externalDir, 'README.md'), '# External documents\n');
+  return { root, projectDir, externalDir, nestedDir };
+}
+
+test('FileChanged injects refreshed context for a new external document', () => {
+  const { root, externalDir, nestedDir } = makeProject();
+  try {
+    const briefingPath = join(externalDir, 'briefing.md');
+    writeFileSync(briefingPath, '# Briefing\n');
+
+    const output = runExternalContextWatch({
+      hook_event_name: 'FileChanged',
+      cwd: root,
+      file_path: briefingPath,
+      event: 'add',
+    });
+
+    assert.equal(output.hookSpecificOutput.hookEventName, 'FileChanged');
+    assert.deepEqual(output.hookSpecificOutput.watchPaths, [externalDir, nestedDir]);
+    assert.match(output.hookSpecificOutput.additionalContext, /ArcKit External Document Update/);
+    assert.match(output.hookSpecificOutput.additionalContext, /A project external document was added/);
+    assert.match(output.hookSpecificOutput.additionalContext, /projects\/001-demo\/external\/briefing\.md/);
+    assert.match(output.hookSpecificOutput.additionalContext, /External documents/);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});
+
+test('FileChanged outside external directories refreshes watches without context', () => {
+  const { root, externalDir, nestedDir, projectDir } = makeProject();
+  try {
+    const notePath = join(projectDir, 'notes.md');
+    writeFileSync(notePath, '# Notes\n');
+
+    const output = runExternalContextWatch({
+      hook_event_name: 'FileChanged',
+      cwd: root,
+      file_path: notePath,
+      event: 'add',
+    });
+
+    assert.equal(output.hookSpecificOutput.hookEventName, 'FileChanged');
+    assert.deepEqual(output.hookSpecificOutput.watchPaths, [externalDir, nestedDir]);
+    assert.equal(output.hookSpecificOutput.additionalContext, undefined);
+  } finally {
+    rmSync(root, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Summary

- Adds a Claude Code `FileChanged` hook for `projects/*/external/` evidence changes.
- Registers existing external directories as `SessionStart` watch paths.
- Injects refreshed ArcKit project context when watched external documents are added, changed, or removed.
- Updates hook docs and changelogs for issue #580 follow-up.

## Validation

- `python scripts/converter.py`
- `node tests/plugin/external-context-watch.test.mjs`
- `pytest tests/plugin/test_release_process.py tests/plugin/test_template_consistency.py`
- `pytest tests/codex/test_codex_extension.py`
- `npx markdownlint-cli2 CHANGELOG.md docs/guides/hooks.md plugins/arckit-claude/CHANGELOG.md plugins/arckit-claude/docs/guides/hooks.md plugins/arckit-claude/hooks/README.md`
- `git diff --check`
