### PR TITLE
fix(doc-types): register GLOS and FWRK; add a doc-type registry CI gate (#712)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
       - "scripts/check-multi-instance-parity.py"
+      - "scripts/check-doc-type-registry.py"
       - "scripts/check-guide-site-links.py"
       - "scripts/check-contributor-credits.py"
       - "docs/contributors.html"
@@ -36,6 +37,7 @@ on:
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
       - "scripts/check-multi-instance-parity.py"
+      - "scripts/check-doc-type-registry.py"
       - "scripts/check-guide-site-links.py"
       - "scripts/check-contributor-credits.py"
       - "docs/contributors.html"
@@ -85,6 +87,9 @@ jobs:
 
       - name: Multi-instance doc-type parity (doc-types.mjs vs both bash copies)
         run: python3 scripts/check-multi-instance-parity.py
+
+      - name: Doc-type registry references (recipes, commands, pages.md)
+        run: python3 scripts/check-doc-type-registry.py
 
       - name: Guide site-link check (every guide reachable, no dead links)
         run: python3 scripts/check-guide-site-links.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`/arckit:glossary` could never write a conforming filename — no glossary code was registered, so the hook blocked every run.** `commands/glossary.md` instructs the model to write `ARC-{PROJECT_ID}-GLOS-v1.0.md` in eight places, but `config/doc-types.mjs` had no `GLOS` entry, so `validate-arc-filename.mjs` rejected the write as an unknown document type and no fallback name existed. Three different spellings were in use and none was registered: `GLOS` in the command, `GLO` in six `/arckit:build` recipes, `GLOSS` in a seventh. `GLOS` is now registered — it is what the command already used, and the 3-character `GLO` was an outlier against the surrounding 4-character codes — with the seven recipes converged on it. Reported by @chrismckelt against 6.7.5 (#712).
+
+  The recipe spellings were the less serious half. `output.type` keys `.arckit/state.json` and is explicitly not used for path construction, so an unregistered code there did not block a write; it produced a state key `--resume` and `--target` could not match. The write-blocking half was entirely command-side.
+
+  Recipe **scope** disagreed too: six recipes wrote `project: "000-global"` while the seventh and the command both said per-project. Settled on per-project, because all seven pass `args: "{P}"`, whereas the genuinely repo-wide targets in the same recipes (`PRIN`, `STRAT`) pass `args: ""` — the six were self-contradictory.
+
+- **`/arckit:framework` was broken the same way, via an unregistered `FWRK`.** Not reported; found by the new registry gate below on its first run. `agents/arckit-framework.md` writes `projects/{P}-{NAME}/framework/ARC-{P}-FWRK-v{VERSION}.md` in three places, and `FWRK` was absent from the registry, so every framework build was blocked at the write. `FWRK` is now registered with a `SUBDIR_MAP` entry routing it to `framework/`, and `commands/framework.md` already told the model to verify "the **FWRK** per-type checks" in a checklist that had no such section — added, along with a `GLOS` section.
+
+  The same agent also described the executive guide as `ARC-{P}-EXEC-vN.N.md` in its deliverables list while its own write step says to name it `{Project-Name}-Executive-Guide.md` and that it is deliberately *not* an `ARC-*` artefact. The deliverables list is now consistent with the write step; no `EXEC` code was registered, since the file should not carry one.
+
+- **Five further classes of recipe code drift, all silent.** Each is a code whose command writes a *different* registered code, so nothing failed loudly: `AIP` → `AIPB`, `HLD` → `HLDR`, `SBD` → `SECD`, `TRACE` → `TRAC`, and twelve invented `UAE-`-prefixed codes in `uae-federal-ai.yaml` (`UAE-CLAS`, `UAE-PDPL`, `UAE-AICH`, …) whose commands write the bare form, as its sibling `uae-agentic-transformation.yaml` already did. Two of the twelve were not simple de-prefixings and were resolved against each command's `generate-document-id.sh` call: `UAE-PRIORITIES` → `NPRA` and `UAE-PROC` → `FPRO`.
+
+### Added
+
+- **`scripts/check-doc-type-registry.py` — a CI gate asserting every doc-type reference resolves against the registry.** Three places name codes independently of `config/doc-types.mjs` and each drifted in its own way, so the gate covers all three: recipe `output.type` values; `ARC-{PID}-{CODE}-v` filenames in command and agent bodies, where an unregistered code is fatal because the PreToolUse hook blocks the write; and the `/arckit:pages` known-artifact-types table, the dual registration `doc-types.mjs` warns about in its header. It reports 161 registered codes against 398 recipe, 685 command/agent and 161 table references, and suggests the intended code where one is obvious (`'GLO' is not in DOC_TYPES (did you mean GLOS?)`).
+
+  This is the check @chrismckelt proposed on #712. He suggested `check_recipes.py`; it went into its own script instead because the drift spans commands and `pages.md` as well as recipes, following the `check-multi-instance-parity.py` precedent for cross-registry parity. It complements `check_doctype_collisions.py`, which asserts uniqueness *within* the registry rather than resolution of references *to* it. Two exemption lists keep it honest rather than over-firing: codes named only inside a negation (`uk-nhs-dcb0129.md` says the Document ID is the literal filename, "**not** an `ARC-NNN-CSCR-vX.Y` identifier"), and prose naming future work (`sobc.md` on the later `OBC`/`FBC` business-case stages). Both are documented inline with the reason.
+
+  Verified by mutation, not just by passing: reintroducing `GLO` in one recipe fails with the `GLOS` suggestion, and un-registering `GLOS` reproduces #712's exact signature of ten errors across `glossary.md` and `pages.md`.
+
 ## [6.7.5] — 2026-07-28
 
 ### Fixed

--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -607,6 +607,12 @@
                         <li>Before/after behaviour table separating the digits-in-name case from the trailing-label case</li>
                         <li>Investigation surfaced the same blind spot in <code>validate-wardley-math.mjs</code>, where it had been letting <code>evolve</code> references to undeclared components pass silently</li>
                     </ul>
+                    <p class="govuk-body-s">Also reported that no glossary doc-type code was registered in <code>config/doc-types.mjs</code>, so <code>/arckit:glossary</code> could never write a conforming filename: the <code>validate-arc-filename.mjs</code> PreToolUse hook rejected every run as an unknown document type, with no correct name available to fall back to (<a href="https://github.com/tractorjuice/arc-kit/issues/712" class="govuk-link">#712</a>, fixed in <a href="https://github.com/tractorjuice/arc-kit/pull/714" class="govuk-link">#714</a>). Documented three different spellings of the missing code across four plugins, recommended <code>GLOS</code> with the reasoning that carried, and correctly identified it as the same class of registry drift as <a href="https://github.com/tractorjuice/arc-kit/issues/545" class="govuk-link">#545</a>.</p>
+                    <ul class="app-contributor-card__highlights">
+                        <li>Four-way evidence table locating every affected recipe and command reference, plus a standalone and a <code>/arckit:build</code> reproduction</li>
+                        <li>Argued that a registry-consistency gate was worth more than fixing the individual codes; that gate then found <code>/arckit:framework</code> broken the same way via an unregistered <code>FWRK</code>, which nobody had reported</li>
+                        <li>Flagged the unresolved question of whether a glossary is per-project or repo-wide, which the fix settled as per-project</li>
+                    </ul>
                 </div>
 
                 <div class="app-contributor-card">

--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-au/recipes/au-federal.yaml
+++ b/plugins/arckit-au/recipes/au-federal.yaml
@@ -137,7 +137,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-ca/recipes/ca-federal-fitaa.yaml
+++ b/plugins/arckit-ca/recipes/ca-federal-fitaa.yaml
@@ -120,7 +120,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`/arckit:glossary` could never write a conforming filename.** `commands/glossary.md` writes `ARC-{PROJECT_ID}-GLOS-v1.0.md` in eight places, but `config/doc-types.mjs` had no `GLOS` entry, so the `validate-arc-filename.mjs` PreToolUse hook blocked every run as an unknown document type — with no correct name to fall back to. In practice the model either failed the write or invented a non-conforming name, producing an artefact that `/arckit:health`, `/arckit:graph-report`, `/arckit:traceability`, `/arckit:search` and the `docs/manifest.json` indexing could all not see. `GLOS` is now registered, and the `/arckit:build` recipes that carried `GLO` or `GLOSS` are converged on it. Reported by @chrismckelt against 6.7.5 (#712).
+
+- **`/arckit:framework` was blocked identically, via an unregistered `FWRK`.** `agents/arckit-framework.md` writes `framework/ARC-{P}-FWRK-v{VERSION}.md`; `FWRK` is now registered with a `SUBDIR_MAP` entry routing it to `framework/`. The agent's deliverables list also described the executive guide as an `ARC-*-EXEC-*` artefact, contradicting its own write step, which names it `{Project-Name}-Executive-Guide.md` and states it is deliberately not governed — the list now matches the write step.
+
+- **`quality-checklist.md` gained the `GLOS` and `FWRK` per-type sections.** `commands/framework.md` already instructed the model to verify "the **FWRK** per-type checks", which did not exist; `commands/glossary.md` now points at the `GLOS` checks in the same way the other commands do.
+
+- **Recipe doc-type drift corrected where a code resolved to the wrong type.** `AIP` → `AIPB`, `HLD` → `HLDR`, `SBD` → `SECD`, `TRACE` → `TRAC`, and the twelve `UAE-`-prefixed codes in `uae-federal-ai.yaml` reduced to the bare codes its commands actually write (including `UAE-PRIORITIES` → `NPRA` and `UAE-PROC` → `FPRO`, which were not simple de-prefixings). `output.type` keys `.arckit/state.json`, so these were silent: they broke `--resume` and `--target` matching rather than the write.
+
+The registry now holds 161 doc-type codes, up from 159.
+
 ## [6.7.5] — 2026-07-28
 
 ### Fixed

--- a/plugins/arckit-claude/agents/arckit-framework.md
+++ b/plugins/arckit-claude/agents/arckit-framework.md
@@ -40,7 +40,7 @@ Given a project's existing artefacts under `projects/{P}-{NAME}/`, you deliver:
 
 1. **Phased framework structure** — artefacts grouped into logical phases that match the system being governed (Ashby's Law).
 2. **Framework overview** — `projects/{P}-{NAME}/framework/ARC-{P}-FWRK-vN.N.md` with the phased index and Document Map.
-3. **Executive guide** — `projects/{P}-{NAME}/framework/ARC-{P}-EXEC-vN.N.md` summarising the framework for senior stakeholders.
+3. **Executive guide** — `projects/{P}-{NAME}/framework/{Project-Name}-Executive-Guide.md` summarising the framework for senior stakeholders. Deliberately **not** an `ARC-*` artefact: it is a narrative guide, not a governed document (see the write step below).
 4. **Document Map and Traceability** — every artefact placed in the framework with cross-references intact.
 5. **Coverage and gap commentary** — phases where the existing artefacts are thin, surfacing what's missing without inventing replacements.
 

--- a/plugins/arckit-claude/commands/glossary.md
+++ b/plugins/arckit-claude/commands/glossary.md
@@ -110,7 +110,7 @@ Generate Document ID: `ARC-{PROJECT_ID}-GLOS-v1.0` (for filename: `ARC-{PROJECT_
 
 ### 6. Quality Check
 
-Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** pass. Fix any failures before proceeding.
+Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GLOS** per-type checks pass. Fix any failures before proceeding.
 
 ### 7. Write the Glossary File
 

--- a/plugins/arckit-claude/commands/pages.md
+++ b/plugins/arckit-claude/commands/pages.md
@@ -237,6 +237,8 @@ Only include these known artifact types. Match by type code pattern `ARC-{PID}-{
 | | CONF | `ARC-*-CONF-*.md` | Conformance Assessment |
 | | GAPS | `ARC-*-GAPS-*.md` | Gap Analysis |
 | | CDAU | `ARC-*-CDAU-*.md` | Codebase Audit |
+| | GLOS | `ARC-*-GLOS-*.md` | Glossary |
+| | FWRK | `ARC-*-FWRK-*.md` | Framework Overview |
 | **Governance (Community-contributed — TOGAF ADM Overlay)** | | | |
 | | GAPA | `ARC-*-GAPA-*.md` | TOGAF Gap Analysis |
 | | BORD | `ARC-*-BORD-*.md` | Architecture Board Charter |

--- a/plugins/arckit-claude/config/doc-types.mjs
+++ b/plugins/arckit-claude/config/doc-types.mjs
@@ -10,6 +10,11 @@
  * there, generated artifacts are silently omitted from the rendered
  * dashboard sidebar even though the manifest hook records them correctly.
  * See PR #317 for context — long term the two registries should be unified.
+ * scripts/check-doc-type-registry.py enforces this parity in CI, along with
+ * every code referenced by a recipe `output.type` or an `ARC-*-CODE-v`
+ * filename in a command or agent body. A code missing from THIS file but
+ * written by a command is fatal: validate-arc-filename.mjs blocks the write
+ * and the command has no conforming name to fall back to (#712).
  *
  * ⚠️ MULTI_INSTANCE_TYPES IS DUPLICATED IN BASH — keep both in sync.
  * generate-document-id.sh carries its own space-separated MULTI_INSTANCE_TYPES
@@ -98,6 +103,8 @@ export const DOC_TYPES = {
   'ANAL':      { name: 'Analysis Report',                  category: 'Governance' },
   'GAPS':      { name: 'Gap Analysis',                     category: 'Governance' },
   'CDAU':      { name: 'Codebase Audit',                   category: 'Governance' },
+  'GLOS':      { name: 'Glossary',                         category: 'Governance' },
+  'FWRK':      { name: 'Framework Overview',               category: 'Governance' },
   // Compliance — UK Gov + MOD officially-maintained
   'TCOP':      { name: 'TCoP Assessment',                  category: 'Compliance', regime: 'UK',  severity: 'HIGH' },
   'SECD':      { name: 'Secure by Design',                 category: 'Compliance',                severity: 'HIGH' },
@@ -303,6 +310,7 @@ export const SUBDIR_MAP = {
   'GLND': 'research',
   'GRNT': 'research',
   'CDAU': 'audits',
+  'FWRK': 'framework',
 };
 
 // Derived: set of all valid type codes

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/au/recipes/au-federal.yaml
+++ b/plugins/arckit-claude/plugins/au/recipes/au-federal.yaml
@@ -137,7 +137,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/ca/recipes/ca-federal-fitaa.yaml
+++ b/plugins/arckit-claude/plugins/ca/recipes/ca-federal-fitaa.yaml
@@ -120,7 +120,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/uae/recipes/uae-agentic-transformation.yaml
+++ b/plugins/arckit-claude/plugins/uae/recipes/uae-agentic-transformation.yaml
@@ -102,7 +102,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ
@@ -281,7 +281,7 @@ targets:
   - id: HLD
     skill: arckit:hld-review
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: HLD }
+    output: { project: "{P}-{NAME}", type: HLDR }
     deps: [REQ, "ADR-*", PRIN]
 
   - id: SOBC
@@ -299,7 +299,7 @@ targets:
   - id: SBD
     skill: arckit:secure
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: SBD }
+    output: { project: "{P}-{NAME}", type: SECD }
     deps: [TCOP, RISK, REQ, "ADR-*"]
 
   - id: DPIA
@@ -324,7 +324,7 @@ targets:
   - id: AIP
     skill: arckit:ai-playbook
     args: "{P} ai-mode=auto-detect-from-REQ-FRs"
-    output: { project: "{P}-{NAME}", type: AIP }
+    output: { project: "{P}-{NAME}", type: AIPB }
     deps: [DPIA, RISK, REQ, ADR-005, UAE_AI_CHARTER]
 
   - id: ATRS
@@ -412,7 +412,7 @@ targets:
   - id: TRACE
     skill: arckit:traceability
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: TRACE }
+    output: { project: "{P}-{NAME}", type: TRAC }
     deps:
       [REQ, STKE, "ADR-*", RISK, HLD, DPIA, SBD, TCOP,
        PLAN, ROADMAP, AIP, ATRS, DEVOPS, FINOPS, OPS,

--- a/plugins/arckit-claude/plugins/uae/recipes/uae-federal-ai.yaml
+++ b/plugins/arckit-claude/plugins/uae/recipes/uae-federal-ai.yaml
@@ -96,7 +96,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ
@@ -115,7 +115,7 @@ targets:
   - id: UAE_PRIORITIES
     skill: arckit:uae-priorities-alignment
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PRIORITIES }
+    output: { project: "{P}-{NAME}", type: NPRA }
     deps: [PRIN, REQ]
 
   # --- Research wave (parallel, before ADRs) -----------------------------
@@ -162,32 +162,32 @@ targets:
   - id: UAE_CLASSIFICATION
     skill: arckit:uae-classification
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-CLAS }
+    output: { project: "{P}-{NAME}", type: CLAS }
     deps: [REQ, UAE_PRIORITIES]
 
   - id: UAE_PDPL
     skill: arckit:uae-pdpl
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PDPL }
+    output: { project: "{P}-{NAME}", type: PDPL }
     deps: [REQ, UAE_CLASSIFICATION]
 
   - id: UAE_DATA_SHARING
     skill: arckit:uae-data-sharing
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-DSHARE }
+    output: { project: "{P}-{NAME}", type: DSHR }
     deps: [UAE_CLASSIFICATION, UAE_PDPL]
 
   - id: UAE_DIGITAL_RECORDS
     skill: arckit:uae-digital-records
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-DREC }
+    output: { project: "{P}-{NAME}", type: DREC }
     deps: [REQ, UAE_CLASSIFICATION]
 
   # --- Cloud residency + identity ----------------------------------------
   - id: UAE_CLOUD_RESIDENCY
     skill: arckit:uae-cloud-residency
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-CRES }
+    output: { project: "{P}-{NAME}", type: CRES }
     # Cloud residency depends on the research wave (which CSP options exist)
     # plus classification (per-tier residency rules)
     deps: [UAE_CLASSIFICATION, AWS_RESEARCH, AZURE_RESEARCH]
@@ -195,7 +195,7 @@ targets:
   - id: UAE_UAEPASS
     skill: arckit:uae-uaepass
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PASS }
+    output: { project: "{P}-{NAME}", type: UPASS }
     deps: [REQ, UAE_PRIORITIES]
 
   # --- ADRs (UAE-themed, deps include research + classification) ---------
