### PR TITLE
chore: make arckit-repo standalone; mark DeepBook guide proprietary

### DIFF
--- a/docs/guides.html
+++ b/docs/guides.html
@@ -861,7 +861,7 @@
                 </h2>
                 <div class="app-guide-category__body">
                     <ul class="app-guide-list">
-                        <li class="app-guide-item"><a href="guide-viewer.html?guide=deepbook" class="govuk-link">DeepBook Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Autonomous book generation with 6-stage workflow and stateful checkpoints</span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=deepbook" class="govuk-link">DeepBook Guide</a> <span class="app-status-tag app-status-beta">BETA</span> <span class="app-guide-desc">Autonomous book generation with 6-stage workflow and stateful checkpoints. Proprietary — not part of the open-source ArcKit distribution and not installable from the public marketplace.</span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/guides/deepbook.md
+++ b/docs/guides/deepbook.md
@@ -1,8 +1,24 @@
 # DeepBook Guide
 
 > **Guide Origin**: Official | **ArcKit Version**: 4.20.1+ | **Status**: BETA
+> **Licence**: PROPRIETARY — not open source, not publicly available
 
 `/arckit:deepbook` generates comprehensive books using DeepBook's large mode workflow with stateful checkpoints and per-topic generation.
+
+---
+
+## Licence and Availability
+
+**DeepBook is proprietary software and is not part of the open-source ArcKit distribution.**
+
+Unlike every other plugin documented here, `arckit-deepbook` is **not** published in the ArcKit marketplace and is **not** covered by the licence that governs the rest of ArcKit. It lives in a separate, private repository.
+
+- **Licence**: Proprietary and confidential. Copyright (c) 2026 Mark Craddock. All rights reserved.
+- **Availability**: Private. It cannot be installed from the public ArcKit marketplace.
+- **Permission**: No right is granted to use, copy, modify, distribute, or sublicense the plugin without prior written consent of the copyright holder.
+- **Generated output**: Books you generate remain your own. The licence governs the software, not its output.
+
+This guide is published for reference and for licensed users. If you want access, contact the copyright holder — installing it is not a self-service step.
 
 ---
 
@@ -10,7 +26,7 @@
 
 DeepBook is an autonomous book generation agent that executes a 6-stage workflow to create comprehensive non-fiction books. It replicates DeepBook's large mode behavior with faithful prompt replication and ArcKit formatting.
 
-**Source**: DeepBook repository commit `318776efe29a995da4b52838389df920d479bf36` (2026-05-03)
+**Source**: DeepBook repository, which is owned by the same copyright holder and covered by the same proprietary terms.
 
 ---
 

--- a/docs/guides/repo-docs.md
+++ b/docs/guides/repo-docs.md
@@ -13,7 +13,7 @@ The command ships in the optional `arckit-repo` plugin. It is inspired by OpenWi
 Install the optional repository plugin with the ArcKit core plugin:
 
 ```bash
-claude plugin install arckit arckit-repo
+claude plugin install arckit-repo
 ```
 
 Create the first repository wiki:

--- a/plugins/arckit-claude/docs/guides/repo-docs.md
+++ b/plugins/arckit-claude/docs/guides/repo-docs.md
@@ -13,7 +13,7 @@ The command ships in the optional `arckit-repo` plugin. It is inspired by OpenWi
 Install the optional repository plugin with the ArcKit core plugin:
 
 ```bash
-claude plugin install arckit arckit-repo
+claude plugin install arckit-repo
 ```
 
 Create the first repository wiki:

--- a/plugins/arckit-claude/plugins/repo/.claude-plugin/plugin.json
+++ b/plugins/arckit-claude/plugins/repo/.claude-plugin/plugin.json
@@ -5,15 +5,10 @@
   "description": "Repository tooling for ArcKit, starting with source-grounded, agent-readable repository docs inspired by OpenWiki.",
   "author": {
     "name": "ArcKit Contributors",
-    "url": "https://github.com/tractorjuice/arckit-repo"
+    "url": "https://github.com/tractorjuice"
   },
-  "repository": "https://github.com/tractorjuice/arckit-repo",
+  "repository": "https://github.com/tractorjuice/arckit-claude",
   "license": "MIT",
   "defaultEnabled": false,
-  "dependencies": [
-    {
-      "name": "arckit",
-      "version": "=6.1.7"
-    }
-  ]
+  "dependencies": []
 }

--- a/plugins/arckit-repo/.claude-plugin/plugin.json
+++ b/plugins/arckit-repo/.claude-plugin/plugin.json
@@ -5,15 +5,10 @@
   "description": "Repository tooling for ArcKit, starting with source-grounded, agent-readable repository docs inspired by OpenWiki.",
   "author": {
     "name": "ArcKit Contributors",
-    "url": "https://github.com/tractorjuice/arckit-repo"
+    "url": "https://github.com/tractorjuice"
   },
-  "repository": "https://github.com/tractorjuice/arckit-repo",
+  "repository": "https://github.com/tractorjuice/arckit-claude",
   "license": "MIT",
   "defaultEnabled": false,
-  "dependencies": [
-    {
-      "name": "arckit",
-      "version": "=6.1.7"
-    }
-  ]
+  "dependencies": []
 }

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -242,15 +242,15 @@ PLUGIN_SOURCES = [
     "plugins/arckit-uk-nhs",
     "plugins/arckit-togaf-adm",
     "plugins/arckit-agent-architecture",
-    "plugins/arckit-repo",
     "plugins/arckit-claude",  # core last
 ]
 # Intentionally EXCLUDED from PLUGIN_SOURCES (Claude Code only, not converted):
 #   - arckit-fde            : standalone site-generator tooling plugin
