### PR TITLE
fix: guard arckit-build waves against the subagent concurrency cap (#580)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`CLAUDE.md` step 3 for adding a command pointed at `plugins/arckit-claude/guides/`, a directory that does not exist** (the real path is `plugins/arckit-claude/docs/guides/`). This was the root cause of the drift: the documented workflow sent guide authors somewhere invalid, so the plugin copy was routinely skipped. Step 3 now names the sync command, and a new "Guide Trees" section documents the canonical direction.
 - `mcp-servers.md` troubleshooting told users to run `echo $GOOGLE_API_KEY`, printing a live credential to the terminal in a guide that elsewhere highlights key redaction for OFFICIAL-SENSITIVE deployments. Replaced with a presence check that does not echo the value.
 
+## [Unreleased]
+
+### Added
+
+- **Recipe wave-width and cycle checks** (`scripts/check_recipes.py`). The validator now computes the topological wave plan for every recipe and fails when a wave exceeds Claude Code's concurrent-subagent cap (20), warns within 4 of it, and detects dependency cycles that previously surfaced only at runtime as an empty wave. Baseline: widest shipped wave is 16 of 20.
+- **`/arckit:build` wave splitting.** The orchestrator now splits any wave wider than 20 at dispatch time rather than assuming the recipe is well-formed — user-authored recipes under `.arckit/recipes/` never pass through CI. A split wave still produces one commit.
+
+### Documentation
+
+- **`build.md` session limits** (#580). Documents the concurrent-subagent (20), per-session subagent (200), and per-session WebSearch (200) caps, and — the point the spike settled — that **all three deny rather than queue**. Verified against the Claude Code v2.1.220 binary: an over-cap spawn throws "Concurrent subagent limit reached ... Do not retry" per excess call. Because the harness is halt-on-fail, an over-wide wave fails rather than running slower. Records the current margin (widest shipped wave 16 of 20, largest total spawn 49 of 200) and notes the ultracode bypass exists but must not be relied on.
+
 ## [6.5.0] — 2026-07-27
 
 ### Added

--- a/docs/guides/build.md
+++ b/docs/guides/build.md
@@ -53,6 +53,26 @@ Recipes ship at `${CLAUDE_PLUGIN_ROOT}/skills/arckit-build/recipes/{name}.yaml`.
 7. **Halt-on-fail** — if any subagent fails or validation fails, write state, do *not* commit, surface a per-target error report. Resume with `--resume`
 8. **Post-build hooks** — `arckit:health` and `arckit:pages` run in parallel after the final target wave
 
+## Session limits (subagents and searches)
+
+Claude Code caps subagent activity per session. Every cap **denies** — none of them queues. Verified against the Claude Code v2.1.220 binary: an over-cap spawn throws a tool error rather than waiting for a slot.
+
+| Limit | Default | Override |
+|---|---|---|
+| Concurrently-running subagents | 20 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` |
+| Subagent spawns per session | 200 | `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` |
+| WebSearch calls per session | 200 | `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` |
+
+**Why this matters here specifically.** The harness dispatches one subagent per target per wave and is halt-on-fail. A wave wider than the concurrency cap therefore does not run slower — the 21st and later `Agent` calls fail immediately with *"Concurrent subagent limit reached … Do not retry"*, which the harness treats as wave failure and halts on. Hitting the per-session cap produces *"Subagent spawn limit reached"* and the same outcome.
+
+**No shipped recipe currently exceeds the concurrency cap.** The widest wave across all bundled recipes is **16 of 20**, in `uk-saas` and `uk-nhs-clinical-safety` with every optional target enabled. The largest total spawn count is 49, against a 200 per-session cap. `scripts/check_recipes.py` enforces this in CI: a recipe wave above 20 is an error, and above 16 warns, so the margin cannot quietly erode as recipes grow.
+
+That margin is only four agents, so it matters when you **write your own recipe**. If you add parallel targets to an existing wave, either keep the wave at 20 or fewer, or add a `deps:` edge to split it. Run `python3 scripts/check_recipes.py` to see the widest wave in your recipe.
+
+**Budgets are per session, not per build.** A build uses one spawn per target, so back-to-back builds, a `--refresh` pass, or research commands in the same session accumulate against the 200 ceiling. `/clear` resets the subagent budget. `--max-budget-usd`, if set, also halts running background subagents once reached.
+
+The concurrency cap is lifted in ultracode mode (which runs at `xhigh` effort and orchestrates dynamic workflows). Don't rely on that to make an over-wide wave work — the default path is what has to hold.
+
 ## Path allocation — trust the hook
 
 Workers don't construct filenames or call `generate-document-id.sh` themselves. The plugin's `validate-arc-filename.mjs` PreToolUse hook normalizes paths at write time: allocates the next sequence number for ADR/DIAG, applies `decisions/` and `diagrams/` subfolders, pads project IDs. Workers read the corrected `ACTUAL_PATH` from the Skill tool result and report it back.

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -31,6 +31,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`CLAUDE.md` step 3 for adding a command pointed at `plugins/arckit-claude/guides/`, a directory that does not exist** (the real path is `plugins/arckit-claude/docs/guides/`). This was the root cause of the drift: the documented workflow sent guide authors somewhere invalid, so the plugin copy was routinely skipped. Step 3 now names the sync command, and a new "Guide Trees" section documents the canonical direction.
 - `mcp-servers.md` troubleshooting told users to run `echo $GOOGLE_API_KEY`, printing a live credential to the terminal in a guide that elsewhere highlights key redaction for OFFICIAL-SENSITIVE deployments. Replaced with a presence check that does not echo the value.
 
+## [Unreleased]
+
+### Added
+
+- **Recipe wave-width and cycle checks** (`scripts/check_recipes.py`). The validator now computes the topological wave plan for every recipe and fails when a wave exceeds Claude Code's concurrent-subagent cap (20), warns within 4 of it, and detects dependency cycles that previously surfaced only at runtime as an empty wave. Baseline: widest shipped wave is 16 of 20.
+- **`/arckit:build` wave splitting.** The orchestrator now splits any wave wider than 20 at dispatch time rather than assuming the recipe is well-formed — user-authored recipes under `.arckit/recipes/` never pass through CI. A split wave still produces one commit.
+
+### Documentation
+
+- **`build.md` session limits** (#580). Documents the concurrent-subagent (20), per-session subagent (200), and per-session WebSearch (200) caps, and — the point the spike settled — that **all three deny rather than queue**. Verified against the Claude Code v2.1.220 binary: an over-cap spawn throws "Concurrent subagent limit reached ... Do not retry" per excess call. Because the harness is halt-on-fail, an over-wide wave fails rather than running slower. Records the current margin (widest shipped wave 16 of 20, largest total spawn 49 of 200) and notes the ultracode bypass exists but must not be relied on.
+
 ## [6.5.0] — 2026-07-27
 
 ### Added

--- a/plugins/arckit-claude/docs/guides/build.md
+++ b/plugins/arckit-claude/docs/guides/build.md
@@ -53,6 +53,26 @@ Recipes ship at `${CLAUDE_PLUGIN_ROOT}/skills/arckit-build/recipes/{name}.yaml`.
 7. **Halt-on-fail** — if any subagent fails or validation fails, write state, do *not* commit, surface a per-target error report. Resume with `--resume`
 8. **Post-build hooks** — `arckit:health` and `arckit:pages` run in parallel after the final target wave
 
+## Session limits (subagents and searches)
+
+Claude Code caps subagent activity per session. Every cap **denies** — none of them queues. Verified against the Claude Code v2.1.220 binary: an over-cap spawn throws a tool error rather than waiting for a slot.
+
+| Limit | Default | Override |
+|---|---|---|
+| Concurrently-running subagents | 20 | `CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS` |
+| Subagent spawns per session | 200 | `CLAUDE_CODE_MAX_SUBAGENTS_PER_SESSION` |
+| WebSearch calls per session | 200 | `CLAUDE_CODE_MAX_WEB_SEARCHES_PER_SESSION` |
+
+**Why this matters here specifically.** The harness dispatches one subagent per target per wave and is halt-on-fail. A wave wider than the concurrency cap therefore does not run slower — the 21st and later `Agent` calls fail immediately with *"Concurrent subagent limit reached … Do not retry"*, which the harness treats as wave failure and halts on. Hitting the per-session cap produces *"Subagent spawn limit reached"* and the same outcome.
+
+**No shipped recipe currently exceeds the concurrency cap.** The widest wave across all bundled recipes is **16 of 20**, in `uk-saas` and `uk-nhs-clinical-safety` with every optional target enabled. The largest total spawn count is 49, against a 200 per-session cap. `scripts/check_recipes.py` enforces this in CI: a recipe wave above 20 is an error, and above 16 warns, so the margin cannot quietly erode as recipes grow.
+
+That margin is only four agents, so it matters when you **write your own recipe**. If you add parallel targets to an existing wave, either keep the wave at 20 or fewer, or add a `deps:` edge to split it. Run `python3 scripts/check_recipes.py` to see the widest wave in your recipe.
+
+**Budgets are per session, not per build.** A build uses one spawn per target, so back-to-back builds, a `--refresh` pass, or research commands in the same session accumulate against the 200 ceiling. `/clear` resets the subagent budget. `--max-budget-usd`, if set, also halts running background subagents once reached.
+
+The concurrency cap is lifted in ultracode mode (which runs at `xhigh` effort and orchestrates dynamic workflows). Don't rely on that to make an over-wide wave work — the default path is what has to hold.
+
 ## Path allocation — trust the hook
 
 Workers don't construct filenames or call `generate-document-id.sh` themselves. The plugin's `validate-arc-filename.mjs` PreToolUse hook normalizes paths at write time: allocates the next sequence number for ADR/DIAG, applies `decisions/` and `diagrams/` subfolders, pads project IDs. Workers read the corrected `ACTUAL_PATH` from the Skill tool result and report it back.

--- a/plugins/arckit-claude/skills/arckit-build/SKILL.md
+++ b/plugins/arckit-claude/skills/arckit-build/SKILL.md
@@ -165,7 +165,12 @@ Standard topological sort with parallelism:
 3. While pending non-empty:
    - `wave = { t ∈ pending : deps(t) ⊆ done }` (after expanding globs)
    - If wave empty → cycle / unresolvable. Halt with error, list involved targets.
+   - **If `|wave| > 20`, split it**: dispatch the first 20 (stable sort by target ID), and leave the remainder in `pending` for the next iteration. They have no unmet deps, so they form the next wave immediately.
    - Emit wave; remove its members from pending; (after dispatch + validate) add to done.
+
+**Why the 20 cap is load-bearing.** Claude Code caps concurrently-running subagents at 20 by default (`CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS`, v2.1.217+) and **denies** over-cap spawns rather than queueing them — the 21st `Agent` call in a single message fails with *"Concurrent subagent limit reached … Do not retry"*. Because this harness is halt-on-fail, an over-wide wave does not run slower, it fails. No bundled recipe exceeds 16 (CI enforces this via `scripts/check_recipes.py`), but a user-authored recipe under `.arckit/recipes/` never passes through CI, so split at dispatch time rather than assuming the recipe is well-formed.
+
+A split wave is still one commit — commit after the whole logical wave completes, not after each chunk of 20.
 
 **Worked example** — for project 001 (UK-SaaS recipe) **starting from empty state**, the algorithm produces something like:
 

--- a/scripts/check_recipes.py
+++ b/scripts/check_recipes.py
@@ -7,12 +7,26 @@ Checks:
 - has unique target IDs within the recipe
 - every target's `deps:` entries resolve to other target IDs in the same recipe
   (glob patterns like "ADR-*" are accepted if at least one target matches)
+- the dependency graph is acyclic (a cycle makes the harness halt at runtime with
+  an empty wave, which is a confusing way to learn about it)
+- no wave is wider than Claude Code's concurrent-subagent cap
+
+That last check exists because the cap DENIES rather than queues. Verified
+against the Claude Code v2.1.220 binary: exceeding it throws "Concurrent
+subagent limit reached ... Do not retry" per excess spawn, surfaced to the model
+as a tool error. `/arckit:build` dispatches one subagent per target per wave and
+is halt-on-fail, so a wave wider than the cap does not run slower -- it fails.
 
 Exits non-zero if any check fails. Prints a one-line summary on success.
 """
 import sys
 import glob
 import fnmatch
+
+# Claude Code's default CLAUDE_CODE_MAX_CONCURRENT_SUBAGENTS (v2.1.217+).
+CONCURRENCY_CAP = 20
+# Warn when a recipe gets within this many agents of the cap.
+HEADROOM_WARN = 4
 
 try:
     import yaml
@@ -23,7 +37,36 @@ except ImportError:
 REQUIRED_TOP_KEYS = {"recipe", "schema_version", "targets", "defaults"}
 
 errors = []
+warnings = []
 recipes_checked = 0
+widest_seen = 0
+
+
+def compute_waves(targets, target_id_set):
+    """Topological waves, mirroring the algorithm in the arckit-build SKILL.md.
+
+    Returns (waves, unresolved). `unresolved` is non-empty only when a cycle or
+    an unsatisfiable dependency leaves targets that can never enter a wave.
+    """
+    deps = {}
+    for t in targets:
+        resolved = set()
+        for dep in t.get("deps") or []:
+            if "*" in dep:
+                resolved |= {tid for tid in target_id_set if fnmatch.fnmatch(tid, dep)}
+            elif dep in target_id_set:
+                resolved.add(dep)
+        deps[t["id"]] = resolved - {t["id"]}
+
+    pending, done, waves = set(target_id_set), set(), []
+    while pending:
+        wave = sorted(tid for tid in pending if deps[tid] <= done)
+        if not wave:
+            return waves, sorted(pending)
+        waves.append(wave)
+        pending -= set(wave)
+        done |= set(wave)
+    return waves, []
 
 paths = sorted(
     glob.glob("plugins/arckit-*/recipes/*.yaml")
@@ -83,6 +126,33 @@ for path in paths:
                     f"{path}: target {t.get('id')}: dep {dep!r} not a target in this recipe"
                 )
 
+    # Wave analysis uses the MAXIMAL target set -- every optional target enabled --
+    # because that is the widest build a user can request with --enable.
+    valid_targets = [t for t in targets if isinstance(t, dict) and "id" in t]
+    if valid_targets:
+        waves, unresolved = compute_waves(valid_targets, target_id_set)
+        if unresolved:
+            errors.append(
+                f"{path}: dependency cycle or unsatisfiable deps -- these targets can "
+                f"never run: {', '.join(unresolved)}"
+            )
+        if waves:
+            widest = max(len(w) for w in waves)
+            widest_seen = max(widest_seen, widest)
+            if widest > CONCURRENCY_CAP:
+                offending = next(w for w in waves if len(w) == widest)
+                errors.append(
+                    f"{path}: wave of {widest} targets exceeds the concurrent-subagent "
+                    f"cap of {CONCURRENCY_CAP}; excess spawns are DENIED, not queued, and "
+                    f"arckit-build is halt-on-fail, so this wave fails at runtime. "
+                    f"Split it by adding deps. Wave: {', '.join(offending)}"
+                )
+            elif widest > CONCURRENCY_CAP - HEADROOM_WARN:
+                warnings.append(
+                    f"{path}: widest wave is {widest}, within {CONCURRENCY_CAP - widest} "
+                    f"of the concurrent-subagent cap ({CONCURRENCY_CAP})"
+                )
+
     recipes_checked += 1
 
 if errors:
@@ -91,4 +161,10 @@ if errors:
         print(f"  {e}", file=sys.stderr)
     sys.exit(1)
 
-print(f"OK: {recipes_checked} recipe(s) validated")
+for w in warnings:
+    print(f"WARN: {w}")
+
+print(
+    f"OK: {recipes_checked} recipe(s) validated "
+    f"(widest wave {widest_seen}/{CONCURRENCY_CAP})"
+)


### PR DESCRIPTION
Closes the spike that was blocking the `build.md` documentation on #580.

## The answer: they deny, they do not queue

Verified against the Claude Code **v2.1.220 binary**, not inferred from release notes. The enforcement path:

```js
D = () => {
  let lt = gPu();                                       // 20 default
  if (registry.getConcurrentSubagents() < lt) return;   // under cap -> proceed
  if (Ke("tengu_amber_kestrel", !1)) return;            // feature flag bypass
  if (bY(mainLoopModel, effortValue, ultracode)) return;// ultracode+xhigh bypass
  return new Error(`Concurrent subagent limit reached. You can run ${lt}
    subagents at once. Do not retry. ...`)
},
U = async () => { let lt = D(); if (lt) throw await at(), lt; ... }
```

The 21st `Agent` call in a message **throws** rather than waiting for a slot. The per-session cap behaves the same way (`Subagent spawn limit reached (N of M agents spawned)`). Defaults read straight from the binary constants: `gty=20` concurrent, `yty=200` per session, `_ty=200` web searches. The concurrency cap is bypassed only under ultracode at `xhigh` effort (`bY` resolves to `ultracode === true && M0() && effort === "xhigh"`).

**This is the bad case for `/arckit:build`**, which is halt-on-fail: an over-wide wave doesn't run slower, it fails the wave.

## Measured every recipe

Rather than assume, I computed the actual wave plan for all 14 recipes using the documented algorithm, with every optional target enabled (the widest a user can request):

| Recipe | Targets | Widest wave |
|---|---|---|
| `uk-nhs-clinical-safety` | 44 | **16** |
| `uk-saas` | 38 | **16** |
| `uk-mod-sovereign` | 38 | 15 |
| `au-federal` | 41 | 11 |
| `uae-agentic-transformation` | 49 | 10 |
| `uae-federal-ai` | 48 | 9 |
| others (8) | ≤34 | ≤8 |

**Nothing shipped exceeds the cap** — widest is 16 of 20, largest total spawn 49 of 200. But four agents of headroom is thin, so this adds two guards.

## Guards

**`scripts/check_recipes.py`** now computes the wave plan: errors above 20, warns above 16, and detects dependency cycles that previously surfaced only at runtime as a confusing empty wave. Summary line now reports `widest wave 16/20` so the margin is visible on every CI run.

**The orchestrator splits waves wider than 20 at dispatch time.** This is the guard that matters in practice: recipes under `.arckit/recipes/` are user-authored and never pass through CI. A split wave still produces one commit.

## Verified behaviour, not just the happy path

- 25-wide wave → error, naming the offending wave
- 18-wide wave → warning, exit 0
- 16-wide wave → silent
- dependency cycle → error, naming the trapped targets
- baseline → `OK: 14 recipe(s) validated (widest wave 16/20)`

Full suite: guide parity clean, cross-references clean, converter regenerated, `tests/codex` 35 passed, plugin tests 123 passed, markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSx9btnejpWU9JiYbEPHqv