@@ -278,7 +278,7 @@ targets:
   - id: HLD
     skill: arckit:hld-review
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: HLD }
+    output: { project: "{P}-{NAME}", type: HLDR }
     deps: [REQ, "ADR-*", PRIN]
 
   - id: SOBC
@@ -296,7 +296,7 @@ targets:
   - id: SBD
     skill: arckit:secure
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: SBD }
+    output: { project: "{P}-{NAME}", type: SECD }
     deps: [TCOP, RISK, REQ, "ADR-*"]
 
   - id: DPIA
@@ -311,19 +311,19 @@ targets:
   - id: UAE_AI_CHARTER
     skill: arckit:uae-ai-charter
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-AICH }
+    output: { project: "{P}-{NAME}", type: AICH }
     deps: [REQ, "ADR-*", RISK, UAE_PRIORITIES]
 
   - id: UAE_AI_AUTONOMY
     skill: arckit:uae-ai-autonomy-tier
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-AUTI }
+    output: { project: "{P}-{NAME}", type: AUTI }
     deps: [REQ, RISK, UAE_AI_CHARTER]
 
   - id: AIP
     skill: arckit:ai-playbook
     args: "{P} ai-mode=auto-detect-from-REQ-FRs"
-    output: { project: "{P}-{NAME}", type: AIP }
+    output: { project: "{P}-{NAME}", type: AIPB }
     deps: [DPIA, RISK, REQ, ADR-004, UAE_AI_CHARTER]
 
   - id: ATRS
