### PR TITLE
fix(hooks): correct the provenance effort-downgrade matrix (#669)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Softened the converter's `generate_kimi_plugin_json` note that asserted Kimi supports `headers` on remote MCP servers. Kimi's published schema documents only `url`, so the two keyed servers (`google-developer-knowledge`, `datacommons-mcp`) may not authenticate under Kimi until confirmed on a live instance.
+- **Build Provenance effort matrix corrected** (#669). The effort helper ranked `xhigh` above `max`, inverting the official Claude Code ordering (`max` is the deepest tier), and used a single per-model cap that could not represent Opus 4.6 / Sonnet 4.6, which support `max` but not `xhigh`. The stamp therefore recorded the wrong "Effective Effort" for those models: `xhigh` was reported as downgraded to `max`, where the harness actually falls back to `high`. Replaced the single cap with per-model supported sets, fixed the level ordering, and dropped the incorrect Haiku 4.5 entry (Haiku does not support effort). Verified against the official model-config docs (`code.claude.com/docs`).
 
 ## [6.4.0] — 2026-07-25
 

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Softened the converter's `generate_kimi_plugin_json` note that asserted Kimi supports `headers` on remote MCP servers. Kimi's published schema documents only `url`, so the two keyed servers (`google-developer-knowledge`, `datacommons-mcp`) may not authenticate under Kimi until confirmed on a live instance.
+- **Build Provenance effort matrix corrected** (#669). The effort helper ranked `xhigh` above `max`, inverting the official Claude Code ordering (`max` is the deepest tier), and used a single per-model cap that could not represent Opus 4.6 / Sonnet 4.6, which support `max` but not `xhigh`. The stamp therefore recorded the wrong "Effective Effort" for those models: `xhigh` was reported as downgraded to `max`, where the harness actually falls back to `high`. Replaced the single cap with per-model supported sets, fixed the level ordering, and dropped the incorrect Haiku 4.5 entry (Haiku does not support effort). Verified against the official model-config docs (`code.claude.com/docs`).
 
 ## [6.4.0] — 2026-07-25
 

--- a/plugins/arckit-claude/hooks/README.md
+++ b/plugins/arckit-claude/hooks/README.md
@@ -41,7 +41,7 @@ Stamped fields:
 
 - **Build context** (Recipe / Wave / Target / Topic) — only present when run via `/arckit:build`, sourced from `projects/{P}/.arckit/state.json`
 - **Requested Effort** — `effort:` field from the invoking command's YAML frontmatter
-- **Effective Effort** — computed by parsing the `AI Model:` line from the existing footer and applying the silent-downgrade matrix in `provenance-stamp.mjs` (`MODEL_MAX_EFFORT`). When the model doesn't support the requested level, the value reads e.g. `high (downgraded from max — model does not support that level)` — the auditable signal that issue #407 was filed for.
+- **Effective Effort** — computed by parsing the `AI Model:` line from the existing footer and applying the silent-downgrade matrix in `provenance-model.mjs` (`MODEL_EFFORTS`, per the official model-config docs). When the model doesn't support the requested level, the value reads e.g. `high (downgraded from xhigh — model does not support that level)` — the auditable signal that issue #407 was filed for.
 - **Stamped at** — ISO 8601 timestamp (per write)
 
 If neither effort nor build context is available (e.g. a non-ArcKit command edited the file), the hook skips stamping entirely — no empty block. Existing artefacts pre-dating the hook are stamped on the next Write/Edit.

--- a/plugins/arckit-claude/hooks/provenance-model.mjs
+++ b/plugins/arckit-claude/hooks/provenance-model.mjs
@@ -6,45 +6,56 @@
  *
  * CLAUDE-ONLY BY DESIGN: provenance-stamp.mjs is a Claude Code plugin hook. It
  * never runs under Codex, OpenCode, or any non-Claude model. Do NOT add
- * non-Claude ids (e.g. Kimi/Moonshot) to MODEL_MAX_EFFORT — it would be a no-op.
+ * non-Claude ids (e.g. Kimi/Moonshot) to MODEL_EFFORTS — it would be a no-op.
  *
  * Pure: no fs, no git, no side effects on import. Unit-tested in
  * tests/plugin/provenance-model.test.mjs.
  */
 
 // ── Effort downgrade matrix ────────────────────────────────────────────
-// Mirrors the Claude Code harness behaviour: effort levels not supported
-// by the active model are silently downgraded to the highest supported.
+// Mirrors the Claude Code harness: an effort level the active model does not
+// support is silently downgraded to the highest supported level at or below the
+// requested one. Ordering and per-model support are from the official docs:
+// https://code.claude.com/docs/en/model-config (Adjust effort level).
 //
-// KNOWN ISSUE (#669): this ranks `xhigh` above `max`, but CLAUDE.md documents
-// `max` as the deepest tier, above `xhigh`. As a result `xhigh` on Opus 4.6
-// downgrades to `max` here, where CLAUDE.md says it should fall to `high`. Left
-// as-is pending verification against the actual harness; see #669.
-export const EFFORT_RANK = { low: 0, medium: 1, high: 2, max: 3, xhigh: 4 };
+// Levels, shallowest to deepest — `max` is the DEEPEST tier, above `xhigh`.
+export const EFFORT_RANK = { low: 0, medium: 1, high: 2, xhigh: 3, max: 4 };
 
-// Claude-only by design (see module header). `claude-opus-4-8`: 'xhigh' is the
-// top rank, so it never downgrades — the row is for explicitness, not behaviour.
+// Effort levels each Claude model supports, for models whose support is NOT the
+// full set. Claude-only by design (see module header). A model ABSENT here is
+// treated as supporting every level (no downgrade): that covers the full-support
+// models (Opus 4.8 / 4.7 / 5, Sonnet 5, Fable 5) and any future model.
 //
-// NOTE: these caps are entangled with the EFFORT_RANK ordering above. When #669
-// corrects that ordering, revisit every cap here (models that support `max`
-// must cap at 'max'), and note that this single-cap shape cannot represent
-// Opus 4.6 / Sonnet 4.6 at all — they support `max` but not `xhigh`, a gap only
-// a per-model supported set can express. See #669.
-export const MODEL_MAX_EFFORT = {
-  'claude-opus-4-8': 'xhigh',
-  'claude-opus-4-7': 'xhigh',
-  'claude-opus-4-6': 'max',
-  'claude-sonnet-4-6': 'high',
-  'claude-haiku-4-5': 'medium',
+// Opus 4.6 and Sonnet 4.6 support `max` but NOT `xhigh` — a non-contiguous set a
+// single cap could not express, so `xhigh` falls to `high`, not `max`. Haiku 4.5
+// and other unlisted models do not support effort at all per the docs; the hook
+// does not fabricate a downgrade for them (they never carry effort frontmatter
+// in practice, so no effort row is stamped).
+export const MODEL_EFFORTS = {
+  'claude-opus-4-6': ['low', 'medium', 'high', 'max'],
+  'claude-sonnet-4-6': ['low', 'medium', 'high', 'max'],
 };
 
+// Downgrade a requested effort to what the model actually runs: the requested
+// level if supported, else the highest supported level at or below it.
 export function downgradeEffort(requested, model) {
   if (!requested) return null;
   if (!model) return null;
-  const cap = MODEL_MAX_EFFORT[model];
-  if (!cap) return requested;
-  if (EFFORT_RANK[requested] <= EFFORT_RANK[cap]) return requested;
-  return cap;
+  const supported = MODEL_EFFORTS[model];
+  if (!supported) return requested; // full-support / unknown model: no downgrade
+  if (supported.includes(requested)) return requested;
+  const reqRank = EFFORT_RANK[requested];
+  if (reqRank == null) return requested; // unknown level: leave untouched
+  let best = null;
+  let bestRank = -1;
+  for (const level of supported) {
+    const rank = EFFORT_RANK[level];
+    if (rank <= reqRank && rank > bestRank) {
+      best = level;
+      bestRank = rank;
+    }
+  }
+  return best ?? requested;
 }
 
 // Detect model from existing footer ("AI Model: claude-opus-4-7" or "Model: ...").

--- a/tests/plugin/provenance-model.test.mjs
+++ b/tests/plugin/provenance-model.test.mjs
@@ -2,7 +2,7 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { resolve } from 'node:path';
 
-const { extractModelFromContent, downgradeEffort, MODEL_MAX_EFFORT } =
+const { extractModelFromContent, downgradeEffort, MODEL_EFFORTS, EFFORT_RANK } =
   await import(resolve('plugins/arckit-claude/hooks/provenance-model.mjs'));
 
 test('extractModelFromContent: plain Claude id parses', () => {
@@ -37,32 +37,66 @@ test('extractModelFromContent: bedrock-style dotted prefix parses', () => {
   assert.equal(extractModelFromContent('**Model**: us.anthropic.claude-opus-4-8\n'), 'us.anthropic.claude-opus-4-8');
 });
 
+// ── Effort ordering (official docs: max is the deepest tier, above xhigh) ──
+
+test('EFFORT_RANK orders max above xhigh', () => {
+  assert.ok(EFFORT_RANK.max > EFFORT_RANK.xhigh);
+  assert.ok(EFFORT_RANK.xhigh > EFFORT_RANK.high);
+});
+
+// ── downgradeEffort ──
+
 test('downgradeEffort: null requested returns null', () => {
   assert.equal(downgradeEffort(null, 'claude-opus-4-6'), null);
 });
 
-test('downgradeEffort: model not in matrix returns requested unchanged', () => {
-  assert.equal(downgradeEffort('high', 'claude-opus-4-8'), 'high');
+test('downgradeEffort: null model returns null', () => {
+  assert.equal(downgradeEffort('high', null), null);
 });
 
-test('downgradeEffort: caps above the model max (current 4-6 behaviour)', () => {
-  // Baseline of current code: EFFORT_RANK ranks xhigh(4) above max(3),
-  // so xhigh on opus-4-6 (cap 'max') downgrades to 'max'. See Task 3 note.
-  assert.equal(downgradeEffort('xhigh', 'claude-opus-4-6'), 'max');
-});
-
-test('downgradeEffort: opus-4-8 is capped at xhigh (never downgrades)', () => {
+test('downgradeEffort: full-support / unlisted model returns requested unchanged', () => {
+  // Opus 4.8 supports every level, so it is absent from MODEL_EFFORTS.
   assert.equal(downgradeEffort('xhigh', 'claude-opus-4-8'), 'xhigh');
   assert.equal(downgradeEffort('max', 'claude-opus-4-8'), 'max');
   assert.equal(downgradeEffort('high', 'claude-opus-4-8'), 'high');
 });
 
-test('MODEL_MAX_EFFORT includes claude-opus-4-8', () => {
-  assert.equal(MODEL_MAX_EFFORT['claude-opus-4-8'], 'xhigh');
+test('downgradeEffort: xhigh on Opus 4.6 falls to high, not max (official rule)', () => {
+  // Opus 4.6 supports low/medium/high/max but NOT xhigh; the harness falls back
+  // to the highest supported level at or below xhigh, which is high.
+  assert.equal(downgradeEffort('xhigh', 'claude-opus-4-6'), 'high');
 });
 
-test('MODEL_MAX_EFFORT is Claude-only (no kimi/moonshot keys)', () => {
-  for (const key of Object.keys(MODEL_MAX_EFFORT)) {
+test('downgradeEffort: max on Opus 4.6 is supported and not downgraded', () => {
+  assert.equal(downgradeEffort('max', 'claude-opus-4-6'), 'max');
+  assert.equal(downgradeEffort('high', 'claude-opus-4-6'), 'high');
+});
+
+test('downgradeEffort: Sonnet 4.6 mirrors Opus 4.6 (xhigh -> high, max kept)', () => {
+  assert.equal(downgradeEffort('xhigh', 'claude-sonnet-4-6'), 'high');
+  assert.equal(downgradeEffort('max', 'claude-sonnet-4-6'), 'max');
+});
+
+test('downgradeEffort: models with no effort support get no fabricated downgrade', () => {
+  // Haiku 4.5 does not support effort per the docs; unlisted -> requested is
+  // returned unchanged rather than inventing a downgrade.
+  assert.equal(downgradeEffort('high', 'claude-haiku-4-5'), 'high');
+});
+
+// ── MODEL_EFFORTS shape ──
+
+test('MODEL_EFFORTS encodes the Opus 4.6 support gap (max, not xhigh)', () => {
+  assert.ok(MODEL_EFFORTS['claude-opus-4-6'].includes('max'));
+  assert.ok(!MODEL_EFFORTS['claude-opus-4-6'].includes('xhigh'));
+});
+
+test('MODEL_EFFORTS omits full-support models (no restriction to encode)', () => {
+  assert.equal(MODEL_EFFORTS['claude-opus-4-8'], undefined);
+  assert.equal(MODEL_EFFORTS['claude-opus-4-7'], undefined);
+});
+
+test('MODEL_EFFORTS is Claude-only (no kimi/moonshot keys)', () => {
+  for (const key of Object.keys(MODEL_EFFORTS)) {
     assert.ok(key.startsWith('claude-'), `unexpected non-Claude matrix key: ${key}`);
   }
 });


### PR DESCRIPTION
## What

Fixes the Build Provenance effort-downgrade matrix (`provenance-model.mjs`). Closes #669, which was deferred from #664 pending verification against the actual harness.

## Verified first

The fix direction was confirmed against the **official** Claude Code docs (`code.claude.com/docs/en/model-config`, "Adjust effort level"), not just ArcKit's CLAUDE.md:

- **Ordering:** `low < medium < high < xhigh < max` — `max` is the deepest tier, above `xhigh`.
- **Opus 4.6 / Sonnet 4.6:** support `low/medium/high/max` but **not** `xhigh`; the harness falls back to "the highest supported level at or below" the requested one, so `xhigh → high` (not `max`).
- **Haiku 4.5:** not listed → does not support effort at all. The old `claude-haiku-4-5: 'medium'` entry was fabricating a downgrade.

## The bug

`EFFORT_RANK` ranked `xhigh` (4) above `max` (3), and `MODEL_MAX_EFFORT` was a single per-model cap. That single cap cannot represent Opus 4.6 / Sonnet 4.6's non-contiguous support (max but not xhigh). The stamp recorded the wrong `Effective Effort` for those models: `xhigh` came out as downgraded to `max`, where the harness runs `high`. Did not bite the current live model (Opus 4.8 supports everything, so no downgrade), but was wrong for 4.6/Sonnet.

## The fix

- `EFFORT_RANK` → `{ low: 0, medium: 1, high: 2, xhigh: 3, max: 4 }`.
- Replace the single-cap `MODEL_MAX_EFFORT` with per-model supported **sets** `MODEL_EFFORTS`. Only restricted models are listed (Opus 4.6 / Sonnet 4.6 = `{low, medium, high, max}`); models absent from the map are treated as full-support with no downgrade, which covers Opus 4.8/4.7/5, Sonnet 5, Fable 5, and any future model.
- Rewrite `downgradeEffort` to return the highest supported level at or below the requested one.
- Drop the incorrect Haiku 4.5 cap (no effort support → no fabricated downgrade; those models never carry effort frontmatter in practice, so no effort row is stamped).
- Fix the stale `hooks/README.md` reference (`provenance-model.mjs` / `MODEL_EFFORTS`; it also still pointed at the old file).

## Testing

- `node --test tests/plugin/provenance-model.test.mjs` — 19 pass (added: `xhigh → high` on Opus 4.6 and Sonnet 4.6; `max` kept on 4.6; full-support models unchanged; ordering `max > xhigh`; the support-gap shape; Haiku no-fabricated-downgrade).
- `node --test tests/plugin/*.test.mjs` — 112 pass, 0 fail.
- markdownlint clean on the changed docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
