### PR TITLE
fix: don't index gitignored artefacts in docs/manifest.json

### DIFF
--- a/plugins/arckit-claude/hooks/update-manifest.mjs
+++ b/plugins/arckit-claude/hooks/update-manifest.mjs
@@ -10,6 +10,17 @@
  *   - docs/manifest.json doesn't exist (no pages setup yet)
  *   - File path doesn't contain /projects/
  *   - Filename doesn't match ARC-NNN-*-vN.N.md pattern
+ *   - The artefact is gitignored (a published index must not reference a
+ *     file that will never be published)
+ *
+ * Ownership of docs/manifest.json:
+ *   - THIS hook owns project artefact entries (projects[] groups), keeping the
+ *     pages dashboard current between /arckit:pages runs. That is the product
+ *     behaviour in a user's repo.
+ *   - scripts/generate-docs-manifest.py owns the guide/template/article/global
+ *     index in the ArcKit repo itself, rebuilt from git-tracked sources.
+ *   The two do not overlap once the gitignore guard is in place, because
+ *   ArcKit gitignores its own projects/.
  *
  * Hook Type: PostToolUse
  * Matcher: Write
@@ -26,6 +37,7 @@
  */
 
 import { readFileSync, writeFileSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
 import { join, basename, resolve } from 'node:path';
 import { DOC_TYPES, SUBDIR_MAP } from '../config/doc-types.mjs';
 import { isDir, isFile, findRepoRoot, parseHookInput, emitUpdatedToolOutput } from './hook-utils.mjs';
@@ -46,6 +58,23 @@ for (const dir of new Set(Object.values(SUBDIR_MAP))) {
 SUBDIR_TO_KEY['reviews'] = 'reviews';
 
 // ── Doc type extraction ──
+
+// True only when git actively ignores the path. Untracked-but-not-ignored
+// returns false, which is the case for any newly written artefact in a repo
+// that tracks projects/. Fail open on any error: no git, not a repo, or git
+// unavailable all mean "cannot prove it is ignored", so index it.
+function isGitIgnored(filePath, repoRoot) {
+  try {
+    const r = spawnSync('git', ['check-ignore', '-q', '--', filePath], {
+      cwd: repoRoot,
+      timeout: 2000,
+      stdio: 'ignore',
+    });
+    return r.status === 0;
+  } catch {
+    return false;
+  }
+}
 
 function extractDocType(filename) {
   const m = filename.match(/^ARC-\d{3}-(.+)-v\d+(\.\d+)?\.md$/);
@@ -113,6 +142,24 @@ if (!repoRoot) process.exit(0);
 
 const manifestPath = join(repoRoot, 'docs', 'manifest.json');
 if (!isFile(manifestPath)) process.exit(0);
+
+// ── Guard: never index an artefact git will not publish ──
+//
+// docs/manifest.json is a published index — in the ArcKit repo itself it is
+// served at arckit.org/manifest.json. Indexing a gitignored artefact puts a
+// reference to a file that exists only on one machine into a file everyone
+// fetches, i.e. a permanent 404.
+//
+// This matters most in the ArcKit repo, where `projects/` is gitignored, so
+// writing any ARC artefact used to append a group referencing an unpublished
+// path — and that also collided with scripts/generate-docs-manifest.py, which
+// rebuilds the same file from tracked sources and legitimately drops them.
+//
+// IGNORED, not merely untracked. A brand-new artefact in a repo that tracks
+// projects/ is untracked until committed and must still be indexed; only an
+// ignored path can never be published. Fail open: if git is unavailable or
+// this is not a repo, index as before.
+if (isGitIgnored(filePath, repoRoot)) process.exit(0);
 
 // ── Parse manifest ──
 let manifest;

--- a/tests/plugin/manifest-gitignore.test.mjs
+++ b/tests/plugin/manifest-gitignore.test.mjs
@@ -1,0 +1,97 @@
+/**
+ * update-manifest.mjs must not index artefacts git will never publish.
+ *
+ * docs/manifest.json is a published index — ArcKit serves its own at
+ * arckit.org/manifest.json. Indexing a gitignored artefact writes a reference
+ * to a one-machine-only file into a file everyone fetches: a permanent 404.
+ *
+ * It also caused a two-writer collision in the ArcKit repo, where `projects/`
+ * is gitignored: the hook appended a project group, and
+ * scripts/generate-docs-manifest.py (which rebuilds the same file from tracked
+ * sources) legitimately dropped it, so `--check` failed after every artefact
+ * write.
+ *
+ * The distinction that matters is IGNORED vs merely UNTRACKED. A brand-new
+ * artefact in a repo that tracks projects/ is untracked until committed and
+ * must still be indexed.
+ *
+ * NOTE the filename: CI globs `tests/plugin/*.test.mjs`, so a `test_*.mjs`
+ * name would never run here.
+ */
+
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve } from 'node:path';
+import { execFileSync, spawnSync } from 'node:child_process';
+
+const HOOK = resolve('plugins/arckit-claude/hooks/update-manifest.mjs');
+const EMPTY = '{"generated":"x","repository":{},"global":[],"projects":[]}';
+
+function makeRepo({ git = true, ignoreProjects = false } = {}) {
+  const root = mkdtempSync(join(tmpdir(), 'mani-'));
+  mkdirSync(join(root, 'docs'), { recursive: true });
+  mkdirSync(join(root, 'projects', '001-demo'), { recursive: true });
+  writeFileSync(join(root, 'docs', 'manifest.json'), EMPTY);
+  writeFileSync(join(root, 'projects', '001-demo', 'ARC-001-REQ-v1.0.md'), '# Requirements\n');
+
+  if (git) {
+    const q = { cwd: root, stdio: 'ignore' };
+    spawnSync('git', ['init', '-q', '.'], q);
+    spawnSync('git', ['config', 'user.email', 't@t'], q);
+    spawnSync('git', ['config', 'user.name', 't'], q);
+    if (ignoreProjects) writeFileSync(join(root, '.gitignore'), 'projects/\n');
+    spawnSync('git', ['add', '-A'], q);
+    spawnSync('git', ['commit', '-qm', 'init'], q);
+  }
+  return root;
+}
+
+function runHook(root) {
+  const file = join(root, 'projects', '001-demo', 'ARC-001-REQ-v1.0.md');
+  execFileSync('node', [HOOK], {
+    input: JSON.stringify({
+      tool_name: 'Write',
+      cwd: root,
+      tool_input: { file_path: file, content: '# Requirements' },
+    }),
+    encoding: 'utf8',
+  });
+  return JSON.parse(readFileSync(join(root, 'docs', 'manifest.json'), 'utf8'));
+}
+
+test('a repo that TRACKS projects/ still gets its artefacts indexed', () => {
+  const m = runHook(makeRepo());
+  assert.equal(m.projects.length, 1, 'normal user repos must be unaffected');
+});
+
+test('a gitignored artefact is NOT indexed', () => {
+  const m = runHook(makeRepo({ ignoreProjects: true }));
+  assert.equal(
+    m.projects.length,
+    0,
+    'a published index must not reference a file that will never be published',
+  );
+});
+
+test('untracked-but-not-ignored is still indexed', () => {
+  // The artefact exists and projects/ is not ignored, but nothing is committed.
+  // This is every artefact at the moment it is written, so it must be indexed.
+  const root = makeRepo({ git: true });
+  spawnSync('git', ['rm', '-r', '--cached', 'projects', '-q'], { cwd: root, stdio: 'ignore' });
+  assert.equal(runHook(root).projects.length, 1);
+});
+
+test('non-git directory fails open and indexes as before', () => {
+  const m = runHook(makeRepo({ git: false }));
+  assert.equal(m.projects.length, 1, 'no git means the ignore state is unknowable');
+});
+
+test('ArcKit own repo: projects/ is gitignored, so nothing is indexed from it', () => {
+  const ignored = spawnSync('git', ['check-ignore', '-q', '--', 'projects/'], {
+    cwd: resolve('.'),
+    stdio: 'ignore',
+  });
+  assert.equal(ignored.status, 0, 'precondition: ArcKit gitignores projects/');
+});


### PR DESCRIPTION
Resolves the two-writer conflict flagged on #689.

## The collision

| Writer | Owns | Scope |
|---|---|---|
| `update-manifest.mjs` | project artefact entries, appended on every Write under `projects/` | product behaviour, user repos |
| `generate-docs-manifest.py` | guide/template/article index, rebuilt from git-**tracked** sources | ArcKit repo only (added #683) |

ArcKit gitignores its own `projects/`, so writing any artefact appended a group referencing an unpublished path, and the generator then dropped it — CI red after every artefact write. Hit while stamping the codebase audit.

## The deeper problem

The collision is the symptom. `docs/manifest.json` is a **published index** — ArcKit serves its own at `arckit.org/manifest.json`. Indexing a gitignored artefact writes a reference to a one-machine-only file into a file everyone fetches. That is a permanent 404, collision or no collision.

## The fix

The hook skips artefacts git actively ignores.

**IGNORED, not merely untracked.** A brand-new artefact in a repo that tracks `projects/` is untracked until committed and must still be indexed — that is every artefact at the moment it is written. Only an ignored path can never be published. Fails open when git is absent or the directory is not a repo, since neither can prove the path is ignored.

## Verified across all four states

```
projects/ tracked           indexed      (normal user repo, unchanged)
projects/ gitignored        NOT indexed  (the fix)
untracked but not ignored   indexed      (every artefact at write time)
not a git repo              indexed      (fail open)
```

Ownership is now documented in the hook header. The two writers no longer overlap.

## Notes

- One `spawnSync('git', ['check-ignore'])` per artefact write, 2s timeout inside the hook's 5s budget. First subprocess in this hook, but `check-ignore` is the only authoritative answer — parsing `.gitignore` by hand gets negations and nested files wrong.
- Tests named `*.test.mjs` so CI's `tests/plugin/*.test.mjs` glob runs them. Removing the guard fails 1 of the 5.

## Verification

1217 pytest / 225 skipped, 135 node tests in the CI glob, plus the legacy `test_update_manifest.mjs` (3) still passing. All nine check scripts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HSx9btnejpWU9JiYbEPHqv