@@ -336,7 +336,7 @@ targets:
   - id: UAE_IAS
     skill: arckit:uae-ias
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-IAS }
+    output: { project: "{P}-{NAME}", type: IAS }
     deps: [REQ, "ADR-*", RISK, SBD]
 
   # --- Diagrams ----------------------------------------------------------
@@ -396,20 +396,20 @@ targets:
   - id: UAE_PROCUREMENT
     skill: arckit:uae-procurement
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PROC }
+    output: { project: "{P}-{NAME}", type: FPRO }
     deps: [STRATEGY, RISK, "ADR-*", UAE_PRIORITIES, ADR-007]
 
   - id: UAE_ZERO_BUREAUCRACY
     skill: arckit:uae-zero-bureaucracy
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-ZBUR }
+    output: { project: "{P}-{NAME}", type: ZBUR }
     deps: [REQ, STKE, OPS, UAE_UAEPASS]
 
   # --- Cross-cutting last -----------------------------------------------
   - id: TRACE
     skill: arckit:traceability
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: TRACE }
+    output: { project: "{P}-{NAME}", type: TRAC }
     deps:
       [REQ, STKE, "ADR-*", RISK, HLD, DPIA, SBD, TCOP,
        PLAN, ROADMAP, AIP, ATRS, DEVOPS, FINOPS, OPS,

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-claude/skills/arckit-build/recipes/uk-mod-sovereign.yaml
+++ b/plugins/arckit-claude/skills/arckit-build/recipes/uk-mod-sovereign.yaml
@@ -87,7 +87,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-claude/skills/arckit-build/recipes/uk-nhs-clinical-safety.yaml
+++ b/plugins/arckit-claude/skills/arckit-build/recipes/uk-nhs-clinical-safety.yaml
@@ -81,7 +81,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: GLOSS }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-claude/skills/arckit-build/recipes/uk-saas.yaml
+++ b/plugins/arckit-claude/skills/arckit-build/recipes/uk-saas.yaml
@@ -98,7 +98,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-uae/recipes/uae-agentic-transformation.yaml
+++ b/plugins/arckit-uae/recipes/uae-agentic-transformation.yaml
@@ -102,7 +102,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ
@@ -281,7 +281,7 @@ targets:
   - id: HLD
     skill: arckit:hld-review
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: HLD }
+    output: { project: "{P}-{NAME}", type: HLDR }
     deps: [REQ, "ADR-*", PRIN]
 
   - id: SOBC
