### PR TITLE
feat(kimi): wire governance hooks and enrich the plugin manifest

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Kimi Code CLI hooks.** The `arckit-kimi` plugin manifest now wires 16 governance and security hooks (session context injection, prompt and file secret detection, file protection, ARC filename validation, score and Wardley-math validation, provenance stamping, manifest updates, stale-artifact notices, session learner, post-compact rehydrate, and telemetry) through a new `hooks/kimi-hook-adapter.mjs`. The adapter runs each unmodified Claude hook as a child and re-expresses its Claude-shaped output in Kimi's contract (context to stdout on exit 0, blocks to exit 2), so the battle-tested Claude hooks stay byte-for-byte unchanged. Path-scoped hooks carry an adapter-level guard that stands in for Claude's `if:` conditions, which Kimi's flat hook schema cannot express. The translation logic is unit-tested in isolation; the end-to-end wiring is not yet smoke-tested against a live Kimi runtime.
+- **Kimi manifest metadata.** `kimi.plugin.json` now carries `author`, `homepage`, `repository`, `license`, `keywords`, and a fuller `interface` block (`longDescription`, `developerName`, `websiteURL`) for the `/plugins` browser.
+
+### Fixed
+
+- Softened the converter's `generate_kimi_plugin_json` note that asserted Kimi supports `headers` on remote MCP servers. Kimi's published schema documents only `url`, so the two keyed servers (`google-developer-knowledge`, `datacommons-mcp`) may not authenticate under Kimi until confirmed on a live instance.
+
 ## [6.4.0] — 2026-07-25
 
 ### Added

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **Kimi Code CLI hooks.** The `arckit-kimi` plugin manifest now wires 16 governance and security hooks (session context injection, prompt and file secret detection, file protection, ARC filename validation, score and Wardley-math validation, provenance stamping, manifest updates, stale-artifact notices, session learner, post-compact rehydrate, and telemetry) through a new `hooks/kimi-hook-adapter.mjs`. The adapter runs each unmodified Claude hook as a child and re-expresses its Claude-shaped output in Kimi's contract (context to stdout on exit 0, blocks to exit 2), so the battle-tested Claude hooks stay byte-for-byte unchanged. Path-scoped hooks carry an adapter-level guard that stands in for Claude's `if:` conditions, which Kimi's flat hook schema cannot express. The translation logic is unit-tested in isolation; the end-to-end wiring is not yet smoke-tested against a live Kimi runtime.
+- **Kimi manifest metadata.** `kimi.plugin.json` now carries `author`, `homepage`, `repository`, `license`, `keywords`, and a fuller `interface` block (`longDescription`, `developerName`, `websiteURL`) for the `/plugins` browser.
+
+### Fixed
+
+- Softened the converter's `generate_kimi_plugin_json` note that asserted Kimi supports `headers` on remote MCP servers. Kimi's published schema documents only `url`, so the two keyed servers (`google-developer-knowledge`, `datacommons-mcp`) may not authenticate under Kimi until confirmed on a live instance.
+
 ## [6.4.0] — 2026-07-25
 
 ### Added

