### PR TITLE
fix(wardley): evolve lines with a trailing label are no longer dropped (#693)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`evolve` lines carrying a trailing `label` were silently dropped from the generated Mermaid block — a side-effect of the #508 fix.** PR #511 anchored the evolve target at end-of-line to stop `003` being taken as the target in `evolve "Foo (Project 003)" 0.74`. That fix was correct, but the anchor also meant no evolve line with *any* trailing text could match, and `owm-to-mermaid.mjs` skips unmatched lines silently. The label suffix is now an optional non-capturing group, so the #508 anchor holds while labels are tolerated and stripped as they were before #511. Reported by @chrismckelt against 6.7.2 (#693).
+
+  Wider than reported in two ways. First, this is the **documented** syntax, not an edge case: `commands/wardley.md` gives the output template as `evolve {Component Name} {target_evolution} label {label text}`, repeats it in the syntax summary, and uses it in worked examples, and both `wardley-map-template.md` copies follow suit — so a `/arckit:wardley` run that followed ArcKit's own instructions lost *every* evolve line from the Mermaid block while the OWM block above it showed them all. Second, the canonical OWM offset form `evolve X 0.8 label [10, -5]` was dropped too, not just free-text labels.
+
+- **`validate-wardley-math.mjs` was blind to the same lines, so nothing caught the inconsistency at write time.** The hook carried the same end-anchored evolve pattern in two places. A labelled evolve line therefore never landed in the reference list, and an evolve pointing at an undeclared or misspelled component passed validation silently. Both patterns now take the same optional label suffix; the dangling-reference check fires on labelled lines as it always should have (#693).
+
+  No documentation change was needed: `commands/wardley.md` describes the converter as handling "`evolve`-label stripping", which was true before #511 and is true again now. The code was wrong, not the doc.
+
 ## [6.7.2] — 2026-07-27
 
 ### Fixed

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,18 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`evolve` lines carrying a trailing `label` were silently dropped from the generated Mermaid block — a side-effect of the #508 fix.** PR #511 anchored the evolve target at end-of-line to stop `003` being taken as the target in `evolve "Foo (Project 003)" 0.74`. That fix was correct, but the anchor also meant no evolve line with *any* trailing text could match, and `owm-to-mermaid.mjs` skips unmatched lines silently. The label suffix is now an optional non-capturing group, so the #508 anchor holds while labels are tolerated and stripped as they were before #511. Reported by @chrismckelt against 6.7.2 (#693).
+
+  Wider than reported in two ways. First, this is the **documented** syntax, not an edge case: `commands/wardley.md` gives the output template as `evolve {Component Name} {target_evolution} label {label text}`, repeats it in the syntax summary, and uses it in worked examples, and both `wardley-map-template.md` copies follow suit — so a `/arckit:wardley` run that followed ArcKit's own instructions lost *every* evolve line from the Mermaid block while the OWM block above it showed them all. Second, the canonical OWM offset form `evolve X 0.8 label [10, -5]` was dropped too, not just free-text labels.
+
+- **`validate-wardley-math.mjs` was blind to the same lines, so nothing caught the inconsistency at write time.** The hook carried the same end-anchored evolve pattern in two places. A labelled evolve line therefore never landed in the reference list, and an evolve pointing at an undeclared or misspelled component passed validation silently. Both patterns now take the same optional label suffix; the dangling-reference check fires on labelled lines as it always should have (#693).
+
+  No documentation change was needed: `commands/wardley.md` describes the converter as handling "`evolve`-label stripping", which was true before #511 and is true again now. The code was wrong, not the doc.
+
 ## [6.7.2] — 2026-07-27
 
 ### Fixed

--- a/plugins/arckit-claude/hooks/validate-wardley-math.mjs
+++ b/plugins/arckit-claude/hooks/validate-wardley-math.mjs
@@ -147,7 +147,10 @@ const owmFenceOpenRe = /^\s*```(?:wardley|owm)\b/;
 // silently slipping through.
 const componentDeclRe = /^\s*(component|anchor|note|submap|market)\s+(.+?)\s+\[\s*(-?[0-9.]+)\s*,\s*(-?[0-9.]+)\s*\]/;
 const pipelineRe = /^\s*pipeline\s+(.+?)\s+\[\s*(-?[0-9.]+)\s*,\s*(-?[0-9.]+)\s*\]/;
-const evolveRe = /^\s*evolve\s+(.+?)\s+[0-9.]+\s*$/;
+// Optional non-capturing `label ...` suffix — without it a labelled evolve
+// line never lands in `references[]`, so an evolve pointing at an undeclared
+// or typo'd component silently skips the undeclared-reference check.
+const evolveRe = /^\s*evolve\s+(.+?)\s+[0-9.]+(?:\s+label\b.*)?$/;
 const annotationRe = /^\s*annotation\s+(\d+)\s+\[/;
 const styleRe = /^\s*style\s+(\S+)/;
 
@@ -316,7 +319,7 @@ function extractNameZones(line) {
   if (m) return [m[1]];
   m = line.match(/^\s*anchor\s+(.+?)\s*\[/);
   if (m) return [m[1]];
-  m = line.match(/^\s*evolve\s+(.+?)\s+[0-9.]+\s*$/);
+  m = line.match(/^\s*evolve\s+(.+?)\s+[0-9.]+(?:\s+label\b.*)?$/);
   if (m) return [m[1]];
   m = line.match(/^\s*pipeline\s+(.+?)(?:\s*\[|\s*$)/);
   if (m) return [m[1]];

--- a/plugins/arckit-claude/scripts/owm-to-mermaid.mjs
+++ b/plugins/arckit-claude/scripts/owm-to-mermaid.mjs
@@ -281,7 +281,12 @@ export function convert(owm, filename = '') {
 
     // evolve — anchor target at end so quoted names with embedded digits
     // (e.g. "Foo (Project 003)") aren't mis-parsed by the lazy name group.
-    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)\s*$/i);
+    // The trailing `label ...` suffix is optional and non-capturing: it keeps
+    // the end-anchor (so #508 stays fixed) while tolerating both the free-text
+    // form (`label Commoditising fast`) and the OWM offset form
+    // (`label [10, -5]`). The label is stripped, not emitted — Mermaid
+    // wardley-beta has no verified `label` grammar on an evolve statement.
+    const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)(?:\s+label\b.*)?$/i);
     if (mev) {
       out.push(`evolve ${quoteName(mev[1].trim())} ${mev[2]}`);
       continue;

--- a/tests/plugin/owm-to-mermaid.test.mjs
+++ b/tests/plugin/owm-to-mermaid.test.mjs
@@ -66,3 +66,31 @@ test('regression — inertia-only component unchanged', () => {
   const out = convert('component "X" [0.5, 0.5] inertia');
   assert.match(out, /component "X" \[0\.5, 0\.5\] \(inertia\)/);
 });
+
+test('issue #693 — evolve with a free-text label is emitted, label stripped', () => {
+  const out = convert('evolve Captioning and Transcription 0.86 label Commoditising fast');
+  assert.match(out, /evolve "Captioning and Transcription" 0\.86\s*$/m);
+  assert.doesNotMatch(out, /label/i);
+});
+
+test('issue #693 — evolve with an OWM label offset is emitted, offset stripped', () => {
+  const out = convert('evolve X 0.8 label [10, -5]');
+  assert.match(out, /evolve "X" 0\.8\s*$/m);
+  assert.doesNotMatch(out, /label/i);
+});
+
+test('issue #693 — embedded digits and a trailing label at once (neither old pattern handled this)', () => {
+  const out = convert('evolve "Foo (Project 003)" 0.74 label Moving right');
+  assert.match(out, /evolve "Foo \(Project 003\)" 0\.74\s*$/m);
+  assert.doesNotMatch(out, /label/i);
+});
+
+test('issue #693 — bare `label` with no trailing text is still tolerated', () => {
+  const out = convert('evolve X 0.8 label');
+  assert.match(out, /evolve "X" 0\.8\s*$/m);
+});
+
+test('issue #693 — a component name containing the word "label" is not truncated', () => {
+  const out = convert('evolve Label Printer 0.8');
+  assert.match(out, /evolve "Label Printer" 0\.8\s*$/m);
+});


### PR DESCRIPTION
Closes #693. Reported by @chrismckelt against 6.7.2.

## The defect

`scripts/owm-to-mermaid.mjs` silently dropped any `evolve` statement carrying a trailing `label`. No warning, no error — the line just did not appear in the Mermaid output.

The reporter's diagnosis is correct in full. PR #511 fixed #508 by anchoring the target capture at end-of-line, which correctly stops `003` being taken as the target in `evolve "Foo (Project 003)" 0.74` — but it also means no line with trailing text can match, and the parser skips unmatched lines silently (`owm-to-mermaid.mjs`, `// unknown — silently skip`). #511's commit message describes the anchoring and never mentions labels, so the side-effect was unintended.

The fix is the reporter's suggested one, with `\b` instead of `\s+` after `label` so a bare trailing `label` is also tolerated:

```javascript
const mev = s.match(/^evolve\s+(.+?)\s+([\d.]+)(?:\s+label\b.*)?$/i);
```

## Wider than reported, in three ways

**1. This is the documented syntax, not an edge case.** `commands/wardley.md` gives the output template as `evolve {Component Name} {target_evolution} label {label text}`, repeats it in the syntax summary, and uses it in two worked examples; both `wardley-map-template.md` copies follow suit. So a `/arckit:wardley` run that followed ArcKit's own instructions lost **every** evolve line from the Mermaid block while the OWM block directly above it showed them all. Not "some maps" — the default path.

**2. The canonical OWM offset form was dropped too.** The issue only tested free-text labels. `evolve X 0.8 label [10, -5]` was also dropped — the same `label [dx, dy]` grammar the `component` handler deliberately preserves.

**3. `validate-wardley-math.mjs` could not have caught it.** The issue hedges that the validator "may catch it at Stop". It cannot: the hook carried the identical end-anchored pattern in two places. A labelled evolve line therefore never landed in `references[]`, so an evolve pointing at an **undeclared or misspelled component passed validation silently**. Both patterns now take the same optional suffix.

Verified end-to-end against a map with `evolve Undeclared Typo 0.86 label Commoditising fast`:

- before: exit 0, no output, write allowed
- after: `{"decision":"block","reason":"... Line 6: evolve references undeclared name 'Undeclared Typo' ..."}`

## Strip or preserve?

Labels are **stripped**, not emitted. That restores pre-#511 behaviour and matches what `commands/wardley.md` already documents ("the converter ... handles `evolve`-label stripping") — which was true before #511 and is true again now. **No documentation change was needed: the code was wrong, not the doc.**

Preserving `label [x, y]` offsets on `evolve`, the way the `component` handler preserves them, would be a new feature and risks emitting grammar Mermaid `wardley-beta` may not accept — a parse error is a worse failure than the drop. Left as a deliberate follow-up rather than guessed at here.

## Tests

Five new tests. The #508 suite regression-tested the embedded-digits case but never labels, which is exactly why this slipped through CI.

| Case | before | after |
|---|---|---|
| `evolve X 0.86 label Commoditising fast` | dropped | `evolve "X" 0.86` |
| `evolve X 0.8 label [10, -5]` | dropped | `evolve "X" 0.8` |
| `evolve "Foo (Project 003)" 0.74 label Moving right` | dropped | `evolve "Foo (Project 003)" 0.74` |
| `evolve X 0.8 label` | dropped | `evolve "X" 0.8` |
| `evolve Label Printer 0.8` (name contains keyword) | ok | ok, not truncated |
| `evolve "Foo (Project 003)" 0.74` (#508) | ok | ok |

The "both at once" case worked with neither the current nor the pre-#511 pattern.

## Verification

- `tests/plugin/owm-to-mermaid.test.mjs` — 14 pass (was 9)
- `node --test tests/plugin/*.test.mjs` — 129 pass, 0 fail
- `python -m pytest tests/` — 1204 pass, 225 skipped
- `python scripts/sync-shared-assets.py --check` — clean
- `npx markdownlint-cli2` on both CHANGELOGs — 0 issues
- `python scripts/converter.py` run; no tracked diff (the seven extension copies are generated and gitignored, rebuilt at publish)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CC1JrMCx2esmTMdf1sH944