@@ -299,7 +299,7 @@ targets:
   - id: SBD
     skill: arckit:secure
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: SBD }
+    output: { project: "{P}-{NAME}", type: SECD }
     deps: [TCOP, RISK, REQ, "ADR-*"]
 
   - id: DPIA
@@ -324,7 +324,7 @@ targets:
   - id: AIP
     skill: arckit:ai-playbook
     args: "{P} ai-mode=auto-detect-from-REQ-FRs"
-    output: { project: "{P}-{NAME}", type: AIP }
+    output: { project: "{P}-{NAME}", type: AIPB }
     deps: [DPIA, RISK, REQ, ADR-005, UAE_AI_CHARTER]
 
   - id: ATRS
@@ -412,7 +412,7 @@ targets:
   - id: TRACE
     skill: arckit:traceability
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: TRACE }
+    output: { project: "{P}-{NAME}", type: TRAC }
     deps:
       [REQ, STKE, "ADR-*", RISK, HLD, DPIA, SBD, TCOP,
        PLAN, ROADMAP, AIP, ATRS, DEVOPS, FINOPS, OPS,

--- a/plugins/arckit-uae/recipes/uae-federal-ai.yaml
+++ b/plugins/arckit-uae/recipes/uae-federal-ai.yaml
@@ -96,7 +96,7 @@ targets:
   - id: GLOSSARY
     skill: arckit:glossary
     args: "{P}"
-    output: { project: "000-global", type: GLO }
+    output: { project: "{P}-{NAME}", type: GLOS }
     deps: [PRIN]
 
   - id: REQ
@@ -115,7 +115,7 @@ targets:
   - id: UAE_PRIORITIES
     skill: arckit:uae-priorities-alignment
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PRIORITIES }
+    output: { project: "{P}-{NAME}", type: NPRA }
     deps: [PRIN, REQ]
 
   # --- Research wave (parallel, before ADRs) -----------------------------