--- a/plugins/arckit-claude/hooks/kimi-hook-adapter.mjs
+++ b/plugins/arckit-claude/hooks/kimi-hook-adapter.mjs
@@ -1,0 +1,165 @@
+/**
+ * ArcKit Kimi hook adapter
+ *
+ * Kimi Code CLI plugin hooks share Claude Code's snake_case stdin contract
+ * (`hook_event_name`, `tool_name`, `tool_input`, `cwd`, `session_id`) but
+ * differ on OUTPUT. Kimi attaches a hook's stdout to context on exit 0 and
+ * blocks on exit 2 (stderr becomes the reason) or a
+ * `hookSpecificOutput.permissionDecision: "deny"` payload. ArcKit's hooks were
+ * written for Claude, which instead reads structured stdout JSON
+ * (`decision: "block"`, `hookSpecificOutput.additionalContext`, `updatedInput`,
+ * `updatedToolOutput`, `permissionDecision`).
+ *
+ * This wrapper lets the UNMODIFIED Claude hooks run under Kimi. Kimi invokes:
+ *
+ *     node ./hooks/kimi-hook-adapter.mjs <target-hook>.mjs [path-guard]
+ *
+ * The adapter pipes Kimi's stdin straight to the child hook, captures the
+ * child's Claude-shaped stdout, and re-expresses it in Kimi's contract. The
+ * Claude hooks themselves are never edited, so their behaviour under Claude is
+ * unchanged; every Claude->Kimi translation lives (and is unit-tested) in the
+ * pure `translate()` below.
+ *
+ * The optional third argument replaces Claude's per-hook `if:` path condition
+ * (e.g. `Write(/projects/**)`), which Kimi's flat hook schema cannot express.
+ * It is a substring matched against the normalised `tool_input.file_path`; when
+ * it does not match, the child hook is skipped entirely. This is why hooks that
+ * must only fire under the projects tree, the vendors/scores.json file, or the
+ * wardley-maps directory stay scoped under Kimi.
+ *
+ * NOTE: this path has not yet been exercised against a live Kimi Code runtime
+ * (project memory: the Kimi extension has never been smoke-tested). The
+ * translation logic is unit-tested in isolation
+ * (tests/plugin/test_kimi_hook_adapter.mjs); the end-to-end wiring still needs
+ * one manual run against Kimi before it can be trusted.
+ */
+
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, join, basename } from 'node:path';
+import { readFileSync } from 'node:fs';
+
+const HERE = dirname(fileURLToPath(import.meta.url));
+
+/**
+ * Translate a Claude hook's result into a Kimi action. Pure: no I/O, no spawn,
+ * so it is fully unit-testable without a running hook or a live Kimi.
+ *
+ * @param {string|null} childStdout  Raw stdout the Claude hook printed.
+ * @param {number|null} childStatus  Child process exit code.
+ * @param {string|null} childStderr  Raw stderr the Claude hook printed.
+ * @returns {{stdout?: string, stderr?: string, exitCode: number}}
+ *   `exitCode` 2 blocks the tool/prompt (stderr is the reason); `exitCode` 0
+ *   allows, optionally attaching `stdout` as context.
+ */
+export function translate(childStdout, childStatus, childStderr) {
+  // A child that already blocked via a non-zero exit is honoured verbatim.
+  if (childStatus === 2) {
+    return { stderr: String(childStderr || 'Blocked by ArcKit hook.'), exitCode: 2 };
+  }
+
+  let out = null;
+  if (childStdout && childStdout.trim()) {
+    try { out = JSON.parse(childStdout); } catch { out = null; }
+  }
+  // Non-JSON, empty, or `{}` output: nothing to inject, allow silently.
+  if (!out || typeof out !== 'object') return { exitCode: 0 };
+
+  const hso = out.hookSpecificOutput && typeof out.hookSpecificOutput === 'object'
+    ? out.hookSpecificOutput
+    : {};
+
+  const decision = out.decision || hso.permissionDecision;
+  const reason = out.reason || hso.permissionDecisionReason;
+
+  // 1) Hard block (secret-detection, secret-file-scanner, validate-arc-filename
+  //    unknown-type, allow-plugin-internals deny, ...).
+  if (decision === 'block' || decision === 'deny') {
+    return { stderr: String(reason || 'Blocked by ArcKit hook.'), exitCode: 2 };
+  }
+
+  // 2) Input mutation (validate-arc-filename auto-correct). Kimi cannot rewrite
+  //    tool input, so translate the intended fix into a block that names the
+  //    correct filename.
+  if (out.updatedInput && out.updatedInput.file_path) {
+    return {
+      stderr: `ArcKit: rename the file to '${basename(out.updatedInput.file_path)}' `
+        + 'to match the naming convention, then retry.',
+      exitCode: 2,
+    };
+  }
+
+  // 3) Context injection -> Kimi attaches stdout text on exit 0.
+  if (hso.additionalContext) {
+    return { stdout: String(hso.additionalContext), exitCode: 0 };
+  }
+
+  // 4) Allow-with-warning (score-validator) -> surface as context, don't block.
+  if (decision === 'allow' && reason) {
+    return { stdout: String(reason), exitCode: 0 };
+  }
+
+  // 5) permissionDecision:'allow', updatedToolOutput, {} -> nothing to inject.
+  //    The hook's file-system side effects (provenance stamp, manifest, tidy)
+  //    already ran inside the child; just allow.
+  return { exitCode: 0 };
+}
+
+/**
+ * Replicate Claude's per-hook `if:` path condition. `guard` is a substring
+ * (e.g. `/projects/`, `/vendors/scores.json`, `/wardley-maps/`) that must
+ * appear in the normalised file path for the hook to run. Pure for testing.
+ *
+ * @param {string} filePath  tool_input.file_path from the hook payload.
+ * @param {string} guard     Required path substring, or empty/undefined.
+ * @returns {boolean} true when the hook should run.
+ */
+export function pathMatchesGuard(filePath, guard) {
+  if (!guard) return true;
+  if (!filePath) return false;
+  const norm = ('/' + String(filePath).replace(/\\/g, '/')).replace(/\/+/g, '/');
+  return norm.includes(guard);
+}
+
+function main() {
+  const target = process.argv[2];
+  // Misconfiguration must never derail the user's turn.
+  if (!target) process.exit(0);
+  const guard = process.argv[3];
+
+  let raw = '';
+  try { raw = readFileSync(0, 'utf8'); } catch { raw = ''; }
+
+  // Apply the path guard (Claude `if:` equivalent) before spawning anything.
+  if (guard) {
+    let filePath = '';
+    try {
+      const data = JSON.parse(raw);
+      filePath = (data && data.tool_input && data.tool_input.file_path) || '';
+    } catch { filePath = ''; }
+    if (!pathMatchesGuard(filePath, guard)) process.exit(0);
+  }
+
+  // basename() prevents a wired target from escaping the hooks directory.
+  const targetPath = join(HERE, basename(target));
+  const child = spawnSync(process.execPath, [targetPath], {
+    input: raw,
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+
+  // Child crashed or was not found: fail open (Kimi treats any exit that is
+  // not 2 as "allow" anyway).
+  if (child.error) process.exit(0);
+
+  const action = translate(child.stdout, child.status, child.stderr);
+  if (action.stdout) process.stdout.write(action.stdout);
+  if (action.stderr) process.stderr.write(action.stderr);
+  process.exit(action.exitCode || 0);
+}
+
+// Run only when executed directly, so importing the module for unit tests does
+// not read stdin or spawn a child.
+if (process.argv[1] && basename(process.argv[1]) === 'kimi-hook-adapter.mjs') {
+  main();
+}

--- a/scripts/converter.py
+++ b/scripts/converter.py
@@ -1074,13 +1074,75 @@ def generate_codex_mcp_json(mcp_json_path, output_path):
     print(f"  Generated: {output_path}")
 
 
+def generate_kimi_hooks():
+    """Build the Kimi plugin-manifest ``hooks`` array.
+
+    Kimi hook entries are flat objects: ``{event, matcher, command, timeout}``.
+    Every entry routes through ``hooks/kimi-hook-adapter.mjs``, which runs the
+    unmodified Claude hook as a child and translates its Claude-shaped output
+    into Kimi's stdout/exit-code contract. The optional third adapter argument
+    is a path substring that replaces Claude's ``if:`` condition, which Kimi's
+    flat schema has no equivalent for.
+
+    Deliberately excluded: version-check / v5-migration-banner (Claude Code
+    version specific), graph-inject and sync-guides (they match Claude
+    ``/arckit:`` slash commands that do not exist in Kimi), allow-plugin-internals
+    / allow-mcp-tools / inject-agent-context (auto-allow and Agent-tool hooks
+    with no effect under Kimi), and external-context-watch (FileChanged has no
+    Kimi event).
+
+    NOTE: not yet smoke-tested against a live Kimi runtime — see the Kimi
+    extension memory. The adapter's translation logic is unit-tested in
+    isolation (tests/plugin/test_kimi_hook_adapter.mjs).
+    """
+    def command(target, guard=None):
+        base = f"node ./hooks/kimi-hook-adapter.mjs {target}"
+        return f"{base} {guard}" if guard else base
+
+    # event, matcher (""=all), target hook, timeout (s), path guard
+    specs = [
+        ("SessionStart", "", "arckit-session.mjs", 5, None),
+        ("SessionStart", "", "notify-stale-artifacts.mjs", 8, None),
+        ("UserPromptSubmit", "", "arckit-context.mjs", 10, None),
+        ("UserPromptSubmit", "", "secret-detection.mjs", 5, None),
+        ("PreToolUse", "Edit|Write", "file-protection.mjs", 5, None),
+        ("PreToolUse", "Edit|Write", "secret-file-scanner.mjs", 5, None),
+        ("PreToolUse", "Write", "validate-arc-filename.mjs", 5, "/projects/"),
+        ("PreToolUse", "Write", "score-validator.mjs", 5, "/vendors/scores.json"),
+        ("PreToolUse", "Write", "validate-wardley-math.mjs", 5, "/wardley-maps/"),
+        ("PostToolUse", "Write|Edit", "provenance-stamp.mjs", 5, "/projects/"),
+        ("PostToolUse", "Write|Edit", "tidy-wardley-labels.mjs", 10, "/wardley-maps/"),
+        ("PostToolUse", "Write", "update-manifest.mjs", 5, "/projects/"),
+        ("PostToolUse", ".*", "telemetry.mjs", 3, None),
+        ("Stop", "", "session-learner.mjs", 10, None),
+        ("StopFailure", "", "session-learner.mjs", 10, None),
+        ("PostCompact", "", "postcompact-rehydrate.mjs", 5, None),
+    ]
+
+    hooks = []
+    for event, matcher, target, timeout, guard in specs:
+        entry = {"event": event}
+        if matcher:
+            entry["matcher"] = matcher
+        entry["command"] = command(target, guard)
+        entry["timeout"] = timeout
+        hooks.append(entry)
+    return hooks
+
+
 def generate_kimi_plugin_json(mcp_json_path, version, output_path):
     """Generate the Kimi Code CLI plugin manifest.
 
-    Kimi's mcpServers schema is close to Claude's: remote servers use `url`
-    with optional `headers`, stdio servers use `command`/`args`/`env`. Claude's
-    `type` discriminator has no Kimi equivalent and is dropped; the shape is
-    inferred from whether `url` or `command` is present.
+    Remote MCP servers map to ``url`` (plus ``headers`` when present); stdio
+    servers map to ``command``/``args``/``env``. Claude's ``type`` discriminator
+    has no Kimi equivalent and is dropped; the shape is inferred from whether
+    ``url`` or ``command`` is present.
+
+    CAVEAT: Kimi's published mcpServers schema documents only ``url`` for remote
+    servers — ``headers`` is NOT documented and is unverified against the Kimi
+    runtime. The two keyed servers (google-developer-knowledge, datacommons-mcp)
+    rely on ``headers`` to send their API key, so those two may fail to
+    authenticate under Kimi until this is confirmed on a live instance.
     """
     servers = {}
     if os.path.isfile(mcp_json_path):
@@ -1109,14 +1171,33 @@ def generate_kimi_plugin_json(mcp_json_path, version, output_path):
             "The Enterprise Architecture Governance Harness: strategy, "
             "architecture, delivery and assurance artefacts."
         ),
+        "author": "ArcKit",
+        "homepage": "https://github.com/tractorjuice/arckit-kimi",
+        "repository": "https://github.com/tractorjuice/arckit-kimi",
+        "license": "MIT",
+        "keywords": [
+            "enterprise-architecture",
+            "governance",
+            "procurement",
+            "public-sector",
+            "kimi",
+        ],
         "skills": "./skills/",
         "sessionStart": {"skill": "architecture-workflow"},
         "mcpServers": servers,
+        "hooks": generate_kimi_hooks(),
         "interface": {
             "displayName": "ArcKit",
             "shortDescription": (
                 "Strategy, architecture, delivery and assurance artefacts"
             ),
+            "longDescription": (
+                "Use ArcKit to create, review, and connect architecture, "
+                "procurement, governance, compliance, research, and delivery "
+                "artefacts in Kimi Code CLI."
+            ),
+            "developerName": "ArcKit",
+            "websiteURL": "https://github.com/tractorjuice/arc-kit",
         },
     }
 
