### PR TITLE
fix: add the two remaining uncredited contributors, guard against recurrence

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -13,6 +13,8 @@ on:
       - "scripts/check-guide-parity.py"
       - "scripts/check-multi-instance-parity.py"
       - "scripts/check-guide-site-links.py"
+      - "scripts/check-contributor-credits.py"
+      - "docs/contributors.html"
       - "docs/guides.html"
       - "docs/roles.html"
       - "plugins/arckit-*/recipes/**"
@@ -35,6 +37,8 @@ on:
       - "scripts/check-guide-parity.py"
       - "scripts/check-multi-instance-parity.py"
       - "scripts/check-guide-site-links.py"
+      - "scripts/check-contributor-credits.py"
+      - "docs/contributors.html"
       - "docs/guides.html"
       - "docs/roles.html"
       - "plugins/arckit-*/recipes/**"
@@ -84,6 +88,9 @@ jobs:
 
       - name: Guide site-link check (every guide reachable, no dead links)
         run: python3 scripts/check-guide-site-links.py
+
+      - name: Contributor credit check (CHANGELOG credits vs contributors page)
+        run: python3 scripts/check-contributor-credits.py
 
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Three contributors credited in the CHANGELOGs were missing from `docs/contributors.html`.** @Yumstezy (authored `docs/guides/custom-commands.md`, #111/#357), @jhonurrego-tekton (reported #688, v6.7.2) and @chrismckelt (reported #693, v6.7.3) all had release-note credits and no card on the site. All three are now listed, and the two counts the page carries — the hero stat and the Community Impact paragraph — are consistent with the 19 cards on it.
+
+### Added
+
+- **`scripts/check-contributor-credits.py`, a CI guard against contributor-credit drift.** The page is hand-maintained and nothing derives it from the CHANGELOGs, so crediting someone at release time and listing them on the site are independent acts — and only one of them is part of the release flow. The failure was silent and one-directional (the CHANGELOG right, the site quietly incomplete), which is why it accumulated across three releases before anyone looked. The guard fails CI when a handle credited in either CHANGELOG has no profile link on the page.
+
+  Checked in one direction only. The reverse would be wrong: a card may legitimately predate the credit convention, or record a contribution such as a proposed overlay or an adopted external spec that never produced a release note.
+
+  Code spans and fenced blocks are stripped before scanning, because a credit is always prose and `@`-prefixed tokens are everywhere in a technical changelog — without it, PlantUML's `@startuml`/`@enduml` register as contributors, as would npm scopes and decorators. Bare version specifiers such as `mermaid@11.15.0` are excluded by a word-boundary guard rather than by the code stripping, so they stay excluded outside backticks too.
+
+  Wiring `docs/contributors.html` into the `lint-markdown.yml` path filters also closes a related gap: a PR touching only that file previously triggered no CI at all.
+
 ## [6.7.3] — 2026-07-28
 
 ### Fixed

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -301,7 +301,7 @@
 
     <div class="app-page-hero app-page-hero--contributors">
         <div class="govuk-width-container app-page-hero__content">
-            <span class="app-page-hero__stat">17 Open Source Contributors</span>
+            <span class="app-page-hero__stat">19 Open Source Contributors</span>
             <h1 class="app-page-hero__title">ArcKit Contributors</h1>
             <p class="app-page-hero__description">Meet the maintainers and community members improving ArcKit through code contributions, issues, feature requests, and feedback.</p>
         </div>
@@ -478,6 +478,22 @@
                         <li>DCB0129 1&ndash;5 severity / likelihood scoring scale and <code>open</code>&nbsp;/&nbsp;<code>mitigated</code>&nbsp;/&nbsp;<code>accepted</code>&nbsp;/&nbsp;<code>closed</code> status vocabulary</li>
                     </ul>
                 </div>
+
+                <div class="app-contributor-card">
+                    <div class="app-contributor-card__header">
+                        <div class="app-contributor-card__avatar">Y</div>
+                        <div>
+                            <p class="app-contributor-card__name"><a href="https://github.com/Yumstezy">@Yumstezy</a></p>
+                            <span class="app-contributor-card__role app-contributor-card__role--code">Code Contributor</span>
+                        </div>
+                    </div>
+                    <p class="govuk-body-s">Authored <code>docs/guides/custom-commands.md</code>, the authoring guide for contributors adding new ArcKit commands (<a href="https://github.com/tractorjuice/arc-kit/issues/111" class="govuk-link">#111</a>, <a href="https://github.com/tractorjuice/arc-kit/issues/357" class="govuk-link">#357</a>). Covers the converter fan-out from plugin source to every target format, the frontmatter reference, the <code>$ARGUMENTS</code> placeholder rewriting table, template-handling differences between Paperclip and the other targets, and the commands/skills/agents/hooks decision table.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>Wrote the contributor-facing command authoring guide</li>
+                        <li>Documented the converter fan-out and frontmatter reference</li>
+                        <li>Added the commands vs skills vs agents vs hooks decision table</li>
+                    </ul>
+                </div>
             </div>
 
             <!-- Feature Requesters & Bug Reporters -->
@@ -592,11 +608,27 @@
                         <li>Investigation surfaced the same blind spot in <code>validate-wardley-math.mjs</code>, where it had been letting <code>evolve</code> references to undeclared components pass silently</li>
                     </ul>
                 </div>
+
+                <div class="app-contributor-card">
+                    <div class="app-contributor-card__header">
+                        <div class="app-contributor-card__avatar">J</div>
+                        <div>
+                            <p class="app-contributor-card__name"><a href="https://github.com/jhonurrego-tekton">@jhonurrego-tekton</a></p>
+                            <span class="app-contributor-card__role app-contributor-card__role--bug">Bug Reporter</span>
+                        </div>
+                    </div>
+                    <p class="govuk-body-s">Reported duplicate plugin entries in <code>installed_plugins.json</code> alongside a "Plugin 'arckit' not cached" warning (<a href="https://github.com/tractorjuice/arc-kit/issues/688" class="govuk-link">#688</a>, fixed in v6.7.2). Root cause was documentation rather than code: <code>CLAUDE.md</code> recommended the <code>tractorjuice/arc-kit</code> marketplace while three other places recommended <code>tractorjuice/arckit-claude</code>. Both publish all 16 plugins under identical names, so a user following both instructions registered every plugin twice and left the plugin manager choosing between ambiguous entries.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>Surfaced a conflict between four separate install instructions</li>
+                        <li>Reported with <code>installed_plugins.json</code> evidence showing the duplicate registrations</li>
+                        <li>Prompted a single-marketplace recommendation across all documentation</li>
+                    </ul>
+                </div>
             </div>
 
             <!-- Community Summary -->
             <h2 class="govuk-heading-l govuk-!-margin-top-8">Community Impact</h2>
-            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 9 code contributors, 2 feature requesters, 5 bug reporters, and 1 domain/spec maintainer, these 17 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, plugin user-config wiring, secret-scanner accuracy, Wardley Map conversion fidelity, accessibility standards alignment, EU / French / Austrian / Australian regulatory compliance coverage, TOGAF ADM support, and AI agent architecture governance.</p>
+            <p class="govuk-body">ArcKit has grown from a solo project into a community-driven toolkit. With 10 code contributors, 2 feature requesters, 6 bug reporters, and 1 domain/spec maintainer, these 19 individuals have collectively shaped ArcKit through merged pull requests, feature ideas that influenced the roadmap, and bug reports that improved reliability. Their contributions span cross-platform compatibility, multi-AI support, business architecture improvements, documentation quality, plugin user-config wiring, secret-scanner accuracy, Wardley Map conversion fidelity, accessibility standards alignment, EU / French / Austrian / Australian regulatory compliance coverage, TOGAF ADM support, and AI agent architecture governance.</p>
 
             <!-- Contributing CTA -->
             <div class="govuk-inset-text govuk-!-margin-top-6">

--- a/scripts/check-contributor-credits.py
+++ b/scripts/check-contributor-credits.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Assert everyone credited in a CHANGELOG has a card on the contributors page.
+
+`docs/contributors.html` is hand-maintained and nothing derives it from the
+CHANGELOGs, so crediting someone at release time and adding them to the site
+are two independent acts. Only one of them is part of the release flow, and it
+is not the site one. The page therefore drifts release by release: at v6.7.3
+it was missing @chrismckelt (#693, that release), @jhonurrego-tekton (#688,
+the release before), and @Yumstezy (#111/#357, long since shipped).
+
+The failure is silent and one-directional — the CHANGELOG is right and the
+site is quietly incomplete — so nobody notices until someone goes looking.
+
+Checked in one direction only: every handle credited in a CHANGELOG must
+appear on the contributors page. The reverse is deliberately NOT checked, as
+a card may legitimately predate the CHANGELOG convention or record a
+contribution (a proposed overlay, an adopted external spec) that never
+produced a release note.
+
+Exit 0 when clean, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+CHANGELOGS = (ROOT / "CHANGELOG.md", ROOT / "plugins/arckit-claude/CHANGELOG.md")
+CONTRIBUTORS = ROOT / "docs/contributors.html"
+
+# A handle mention must not be preceded by a word character, or every
+# `mermaid@11.15.0` / `mermaid@7147` package specifier in the CHANGELOG reads
+# as a credit to "@11" / "@7147". GitHub handles are alphanumeric plus internal
+# hyphens, max 39 chars.
+HANDLE_RE = re.compile(r"(?<![\w@/-])@([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)\b")
+PROFILE_RE = re.compile(r"github\.com/([A-Za-z0-9](?:[A-Za-z0-9-]{0,37}[A-Za-z0-9])?)[\"/]")
+
+# Code is stripped before scanning: a credit is always prose, never code, and
+# `@`-prefixed tokens are everywhere in code. Without this, PlantUML's
+# `@startuml`/`@enduml` read as contributors — as would npm scopes
+# (`@types/node`), decorators (`@Component`), and Python's `@property`.
+FENCED_RE = re.compile(r"^```.*?^```", re.MULTILINE | re.DOTALL)
+INLINE_CODE_RE = re.compile(r"`[^`\n]*`")
+
+
+def strip_code(text: str) -> str:
+    return INLINE_CODE_RE.sub(" ", FENCED_RE.sub(" ", text))
+# Handles that are mentioned in a CHANGELOG but are not outside contributors.
+# Keep this list short and justified.
+NOT_CONTRIBUTORS = {
+    # Repository owner and maintainer — the whole CHANGELOG is their work.
+    "tractorjuice",
+}
+
+
+def handles_in_changelogs() -> dict[str, list[str]]:
+    """Map each credited handle to the changelog files mentioning it."""
+    found: dict[str, list[str]] = {}
+    for path in CHANGELOGS:
+        if not path.is_file():
+            raise SystemExit(f"ERROR: changelog not found: {path.relative_to(ROOT)}")
+        prose = strip_code(path.read_text(encoding="utf-8"))
+        for handle in set(HANDLE_RE.findall(prose)):
+            if handle.isdigit() or handle in NOT_CONTRIBUTORS:
+                continue
+            found.setdefault(handle, []).append(str(path.relative_to(ROOT)))
+    return found
+
+
+def handles_on_page() -> set[str]:
+    if not CONTRIBUTORS.is_file():
+        raise SystemExit(f"ERROR: contributors page not found: {CONTRIBUTORS.relative_to(ROOT)}")
+    return set(PROFILE_RE.findall(CONTRIBUTORS.read_text(encoding="utf-8")))
+
+
+def main() -> int:
+    credited = handles_in_changelogs()
+    if not credited:
+        print("ERROR: no contributor handles found in any CHANGELOG — check HANDLE_RE", file=sys.stderr)
+        return 1
+
+    listed = {h.lower() for h in handles_on_page()}
+    missing = {h: files for h, files in credited.items() if h.lower() not in listed}
+
+    if missing:
+        print("Contributors credited in a CHANGELOG but missing from the site:\n", file=sys.stderr)
+        for handle in sorted(missing, key=str.lower):
+            print(f"  @{handle}  (credited in {', '.join(sorted(missing[handle]))})", file=sys.stderr)
+        print(
+            f"\nAdd a card for each to {CONTRIBUTORS.relative_to(ROOT)}, then update the two"
+            "\ncounts it carries: the `app-page-hero__stat` and the Community Impact paragraph."
+            "\nIf a handle is not an outside contributor, add it to NOT_CONTRIBUTORS in"
+            f"\n{Path(__file__).relative_to(ROOT)} with a reason.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"All {len(credited)} contributors credited in the CHANGELOGs are listed on the site.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/plugin/test_contributor_credits.py
+++ b/tests/plugin/test_contributor_credits.py
@@ -1,0 +1,107 @@
+"""Tests for scripts/check-contributor-credits.py.
+
+The guard exists because `docs/contributors.html` drifted from the CHANGELOGs
+across three separate releases. These tests pin the two things that make it
+useful: it fails when someone credited is missing, and it does not fire on the
+`@`-prefixed tokens that litter a technical changelog.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / "scripts/check-contributor-credits.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("check_contributor_credits", SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+guard = _load()
+
+
+def handles(text: str) -> set[str]:
+    """Handles the guard would credit from a changelog body."""
+    return set(guard.HANDLE_RE.findall(guard.strip_code(text)))
+
+
+def test_repo_is_currently_clean():
+    """The committed tree must pass, or CI is red on arrival."""
+    result = subprocess.run([sys.executable, str(SCRIPT)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_credits_in_prose_are_found():
+    assert handles("Reported by @chrismckelt against 6.7.2 (#693).") == {"chrismckelt"}
+
+
+def test_handle_with_internal_hyphen_is_found():
+    assert handles("Reported by @jhonurrego-tekton, who found duplicates.") == {
+        "jhonurrego-tekton"
+    }
+
+
+def test_multiple_credits_on_one_line():
+    assert handles("Thanks to @umag and @gtonic for the fix.") == {"umag", "gtonic"}
+
+
+@pytest.mark.parametrize(
+    "text",
+    [
+        "bumped `mermaid@11.15.0` across all templates",
+        "moves from the `pkg.pr.new/mermaid@7147` pre-release build",
+        "validates `@startuml`/`@enduml` wrappers",
+        "installs `@types/node` for the harness",
+        "the `@property` decorator is used throughout",
+    ],
+)
+def test_code_tokens_are_not_credits(text):
+    """`@`-prefixed tokens inside code spans are never contributor credits."""
+    assert handles(text) == set()
+
+
+def test_fenced_code_blocks_are_stripped():
+    text = "Prose crediting @realperson.\n\n```python\n@decorator\ndef f(): ...\n```\n"
+    assert handles(text) == {"realperson"}
+
+
+def test_bare_version_specifier_outside_code_is_not_a_credit():
+    """The word-boundary guard holds even without backticks to help."""
+    assert handles("bumped mermaid@11.15.0 today") == set()
+
+
+def test_email_addresses_are_not_credits():
+    assert handles("Contact noreply@example.com for details.") == set()
+
+
+def test_maintainer_is_excluded():
+    assert "tractorjuice" in guard.NOT_CONTRIBUTORS
+
+
+def test_page_handles_are_extracted_from_profile_links():
+    found = guard.handles_on_page()
+    assert "chrismckelt" in found
+    assert len(found) >= 19
+
+
+def test_every_credited_handle_is_listed():
+    credited = set(guard.handles_in_changelogs())
+    listed = {h.lower() for h in guard.handles_on_page()}
+    assert {h for h in credited if h.lower() not in listed} == set()
+
+
+def test_hero_stat_matches_card_count():
+    """The page carries its own count in two places; both must match reality."""
+    page = (ROOT / "docs/contributors.html").read_text(encoding="utf-8")
+    cards = page.count('<p class="app-contributor-card__name">')
+    assert f"{cards} Open Source Contributors" in page
+    assert f"these {cards} individuals" in page


### PR DESCRIPTION
Follow-up to #696. That PR added @chrismckelt; this one adds everyone else who was missing and stops the page drifting again.

## The drift was worse than one person

Comparing `@handle` credits in both CHANGELOGs against profile links on `docs/contributors.html` turned up **three** missing, accumulated across three separate releases:

| Handle | Contribution | Released |
|---|---|---|
| @Yumstezy | Authored `docs/guides/custom-commands.md` (#111, #357) | long since |
| @jhonurrego-tekton | Reported #688 | v6.7.2 |
| @chrismckelt | Reported #693 | v6.7.3 (added in #696) |

@Yumstezy was the surprise — a **code** contributor, not a reporter, so the card goes in Code Contributors.

Both counts the page carries (hero stat, Community Impact paragraph) now reconcile with its 19 cards, and a test asserts that rather than trusting the next editor to remember.

## Why it kept happening

The page is hand-maintained and nothing derives it from the CHANGELOGs, so crediting someone at release time and listing them on the site are independent acts — and only one of them is part of the release flow. The failure is silent and one-directional: the CHANGELOG is right, the site is quietly incomplete. Nobody notices without going to look.

## The guard

`scripts/check-contributor-credits.py` fails CI when a handle credited in either CHANGELOG has no profile link on the page.

**One direction only, deliberately.** The reverse would be wrong: a card may predate the credit convention, or record a contribution such as a proposed overlay or an adopted external spec that never produced a release note.

**Code is stripped before scanning.** A credit is always prose, and `@`-prefixed tokens are everywhere in a technical changelog. Without stripping, PlantUML's `@startuml`/`@enduml` register as contributors — which is what the first run actually reported, rather than something I anticipated. Same class covers npm scopes (`@types/node`) and decorators (`@property`). Bare version specifiers like `mermaid@11.15.0` are handled by a word-boundary guard instead of by stripping, so they stay excluded outside backticks too.

**Verified it fails, not merely that it passes.** Removing @chrismckelt's profile link exits 1 naming him; restoring it exits 0.

## Also closed

Wiring `docs/contributors.html` into the `lint-markdown.yml` path filters fixes a related gap: a PR touching only that file previously triggered **no CI at all**. That is exactly what happened on #696, which merged with zero checks.

## Verification

- `python3 scripts/check-contributor-credits.py` — clean, 8 credited handles all listed
- `tests/plugin/test_contributor_credits.py` — 16 new tests (prose credits, hyphenated handles, five false-positive classes, fenced blocks, emails, count reconciliation)
- `python -m pytest tests/` — 1220 pass, 225 skipped
- `markdownlint-cli2` — 0 issues
- Workflow YAML parses; step present

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CC1JrMCx2esmTMdf1sH944