### PR TITLE
ci: guard that every guide is reachable from the published site

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -12,6 +12,9 @@ on:
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
       - "scripts/check-multi-instance-parity.py"
+      - "scripts/check-guide-site-links.py"
+      - "docs/guides.html"
+      - "docs/roles.html"
       - "plugins/arckit-*/recipes/**"
       - "plugins/arckit-claude/skills/arckit-build/recipes/**"
       - "plugins/arckit-claude/config/doc-types.mjs"
@@ -31,6 +34,9 @@ on:
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
       - "scripts/check-multi-instance-parity.py"
+      - "scripts/check-guide-site-links.py"
+      - "docs/guides.html"
+      - "docs/roles.html"
       - "plugins/arckit-*/recipes/**"
       - "plugins/arckit-claude/skills/arckit-build/recipes/**"
       - "plugins/arckit-claude/config/doc-types.mjs"
@@ -75,6 +81,9 @@ jobs:
 
       - name: Multi-instance doc-type parity (doc-types.mjs vs both bash copies)
         run: python3 scripts/check-multi-instance-parity.py
+
+      - name: Guide site-link check (every guide reachable, no dead links)
+        run: python3 scripts/check-guide-site-links.py
 
       - uses: actions/setup-node@v4
         with:

--- a/scripts/check-guide-site-links.py
+++ b/scripts/check-guide-site-links.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Assert every guide is reachable from the published site, and no site link is dead.
+
+`docs/guides.html` and `docs/roles.html` are hand-maintained. Nothing derives
+them from `docs/guides/`, so a guide can exist in both guide trees, pass
+`check-guide-parity.py`, ship to all seven extension formats, and still be
+invisible on the site: reachable only by guessing its `guide-viewer.html?guide=`
+URL. That shipped with `/arckit:repo-audit` in v6.7.0 and was fixed in PR #681.
+
+Two directions are checked:
+
+  unlinked  a guide on disk that no site page links to
+  dead      a site link pointing at a guide that does not exist
+
+A guide counts as reachable if ANY page in SITE_PAGES links it. That is
+deliberate: role guides live on roles.html rather than guides.html, and
+hardcoding "roles/ is exempt" would silently hide a role guide going missing
+from roles.html too.
+
+Exit 0 when clean, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+GUIDES_DIR = ROOT / "docs/guides"
+SITE_PAGES = (ROOT / "docs/guides.html", ROOT / "docs/roles.html")
+
+LINK_RE = re.compile(r"guide=([A-Za-z0-9._/-]+)")
+
+# Guides deliberately not linked from any site page. Keep this list short and
+# justified — an entry here is a guide no site visitor can ever reach.
+UNLINKED_BY_DESIGN = {
+    # Index page for the roles/ subtree; roles.html links the 18 role guides
+    # themselves and needs no card for their contents page.
+    "roles/README",
+}
+
+
+def guides_on_disk() -> set[str]:
+    return {
+        str(p.relative_to(GUIDES_DIR)).removesuffix(".md")
+        for p in GUIDES_DIR.rglob("*.md")
+    }
+
+
+def links_by_page() -> dict[Path, set[str]]:
+    found: dict[Path, set[str]] = {}
+    for page in SITE_PAGES:
+        if not page.is_file():
+            raise SystemExit(f"ERROR: site page not found: {page.relative_to(ROOT)}")
+        found[page] = set(LINK_RE.findall(page.read_text(encoding="utf-8")))
+    return found
+
+
+def main() -> int:
+    if not GUIDES_DIR.is_dir():
+        print(f"ERROR: {GUIDES_DIR} not found", file=sys.stderr)
+        return 1
+
+    disk = guides_on_disk()
+    if not disk:
+        print(f"ERROR: no guides found under {GUIDES_DIR.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    per_page = links_by_page()
+    linked = set().union(*per_page.values()) if per_page else set()
+
+    unlinked = sorted(disk - linked - UNLINKED_BY_DESIGN)
+    dead = sorted(linked - disk)
+    stale_exempt = sorted(UNLINKED_BY_DESIGN - disk)
+
+    failed = False
+
+    if unlinked:
+        failed = True
+        print(f"FAIL {len(unlinked)} guide(s) on disk that no site page links to:", file=sys.stderr)
+        for name in unlinked:
+            print(f"  docs/guides/{name}.md", file=sys.stderr)
+        print(
+            "\n  A site visitor cannot reach these. Add a list entry to "
+            "docs/guides.html (or docs/roles.html for role guides) linking\n"
+            '  guide-viewer.html?guide=<name>, and remember to bump that '
+            "section's guide count. If a guide is intentionally\n"
+            "  unreachable, add it to UNLINKED_BY_DESIGN in this script with a reason.",
+            file=sys.stderr,
+        )
+
+    if dead:
+        failed = True
+        print(f"\nFAIL {len(dead)} site link(s) pointing at a guide that does not exist:", file=sys.stderr)
+        for name in dead:
+            pages = sorted(p.name for p, links in per_page.items() if name in links)
+            print(f"  guide={name}  (linked from {', '.join(pages)})", file=sys.stderr)
+
+    if stale_exempt:
+        failed = True
+        print(
+            f"\nFAIL {len(stale_exempt)} UNLINKED_BY_DESIGN entr(y/ies) no longer on disk: "
+            f"{', '.join(stale_exempt)}",
+            file=sys.stderr,
+        )
+        print("  Remove them from this script.", file=sys.stderr)
+
+    if failed:
+        return 1
+
+    counts = ", ".join(
+        f"{page.name}: {len(links & disk)}" for page, links in sorted(per_page.items())
+    )
+    print(f"Guide site-link check OK: {len(disk)} guide(s) on disk, all reachable ({counts}).")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugin/test_guide_site_links.py
+++ b/tests/plugin/test_guide_site_links.py
@@ -1,0 +1,71 @@
+"""Tests for scripts/check-guide-site-links.py.
+
+The guard exists because docs/guides.html and docs/roles.html are
+hand-maintained: a guide can pass check-guide-parity.py, ship to all seven
+extension formats, and still be unreachable on the site. That happened with
+/arckit:repo-audit in v6.7.0 (fixed in PR #681).
+"""
+
+import importlib.util
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / "scripts/check-guide-site-links.py"
+
+
+def load_guard():
+    spec = importlib.util.spec_from_file_location("check_guide_site_links", GUARD)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_guard_exists():
+    assert GUARD.is_file(), "guide site-link guard missing"
+
+
+def test_guard_passes_on_current_tree():
+    result = subprocess.run(
+        ["python3", str(GUARD)], capture_output=True, text=True, cwd=REPO_ROOT
+    )
+    assert result.returncode == 0, f"guard failed:\n{result.stdout}\n{result.stderr}"
+
+
+def test_guard_is_wired_into_ci():
+    workflow = (REPO_ROOT / ".github/workflows/lint-markdown.yml").read_text()
+    assert "check-guide-site-links.py" in workflow, "guard not run in CI"
+    # The hand-maintained pages must also trigger the workflow, or an edit that
+    # removes a link would not be checked until some unrelated .md changed.
+    assert '"docs/guides.html"' in workflow
+    assert '"docs/roles.html"' in workflow
+
+
+@pytest.mark.parametrize(
+    "href,expected",
+    [
+        ('guide-viewer.html?guide=repo-audit"', "repo-audit"),
+        ('guide-viewer.html?guide=roles/security-architect"', "roles/security-architect"),
+        ('guide-viewer.html?guide=wardley.gameplay"', "wardley.gameplay"),
+    ],
+)
+def test_link_regex_handles_real_href_shapes(href, expected):
+    # Nested (roles/) and dotted (wardley.x) guide names both occur on the site;
+    # a regex that missed either would under-report links and fail open.
+    assert load_guard().LINK_RE.findall(href) == [expected]
+
+
+def test_every_exemption_still_exists_on_disk():
+    guard = load_guard()
+    on_disk = guard.guides_on_disk()
+    stale = sorted(guard.UNLINKED_BY_DESIGN - on_disk)
+    assert not stale, f"UNLINKED_BY_DESIGN names guides that no longer exist: {stale}"
+
+
+def test_repo_audit_is_linked():
+    # Explicit regression for the bug that motivated the guard.
+    guard = load_guard()
+    linked = set().union(*guard.links_by_page().values())
+    assert "repo-audit" in linked, "/arckit:repo-audit guide is unreachable from the site again"


### PR DESCRIPTION
Follow-up to #681, which fixed a symptom. This closes the class.

`docs/guides.html` and `docs/roles.html` are hand-maintained and nothing derives them from `docs/guides/`. A guide can exist in both guide trees, pass `check-guide-parity.py`, ship to all seven extension formats, and still be invisible on the site: reachable only by guessing its `guide-viewer.html?guide=` URL. That is what happened to `/arckit:repo-audit` in v6.7.0.

## What it checks

- **unlinked** — a guide on disk that no site page links to
- **dead** — a site link pointing at a guide that does not exist
- **stale** — an `UNLINKED_BY_DESIGN` entry whose guide is gone

## The design decision worth reviewing

Reachability is satisfied by **any** page in `SITE_PAGES`, not by `guides.html` alone.

The obvious implementation checks `guides.html` and exempts `roles/`. I did not do that, because 18 of the 19 role guides are linked from `roles.html`, and a blanket `roles/` exemption would have hidden a role guide going missing from `roles.html` too. Only `roles/README` is exempt, as the subtree's contents page, with the reason recorded inline.

## Baseline

238 guides, all reachable: `guides.html` 219, `roles.html` 18, plus the one exemption. Zero dead links today, so that direction is locked in rather than fixed.

## Negative-tested

A guard that only passes proves nothing, so all three failure modes were exercised:

- removing the `repo-audit` link reproduces the #681 bug, exit 1
- typo-ing a link reports both the orphaned guide and the dead link, exit 1
- a phantom `UNLINKED_BY_DESIGN` entry, exit 1

Each names the file and the fix, including the reminder to bump the section's guide count.

Both hand-maintained pages are added to the workflow path triggers, or an edit that deleted a link would go unchecked until some unrelated `.md` changed.

## Verification

1176 passed / 225 skipped (8 new). All seven CI check scripts clean. `docs/guides.html` confirmed byte-identical to `main` after the negative tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSx9btnejpWU9JiYbEPHqv