### PR TITLE
docs: correct two false claims about bundled MCP servers

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -130,7 +130,11 @@ Plugin-level user config is declared in `plugins/arckit-claude/.claude-plugin/pl
 
 Substitution uses `${user_config.KEY}`. Sensitive values are never substituted into prompt content. The converter rewrites `${user_config.KEY}` → `${KEY}` for non-Claude extensions (which fall back to shell env vars).
 
-**MCP `alwaysLoad`** (v2.1.121): `aws-knowledge` and `microsoft-learn` are eagerly loaded since the AWS/Azure research commands always reach for them. Other MCP servers stay deferred. The field is passed through unchanged to non-Claude extensions.
+**MCP `alwaysLoad`** (v2.1.121): **all six** bundled servers set it — not just the AWS/Azure pair. This is load-bearing, not an optimisation: a deferred (non-`alwaysLoad`) plugin MCP server is **not injected into subagent context**, so only the main agent could reach it via ToolSearch. Every MCP-backed agent therefore needs its server eagerly loaded — `arckit-gcp-research` calls `google-developer-knowledge`, `arckit-datascout-reader` calls `datacommons-mcp`, the `gov-*` agents call `govreposcrape`, and so on. **Do not remove `alwaysLoad` to tidy up a server that fails to connect** — it breaks the agent that depends on it. (See also the tool-name prefix rule: agents must allowlist `mcp__plugin_arckit_<server>__<tool>`; a bare `mcp__<server>__<tool>` matches nothing.)
+
+The two **keyed** servers (`google-developer-knowledge`, `datacommons-mcp`) need `${user_config.*}` API keys. On a keyless session they attempt to connect at startup, fail auth, and are marked **failed** in `/plugin` — the session continues normally, bounded by the connect timeout. This is expected and harmless; there is no way to conditionally omit an MCP server based on whether its config value is set, so a blank key means a failed server, **not** an absent one. Do not document it as "leave blank to disable".
+
+The field is passed through unchanged to non-Claude extensions.
 
 ### Plugin Hooks
 

--- a/plugins/arckit-claude/.claude-plugin/plugin.json
+++ b/plugins/arckit-claude/.claude-plugin/plugin.json
@@ -23,13 +23,13 @@
   "userConfig": {
     "GOOGLE_API_KEY": {
       "title": "Google API Key",
-      "description": "Google API key for the google-developer-knowledge MCP server (optional — leave blank to disable)",
+      "description": "Google API key for the google-developer-knowledge MCP server, used by /arckit:gcp-research. Only needed if you run that command. Left blank, the server shows as 'failed to connect' in /plugin — harmless, and everything else works normally.",
       "type": "string",
       "sensitive": true
     },
     "DATA_COMMONS_API_KEY": {
       "title": "Data Commons API Key",
-      "description": "Data Commons API key for the datacommons-mcp MCP server (optional — leave blank to disable)",
+      "description": "Data Commons API key (from apikeys.datacommons.org) for the datacommons-mcp MCP server, used by /arckit:datascout. Only needed if you run that command. Left blank, the server shows as 'failed to connect' in /plugin — harmless, and everything else works normally.",
       "type": "string",
       "sensitive": true
     },


### PR DESCRIPTION
Both surfaced while diagnosing why `google-developer-knowledge` and `datacommons-mcp` show **failed to connect** in `/plugin`.

## The two false claims

**1. `plugin.json`: "optional — leave blank to disable"** (both API keys)

Blank does not disable them. There is no way to conditionally omit an MCP server based on whether its config value is set, so a blank key yields a *failed* server, not an absent one. Every ArcKit user without a Google or Data Commons key — which is most of them — sees two permanently red servers and is told, in the config dialog itself, that this is how you turn them off.

The descriptions now say what actually happens, which command needs the key, and where to get the Data Commons one (its 401 body points at `apikeys.datacommons.org`).

**2. `CLAUDE.md`: "`aws-knowledge` and `microsoft-learn` are eagerly loaded… Other MCP servers stay deferred"**

All **six** bundled servers are `alwaysLoad`. The claim has been stale for a while.

## What I did NOT do, and why

I originally intended to drop `alwaysLoad` from the two keyed servers so they stop dialling out on every session. **That would have been a regression.**

A deferred (non-`alwaysLoad`) plugin MCP server is not injected into subagent context — only the main agent can reach it via ToolSearch. Both of these servers are called *by subagents*:

- `arckit-gcp-research` → `mcp__plugin_arckit_google-developer-knowledge__*`
- `arckit-datascout-reader` → `mcp__plugin_arckit_datacommons-mcp__*`

Removing `alwaysLoad` would break `/arckit:gcp-research` and `/arckit:datascout` for users who *do* have keys, in order to tidy a cosmetic red line for users who do not. Bad trade.

The failed state is already known-harmless: a bounded connect timeout at startup, after which the session continues normally.

So `CLAUDE.md` now records the constraint explicitly — **do not remove `alwaysLoad` to tidy up a failing server** — so the next person (or the next agent) does not attempt the same "cleanup" and land the regression.

## Diagnosis notes

For the record, the three distinct causes behind a `/plugin` list full of unhappy servers:

| Status | Servers | Cause |
|---|---|---|
| Needs authentication | canva, figma, notion, ahrefs, amplitude, klaviyo | OAuth. They return `401` + `www-authenticate: Bearer … resource_metadata=…`, so Claude Code can discover the auth server and offer an interactive sign-in. Working as designed. |
| Failed to connect | gmail, google-calendar, slack, hubspot, similarweb | claude.ai connectors, disabled because `ANTHROPIC_API_KEY` is set and takes precedence over the claude.ai login. |
| Failed to connect | **google-developer-knowledge, datacommons-mcp** | **Ours.** Static API keys in headers, no OAuth advertisement, so no interactive flow is possible — the key must be in config before the first connection. |

## Verification

- `python scripts/converter.py` → clean, 1155 files
- `python scripts/sync-shared-assets.py --check` → passes
- `pytest tests/codex/` → 33 passed
- `markdownlint-cli2 CLAUDE.md` → 0 errors
- `claude plugin validate .` → passes

No functional change — `.mcp.json` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FVjabPKY2ubELhDNuJmPVS