### PR TITLE
fix(docs): repair the plugin-tag validation loop in RELEASING.md and /release

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -66,10 +66,18 @@ git status && git diff --stat
 git add -A && git commit -m "chore: bump version to X.Y.Z"
 
 # 7. Validate EVERY plugin manifest against the marketplace entry.
-#    Discover plugins dynamically — do NOT hardcode the list (it grows):
-for manifest in $(find . -maxdepth 3 -path '*/.claude-plugin/plugin.json' -not -path '*/node_modules/*' | sort); do
-  p=$(python3 -c "import json;print(json.load(open('$manifest'))['name'])")
-  claude plugin tag "$p" --dry-run || { echo "VERSION DRIFT: $p"; exit 1; }
+#    Discover plugins dynamically — do NOT hardcode the list (it grows).
+#    Search from `plugins`, not `.`: from the repo root the manifests sit at
+#    depth 4, so `find . -maxdepth 3` matches nothing and the loop below
+#    "passes" having validated not one plugin.
+mapfile -t manifests < <(find plugins -maxdepth 3 -path '*/.claude-plugin/plugin.json' | sort)
+
+(( ${#manifests[@]} > 0 )) || { echo "No plugin manifests found — check the find path"; exit 1; }
+echo "Validating ${#manifests[@]} plugin manifests..."
+
+for manifest in "${manifests[@]}"; do
+  dir=${manifest%/.claude-plugin/plugin.json}   # PATH — `claude plugin tag` rejects the name
+  claude plugin tag "$dir" --dry-run || { echo "VERSION DRIFT: $dir"; exit 1; }
 done
 
 # 8. (optional) Prune orphaned plugin deps:
@@ -109,11 +117,24 @@ The highest-signal failures — collected from real releases. Read these before 
 - **Skipping extension tests.** Run the step 4 extension suite after `converter.py`. It validates
   Codex, Gemini, OpenCode, Copilot, Vibe, Paperclip, release inventory, version alignment, and
   platform-specific command rewrites before anything is tagged.
-- **Hardcoding the plugin list.** The Claude marketplace now ships 15 plugins (core plus
+- **Hardcoding the plugin list.** The Claude marketplace now ships 16 plugins (core plus
   regional, sector, method, agent-architecture, tooling, and supplier overlays) and keeps growing. Older examples listed
   only 7, silently skipping newer plugins. Discover plugins dynamically (step 7) -- this is the
   exact bug that shipped `arckit-uk-nhs` untagged mid-v5.4.0, which is why `tag-plugins.sh`
   now auto-discovers. Never copy a static plugin array.
+- **A `for` loop over an empty glob exits 0.** Step 7's discovery searched from `.` while the
+  manifests sit at depth 4, so `-maxdepth 3` matched nothing and the validation reported a
+  clean pass having checked not one plugin -- through every release from v6.0.0 to v6.7.4.
+  Dynamic discovery only helps if you assert it found something, hence the count check and the
+  `Validating N plugin manifests...` line. Treat any loop whose body might never run as
+  unvalidated until it prints what it covered.
+- **`claude plugin tag` takes a PATH, not a plugin name.** Passing the `name` from `plugin.json`
+  (`arckit`) resolves relative to the repo root and fails `✘ Path not found: /…/arckit`. Use the
+  plugin directory: `plugins/arckit-claude`. This compounded the bug above -- had the glob ever
+  matched, every iteration would have failed anyway.
+- **Validate before `tag-plugins.sh`, never after.** Once the native `name--vX.Y.Z` tags exist,
+  the dry-run fails with `Tag "…" already exists locally` -- correct behaviour, not version drift,
+  but it will send you hunting for a problem that isn't there.
 - **`claude plugin tag` needs a clean tree.** Run it *after* the commit (step 6), not before, or
   it errors on the dirty working tree.
 - **`claude plugin tag` is `--dry-run` only here.** It creates `name--vX.Y.Z` style tags that do

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -126,18 +126,38 @@ This command creates `{plugin-name}--vX.Y.Z` style tags (e.g. `arckit--v4.14.0`)
 
 ## v6.0.0+ — single Claude marketplace repo
 
-From v6.0.0 the standalone `tractorjuice/arckit-claude` repo is the preferred Claude Code marketplace. It ships 15 plugins in one repo: the `arckit` core plugin at the root plus regional, sector, method, agent-architecture, tooling, and supplier overlays under structured `plugins/...` paths. All Claude plugins share one version, bumped together. The `arckit-uk-gcloud` overlay is public for installation and inspection but remains proprietary, so the standalone repo license carries an explicit exception for `plugins/uk/gcloud/`.
+From v6.0.0 the standalone `tractorjuice/arckit-claude` repo is the preferred Claude Code marketplace. It ships 16 plugins in one repo: the `arckit` core plugin at the root plus regional, sector, method, agent-architecture, tooling, and supplier overlays under structured `plugins/...` paths. All Claude plugins share one version, bumped together. The `arckit-uk-gcloud` overlay is public for installation and inspection but remains proprietary, so the standalone repo license carries an explicit exception for `plugins/uk/gcloud/`.
 
 The root `.claude-plugin/marketplace.json` in `tractorjuice/arc-kit` remains a compatibility marketplace for existing users who already added the old repo. Keep its `name` as `arc-kit` and its sources pointed at monorepo paths such as `./plugins/arckit-claude` and `./plugins/arckit-uae`. The standalone marketplace metadata lives at `plugins/arckit-claude/.claude-plugin/marketplace.json` and uses `.` plus `./plugins/...` sources for `tractorjuice/arckit-claude`.
 
 Step 8 changes — validate every plugin manifest:
 
 ```bash
-for manifest in $(find plugins -maxdepth 3 -path '*/.claude-plugin/plugin.json' | sort); do
-  p=$(python3 -c "import json;print(json.load(open('$manifest'))['name'])")
-  claude plugin tag "$p" --dry-run || { echo "VERSION DRIFT: $p"; exit 1; }
+mapfile -t manifests < <(find plugins -maxdepth 3 -path '*/.claude-plugin/plugin.json' | sort)
+
+# An empty glob would make the loop below exit 0 having validated nothing.
+(( ${#manifests[@]} > 0 )) || { echo "No plugin manifests found — check the find path"; exit 1; }
+echo "Validating ${#manifests[@]} plugin manifests..."
+
+for manifest in "${manifests[@]}"; do
+  dir=${manifest%/.claude-plugin/plugin.json}          # a PATH, not the plugin name
+  claude plugin tag "$dir" --dry-run || { echo "VERSION DRIFT: $dir"; exit 1; }
 done
 ```
+
+> **`claude plugin tag` takes a path, not a plugin name.** Passing the `name` field
+> from `plugin.json` (`arckit`) resolves it relative to the repo root and fails with
+> `✘ Path not found: /…/arckit`. Post-relayout the path is the plugin directory —
+> `plugins/arckit-claude`, not `arckit` and not a bare `arckit-claude`.
+>
+> **Keep the `-maxdepth 3` and the `plugins` prefix.** Together they select exactly
+> the 16 real plugin directories. Searching from `.` instead pushes the manifests to
+> depth 4 and matches nothing; raising the depth pulls in the nested publish mirrors
+> under `plugins/arckit-claude/plugins/…`, which are not separately taggable.
+>
+> **Run this before `tag-plugins.sh`, not after.** Once the native `name--vX.Y.Z`
+> tags exist the dry-run fails with `Tag "…" already exists locally`, which is not
+> version drift.
 
 After the umbrella tag (step 10), also create native per-plugin tags:
 


### PR DESCRIPTION
The release flow's step 7/8 cross-checks every `plugin.json` against its marketplace entry to catch version drift before tagging. **It has never done so.**

## Two independent bugs, both silent

**1. The skill's discovery matched nothing.** `.claude/skills/release/SKILL.md` used `find . -maxdepth 3`. From the repo root the manifests sit at depth 4, so the glob returned empty, the `for` body never ran, and the loop exited 0 — reporting a clean validation having checked not one plugin. Every release from v6.0.0 through v6.7.4 "passed" this way.

`docs/RELEASING.md` used `find plugins`, which does match all 16. Only the skill had this one — I previously described both as having it, which was wrong.

**2. Both passed a name where a path was required.** `claude plugin tag` takes a PATH; both fed it the `name` field from `plugin.json`:

```
$ claude plugin tag arckit --dry-run
✘ Path not found: /workspaces/arc-kit/arckit
```

Had the glob in (1) ever matched, every iteration would have failed anyway.

## The fix

```bash
mapfile -t manifests < <(find plugins -maxdepth 3 -path '*/.claude-plugin/plugin.json' | sort)

# An empty glob would make the loop below exit 0 having validated nothing.
(( ${#manifests[@]} > 0 )) || { echo "No plugin manifests found — check the find path"; exit 1; }
echo "Validating ${#manifests[@]} plugin manifests..."

for manifest in "${manifests[@]}"; do
  dir=${manifest%/.claude-plugin/plugin.json}          # a PATH, not the plugin name
  claude plugin tag "$dir" --dry-run || { echo "VERSION DRIFT: $dir"; exit 1; }
done
```

`-maxdepth 3` with the `plugins` prefix is load-bearing in both directions: searching from `.` matches nothing, and raising the depth pulls in the nested publish mirrors under `plugins/arckit-claude/plugins/…`, which are not separately taggable.

**The count assertion is the actual fix.** Dynamic discovery was already policy — the skill's own gotchas warn against hardcoding the plugin list — and that is precisely what made an empty result look like success. A loop whose body might never run is unvalidated until it prints what it covered.

## Verified in all three states

| State | Result |
|---|---|
| Old skill loop, as documented | exits 0, "reported SUCCESS", validated nothing |
| New loop, discovery | finds and announces 16 manifests |
| New loop, plugin with no existing tag | exits 0 for the right reason |

The last one needed care: post-release every `name--vX.Y.Z` tag exists, so a dry-run correctly fails with `Tag "…" already exists locally`. I deleted one local tag, confirmed a genuine `rc=0`, then restored it from origin. Without that step "it passes now" would have been indistinguishable from the bug being fixed.

That behaviour is now documented too — validation must run **before** `tag-plugins.sh`, since afterwards the failure is correct behaviour rather than drift and sends you hunting a phantom.

## Also

Both files claimed the marketplace ships 15 plugins. It ships 16 — matching both marketplace manifests and the directories on disk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CC1JrMCx2esmTMdf1sH944