### PR TITLE
fix(ci): run the full Python test suite, unfiltered (#719)

### DIFF
--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -1,0 +1,51 @@
+name: Python Tests
+
+# Deliberately NOT path-filtered.
+#
+# Every other workflow in this repo gates on `paths:`, and that is what left
+# the Python suites ungated: `codex-plugin.yml` ran 52 of 1,445 collected tests
+# and `lint-markdown.yml` covered only the `.mjs` suites, so a failing Python
+# test showed green indefinitely (#719). A path filter on a test job
+# reintroduces exactly that class of gap — a PR is skipped by virtue of which
+# files it happens to touch, which is also how #718 broke `npm ci` for every
+# subsequent PR.
+#
+# The full suite runs in well under 30s, so there is nothing to buy by
+# filtering it.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  pytest:
+    name: Full Python suite
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # The suite's only third-party imports are pytest and yaml. `-e .` is
+      # needed because several suites import from `src/arckit_cli/`.
+      - name: Install test dependencies
+        run: python -m pip install -e . pytest pyyaml
+
+      # The generated content under extensions/** is gitignored (see .gitignore
+      # "Generated distribution formats"), so a fresh checkout holds only each
+      # extension's tracked skeleton. The seven extension suites (codex,
+      # copilot, gemini, kimi, opencode, paperclip, vibe) assert against
+      # converter output — without this step they fail 74 / error 10 on a clean
+      # checkout. tests/plugin/ is converter-independent.
+      - name: Generate extension formats
+        run: python scripts/converter.py
+
+      # testpaths is set in pyproject.toml, so this collects the same tests a
+      # bare local `python -m pytest` does. Run via `python -m` (not the
+      # `pytest` entry point) so the repo root lands on sys.path for the
+      # `tests.extension_helpers` imports.
+      - name: Run Python test suite
+        run: python -m pytest -q

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,18 @@ Issues = "https://github.com/tractorjuice/arc-kit/issues"
 [project.scripts]
 arckit = "arckit_cli:main"
 
+[tool.pytest.ini_options]
+# Without this the collected set depends on whatever path a caller happens to
+# type, which is the enumeration drift that hid the ungated Python suites
+# (#719). Setting testpaths means a bare `python -m pytest` from the repo root
+# collects exactly what CI collects.
+#
+# No `norecursedirs` entry is needed for tests/mermaid-wardley/node_modules:
+# pytest's default norecursedirs already excludes node_modules, and the
+# vendored katex Python files there are not named test_*.py, so they were
+# never collected.
+testpaths = ["tests"]
+
 [build-system]
 requires = ["hatchling"]
 build-backend = "hatchling.build"


### PR DESCRIPTION
Closes #719.

## Problem

CI ran **52 of 1,445** collected pytest tests. `codex-plugin.yml` invoked only `tests/codex/test_codex_extension.py` (35) and `tests/kimi/` (17). The other 1,393 were never executed by any workflow, so a failing Python test could show green indefinitely.

The JavaScript side was already covered — `lint-markdown.yml:140` runs `node --test tests/plugin/*.test.mjs` plus four handoff-schema validators — so the gap was strictly the **Python** suites, including the 11 `.py` files sitting in the same directory as those gated `.mjs` files.

## Changes

**`.github/workflows/python-tests.yml`** (new) — runs the whole suite, with **no `paths:` filter**. A path-filtered test gate can be skipped by virtue of which files a PR happens to touch, which is the same blind spot that let #718 break `npm ci` for every subsequent PR. The suite runs in under 30s, so filtering buys nothing.

The workflow regenerates extension formats **before** pytest. This is load-bearing, and it is the one thing missing from the issue's proposed command: content under `extensions/**` is gitignored, so a fresh checkout holds only each extension's tracked skeleton. Running the issue's command as written on a clean checkout gives **74 failed, 10 errors** — every one an extension suite (codex, copilot, gemini, kimi, opencode, paperclip, vibe). `tests/plugin/`, which is the bulk of the previously ungated tests, is converter-independent and passes on a bare checkout.

**`pyproject.toml`** — adds `[tool.pytest.ini_options]` with `testpaths = ["tests"]`. There was no pytest config of any kind before (no `pytest.ini`, `setup.cfg`, `tox.ini`, `conftest.py`, or `[tool.pytest.ini_options]`), so the collected set depended on whatever path a caller typed — the same enumeration drift the issue is about. Now a bare `python -m pytest` from the repo root collects exactly what CI collects.

## Two corrections to the issue, both verified

**No extra dependencies are needed.** The issue hedges that the full suite "may need more" than `pytest pyyaml`. It doesn't — the only third-party imports across all suites are `pytest` and `yaml`. And for #711 specifically, `httpx` is already a runtime dep in `pyproject.toml` (`httpx[socks]`) that `pip install -e .` pulls in, so **`pytest-asyncio` is the only genuinely absent package**.

**`--ignore=tests/mermaid-wardley` is unnecessary.** pytest's default `norecursedirs` already excludes `node_modules`, and the vendored katex Python files there (`extract_ttfs.py`, `extract_tfms.py`, `generate_fonts.py`) are not named `test_*.py`. Collection returns the same 1,445 with or without the flag; `pytest tests/mermaid-wardley` collects nothing.

## Verification

Clean `git worktree` with an isolated venv, running the exact workflow steps:

| Scenario | Result |
|---|---|
| Fresh checkout, **no** converter (the issue's command as written) | 74 failed, 10 errors |
| Fresh checkout, converter first (this PR) | **1,220 passed, 225 skipped, exit 0** |
| Same, plus a deliberately failing canary test | **exit 1** — the gate blocks |

The 225 skips are all benign: 3 x 75 from `test_commands_structure.py`, all "pre-existing command — not yet updated to full standard". No stale backlog to fix first.

## Acceptance criteria

- [x] Every Python test in `tests/` runs in CI on pull requests and on pushes to `main`
- [x] A failing Python test blocks the PR (canary verified, exit 1)
- [x] The workflow installs whatever the full suite requires (`pytest pyyaml` + `-e .`; nothing else was missing)
- [x] No path filter on the test job

## Notes for review

- **Expected to make #711 red.** That PR's five async tests are inert without `pytest-asyncio`. Per the issue, that is the correct outcome.
- **The pytest steps in `codex-plugin.yml` are now redundant** — this workflow is unfiltered, so it covers `tests/codex/` and `tests/kimi/` on every PR. I left them in place rather than widen the diff; they still give plugin PRs a targeted check name, and the duplicate cost is a few seconds. Happy to remove them in a follow-up if you'd prefer.
- No `.md` files change here, so `lint-markdown.yml` won't trigger. `codex-plugin.yml` will, since `pyproject.toml` is in its path filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fn6shRoNVcztoUYrDe7cvT
