### PR TITLE
fix: repo-audit mode inference and create-project.sh silent failure (#616)

### DIFF
--- a/docs/guides/repo-audit.md
+++ b/docs/guides/repo-audit.md
@@ -54,6 +54,10 @@ You never pass a mode flag. The command works out which one applies.
 
 If only one of the two artefacts exists, the audit scores against it and marks the other as not assessed. Unlike `/arckit:conformance`, it does not refuse to run when prerequisites are thin, because auditing an inherited codebase is often the first thing you do on a project.
 
+**A project existing in your repo is not enough.** Before scoring anything, the audit checks that the project's requirements actually describe the codebase you pointed it at, and asks you if the evidence is ambiguous. A repository can easily hold a project about a market study, a policy, or a procurement; scoring source code against those would produce a page of confident verdicts that mean nothing. When correspondence is not confirmed, the audit falls back to cold mode and says so in its Audit Scope.
+
+Run with `--check` first to see which project and mode it would pick, without writing anything.
+
 ---
 
 ## What It Will Not Do

--- a/plugins/arckit-claude/docs/guides/repo-audit.md
+++ b/plugins/arckit-claude/docs/guides/repo-audit.md
@@ -54,6 +54,10 @@ You never pass a mode flag. The command works out which one applies.
 
 If only one of the two artefacts exists, the audit scores against it and marks the other as not assessed. Unlike `/arckit:conformance`, it does not refuse to run when prerequisites are thin, because auditing an inherited codebase is often the first thing you do on a project.
 
+**A project existing in your repo is not enough.** Before scoring anything, the audit checks that the project's requirements actually describe the codebase you pointed it at, and asks you if the evidence is ambiguous. A repository can easily hold a project about a market study, a policy, or a procurement; scoring source code against those would produce a page of confident verdicts that mean nothing. When correspondence is not confirmed, the audit falls back to cold mode and says so in its Audit Scope.
+
+Run with `--check` first to see which project and mode it would pick, without writing anything.
+
 ---
 
 ## What It Will Not Do

--- a/plugins/arckit-claude/plugins/repo/commands/repo-audit.md
+++ b/plugins/arckit-claude/plugins/repo/commands/repo-audit.md
@@ -86,16 +86,34 @@ git -C "<repo>" shortlog -sn --all | wc -l
 
 Use `.arckit/scripts/bash/list-projects.sh --json` to enumerate projects. If that path does not exist, glob `projects/*/` directly rather than failing.
 
-- **No project exists** → Cold mode.
-- **Exactly one project** → use it.
+### 3a. Pick a candidate project
+
+- **No project exists** → skip to 3c, Cold mode. Do **not** call `create-project.sh` here: it requires `ARC-000-PRIN-*.md` and will refuse, which would block the audit on a prerequisite this command deliberately does not need. Write the artefact to `projects/001-{repo-slug}/audits/`, creating the directory directly.
+- **Exactly one project** → treat it as a *candidate*, not a decision. Continue to 3b.
 - **More than one** and the arguments do not name one → ask which project the audit belongs to. Do not guess.
 
-Then look for `ARC-{PID}-PRIN-v*.md` in `projects/000-global/` and `ARC-{PID}-REQ-v*.md` in the project directory.
+### 3b. Confirm the project actually describes this repository
+
+**A project existing in the repo does not mean it describes the code you are auditing.** Check before scoring anything against it. Read the candidate's `REQ` (and `PRIN`) title, Document Purpose, and a sample of requirements, then judge whether they describe *this* codebase.
+
+Signals that it does **not**:
+
+- The project name refers to a market study, a policy, an organisation, or a procurement rather than a system.
+- Requirements describe business outcomes with no counterpart anywhere in the source tree.
+- No requirement references a component, service, or technology present in the repository.
+
+If the evidence is weak or contradictory, **ask the user**: "Project `{id}-{name}` looks like it describes `{summary}` rather than this codebase. Audit against it, or run a standalone audit?" A wrong answer here is expensive: it produces a full page of confident Met/Not-met verdicts scoring the code against requirements for an unrelated system.
+
+Record the outcome in the artefact's Audit Scope, whichever way it goes.
+
+### 3c. Select the mode
+
+Only once 3b confirms correspondence:
 
 | Found | Mode |
 |---|---|
-| PRIN and/or REQ | **Conformance** — score the codebase against them. |
-| Neither | **Cold** — standalone as-built audit. |
+| PRIN and/or REQ, confirmed to describe this repo | **Conformance** — score the codebase against them. |
+| Neither, or correspondence not confirmed | **Cold** — standalone as-built audit. |
 
 If only one of the two exists, score against it and mark the other as not assessed. **Do not hard-error on missing prerequisites.** A repo audit is often the first thing a user runs, and blocking on artefacts they have not created yet defeats the command.
 
@@ -157,7 +175,9 @@ Populate every section of the template. Specific requirements:
 
 ## Step 7: Check Mode
 
-With `--check` or `--dry-run`: report the resolved target, whether it is local or would be cloned, the detected project and mode, which artefacts would be scored against, and which dimensions would run. Write nothing, and do not clone.
+With `--check` or `--dry-run`: report the resolved target, whether it is local or would be cloned, the detected project, **whether that project appears to describe this repository** (step 3b) and the mode that follows from it, which artefacts would be scored against, and which dimensions would run. Write nothing, and do not clone.
+
+Check mode is the cheapest way to catch a wrong project before a full run.
 
 ## Success Criteria
 

--- a/plugins/arckit-claude/scripts/bash/create-project.sh
+++ b/plugins/arckit-claude/scripts/bash/create-project.sh
@@ -67,7 +67,16 @@ if [[ "$FORCE_CREATE" != "true" ]]; then
     GLOBAL_DIR="$(get_memory_dir "$REPO_ROOT")"
 
     # Look for principles file with new naming convention (ARC-000-PRIN-*.md)
-    PRINCIPLES_FILE=$(find "$GLOBAL_DIR" -name "ARC-000-PRIN-*.md" 2>/dev/null | head -1)
+    #
+    # `find` exits non-zero when $GLOBAL_DIR does not exist, and `2>/dev/null`
+    # hides the reason. Under `set -euo pipefail` that killed the script right
+    # here, exit 1 with NO output at all — so a fresh repository, the exact case
+    # that needs the "run /arckit:principles" guidance below, got silence.
+    # Guard the directory and tolerate a non-zero find so the message can print.
+    PRINCIPLES_FILE=""
+    if [[ -d "$GLOBAL_DIR" ]]; then
+        PRINCIPLES_FILE=$(find "$GLOBAL_DIR" -name "ARC-000-PRIN-*.md" 2>/dev/null | head -1) || true
+    fi
 
     if [[ -z "$PRINCIPLES_FILE" || ! -f "$PRINCIPLES_FILE" ]]; then
         log_error "Prerequisites not met: Architecture principles not found"

--- a/plugins/arckit-repo/commands/repo-audit.md
+++ b/plugins/arckit-repo/commands/repo-audit.md
@@ -86,16 +86,34 @@ git -C "<repo>" shortlog -sn --all | wc -l
 
 Use `.arckit/scripts/bash/list-projects.sh --json` to enumerate projects. If that path does not exist, glob `projects/*/` directly rather than failing.
 
-- **No project exists** → Cold mode.
-- **Exactly one project** → use it.
+### 3a. Pick a candidate project
+
+- **No project exists** → skip to 3c, Cold mode. Do **not** call `create-project.sh` here: it requires `ARC-000-PRIN-*.md` and will refuse, which would block the audit on a prerequisite this command deliberately does not need. Write the artefact to `projects/001-{repo-slug}/audits/`, creating the directory directly.
+- **Exactly one project** → treat it as a *candidate*, not a decision. Continue to 3b.
 - **More than one** and the arguments do not name one → ask which project the audit belongs to. Do not guess.
 
-Then look for `ARC-{PID}-PRIN-v*.md` in `projects/000-global/` and `ARC-{PID}-REQ-v*.md` in the project directory.
+### 3b. Confirm the project actually describes this repository
+
+**A project existing in the repo does not mean it describes the code you are auditing.** Check before scoring anything against it. Read the candidate's `REQ` (and `PRIN`) title, Document Purpose, and a sample of requirements, then judge whether they describe *this* codebase.
+
+Signals that it does **not**:
+
+- The project name refers to a market study, a policy, an organisation, or a procurement rather than a system.
+- Requirements describe business outcomes with no counterpart anywhere in the source tree.
+- No requirement references a component, service, or technology present in the repository.
+
+If the evidence is weak or contradictory, **ask the user**: "Project `{id}-{name}` looks like it describes `{summary}` rather than this codebase. Audit against it, or run a standalone audit?" A wrong answer here is expensive: it produces a full page of confident Met/Not-met verdicts scoring the code against requirements for an unrelated system.
+
+Record the outcome in the artefact's Audit Scope, whichever way it goes.
+
+### 3c. Select the mode
+
+Only once 3b confirms correspondence:
 
 | Found | Mode |
 |---|---|
-| PRIN and/or REQ | **Conformance** — score the codebase against them. |
-| Neither | **Cold** — standalone as-built audit. |
+| PRIN and/or REQ, confirmed to describe this repo | **Conformance** — score the codebase against them. |
+| Neither, or correspondence not confirmed | **Cold** — standalone as-built audit. |
 
 If only one of the two exists, score against it and mark the other as not assessed. **Do not hard-error on missing prerequisites.** A repo audit is often the first thing a user runs, and blocking on artefacts they have not created yet defeats the command.
 
@@ -157,7 +175,9 @@ Populate every section of the template. Specific requirements:
 
 ## Step 7: Check Mode
 
-With `--check` or `--dry-run`: report the resolved target, whether it is local or would be cloned, the detected project and mode, which artefacts would be scored against, and which dimensions would run. Write nothing, and do not clone.
+With `--check` or `--dry-run`: report the resolved target, whether it is local or would be cloned, the detected project, **whether that project appears to describe this repository** (step 3b) and the mode that follows from it, which artefacts would be scored against, and which dimensions would run. Write nothing, and do not clone.
+
+Check mode is the cheapest way to catch a wrong project before a full run.
 
 ## Success Criteria
 

--- a/scripts/bash/create-project.sh
+++ b/scripts/bash/create-project.sh
@@ -67,7 +67,16 @@ if [[ "$FORCE_CREATE" != "true" ]]; then
     GLOBAL_DIR="$(get_memory_dir "$REPO_ROOT")"
 
     # Look for principles file with new naming convention (ARC-000-PRIN-*.md)
-    PRINCIPLES_FILE=$(find "$GLOBAL_DIR" -name "ARC-000-PRIN-*.md" 2>/dev/null | head -1)
+    #
+    # `find` exits non-zero when $GLOBAL_DIR does not exist, and `2>/dev/null`
+    # hides the reason. Under `set -euo pipefail` that killed the script right
+    # here, exit 1 with NO output at all — so a fresh repository, the exact case
+    # that needs the "run /arckit:principles" guidance below, got silence.
+    # Guard the directory and tolerate a non-zero find so the message can print.
+    PRINCIPLES_FILE=""
+    if [[ -d "$GLOBAL_DIR" ]]; then
+        PRINCIPLES_FILE=$(find "$GLOBAL_DIR" -name "ARC-000-PRIN-*.md" 2>/dev/null | head -1) || true
+    fi
 
     if [[ -z "$PRINCIPLES_FILE" || ! -f "$PRINCIPLES_FILE" ]]; then
         log_error "Prerequisites not met: Architecture principles not found"

--- a/tests/plugin/test_repo_audit.py
+++ b/tests/plugin/test_repo_audit.py
@@ -221,3 +221,77 @@ def test_guide_exists_in_both_trees_and_matches():
     assert root_guide.is_file(), "root guide missing"
     assert plugin_guide.is_file(), "plugin guide copy missing"
     assert read(root_guide) == read(plugin_guide), "guide trees drifted"
+
+
+# --- F-010: project/repo correspondence before conformance mode -----------
+
+
+def test_command_confirms_project_describes_the_repo():
+    """A project existing in the repo does not mean it describes the audited code.
+
+    Found on the first real run: arc-kit's only project is a UK-government
+    consulting market study, and the command would have scored this codebase
+    against its 28 unrelated requirements.
+    """
+    body = read(COMMAND)
+    assert "Confirm the project actually describes this repository" in body
+    assert "treat it as a *candidate*, not a decision" in body
+
+
+def test_command_falls_back_to_cold_when_correspondence_unconfirmed():
+    body = read(COMMAND)
+    assert "Neither, or correspondence not confirmed" in body, (
+        "unconfirmed correspondence must select cold mode, not conformance"
+    )
+
+
+def test_command_does_not_call_create_project_when_no_project_exists():
+    # create-project.sh requires ARC-000-PRIN-*.md and refuses without it,
+    # which would block the audit on a prerequisite it deliberately avoids.
+    body = read(COMMAND)
+    assert "Do **not** call `create-project.sh` here" in body
+
+
+def test_check_mode_reports_correspondence():
+    body = read(COMMAND)
+    assert "whether that project appears to describe this repository" in body
+
+
+# --- F-005: create-project.sh must not fail silently ---------------------
+
+
+CREATE_PROJECT_COPIES = (
+    REPO_ROOT / "scripts/bash/create-project.sh",
+    REPO_ROOT / "plugins/arckit-claude/scripts/bash/create-project.sh",
+)
+
+
+@pytest.mark.parametrize("script", CREATE_PROJECT_COPIES, ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_create_project_guards_the_principles_lookup(script: Path):
+    """`find` on a missing dir exits non-zero; under `set -euo pipefail` that
+    killed the script before its own error message could print."""
+    body = read(script)
+    assert 'if [[ -d "$GLOBAL_DIR" ]]; then' in body, "missing directory guard"
+    assert '| head -1) || true' in body, "find failure must be tolerated"
+
+
+@pytest.mark.parametrize("script", CREATE_PROJECT_COPIES, ids=lambda p: str(p.relative_to(REPO_ROOT)))
+def test_create_project_reports_missing_principles(tmp_path: Path, script: Path):
+    """End-to-end: no projects/000-global at all must still explain itself."""
+    (tmp_path / ".arckit").mkdir()
+    (tmp_path / "projects").mkdir()
+    result = subprocess.run(
+        ["bash", str(script), "--name", "Test Project", "--json"],
+        capture_output=True, text=True, cwd=tmp_path,
+    )
+    assert result.returncode == 1, "should fail without principles"
+    combined = result.stdout + result.stderr
+    assert combined.strip(), "failed SILENTLY - the whole point of this fix"
+    assert "/arckit:principles" in combined, (
+        f"error must name the fix, got: {combined!r}"
+    )
+
+
+def test_create_project_copies_are_identical():
+    a, b = (read(p) for p in CREATE_PROJECT_COPIES)
+    assert a == b, "create-project.sh copies have drifted"


### PR DESCRIPTION
Both defects were found by the **first real end-to-end run** of `/arckit:repo-audit`, against this repository. Neither was reachable by static review.

## F-010: mode inference assumed any project described the audited repo

arc-kit's only project is `001-uk-gov-consulting-market`, a market study. A conformance-mode run would have scored **this codebase** against 28 requirements about a consulting market, producing a full page of confident Met/Not-met verdicts that mean nothing.

Step 3 now separates *picking* a candidate from *accepting* it:

- the candidate is checked against the repository (does any requirement reference a component, service, or technology that actually exists in the tree?)
- the user is asked when the evidence is ambiguous
- unconfirmed correspondence falls back to **cold mode**, not conformance
- `--check` reports the judgement, so it is the cheap way to catch a wrong project before a full run

Step 3 also no longer routes through `create-project.sh` when no project exists — that script requires `ARC-000-PRIN-*.md` and refuses without it, which would have blocked the audit on exactly the prerequisite this command is designed not to need.

## F-005: create-project.sh failed silently

It exited 1 with **zero bytes on stdout and stderr** when `projects/000-global/` was absent. `find` returns non-zero on a missing directory, `2>/dev/null` hid the reason, and `set -euo pipefail` killed the script at the assignment — three lines before the error that would have said `Run: /arckit:principles`.

A fresh repository is the case that most needs that guidance, and it got silence. This is the next thing @johnfelipe would have hit on #680, since their project almost certainly has no `PRIN`.

## Verification

Negative-tested against a reconstructed pre-fix copy, because a test that only passes proves nothing:

| | exit | stdout | stderr | names the fix |
|---|---|---|---|---|
| pre-fix | 1 | 0 B | 0 B | no |
| post-fix | 1 | 0 B | 384 B | yes |

Happy path and `--force` verified unaffected: project creation still returns JSON and exit 0, and `--force` still works with no principles directory at all. Both copies of the script are patched and remain byte-identical.

9 new tests, including an end-to-end one asserting the failure is **not silent** — the property that actually regressed, rather than just the exit code.

1198 passed / 225 skipped. All eight CI check scripts clean. markdownlint clean on both changed guides.

## Note

`.claude/settings.json` is deliberately **not** in this PR. It was modified locally by `/plugin`, which is a separate concern from these fixes — see the review comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSx9btnejpWU9JiYbEPHqv