@@ -162,32 +162,32 @@ targets:
   - id: UAE_CLASSIFICATION
     skill: arckit:uae-classification
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-CLAS }
+    output: { project: "{P}-{NAME}", type: CLAS }
     deps: [REQ, UAE_PRIORITIES]
 
   - id: UAE_PDPL
     skill: arckit:uae-pdpl
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PDPL }
+    output: { project: "{P}-{NAME}", type: PDPL }
     deps: [REQ, UAE_CLASSIFICATION]
 
   - id: UAE_DATA_SHARING
     skill: arckit:uae-data-sharing
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-DSHARE }
+    output: { project: "{P}-{NAME}", type: DSHR }
     deps: [UAE_CLASSIFICATION, UAE_PDPL]
 
   - id: UAE_DIGITAL_RECORDS
     skill: arckit:uae-digital-records
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-DREC }
+    output: { project: "{P}-{NAME}", type: DREC }
     deps: [REQ, UAE_CLASSIFICATION]
 
   # --- Cloud residency + identity ----------------------------------------
   - id: UAE_CLOUD_RESIDENCY
     skill: arckit:uae-cloud-residency
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-CRES }
+    output: { project: "{P}-{NAME}", type: CRES }
     # Cloud residency depends on the research wave (which CSP options exist)
     # plus classification (per-tier residency rules)
     deps: [UAE_CLASSIFICATION, AWS_RESEARCH, AZURE_RESEARCH]
@@ -195,7 +195,7 @@ targets:
   - id: UAE_UAEPASS
     skill: arckit:uae-uaepass
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PASS }
+    output: { project: "{P}-{NAME}", type: UPASS }
     deps: [REQ, UAE_PRIORITIES]
 
   # --- ADRs (UAE-themed, deps include research + classification) ---------
@@ -278,7 +278,7 @@ targets:
   - id: HLD
     skill: arckit:hld-review
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: HLD }
+    output: { project: "{P}-{NAME}", type: HLDR }
     deps: [REQ, "ADR-*", PRIN]
 
   - id: SOBC
@@ -296,7 +296,7 @@ targets:
   - id: SBD
     skill: arckit:secure
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: SBD }
+    output: { project: "{P}-{NAME}", type: SECD }
     deps: [TCOP, RISK, REQ, "ADR-*"]
 
   - id: DPIA
@@ -311,19 +311,19 @@ targets:
   - id: UAE_AI_CHARTER
     skill: arckit:uae-ai-charter
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-AICH }
+    output: { project: "{P}-{NAME}", type: AICH }
     deps: [REQ, "ADR-*", RISK, UAE_PRIORITIES]
 
   - id: UAE_AI_AUTONOMY
     skill: arckit:uae-ai-autonomy-tier
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-AUTI }
+    output: { project: "{P}-{NAME}", type: AUTI }
     deps: [REQ, RISK, UAE_AI_CHARTER]
 
   - id: AIP
     skill: arckit:ai-playbook
     args: "{P} ai-mode=auto-detect-from-REQ-FRs"
-    output: { project: "{P}-{NAME}", type: AIP }
+    output: { project: "{P}-{NAME}", type: AIPB }
     deps: [DPIA, RISK, REQ, ADR-004, UAE_AI_CHARTER]
 
   - id: ATRS
@@ -336,7 +336,7 @@ targets:
   - id: UAE_IAS
     skill: arckit:uae-ias
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-IAS }
+    output: { project: "{P}-{NAME}", type: IAS }
     deps: [REQ, "ADR-*", RISK, SBD]
 
   # --- Diagrams ----------------------------------------------------------
