### PR TITLE
docs: list /arckit:repo-audit on the guides site (#616)

### DIFF
--- a/docs/guides.html
+++ b/docs/guides.html
@@ -811,12 +811,13 @@
             <div class="app-guide-category">
                 <h2 class="govuk-heading-s app-guide-category__heading" onclick="toggleCategory(this)">
                     <span class="app-guide-category__toggle">&#9662;</span> Repository Plugin
-                    <span class="app-guide-category__count">1 guide</span>
+                    <span class="app-guide-category__count">2 guides</span>
                 </h2>
                 <div class="app-guide-category__body">
-                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Optional repository tooling plugin. Starts with source-grounded, agent-readable repository documentation; future commands can cover git and repository operations.</em></p>
+                    <p class="govuk-body-s govuk-!-margin-bottom-2"><em>Optional repository tooling plugin: source-grounded documentation of a repository, and governance auditing of one.</em></p>
                     <ul class="app-guide-list">
                         <li class="app-guide-item"><a href="guide-viewer.html?guide=repo-docs" class="govuk-link">Repository Documentation Wiki</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Generate and maintain source-grounded repository docs under <code>docs/repository/</code></span></li>
+                        <li class="app-guide-item"><a href="guide-viewer.html?guide=repo-audit" class="govuk-link">Codebase Audit</a> <span class="app-status-tag app-status-experimental">EXPERIMENTAL</span> <span class="app-guide-desc">Audit a codebase against architecture principles and requirements, writing a <code>CDAU</code> artefact to <code>audits/</code></span></li>
                     </ul>
                 </div>
             </div>

--- a/docs/guides/repo-docs.md
+++ b/docs/guides/repo-docs.md
@@ -81,10 +81,11 @@ The command can create a temporary `docs/repository/_plan.md` while preparing a 
 | Command | Scope | Output |
 |---|---|---|
 | `/arckit:repo-docs` | Source-code repository understanding | `docs/repository/*.md` |
+| `/arckit:repo-audit` | Source-code repository assessment | `ARC-{PID}-CDAU-*.md` in `audits/` |
 | `/arckit:pages` | Static site for ArcKit artifacts and guides | `docs/index.html`, `docs/manifest.json`, `docs/llms.txt` |
 | `/arckit:architecture-repository` | TOGAF-style governance repository | `ARC-000-REPO-v*.md` or project repository artifact |
 
-Use `/arckit:repo-docs` when the question is "how does this repo work?" Use `/arckit:pages` when the question is "how do we publish ArcKit artifacts?" Use the TOGAF architecture repository when the question is "what reusable architecture knowledge has this organisation captured?"
+Use `/arckit:repo-docs` when the question is "how does this repo work?" Use `/arckit:repo-audit` when the question is "is this repo any good, and what did we never write down?" Use `/arckit:pages` when the question is "how do we publish ArcKit artifacts?" Use the TOGAF architecture repository when the question is "what reusable architecture knowledge has this organisation captured?"
 
 ---
 

--- a/docs/manifest.json
+++ b/docs/manifest.json
@@ -360,6 +360,11 @@
           "path": "docs/guides/repo-docs.md",
           "title": "Repository Documentation Wiki",
           "category": "Repository Plugin"
+        },
+        {
+          "path": "docs/guides/repo-audit.md",
+          "title": "Codebase Audit",
+          "category": "Repository Plugin"
         }
       ]
     },

--- a/plugins/arckit-claude/docs/guides/repo-docs.md
+++ b/plugins/arckit-claude/docs/guides/repo-docs.md
@@ -81,10 +81,11 @@ The command can create a temporary `docs/repository/_plan.md` while preparing a 
 | Command | Scope | Output |
 |---|---|---|
 | `/arckit:repo-docs` | Source-code repository understanding | `docs/repository/*.md` |
+| `/arckit:repo-audit` | Source-code repository assessment | `ARC-{PID}-CDAU-*.md` in `audits/` |
 | `/arckit:pages` | Static site for ArcKit artifacts and guides | `docs/index.html`, `docs/manifest.json`, `docs/llms.txt` |
 | `/arckit:architecture-repository` | TOGAF-style governance repository | `ARC-000-REPO-v*.md` or project repository artifact |
 
-Use `/arckit:repo-docs` when the question is "how does this repo work?" Use `/arckit:pages` when the question is "how do we publish ArcKit artifacts?" Use the TOGAF architecture repository when the question is "what reusable architecture knowledge has this organisation captured?"
+Use `/arckit:repo-docs` when the question is "how does this repo work?" Use `/arckit:repo-audit` when the question is "is this repo any good, and what did we never write down?" Use `/arckit:pages` when the question is "how do we publish ArcKit artifacts?" Use the TOGAF architecture repository when the question is "what reusable architecture knowledge has this organisation captured?"
 
 ---
 

--- a/plugins/arckit-claude/plugins/repo/commands/repo-docs.md
+++ b/plugins/arckit-claude/plugins/repo/commands/repo-docs.md
@@ -275,6 +275,7 @@ Document:
 
 ## Related Commands
 
+- `/arckit:repo-audit` judges a codebase against architecture principles and requirements. This command describes a repository; that one assesses one.
 - `/arckit:pages` publishes ArcKit artifacts, guides, and documentation indexes.
 - `/arckit:search` locates ArcKit artifacts and guide references.
 - `/arckit:architecture-repository` in the TOGAF ADM overlay creates a governance repository artifact, not source-code repository docs.

--- a/plugins/arckit-repo/commands/repo-docs.md
+++ b/plugins/arckit-repo/commands/repo-docs.md
@@ -275,6 +275,7 @@ Document:
 
 ## Related Commands
 
+- `/arckit:repo-audit` judges a codebase against architecture principles and requirements. This command describes a repository; that one assesses one.
 - `/arckit:pages` publishes ArcKit artifacts, guides, and documentation indexes.
 - `/arckit:search` locates ArcKit artifacts and guide references.
 - `/arckit:architecture-repository` in the TOGAF ADM overlay creates a governance repository artifact, not source-code repository docs.


### PR DESCRIPTION
Follow-up to #679. The `/arckit:repo-audit` guide shipped in v6.7.0 and is present in both guide trees, but **nothing on the published site linked to it**, so it was only reachable by guessing the `guide-viewer.html?guide=repo-audit` URL.

`docs/guides.html` is hand-maintained. No check covers it, which is why this slipped.

## Changes

- **`docs/guides.html`** — add the Codebase Audit entry to the Repository Plugin section, bump that section's count from `1 guide` to `2 guides`, and rewrite the section description, which still said the plugin "starts with" documentation and that "future commands can cover git and repository operations".
- **`docs/manifest.json`** — add the guide to the `guides-repository` project so the dashboard lists it.
- **Reciprocal cross-references.** These were one-way: `repo-audit` pointed at `repo-docs`, not the reverse. The `repo-docs` command's Related Commands and the guide's relationship table now name `repo-audit`, with the distinction stated plainly: `repo-docs` describes a repository, `repo-audit` assesses one.

## How this was found

Swept every file mentioning `repo-docs` and checked which lacked `repo-audit`. Four did, all fixed here. The sweep is now clean.

## Verification

- 1168 passed / 225 skipped
- All CI check scripts clean, including guide parity after `--sync`
- `docs/manifest.json` parses; the JSON edit is a 5-line addition with no reformatting
- Repository Plugin section in `guides.html` has 2 balanced `<li>` entries
- markdownlint clean on both changed markdown files

## Note

This is a docs-only fix for content already released in v6.7.0. The site rebuilds from `main`, so it does not need a new tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSx9btnejpWU9JiYbEPHqv