### PR TITLE
fix: provenance stamp emitted underscore emphasis, failing MD049 in every stamped artefact

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -89,6 +89,12 @@
     "**/node_modules/**",
     "docs/articles/**",
     "docs/plans/**",
+    // Gitignored, zero tracked files — CI never sees these, but every local
+    // run (bump-version.sh included) reported errors in them, which is noise
+    // that can mask a real failure in tracked content. `books/` alone
+    // accounted for 1,259 of them.
+    "docs/pitch-decks/**",
+    "books/**",
     "docs/superpowers/**",
     "tests/mermaid-wardley/owm-maps/**",
     "tests/mermaid-wardley/node_modules/**",

--- a/extensions/arckit-codex/hooks/arckit-codex-hook.mjs
+++ b/extensions/arckit-codex/hooks/arckit-codex-hook.mjs
@@ -1130,7 +1130,10 @@ function buildProvenanceBlock(data) {
   }
 
   const tableRows = rows.map(([key, value]) => `| ${key} | ${value} |`).join("\n");
-  return `${PROV_START}\n\n## Build Provenance\n\n_Stamped automatically by the ArcKit Codex PostToolUse hook. This records runtime context that should not be manually invented in generated artifacts._\n\n| Field | Value |\n|-------|-------|\n${tableRows}\n\n${PROV_END}\n`;
+  // Asterisk emphasis, not underscore — MD049 is configured to `asterisk`, and
+  // this block lands in every stamped artefact, so an underscore fails lint in
+  // each one. Mirrors the same fix in the plugin's provenance-stamp.mjs.
+  return `${PROV_START}\n\n## Build Provenance\n\n*Stamped automatically by the ArcKit Codex PostToolUse hook. This records runtime context that should not be manually invented in generated artifacts.*\n\n| Field | Value |\n|-------|-------|\n${tableRows}\n\n${PROV_END}\n`;
 }
 
 function stampProvenance(filePath, data) {

--- a/plugins/arckit-claude/hooks/provenance-stamp.mjs
+++ b/plugins/arckit-claude/hooks/provenance-stamp.mjs
@@ -237,7 +237,10 @@ function buildProvenanceBlock(fields) {
 
   rows.push(['Stamped at', timestamp]);
 
-  let body = `${PROV_START}\n\n## Build Provenance\n\n_Stamped automatically by the ArcKit plugin's \`provenance-stamp.mjs\` PostToolUse hook. Complements (does not replace) the human-authored footer above. Carries only fields the model can't authoritatively self-report: build context from \`.arckit/state.json\` and effort levels derived from command frontmatter + the silent-downgrade matrix._\n\n| Field | Value |\n|-------|-------|\n`;
+  // Emphasis uses asterisks, not underscores: MD049 is configured to
+  // `asterisk`, and this block is appended to every stamped artefact — an
+  // underscore here fails lint in each one, in user repos as well as this one.
+  let body = `${PROV_START}\n\n## Build Provenance\n\n*Stamped automatically by the ArcKit plugin's \`provenance-stamp.mjs\` PostToolUse hook. Complements (does not replace) the human-authored footer above. Carries only fields the model can't authoritatively self-report: build context from \`.arckit/state.json\` and effort levels derived from command frontmatter + the silent-downgrade matrix.*\n\n| Field | Value |\n|-------|-------|\n`;
   for (const [k, v] of rows) body += `| ${k} | ${v} |\n`;
   body += `\n${PROV_END}\n`;
   return body;

--- a/tests/plugin/provenance-emphasis.test.mjs
+++ b/tests/plugin/provenance-emphasis.test.mjs
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+// The Build Provenance block is appended to every artefact ArcKit stamps, so a
+// markdown defect in it fails lint in each one — in user repos as well as this
+// one. `.markdownlint-cli2.jsonc` sets MD049 to `asterisk`; both stamping hooks
+// emitted `_..._` and shipped that violation into every stamped artefact.
+//
+// Asserted against the source text rather than by invoking the hooks: both are
+// PostToolUse entry points that read stdin and write files, and the emphasis
+// characters are what the lint rule actually sees.
+const STAMPERS = [
+  'plugins/arckit-claude/hooks/provenance-stamp.mjs',
+  'extensions/arckit-codex/hooks/arckit-codex-hook.mjs',
+];
+
+for (const rel of STAMPERS) {
+  const src = readFileSync(resolve(rel), 'utf8');
+
+  test(`${rel}: provenance preamble opens with asterisk emphasis (MD049)`, () => {
+    assert.match(src, /\*Stamped automatically by/);
+  });
+
+  test(`${rel}: provenance preamble uses no underscore emphasis (MD049)`, () => {
+    assert.doesNotMatch(src, /_Stamped automatically by/);
+  });
+
+  test(`${rel}: the emphasis run is closed with an asterisk`, () => {
+    // Grab the emitted preamble and check it terminates on `*` before the
+    // following blank line — an unclosed run renders as a literal asterisk.
+    const m = src.match(/\*Stamped automatically by[\s\S]*?(\\n\\n\| Field)/);
+    assert.ok(m, 'could not locate the provenance preamble');
+    assert.match(m[0], /\.\*\\n\\n\| Field/, 'preamble should end `.*` before the table');
+  });
+}


### PR DESCRIPTION
Chasing the markdownlint noise in `bump-version.sh` output turned up a real product defect behind it.

## The defect

`.markdownlint-cli2.jsonc` sets MD049 to `asterisk`. Both provenance stamping hooks emitted their preamble as `_Stamped automatically by …_`.

That block is appended to **every artefact ArcKit stamps**, so every one of them carries a lint violation — in user repos as well as this one. Not repo hygiene; a shipped defect.

Fixed in both stamping sources:

| File | Note |
|---|---|
| `plugins/arckit-claude/hooks/provenance-stamp.mjs` | Propagates to the generated extensions |
| `extensions/arckit-codex/hooks/arckit-codex-hook.mjs` | Hand-maintained, has its own stamp string with the same defect — the converter cannot reach it |

`tests/plugin/provenance-emphasis.test.mjs` asserts both open and close on `*` and that no underscore form survives in either source. Verified it fails without the fix (3 pass / 3 fail) and passes with it (6 / 0).

## The noise that hid it

Two gitignored, **entirely untracked** trees were being linted on every local run — CI never sees them, since they contain zero tracked files:

- `books/` — 1,259 errors
- `docs/pitch-decks/` — confidential, gitignored

Both now excluded, matching how `docs/articles/`, `docs/plans/` and `research/` are already handled. That volume of noise is precisely what let the real defect sit unnoticed in `bump-version.sh` output.

## What is deliberately still linted

`projects/**` is gitignored in this repo too, but stays in scope. Those artefacts are ArcKit's own output, and linting them is exactly what surfaced this bug — excluding it would have hidden a user-facing defect rather than fixing it. The three local artefacts that were failing (one `CMPT`, two `CDAU`) are fixed on disk but are untracked, so they do not appear in this diff.

I earlier described those three as tracked files. They are not — they are gitignored and local-only, which is why the artefact-level fix carries no product value and the hook-level fix carries all of it.

## Verification

- `npx markdownlint-cli2 "**/*.md"` — **3502 files, 0 issues, exit 0** (was 1,264 errors)
- `node --test tests/plugin/*.test.mjs` — 135 pass, 0 fail (was 129; +6 new)
- `python -m pytest tests/` — 1220 pass, 225 skipped
- `python scripts/converter.py` run; no underscore form remains in any plugin or extension copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CC1JrMCx2esmTMdf1sH944