@@ -396,20 +396,20 @@ targets:
   - id: UAE_PROCUREMENT
     skill: arckit:uae-procurement
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-PROC }
+    output: { project: "{P}-{NAME}", type: FPRO }
     deps: [STRATEGY, RISK, "ADR-*", UAE_PRIORITIES, ADR-007]
 
   - id: UAE_ZERO_BUREAUCRACY
     skill: arckit:uae-zero-bureaucracy
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: UAE-ZBUR }
+    output: { project: "{P}-{NAME}", type: ZBUR }
     deps: [REQ, STKE, OPS, UAE_UAEPASS]
 
   # --- Cross-cutting last -----------------------------------------------
   - id: TRACE
     skill: arckit:traceability
     args: "{P}"
-    output: { project: "{P}-{NAME}", type: TRACE }
+    output: { project: "{P}-{NAME}", type: TRAC }
     deps:
       [REQ, STKE, "ADR-*", RISK, HLD, DPIA, SBD, TCOP,
        PLAN, ROADMAP, AIP, ATRS, DEVOPS, FINOPS, OPS,

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -146,6 +146,22 @@ All artifacts must pass these 10 checks:
 - Coverage percentages calculated per requirement type
 - Gaps identified with severity and recommended actions
 
+### GLOS -- Glossary
+
+- Terms and acronyms drawn from the project's existing artefacts, not invented
+- Each entry has a definition written for the intended audience, not a circular restatement
+- Acronyms expanded on first use and listed separately from general terms
+- Entries sorted so a reader can find a term without searching
+- Source artefact cited for any term whose meaning is project-specific rather than industry-standard
+
+### FWRK -- Framework Overview
+
+- Every artefact in the project appears exactly once in the Document Map
+- Phases reflect the system being governed, not a generic lifecycle
+- Coverage and gap commentary names thin phases explicitly instead of implying completeness
+- Cross-references between artefacts preserved and resolvable
+- Executive guide written as narrative, and deliberately not an `ARC-*` governed artefact
+
 ### BKLG -- Product Backlog
 
 - User stories follow "As a... I want... So that..." format

--- a/scripts/check-doc-type-registry.py
+++ b/scripts/check-doc-type-registry.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+"""Assert every doc-type code referenced anywhere resolves against the registry.
+
+`plugins/arckit-claude/config/doc-types.mjs` is the single source of truth for
+doc-type codes. Three other places name codes independently, and each drifts
+silently in its own way:
+
+  1. Recipe `output.type` values (`plugins/arckit-*/recipes/*.yaml` and
+     `plugins/arckit-claude/skills/arckit-build/recipes/*.yaml`).
+     `output.type` keys `.arckit/state.json`, so an unregistered code does not
+     block a write -- it produces a state key that `--resume` and `--target`
+     cannot match, and a build target that cannot be validated.
+
+  2. `ARC-{PID}-{CODE}-v` filenames written by commands and agents
+     (`plugins/*/commands/*.md`, `plugins/*/agents/*.md`).
+     This one is fatal: `validate-arc-filename.mjs` is a PreToolUse hook that
+     BLOCKS any write whose code is not in KNOWN_TYPES, and the command has no
+     conforming name to fall back to. The command is simply unusable.
+
+  3. The `/arckit:pages` known-artifact-types table inside
+     `plugins/arckit-claude/commands/pages.md` -- the dual registration that
+     doc-types.mjs's header warns about. A code missing there is omitted from
+     the rendered dashboard sidebar even though the manifest records it.
+
+This gate exists because that drift shipped. #712 found `/arckit:glossary`
+writing `ARC-{P}-GLOS-v1.0.md` with no `GLOS` in the registry, so every run was
+blocked by the hook, plus three different spellings of the same missing code
+(`GLOS`, `GLO`, `GLOSS`) across seven recipes in four plugins. `/arckit:framework`
+was broken the same way via an unregistered `FWRK`. #545 was the same class of
+bug one registry over (`regime: 'US'` missing from `REGIMES`).
+
+Exit 0 when every reference resolves, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import glob
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+MJS = ROOT / "plugins/arckit-claude/config/doc-types.mjs"
+PAGES = ROOT / "plugins/arckit-claude/commands/pages.md"
+
+# Recipe target `output.type` values that deliberately name no registered
+# doc-type. These targets invoke commands that write filenames outside the
+# ARC-* convention entirely, so there is nothing to register; the value is an
+# informational state.json key only. Keep this list short and justified -- an
+# entry here silences a real gate.
+NOT_A_DOC_TYPE = {
+    # uk-nhs-clinical-safety.yaml: the DCB0129/DCB0160 commands write
+    # Marcus-conventioned filenames under clinical-safety/, which carry no
+    # ARC- prefix and therefore no doc-type code. The recipe says so inline.
+    "NHSCSCR",
+    "NHSDCSC",
+}
+
+# Tokens that occupy the code position in an `ARC-...-{X}-v` pattern but are
+# placeholders or prose, not doc-type codes.
+NOT_A_CODE_IN_PROSE = {
+    # Multi-instance sequence placeholder: ARC-{P}-GRNT-NN-vN.N.md
+    "NN",
+    "NNN",
+    # sobc.md names the later Green Book business-case stages as future work:
+    # "Later stages will be: ARC-{PID}-OBC-v*.md, ARC-{PID}-FBC-v*.md".
+    # Neither command exists yet, so neither code is registered.
+    "OBC",
+    "FBC",
+    # uk-nhs-dcb0129.md / uk-nhs-dcb0160.md mention these codes only inside a
+    # negation: the DCB Document ID "should be the literal filename ... NOT an
+    # ARC-NNN-CSCR-vX.Y identifier". The Marcus convention is deliberate, so
+    # there is nothing to register.
+    "CSCR",
+    "DSCR",
+}
+
+errors: list[str] = []
+
+
+def load_registry() -> tuple[set[str], set[str]]:
+    """Return (DOC_TYPES keys, SUBDIR_MAP keys) parsed from doc-types.mjs.
+
+    Regex rather than a node subprocess: this must run in CI without assuming a
+    node toolchain, and the file is a flat object literal.
+    """
+    text = MJS.read_text()
+
+    def block(export_name: str, open_char: str, close_char: str) -> str:
+        start = text.index(f"export const {export_name} = ")
+        depth = 0
+        for i in range(start, len(text)):
+            if text[i] == open_char:
+                depth += 1
+            elif text[i] == close_char:
+                depth -= 1
+                if depth == 0:
+                    return text[start : i + 1]
+        raise ValueError(f"unterminated {export_name} block in {MJS}")
+
+    doc_types = set(re.findall(r"^\s*'([A-Z0-9-]+)':\s*\{", block("DOC_TYPES", "{", "}"), re.M))
+    subdirs = set(re.findall(r"^\s*([A-Z0-9-]+):\s*'", block("SUBDIR_MAP", "{", "}"), re.M))
+    return doc_types, subdirs
+
+
+def recipe_paths() -> list[str]:
+    return sorted(
+        glob.glob(str(ROOT / "plugins/arckit-*/recipes/*.yaml"))
+        + glob.glob(str(ROOT / "plugins/arckit-claude/skills/arckit-build/recipes/*.yaml"))
+    )
+
+
+def check_recipe_types(known: set[str]) -> int:
+    """Every `output.type` in every recipe resolves, or is declared exempt."""
+    checked = 0
+    # Match the code inside an inline `output: { ... type: CODE ... }` mapping
+    # as well as a block-style `type: CODE` nested under `output:`.
+    pat = re.compile(r"\btype:\s*([A-Za-z0-9][A-Za-z0-9-]*)")
+    for path in recipe_paths():
+        rel = Path(path).relative_to(ROOT)
+        for lineno, line in enumerate(Path(path).read_text().splitlines(), 1):
+            if "output:" not in line and "type:" not in line:
+                continue
+            # Only consider type: values that sit on an output mapping line.
+            if "output:" not in line:
+                continue
+            m = pat.search(line)
+            if not m:
+                continue
+            code = m.group(1)
+            checked += 1
+            if code in known or code in NOT_A_DOC_TYPE:
+                continue
+            hint = suggest(code, known)
+            errors.append(
+                f"{rel}:{lineno}: recipe output.type {code!r} is not in DOC_TYPES{hint}"
+            )
+    return checked
+
+
+def check_command_codes(known: set[str]) -> int:
+    """Every ARC-*-CODE-v filename in a command or agent body resolves.
+
+    Unregistered codes here are fatal at runtime: validate-arc-filename.mjs
+    blocks the write outright.
+    """
+    checked = 0
+    # ARC-<pid-or-placeholder>-<CODE>-v...  CODE may be compound (PRIN-COMP).
+    pat = re.compile(r"ARC-[A-Za-z0-9{}\[\]_-]*?-([A-Z][A-Z0-9]*(?:-[A-Z][A-Z0-9]*)*)-v")
+    sources = sorted(
+        glob.glob(str(ROOT / "plugins/*/commands/*.md"))
+        + glob.glob(str(ROOT / "plugins/*/agents/*.md"))
+    )
+    for path in sources:
+        rel = Path(path).relative_to(ROOT)
+        for lineno, line in enumerate(Path(path).read_text().splitlines(), 1):
+            # A line may name the same code twice ("`ARC-001-GLOS-v1.0` (for
+            # filename: `ARC-001-GLOS-v1.0.md`)"); report it once.
+            for code in dict.fromkeys(pat.findall(line)):
+                # A compound match may be a registered compound code, or a
+                # registered simple code followed by a placeholder segment.
+                if code in known or code in NOT_A_CODE_IN_PROSE:
+                    checked += 1
+                    continue
+                head = code.rsplit("-", 1)
+                if len(head) == 2 and head[0] in known and head[1] in NOT_A_CODE_IN_PROSE:
+                    checked += 1
+                    continue
+                checked += 1
+                hint = suggest(code, known)
+                errors.append(
+                    f"{rel}:{lineno}: writes ARC-*-{code}-v* but {code!r} is not in "
+                    f"DOC_TYPES -- validate-arc-filename.mjs will BLOCK this write{hint}"
+                )
+    return checked
+
+
+def check_pages_parity(known: set[str]) -> int:
+    """The /arckit:pages known-types table must list exactly the registry."""
+    rows = set(
+        re.findall(r"^\|\s*\|\s*([A-Z][A-Z0-9-]*)\s*\|\s*`ARC-", PAGES.read_text(), re.M)
+    )
+    rel = PAGES.relative_to(ROOT)
+    for code in sorted(known - rows):
+        errors.append(
+            f"{rel}: DOC_TYPES has {code!r} but the known-artifact-types table does "
+            f"not -- /arckit:pages will omit it from the dashboard sidebar"
+        )
+    for code in sorted(rows - known):
+        errors.append(
+            f"{rel}: known-artifact-types table lists {code!r}, which is not in DOC_TYPES"
+        )
+    return len(rows)
+
+
+def suggest(code: str, known: set[str]) -> str:
+    """Point at the most likely intended code, when one is obvious."""
+    candidates = [k for k in known if k.startswith(code) or code.startswith(k)]
+    if not candidates:
+        return ""
+    return f" (did you mean {' or '.join(sorted(candidates))}?)"
+
+
+def main() -> int:
+    known, _subdirs = load_registry()
+    n_recipe = check_recipe_types(known)
+    n_cmd = check_command_codes(known)
+    n_pages = check_pages_parity(known)
+
+    if errors:
+        print(f"FAIL: {len(errors)} doc-type registry error(s):", file=sys.stderr)
+        for e in errors:
+            print(f"  {e}", file=sys.stderr)
+        print(
+            "\nFix by registering the code in "
+            "plugins/arckit-claude/config/doc-types.mjs AND adding a row to the "
+            "known-artifact-types table in plugins/arckit-claude/commands/pages.md, "
+            "or by correcting the reference to an existing code.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Doc-type registry OK: {len(known)} registered codes; "
+        f"{n_recipe} recipe output.type, {n_cmd} command/agent filename, "
+        f"{n_pages} pages.md table reference(s) all resolve."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Fixes #712.

## The reported bug

`/arckit:glossary` could never write a conforming filename. `commands/glossary.md` instructs the model to write `ARC-{PROJECT_ID}-GLOS-v1.0.md` in eight places, but `config/doc-types.mjs` had no `GLOS` entry, so `validate-arc-filename.mjs` blocked every run as an unknown document type — with no correct name to fall back to. Three spellings were in use and none was registered: `GLOS` in the command, `GLO` in six recipes, `GLOSS` in a seventh.

Registered `GLOS` (what the command already used; `GLO` was a 3-character outlier against the surrounding 4-character codes) and converged all seven recipes on it.

**Scope**, which @chrismckelt flagged as undecided, is settled as **per-project**. Six recipes said `project: "000-global"` while the seventh and the command said per-project — but all seven pass `args: "{P}"`, whereas the genuinely repo-wide targets in the same recipes (`PRIN`, `STRAT`) pass `args: ""`. The six were self-contradictory, so this is a correction rather than a preference.

One correction to the report: the recipe spellings were the less serious half. `output.type` keys `.arckit/state.json` and is explicitly not used for path construction, so an unregistered code there did not block a write — it produced a state key `--resume`/`--target` could not match. The write-blocking half was entirely command-side.

## What the new gate found that wasn't reported

**`/arckit:framework` was broken identically.** `agents/arckit-framework.md` writes `framework/ARC-{P}-FWRK-v{VERSION}.md` in three places and `FWRK` was unregistered, so every framework build was blocked at the write. Registered with a `SUBDIR_MAP` entry routing it to `framework/`.

That agent also listed the executive guide as `ARC-{P}-EXEC-vN.N.md` while its own write step names it `{Project-Name}-Executive-Guide.md` and states it is deliberately *not* a governed artefact. The deliverables list now matches the write step; no `EXEC` code is registered, since the file shouldn't carry one.

**Five classes of silent drift** where the code resolved but to the *wrong* type, so nothing failed loudly: `AIP`→`AIPB`, `HLD`→`HLDR`, `SBD`→`SECD`, `TRACE`→`TRAC`, and twelve invented `UAE-` prefixes in `uae-federal-ai.yaml` reduced to the bare codes its commands write, as its sibling recipe already did. Two weren't simple de-prefixings and were resolved against each command's `generate-document-id.sh` call: `UAE-PRIORITIES`→`NPRA`, `UAE-PROC`→`FPRO`.

## The gate

`scripts/check-doc-type-registry.py`, wired into `lint-markdown.yml`. Three places name codes independently of the registry and each had drifted, so it covers all three:

- recipe `output.type` values
- `ARC-{PID}-{CODE}-v` filenames in command and agent bodies, where an unregistered code is fatal
- the `/arckit:pages` known-artifact-types table — the dual registration `doc-types.mjs` warns about in its header, now enforced rather than just documented

@chrismckelt suggested folding this into `check_recipes.py`. It's a separate script because the drift spans commands and `pages.md` as well as recipes, following the `check-multi-instance-parity.py` precedent for cross-registry parity. It complements `check_doctype_collisions.py`, which asserts uniqueness *within* the registry rather than resolution of references *to* it.

Two documented exemption lists keep it from over-firing, both verified as genuine false positives:

- codes appearing only inside a **negation** — `uk-nhs-dcb0129.md` says the Document ID is the literal filename, "**not** an `ARC-NNN-CSCR-vX.Y` identifier"
- prose naming **future work** — `sobc.md` on the later `OBC`/`FBC` business-case stages

Compound codes (`PRIN-COMP`, `SECD-MOD`) and the multi-instance `-NN-` placeholder are handled, so a naive last-segment match doesn't produce phantom `COMP`/`MOD` failures.

## Verification

Verified by mutation, not just by passing:

- reintroducing `GLO` in one recipe fails with `'GLO' is not in DOC_TYPES (did you mean GLOS?)`
- un-registering `GLOS` reproduces #712's exact signature: ten errors across `glossary.md` and `pages.md`
- driving `validate-arc-filename.mjs` directly: `ARC-001-GLOS-v1.0.md` is **blocked** with the reported message before the change and **accepted** after; `ARC-001-FWRK-v1.0.md` written to the project root is auto-routed into `framework/`; a bogus `ARC-001-NOPE-v1.0.md` is still blocked, so the guard isn't weakened

All green: 1,220 tests pass (225 skipped), `markdownlint` clean over 3,502 files, and `check-doc-type-registry`, `check_recipes`, `check_doctype_collisions`, `check-multi-instance-parity`, `check_references`, `check-guide-parity`, `check-guide-site-links` all pass. Converter regenerated; shared assets and the Claude standalone mirror both in sync.

Registry goes from 159 to 161 codes. Also added the missing `GLOS` and `FWRK` sections to `quality-checklist.md` — `framework.md` already told the model to verify "the **FWRK** per-type checks", which did not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fn6shRoNVcztoUYrDe7cvT