@@ -2201,6 +2282,25 @@ if __name__ == "__main__":
         os.path.join(plugin_dir, ".mcp.json"),
         kimi_version,
         "extensions/arckit-kimi/kimi.plugin.json",
+    )
+    # Copy every hook script plus the Kimi adapter so the wired hooks — and
+    # their hook-to-hook imports (hook-utils, project-context-builder,
+    # session-nudge, wardley-tidy, okf-frontmatter, ...) — resolve inside the
+    # extension. config/doc-types.mjs is already copied via the config dir.
+    kimi_hooks_dst = "extensions/arckit-kimi/hooks"
+    os.makedirs(kimi_hooks_dst, exist_ok=True)
+    kimi_hooks_src = os.path.join(plugin_dir, "hooks")
+    kimi_hook_count = 0
+    for hook_file in sorted(os.listdir(kimi_hooks_src)):
+        if hook_file.endswith(".mjs"):
+            shutil.copy2(
+                os.path.join(kimi_hooks_src, hook_file),
+                os.path.join(kimi_hooks_dst, hook_file),
+            )
+            kimi_hook_count += 1
+    print(
+        f"  Copied {kimi_hook_count} hook scripts "
+        f"(incl. kimi-hook-adapter.mjs) to {kimi_hooks_dst}"
     )
     copy_reference_skills(
         os.path.join(plugin_dir, "skills"),

--- a/tests/kimi/test_kimi_extension.py
+++ b/tests/kimi/test_kimi_extension.py
@@ -108,7 +108,10 @@ def test_generate_kimi_plugin_json_is_strict_json(tmp_path):
     converter.generate_kimi_plugin_json(str(mcp_src), "6.3.0", str(out))
 
     raw = out.read_text(encoding="utf-8")
-    assert "//" not in raw
+    # No JS-style comments. URLs (homepage, repository, websiteURL) legitimately
+    # contain "//", so match comment patterns precisely rather than bare "//".
+    assert "\n//" not in raw and not raw.lstrip().startswith("//")
+    assert "/*" not in raw
     json.loads(raw)  # raises if malformed
 
 
@@ -207,3 +210,95 @@ def test_all_mcp_servers_mapped_without_user_config():
 def test_arckit_build_skill_is_excluded():
     """arckit-build orchestrates parallel Agent dispatch and is Claude-only."""
     assert not (KIMI_SKILLS / "arckit-build").exists()
+
+
+# Events Kimi Code CLI documents for hooks. A wired event outside this set would
+# be rejected (or silently ignored) at load time.
+KIMI_HOOK_EVENTS = {
+    "UserPromptSubmit",
+    "PreToolUse",
+    "Stop",
+    "PostToolUse",
+    "PostToolUseFailure",
+    "PermissionRequest",
+    "PermissionResult",
+    "SessionStart",
+    "SessionEnd",
+    "SubagentStart",
+    "SubagentStop",
+    "StopFailure",
+    "Interrupt",
+    "PreCompact",
+    "PostCompact",
+    "Notification",
+}
+
+# Claude hooks intentionally NOT wired for Kimi (Claude Code-version specific,
+# Claude slash-command matchers, auto-allow/Agent hooks with no Kimi effect, or
+# events Kimi lacks). See generate_kimi_hooks() in scripts/converter.py.
+KIMI_EXCLUDED_HOOKS = {
+    "version-check.mjs",
+    "v5-migration-banner.mjs",
+    "graph-inject.mjs",
+    "sync-guides.mjs",
+    "allow-plugin-internals.mjs",
+    "allow-mcp-tools.mjs",
+    "inject-agent-context.mjs",
+    "external-context-watch.mjs",
+}
+
+
+def _manifest_hooks():
+    manifest = json.loads(KIMI_MANIFEST.read_text(encoding="utf-8"))
+    return manifest.get("hooks", [])
+
+
+def test_manifest_has_hooks_array():
+    hooks = _manifest_hooks()
+    assert hooks, "kimi.plugin.json has no hooks array"
+    for entry in hooks:
+        assert entry["event"] in KIMI_HOOK_EVENTS, f"unsupported hook event: {entry['event']}"
+        assert "kimi-hook-adapter.mjs" in entry["command"], (
+            f"hook command bypasses the adapter: {entry['command']}"
+        )
+        assert isinstance(entry["timeout"], int) and entry["timeout"] > 0
+
+
+def test_wired_hook_targets_and_adapter_exist_on_disk():
+    """Every wired hook (and the adapter) must be a real file in the extension."""
+    hooks_dir = KIMI_ROOT / "hooks"
+    assert (hooks_dir / "kimi-hook-adapter.mjs").is_file(), "adapter missing from extension"
+    for entry in _manifest_hooks():
+        # command: "node ./hooks/kimi-hook-adapter.mjs <target>.mjs [guard]"
+        # tokens:   0     1                            2           3
+        parts = entry["command"].split()
+        target = parts[2]
+        assert (hooks_dir / target).is_file(), f"wired hook target missing on disk: {target}"
+
+
+def test_excluded_hooks_are_not_wired():
+    wired = {entry["command"].split()[2] for entry in _manifest_hooks()}
+    leaked = wired & KIMI_EXCLUDED_HOOKS
+    assert not leaked, f"Claude-only hooks wired for Kimi: {sorted(leaked)}"
+
+
+def test_hook_utils_dependency_is_shipped():
+    """The adapter runs the real hooks, which import hook-utils.mjs."""
+    assert (KIMI_ROOT / "hooks" / "hook-utils.mjs").is_file()
+    assert (KIMI_ROOT / "config" / "doc-types.mjs").is_file()
+
+
+def test_generate_kimi_hooks_scopes_project_hooks_with_a_guard():
+    """Hooks that must fire only under projects/ carry the adapter path guard."""
+    converter = _load_converter()
+    hooks = converter.generate_kimi_hooks()
+    guarded = {
+        h["command"].split()[2]: h["command"].split()[3]
+        for h in hooks
+        if len(h["command"].split()) > 3
+    }
+    assert guarded.get("validate-arc-filename.mjs") == "/projects/"
+    assert guarded.get("score-validator.mjs") == "/vendors/scores.json"
+    assert guarded.get("validate-wardley-math.mjs") == "/wardley-maps/"
+    assert guarded.get("provenance-stamp.mjs") == "/projects/"
+    assert guarded.get("update-manifest.mjs") == "/projects/"

--- a/tests/plugin/test_kimi_hook_adapter.mjs
+++ b/tests/plugin/test_kimi_hook_adapter.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+/**
+ * Unit tests for plugins/arckit-claude/hooks/kimi-hook-adapter.mjs
+ *
+ * The adapter lets ArcKit's unmodified Claude hooks run under Kimi Code CLI by
+ * translating their Claude-shaped stdout into Kimi's stdout/exit-code contract.
+ * These tests exercise the two pure functions (translate, pathMatchesGuard) so
+ * the Claude->Kimi mapping is verified without a live Kimi runtime.
+ *
+ * Run with:  node tests/plugin/test_kimi_hook_adapter.mjs
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  translate,
+  pathMatchesGuard,
+} from '../../plugins/arckit-claude/hooks/kimi-hook-adapter.mjs';
+
+const j = (obj) => JSON.stringify(obj);
+
+// ── translate(): blocking ──
+
+test('decision:block -> exit 2 with the reason on stderr', () => {
+  const r = translate(j({ decision: 'block', reason: 'secret found' }), 0, '');
+  assert.deepEqual(r, { stderr: 'secret found', exitCode: 2 });
+});
+
+test('permissionDecision:deny -> exit 2 with permissionDecisionReason', () => {
+  const r = translate(
+    j({ hookSpecificOutput: { permissionDecision: 'deny', permissionDecisionReason: 'nope' } }),
+    0,
+    '',
+  );
+  assert.deepEqual(r, { stderr: 'nope', exitCode: 2 });
+});
+
+test('block with no reason falls back to a default reason', () => {
+  const r = translate(j({ decision: 'block' }), 0, '');
+  assert.equal(r.exitCode, 2);
+  assert.match(r.stderr, /Blocked by ArcKit hook/);
+});
+
+test('a child that itself exited 2 is honoured verbatim', () => {
+  const r = translate('', 2, 'boom');
+  assert.deepEqual(r, { stderr: 'boom', exitCode: 2 });
+});
+
+// ── translate(): context injection ──
+
+test('additionalContext -> exit 0 with the text on stdout', () => {
+  const r = translate(j({ hookSpecificOutput: { additionalContext: 'ctx' } }), 0, '');
+  assert.deepEqual(r, { stdout: 'ctx', exitCode: 0 });
+});
+
+test('allow-with-warning surfaces the reason as context, does not block', () => {
+  const r = translate(j({ decision: 'allow', reason: 'heads up' }), 0, '');
+  assert.deepEqual(r, { stdout: 'heads up', exitCode: 0 });
+});
+
+// ── translate(): input mutation ──
+
+test('updatedInput.file_path -> exit 2 naming the corrected basename', () => {
+  const r = translate(
+    j({ updatedInput: { file_path: '/repo/projects/001-x/ARC-001-REQ-v1.0.md' } }),
+    0,
+    '',
+  );
+  assert.equal(r.exitCode, 2);
+  assert.match(r.stderr, /ARC-001-REQ-v1\.0\.md/);
+  assert.doesNotMatch(r.stderr, /\/repo\/projects/); // basename only, no full path
+});
+
+// ── translate(): allow / no-op ──
+
+test('permissionDecision:allow -> exit 0, nothing injected', () => {
+  const r = translate(j({ hookSpecificOutput: { permissionDecision: 'allow' } }), 0, '');
+  assert.deepEqual(r, { exitCode: 0 });
+});
+
+test('updatedToolOutput (side-effect hook) -> exit 0, nothing injected', () => {
+  const r = translate(j({ hookSpecificOutput: { updatedToolOutput: 'x' } }), 0, '');
+  assert.deepEqual(r, { exitCode: 0 });
+});
+
+test('empty {} -> exit 0', () => {
+  assert.deepEqual(translate('{}', 0, ''), { exitCode: 0 });
+});
+
+test('empty string / non-JSON -> exit 0 (fail open)', () => {
+  assert.deepEqual(translate('', 0, ''), { exitCode: 0 });
+  assert.deepEqual(translate('not json', 0, ''), { exitCode: 0 });
+  assert.deepEqual(translate(null, 0, ''), { exitCode: 0 });
+});
+
+// ── pathMatchesGuard() ──
+
+test('no guard always matches', () => {
+  assert.equal(pathMatchesGuard('anything', ''), true);
+  assert.equal(pathMatchesGuard('', undefined), true);
+});
+
+test('guard matches relative and absolute paths', () => {
+  assert.equal(pathMatchesGuard('projects/001/x.md', '/projects/'), true);
+  assert.equal(pathMatchesGuard('/home/u/repo/projects/001/x.md', '/projects/'), true);
+  assert.equal(pathMatchesGuard('projects/001/vendors/scores.json', '/vendors/scores.json'), true);
+  assert.equal(pathMatchesGuard('projects/001/wardley-maps/m.owm', '/wardley-maps/'), true);
+});
+
+test('guard misses unrelated paths and empty file paths', () => {
+  assert.equal(pathMatchesGuard('src/app.ts', '/projects/'), false);
+  assert.equal(pathMatchesGuard('', '/projects/'), false);
+  assert.equal(pathMatchesGuard(undefined, '/projects/'), false);
+});
+
+test('guard normalises backslashes so Windows paths still match', () => {
+  assert.equal(pathMatchesGuard('repo\\projects\\001\\x.md', '/projects/'), true);
+});


### PR DESCRIPTION
## What

Reviews the `arckit-kimi` extension against the current Kimi Code CLI [plugins](https://www.kimi.com/code/docs/en/kimi-code-cli/customization/plugins.html) and [hooks](https://www.kimi.com/code/docs/kimi-code-cli/customization/hooks.html) docs and closes the gaps. Three changes, all in converter source (the extension tree is generated/gitignored):

### 1. Full hook port via an adapter (the main change)

Kimi supports plugin hooks with a nearly Claude-compatible **input** contract but a different **output** contract (context attaches from stdout on exit 0; blocks use exit 2 / `permissionDecision:deny`). ArcKit's hooks emit Claude-shaped JSON (`decision:block`, `hookSpecificOutput.additionalContext`, `updatedInput`, ...).

Rather than edit the 14 battle-tested Claude hook scripts, this adds one wrapper, `hooks/kimi-hook-adapter.mjs`, that Kimi invokes:

```
node ./hooks/kimi-hook-adapter.mjs <target-hook>.mjs [path-guard]
```

It pipes Kimi's stdin to the real hook, runs it as a child, and translates the child's output into Kimi's contract. **The Claude hooks are never touched, so their Claude behaviour is byte-for-byte unchanged**, and all Claude→Kimi translation lives in the adapter's pure `translate()` / `pathMatchesGuard()` (unit-tested).

`generate_kimi_hooks()` emits a **16-entry** manifest `hooks` array across `SessionStart`, `UserPromptSubmit`, `PreToolUse`, `PostToolUse`, `Stop`, `StopFailure`, `PostCompact`. Path-scoped hooks carry an adapter path-substring guard that stands in for Claude's `if:` conditions (Kimi's flat `{event,matcher,command,timeout}` schema has no equivalent).

Deliberately excluded (documented in `generate_kimi_hooks`): `version-check` / `v5-migration-banner` (Claude Code version specific), `graph-inject` / `sync-guides` (Claude slash-command matchers), `allow-plugin-internals` / `allow-mcp-tools` / `inject-agent-context` (no Kimi effect), `external-context-watch` (FileChanged has no Kimi event).

### 2. Manifest metadata

`kimi.plugin.json` now carries `author`, `homepage`, `repository`, `license`, `keywords`, and a fuller `interface` block (`longDescription`, `developerName`, `websiteURL`) for the `/plugins` browser, matching the Codex manifest shape.

### 3. Docstring correction

The converter previously asserted Kimi supports `headers` on remote MCP servers. Kimi's published schema documents only `url`, so the note now flags that the two keyed servers (`google-developer-knowledge`, `datacommons-mcp`) may not authenticate under Kimi until confirmed on a live instance.

## Testing

- `tests/plugin/test_kimi_hook_adapter.mjs` — 15 unit tests over `translate()` (block, deny, context, updatedInput→rename, allow-with-warning, side-effect no-op, fail-open) and `pathMatchesGuard()` (relative/absolute/Windows/miss).
- `tests/kimi/test_kimi_extension.py` — asserts the hooks array (supported events, adapter routing, targets exist on disk, excluded hooks absent, project-scoped guards present). 17 pass.
- End-to-end adapter pipe exercised against real hooks (secret-detection → exit 2; validate-arc-filename absolute bad path → exit 2 with rename message; guard skips off-path writes).
- `tests/codex` (35) + all other extension suites (1088) + `sync-shared-assets --check` green; markdownlint clean.

## Not done / caveats

- **Not yet smoke-tested against a live Kimi runtime** (requires a Moonshot login). The translation logic is unit-tested in isolation, but the end-to-end wiring needs one manual run: install the plugin, log in, trigger a `Write` under `projects/` and confirm provenance stamping + filename validation fire. Fix the generator (not the test) on any mismatch.
- **Deferred:** the `/arckit:wardley --tidy-owm` step references `.arckit/hooks/owm-tidy.mjs`, which `arckit init` does not stage (a pre-existing, cross-extension CLI/packaging gap affecting opencode/vibe too). Left out here to avoid a tracked-duplicate drift risk; worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
