### PR TITLE
fix(ci): drop the now-redundant pytest steps from codex-plugin

### DIFF
--- a/.github/workflows/codex-plugin.yml
+++ b/.github/workflows/codex-plugin.yml
@@ -9,7 +9,6 @@ on:
       - "plugins/**"
       - "scripts/converter.py"
       - "src/arckit_cli/**"
-      - "tests/codex/**"
       - "pyproject.toml"
   pull_request:
     paths:
@@ -18,7 +17,6 @@ on:
       - "plugins/**"
       - "scripts/converter.py"
       - "src/arckit_cli/**"
-      - "tests/codex/**"
       - "pyproject.toml"
 
 jobs:
@@ -35,13 +33,17 @@ jobs:
         with:
           python-version: "3.12"
 
-      - name: Install Python test dependencies
-        run: python -m pip install -e . pytest pyyaml
+      # converter.py imports yaml and nothing else third-party. pytest and
+      # `-e .` are no longer needed here: the pytest steps moved to
+      # python-tests.yml, which also runs `pip install -e .` unfiltered on every
+      # PR, so the pyproject build is still smoke-tested there.
+      - name: Install converter dependencies
+        run: python -m pip install pyyaml
 
       # The extensions/arckit-codex/ extension is generated from plugins/arckit-claude (and
       # the community overlays) by converter.py and is no longer tracked in git
-      # (see .gitignore "Generated distribution formats"). Regenerate it before
-      # the tests so a fresh checkout has the files the suite asserts against.
+      # (see .gitignore "Generated distribution formats"). Regenerate it so the
+      # hook syntax check below has a file to parse.
       - name: Generate extension formats
         run: python scripts/converter.py
 
@@ -50,9 +52,3 @@ jobs:
 
       - name: Check CLI syntax
         run: python -m py_compile src/arckit_cli/__init__.py
-
-      - name: Run Codex plugin tests
-        run: python -m pytest tests/codex/test_codex_extension.py
-
-      - name: Test Kimi extension
-        run: python -m pytest tests/kimi/


### PR DESCRIPTION
Follow-up to #720, which I flagged there as an optional cleanup.

`python-tests.yml` runs the full suite unfiltered on every PR and every push to `main`, so `tests/codex/test_codex_extension.py` and `tests/kimi/` were being executed twice. This removes both steps from `codex-plugin.yml`. **pytest now lives in exactly one workflow.**

## What this job still does — and why it stays

Three things, none covered by the pytest suite:

- `python scripts/converter.py` — regenerate the extension formats
- `node --check extensions/arckit-codex/hooks/arckit-codex-hook.mjs` — the generated Codex hook parses
- `python -m py_compile src/arckit_cli/__init__.py` — CLI entry point compiles

## Two consequential cleanups

Removing the test steps left dead config behind, so:

**Install trimmed to `pyyaml`.** `converter.py` imports `yaml` and nothing else third-party; neither remaining check needs the package installed. Dropping `-e .` loses no coverage — `python-tests.yml` runs `pip install -e .` unfiltered on every PR, so the `pyproject.toml` build is still smoke-tested, and across a wider trigger set than this job's path filter ever covered.

**`tests/codex/**` removed from both path filters.** It triggered a job that no longer runs any test. The suite it pointed at is now gated unfiltered, so nothing is lost.

This second one is slightly beyond a literal "delete the two steps" — easy to revert on its own if you'd rather keep the trigger.

## Verification

Clean `git worktree`, venv containing **only** `PyYAML==6.0.3`:

| Step | Exit |
|---|---|
| `python scripts/converter.py` | 0 |
| `node --check .../arckit-codex-hook.mjs` | 0 |
| `python -m py_compile src/arckit_cli/__init__.py` | 0 |

Confirms `pytest` and `-e .` were genuinely unnecessary here rather than incidentally unused.

Note this PR touches only `.github/workflows/codex-plugin.yml`, which is in that workflow's own path filter — so the job runs on this PR and exercises the trimmed configuration directly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Fn6shRoNVcztoUYrDe7cvT
