### PR TITLE
docs(hooks): fix kimi-k3 name and flag the deferred effort-matrix issue (#669)

### DIFF
--- a/plugins/arckit-claude/hooks/provenance-model.mjs
+++ b/plugins/arckit-claude/hooks/provenance-model.mjs
@@ -15,10 +15,21 @@
 // ── Effort downgrade matrix ────────────────────────────────────────────
 // Mirrors the Claude Code harness behaviour: effort levels not supported
 // by the active model are silently downgraded to the highest supported.
+//
+// KNOWN ISSUE (#669): this ranks `xhigh` above `max`, but CLAUDE.md documents
+// `max` as the deepest tier, above `xhigh`. As a result `xhigh` on Opus 4.6
+// downgrades to `max` here, where CLAUDE.md says it should fall to `high`. Left
+// as-is pending verification against the actual harness; see #669.
 export const EFFORT_RANK = { low: 0, medium: 1, high: 2, max: 3, xhigh: 4 };
 
 // Claude-only by design (see module header). `claude-opus-4-8`: 'xhigh' is the
 // top rank, so it never downgrades — the row is for explicitness, not behaviour.
+//
+// NOTE: these caps are entangled with the EFFORT_RANK ordering above. When #669
+// corrects that ordering, revisit every cap here (models that support `max`
+// must cap at 'max'), and note that this single-cap shape cannot represent
+// Opus 4.6 / Sonnet 4.6 at all — they support `max` but not `xhigh`, a gap only
+// a per-model supported set can express. See #669.
 export const MODEL_MAX_EFFORT = {
   'claude-opus-4-8': 'xhigh',
   'claude-opus-4-7': 'xhigh',
@@ -41,7 +52,7 @@ export function downgradeEffort(requested, model) {
 // today and is the only source of truth until upstream Claude Code exposes
 // the active model to hooks (see arc-kit#407).
 export function extractModelFromContent(content) {
-  // Character class covers provider prefixes (moonshotai/kimi-v3), colon/dot
+  // Character class covers provider prefixes (moonshotai/kimi-k3), colon/dot
   // versioned ids (us.anthropic.claude-...), and bracketed context suffixes
   // (claude-opus-4-8[1m]). `-` is last, brackets and slash are escaped.
   const m = content.match(/^\s*\*?\*?(?:AI )?Model\*?\*?:\s*`?([a-z0-9._:\/\[\]-]+)`?\s*$/im);

--- a/tests/plugin/provenance-model.test.mjs
+++ b/tests/plugin/provenance-model.test.mjs
@@ -22,7 +22,7 @@ test('extractModelFromContent: no model line returns null', () => {
 });
 
 test('extractModelFromContent: provider-prefixed id (slash) parses', () => {
-  assert.equal(extractModelFromContent('**Model**: moonshotai/kimi-v3\n'), 'moonshotai/kimi-v3');
+  assert.equal(extractModelFromContent('**Model**: moonshotai/kimi-k3\n'), 'moonshotai/kimi-k3');
 });
 
 test('extractModelFromContent: context-window suffix (brackets) parses', () => {


### PR DESCRIPTION
## What

Two follow-up nits from the review of #664. Both are comment/fixture only, no behaviour change.

1. **`kimi-v3` → `kimi-k3`.** The regex comment in `provenance-model.mjs` and one test fixture used `moonshotai/kimi-v3`, a model id that does not exist (the Moonshot model is `kimi-k3`; "Kimi V3" is a name that should never be written).
2. **Document the deferred effort-matrix defect (#669) at source.** Added `#669` pointers where the two coupled problems live: `EFFORT_RANK` ranks `xhigh` above `max` (CLAUDE.md has `max` as the deepest tier), and the single-cap `MODEL_MAX_EFFORT` cannot represent Opus 4.6 / Sonnet 4.6's support gap (they support `max` but not `xhigh`). The matrix values are intentionally left unchanged here — the fix needs harness verification and is tracked in #669.

## Testing

- `node --test tests/plugin/provenance-model.test.mjs` — 14/14 pass (unchanged; only the fixture string changed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
