### PR TITLE
fix(converter): stop swallowing trailing punctuation in skill invocations

### DIFF
--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -1527,31 +1527,40 @@ def _rewrite_skill_content(
             f"This location is auto-discovered by {platform_label} as a project-level skill",
         )
 
+    # The command-name capture must END in a word char so a sentence-final
+    # full stop (or other trailing punctuation) is left as a literal rather
+    # than swallowed into the name — otherwise `/arckit:stakeholders.` renders
+    # as `$arckit-stakeholders-` (the `.` is captured then mapped `.`->`-`).
+    # Internal dots/hyphens (wardley.climate, security-assessment) are kept.
+    _cmd_name = r"(\w(?:[\w.-]*\w)?)"
+
     # Rewrite /arckit:X -> platform invocation (colon-prefixed plugin format)
     content = re.sub(
-        r"(?<![\w/])/arckit:(\w[\w.-]*)",
+        r"(?<![\w/])/arckit:" + _cmd_name,
         normalize_invocation,
         content,
     )
 
     # Rewrite /arckit.X -> platform invocation (dot-prefixed format)
     content = re.sub(
-        r"(?<![\w/])/arckit\.(\w[\w.-]*)",
+        r"(?<![\w/])/arckit\." + _cmd_name,
         normalize_invocation,
         content,
     )
 
     # Rewrite /prompts:arckit.X -> platform invocation (old Codex prompt format)
     content = re.sub(
-        r"/prompts:arckit\.(\w[\w.-]*)",
+        r"/prompts:arckit\." + _cmd_name,
         normalize_invocation,
         content,
     )
 
     # Normalize any already-rewritten skill invocations that still
     # contain command-name dots, such as $arckit-wardley.climate.
+    # The capture must end in an alphanumeric so a trailing full stop is not
+    # re-consumed (otherwise it undoes the trailing-punctuation fix above).
     content = re.sub(
-        re.escape(inv_prefix) + r"([A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z0-9.-]*)",
+        re.escape(inv_prefix) + r"([A-Za-z0-9][A-Za-z0-9.-]*\.[A-Za-z0-9.-]*[A-Za-z0-9])",
         normalize_invocation,
         content,
     )

--- a/tests/codex/test_codex_extension.py
+++ b/tests/codex/test_codex_extension.py
@@ -828,6 +828,42 @@ def test_codex_skills_do_not_expose_claude_command_syntax_or_hooks():
     assert not offenders
 
 
+def test_codex_skill_rewrite_preserves_trailing_punctuation():
+    """A command reference at the end of a sentence must not swallow the full stop.
+
+    Regression for the greedy `(\\w[\\w.-]*)` capture: `/arckit:stakeholders.`
+    used to render as `$arckit-stakeholders-` (period consumed into the name,
+    then mapped `.`->`-`). The period is sentence punctuation, not part of the
+    command name, and must survive as a literal.
+    """
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "arckit_converter", REPO_ROOT / "scripts" / "converter.py"
+    )
+    converter = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(converter)
+
+    sample = (
+        "Run /arckit:stakeholders.\n"
+        "Then /arckit.adr.\n"
+        "And /arckit:wardley.climate.\n"
+    )
+    expected = (
+        "Run $arckit-stakeholders.\n"
+        "Then $arckit-adr.\n"
+        "And $arckit-wardley-climate.\n"
+    )
+    result = converter._rewrite_skill_content(
+        sample,
+        skill_dir_name="arckit-requirements",
+        invocation_fn=converter.codex_skill_invocation,
+        platform_label="Codex",
+        plugin_root_prefix=".arckit",
+    )
+    assert result == expected
+
+
 def test_codex_skill_rewrite_is_stable():
     """Golden test: locks rewrite output so the shared-core extraction is provably safe.
 
@@ -851,15 +887,12 @@ def test_codex_skill_rewrite_is_stable():
         "Templates live in ${CLAUDE_PLUGIN_ROOT}/templates/.\n"
         "Beware Claude Code's 32K token output limit.\n"
     )
-    # NOTE: `$arckit-stakeholders-` and `$arckit-adr-` are correct here, not a
-    # typo. The capture group `(\w[\w.-]*)` is greedy and swallows a
-    # sentence-final full stop, which codex_skill_invocation then maps `.`->`-`.
-    # This quirk predates the shared-core extraction; this golden test locks
-    # current behaviour so the refactor is provably behaviour-preserving.
-    # Fixing the quirk is tracked separately.
+    # Sentence-final full stops after a command reference stay as literal
+    # punctuation (`$arckit-stakeholders.`, `$arckit-adr.`), not swallowed into
+    # the name. See test_codex_skill_rewrite_preserves_trailing_punctuation.
     expected = (
-        "Run $arckit-requirements then $arckit-stakeholders-\n"
-        "Also $arckit-wardley-climate and $arckit-adr-\n"
+        "Run $arckit-requirements then $arckit-stakeholders.\n"
+        "Also $arckit-wardley-climate and $arckit-adr.\n"
         "Please ask the user for the project name.\n"
         "Templates live in .arckit/templates/.\n"
         "Beware Codex output limits.\n"


### PR DESCRIPTION
## Summary

Fixes a pre-existing bug where a command reference at the end of a sentence had its full stop swallowed into the command name.

`/arckit:stakeholders.` rendered as `$arckit-stakeholders-`: the greedy `(\w[\w.-]*)` capture pulled the sentence-final `.` into the name, which the invocation mapper then turned `.` → `-`. Three occurrences shipped in the Codex extension (`arckit-presentation`, and `arckit-operationalize` as referenced from two UK-finance skills). The shared rewrite core carried the same bug into the new Kimi extension.

## Fix

The command-name capture must end in a word char, so trailing punctuation stays a literal. Applied to the three `/arckit:`, `/arckit.`, `/prompts:arckit.` captures **and** to the dotted-invocation normaliser, which re-consumed the full stop after the primary fix (that second site is why a one-line change wasn't enough).

Internal dots and hyphens are preserved: `wardley.climate` still becomes `wardley-climate`, `security-assessment` is untouched.

## Base branch

Stacked on `feat/arckit-kimi-extension` (#665), because the fix lives in `_rewrite_skill_content`, the shared core that PR introduced. The bug exists on `main` too (in the pre-refactor `rewrite_codex_skills`), but fixing it there would collide with #665's restructuring of that exact function. Merges cleanly once #665 lands.

## Testing

- New `test_codex_skill_rewrite_preserves_trailing_punctuation` (written first, watched fail on `$arckit-stakeholders-`, then pass).
- Task 3's golden test previously locked the buggy output on purpose (to prove the extraction was behaviour-preserving); updated here to the corrected output.
- Regenerated all extensions and diffed Codex skill output: **exactly** the 3 mangled occurrences changed, each `$arckit-…-` → `$arckit-….`, nothing else. Zero trailing-hyphen mangles remain in Codex or Kimi.
- `pytest tests/codex/ tests/kimi/ tests/opencode/` — 54 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