+#   - arckit-repo           : standalone repository-docs tooling plugin
 #   - arckit-uk-gcloud      : PROPRIETARY overlay — must NOT be copied into the
 #                             MIT-licensed public extension repos (licence leak).
 #                             Ships as a Claude Code marketplace plugin only.
-# (Both still appear in marketplace.json; exclusion here is deliberate, not drift.)
+# (All still appear in marketplace.json; exclusion here is deliberate, not drift.)
 
 
 # --- Agent configuration: adding a new AI target = adding a dictionary entry ---

--- a/tests/codex/test_codex_extension.py
+++ b/tests/codex/test_codex_extension.py
@@ -28,7 +28,6 @@ PLUGIN_COMMAND_DIRS = [
     REPO_ROOT / "plugins" / "arckit-uk-nhs" / "commands",
     REPO_ROOT / "plugins" / "arckit-togaf-adm" / "commands",
     REPO_ROOT / "plugins" / "arckit-agent-architecture" / "commands",
-    REPO_ROOT / "plugins" / "arckit-repo" / "commands",
 ]
 CODEX_ROOT = REPO_ROOT / "extensions" / "arckit-codex"
 CODEX_SKILLS = CODEX_ROOT / "skills"

--- a/tests/extension_helpers.py
+++ b/tests/extension_helpers.py
@@ -22,9 +22,11 @@ PLUGIN_COMMAND_DIRS = [
     REPO_ROOT / "plugins" / "arckit-uk-nhs" / "commands",
     REPO_ROOT / "plugins" / "arckit-togaf-adm" / "commands",
     REPO_ROOT / "plugins" / "arckit-agent-architecture" / "commands",
-    REPO_ROOT / "plugins" / "arckit-repo" / "commands",
     REPO_ROOT / "plugins" / "arckit-claude" / "commands",
 ]
+# arckit-fde, arckit-repo, and arckit-uk-gcloud are absent by design: they are
+# Claude Code only and excluded from converter.py PLUGIN_SOURCES, so their
+# commands never appear in the generated extensions.
 CLAUDE_AGENTS = REPO_ROOT / "plugins" / "arckit-claude" / "agents"
 CLAUDE_ONLY_COMMANDS = {"build.md"}
 CLAUDE_ONLY_AGENT_FIELDS = {

--- a/tests/paperclip/test_commands_json.py
+++ b/tests/paperclip/test_commands_json.py
@@ -29,8 +29,9 @@ PLUGIN_COMMAND_DIRS = [
     REPO_ROOT / "plugins" / "arckit-uk-nhs" / "commands",
     REPO_ROOT / "plugins" / "arckit-togaf-adm" / "commands",
     REPO_ROOT / "plugins" / "arckit-agent-architecture" / "commands",
-    REPO_ROOT / "plugins" / "arckit-repo" / "commands",
 ]
+# arckit-fde, arckit-repo, and arckit-uk-gcloud are absent by design: Claude Code
+# only, excluded from converter.py PLUGIN_SOURCES.
 
 
 def expected_command_count():

--- a/tests/plugin/test_template_consistency.py
+++ b/tests/plugin/test_template_consistency.py
@@ -31,8 +31,9 @@ PLUGIN_SOURCES = [
     "plugins/arckit-uk-nhs",
     "plugins/arckit-togaf-adm",
     "plugins/arckit-agent-architecture",
-    "plugins/arckit-repo",
 ]
+# arckit-fde and arckit-repo are absent by design: tooling plugins with no
+# governance templates to mirror into .arckit/templates/.
 CLI_TEMPLATES_DIR = os.path.join(REPO_ROOT, ".arckit", "templates")
 
 _TEMPLATE_RE = re.compile(r"\$\{CLAUDE_PLUGIN_ROOT\}/templates/([\w-]+\.md)")


### PR DESCRIPTION
## arckit-repo becomes a standalone tooling plugin

Follows the `arckit-fde` precedent: a Claude Code only tooling plugin that ships via the marketplace but is not part of the converted, cross-platform surface.

- **`dependencies: []`** (was pinned `arckit =6.1.7`). It generates repository docs; it does not need the governance core.
- **Removed from `converter.py` PLUGIN_SOURCES** — `/arckit:repo-docs` no longer converts into the six extensions. Stale artefacts from the previous conversion were deleted, because `push-extensions.sh` tars the *working tree*, so they would otherwise have shipped.
- **Dropped from the test enumerations `arckit-fde` is also absent from**: `extension_helpers.py`, `tests/codex`, `tests/paperclip`, `test_template_consistency.py`.
- **Install line corrected** to `claude plugin install arckit-repo` — there is no core dependency to co-install.

### One reversal worth reviewing

`plugin.json` `repository`/`author` are realigned to `arckit-claude`, which **reverts 69fc33b5** ("point repo plugin at standalone repository"). `test_release_process` asserts that every plugin in the `arckit-claude` marketplace resolves to that marketplace repo, and `arckit-fde` — the stated model — points at `arckit-claude` too. A public `tractorjuice/arckit-repo` repo does exist; if the intent is to publish from there instead of bundling, that is a different distribution model and this bit should change.

## DeepBook guide marked proprietary

`arckit-deepbook` is now proprietary and lives in a private repo, so `docs/guides/deepbook.md` gains a **Licence and Availability** section: not open source, not covered by ArcKit's licence, not installable from the public marketplace, no rights granted without written consent — and generated books remain the user's own. The `guides.html` card carries the same warning so it is visible without clicking through.

## Verification

All gates pass locally: markdownlint (0 errors), shared-asset drift, recipe linter, doc-type collisions, dual-registration, `tests/codex` (33), `tests/paperclip` (11), and the full `tests/plugin` suite (1,016 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)