### PR TITLE
docs: add @chrismckelt to the contributors page

### DIFF
--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -301,7 +301,7 @@
 
     <div class="app-page-hero app-page-hero--contributors">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">16 Open Source Contributors</span>
+            <span class="app-page-hero__stat">17 Open Source Contributors</span>
             <h1 class="app-page-hero__title">ArcKit Contributors</h1>
             <p class="app-page-hero__description">Meet the maintainers and community members improving ArcKit through code contributions, issues, feature requests, and feedback.</p>
         </div>
@@ -576,11 +576,27 @@
                         <li>Motivated a provider-agnostic reference guard plus a cross-hook sync regression test</li>
                     </ul>
                 </div>
+
+                <div class="app-contributor-card">
+                    <div class="app-contributor-card__header">
+                        <div class="app-contributor-card__avatar">C</div>
+                        <div>
+                            <p class="app-contributor-card__name"><a href="https://github.com/chrismckelt">@chrismckelt</a> &mdash; Chris McKelt</p>
+                            <span class="app-contributor-card__role app-contributor-card__role--bug">Bug Reporter</span>
+                        </div>
+                    </div>
+                    <p class="govuk-body-s">Reported that <code>owm-to-mermaid.mjs</code> silently dropped any <code>evolve</code> statement carrying a trailing <code>label</code>, so a Wardley Map's OWM block showed evolution movements while the converter-generated Mermaid block below it showed none (<a href="https://github.com/tractorjuice/arc-kit/issues/693" class="govuk-link">#693</a>, fixed in <a href="https://github.com/tractorjuice/arc-kit/pull/694" class="govuk-link">#694</a>, shipped in v6.7.3). Correctly identified it as a side-effect of the end-of-line anchor added to fix <a href="https://github.com/tractorjuice/arc-kit/issues/508" class="govuk-link">#508</a> rather than a regression of #508 itself, and proposed the optional non-capturing label group that landed as the fix.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>Traced the drop to the anchoring change in <a href="https://github.com/tractorjuice/arc-kit/pull/511" class="govuk-link">#511</a> and ruled out the obvious wrong culprit</li>
+                        <li>Before/after behaviour table separating the digits-in-name case from the trailing-label case</li>
+                        <li>Investigation surfaced the same blind spot in <code>validate-wardley-math.mjs</code>, where it had been letting <code>evolve</code> references to undeclared components pass silently</li>
+                    </ul>
+                </div>
             </div>
 
             <!-- Community Summary -->
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Community Impact</h2>
-            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 9 code contributors, 2 feature requesters, 4 bug reporters, and 1 domain/spec maintainer, these 16 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, plugin user-config wiring, secret-scanner accuracy, accessibility standards alignment, EU / French / Austrian / Australian regulatory compliance coverage, TOGAF ADM support, and AI agent architecture governance.</p>
+            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 9 code contributors, 2 feature requesters, 5 bug reporters, and 1 domain/spec maintainer, these 17 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, plugin user-config wiring, secret-scanner accuracy, Wardley Map conversion fidelity, accessibility standards alignment, EU / French / Austrian / Australian regulatory compliance coverage, TOGAF ADM support, and AI agent architecture governance.</p>
 
             <!-- Contributing CTA -->
             <div class="govuk-inset-text govuk-!-margin-top-6">


### PR DESCRIPTION
@chrismckelt reported #693 and was credited in both CHANGELOGs at the v6.7.3 release, but never made it onto `docs/contributors.html`. This adds him.

Card goes in **Feature Requesters & Bug Reporters**, matching the existing markup. Content notes what made the report unusually good: he correctly identified the drop as a *side-effect* of the end-of-line anchor added to fix #508 rather than a regression of #508 itself, gave a before/after behaviour table separating the two cases, and proposed the optional non-capturing group that landed as the fix.

Counts updated in the two places that carry them:

- hero stat: 16 → 17 Open Source Contributors
- Community Impact paragraph: 4 → 5 bug reporters, 16 → 17 individuals

Verified: 17 `app-contributor-card__name` cards on the page, matching both counts, and the paragraph's own arithmetic still balances (9 + 2 + 5 + 1 = 17). HTML parses with no unclosed or mismatched tags.

## Two things found while doing this, not fixed here

**1. @jhonurrego-tekton is also missing.** They reported #688 in v6.7.2 (duplicate plugin entries in `installed_plugins.json` from the two marketplaces registering identical plugin names, alongside a "Plugin 'arckit' not cached" warning) and are credited in the CHANGELOG but not on the page. Same omission class as this one. Left out because writing someone else's citation is a judgment call worth making deliberately rather than bundling into a PR about a different person — happy to add in a follow-up.

**2. The "1 domain/spec maintainer" figure in the Community Impact paragraph looks stale independently of this change.** The page actually carries four Domain Maintainer badges (AT, AU, EU & FR, UK NHS — proposed) plus one Spec Author (SAFETY.md). The badge total (21) exceeds the card total (17) because some people hold two, so the paragraph may be counting people rather than badges — but either way "1" does not match. Not touched here to keep this PR to a single addition.

**Underlying process gap:** nothing links "credited in the CHANGELOG" to "listed on the contributors page", so the page drifts release by release. Two misses in two releases suggests this wants a CI guard — cross-check `@handle` mentions in `CHANGELOG.md` against handles in `docs/contributors.html` and fail on any that appear in one but not the other.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CC1JrMCx2esmTMdf1sH944