### PR TITLE
chore: monthly traction report 2026-08

### DIFF
--- a/reports/traction/2026-08-01-traction.md
+++ b/reports/traction/2026-08-01-traction.md
@@ -1,0 +1,189 @@
+# ArcKit Monthly Traction Report — 2026-08-01
+
+> **Data source:** GitHub MCP server (`mcp__github__*` tools).
+> **Data gaps flagged inline:** The GitHub MCP server does not expose the starred-at timestamp endpoint (`Accept: application/vnd.github.star+json`) or the fork-list endpoint. Sections 2–4 flag where historical bucketing or fork divergence could not be computed and state what CLI command would fill the gap.
+
+---
+
+## 1. Headline Numbers
+
+| Metric | Value | Change vs Jul 20 report |
+|--------|-------|-------------------------|
+| Stars | **2,111** | +18 (+0.9%) |
+| Forks | **263** | +9 |
+| Watchers | **2,111** | +18 (GitHub equates to star count) |
+| Open issues | **20** | +4 |
+| Days since creation (2025-10-14) | **291 days** (~9.7 months) | — |
+| Latest release | v6.7.5 (2026-07-28) | — |
+| Last push | 2026-07-31 | — |
+
+---
+
+## 2. Star Delta vs. Last 30 / 60 / 90 Days
+
+**Data gap:** The GitHub MCP tools do not expose the starred-at timestamp API. The only hard prior data point is the previous traction report (2026-07-20: 2,093 stars).
+
+| Window | Stars | Delta | Implied rate |
+|--------|-------|-------|-------------|
+| 2026-08-01 (today) | **2,111** | — | — |
+| 2026-07-20 (prev report, 12 days ago) | 2,093 | **+18** | ~1.5 stars/day |
+| 2026-05-01 (est., ~92 days ago) | ~1,700 est. | ~+411 est. | ~4.5/day post-trending est. |
+| 2026-04-21 (end of trending event) | ~1,420 est. | — | — |
+| 2026-04-16 (start of trending event) | ~93 est. | +1,327 in 6 days | **~221/day peak** |
+
+**Single-day spike flag:** No spike >50 stars detected in the Jul 20–Aug 1 window (+18 total over 12 days). The Apr 16–21 trending event remains the sole spike on record.
+
+*To compute exact 30/60/90-day deltas:*
+```bash
+gh api repos/tractorjuice/arc-kit/stargazers \
+  -H "Accept: application/vnd.github.star+json" \
+  --paginate | jq '[.[] | .starred_at] | sort | reverse | .[0:200]'
+```
+
+---
+
+## 3. Post-Trending Decay Curve
+
+The major trending event (2026-04-16 to 2026-04-21) peaked at **~221 stars/day**. Estimated current organic rate (Jul 20–Aug 1): **~1.5 stars/day** — a ~99% decline from peak, consistent with normal post-Trending long-tail decay.
+
+**ASCII sparkline — estimated stars/day for the last 30 days (Jul 2 – Aug 1)**
+
+```
+Day:  Jul02 05  08  11  14  17  20  23  26  29 Aug01
+Rate:  ▄▄▄▄  ▃▃  ▃▃  ▂▂  ▂▂  ▂▂  ▂▂  ▁▁  ▁▁  ▁▁  ▁
+       ~3/d      ~2.5/d  ~2/d    ~1.5/d   (measured)
+```
+
+*Note: bars Jul 2–19 are interpolated from the Apr 21→Jul 20 arc (+673 stars in 89 days ≈ 7.5/day avg over the full arc, weighted front-heavy). Jul 20–Aug 1 uses the measured +18 in 12 days.*
+
+**Assessment: Stabilised/decaying.** The rate has not re-spiked and appears to have settled near 1–2 stars/day. No secondary viral event is evidenced in commit, issue, or PR activity. The project is in organic long-tail mode.
+
+---
+
+## 4. Fork Engagement
+
+| Metric | Value | Note |
+|--------|-------|------|
+| Total forks | **263** | +9 vs Jul 20 (12 days) |
+| Forks with `ahead_by > 0` | **Not available** | Fork-list endpoint absent from MCP tools |
+| Forks owned by Organizations | **Not available** | Same limitation |
+| Forks with their own stars | **Not available** | Same limitation |
+| **May 2026 baseline: forks with commits ahead** | **0** | Provided baseline |
+
+**⚠ ZERO-AHEAD BASELINE STATUS:** The 2026-05-01 baseline recorded **zero forks ahead of upstream**. This session cannot verify whether that has changed — the MCP server does not expose `GET /repos/.../forks`. No inbound PRs originating from a fork were detected in July issue/PR activity beyond the three external PRs already present in main (which came from personal fork branches). No evidence of divergent production deployments.
+
+*To verify programmatically:*
+```bash
+gh api repos/tractorjuice/arc-kit/forks --paginate \
+  | jq '.[] | {name: .full_name, stars: .stargazers_count, \
+               owner_type: .owner.type}' \
+  | jq -s 'sort_by(-.stars)'
+```
+
+---
+
+## 5. Notable New Contributors / Stargazers (Last 30 Days)
+
+**Data gap:** Timestamped stargazer sampling requires the `Accept: application/vnd.github.star+json` endpoint which is unavailable via MCP tools. The section below reports contribution activity instead — a stronger engagement signal than passive starring.
+
+### External contributors active in July 2026
+
+| User | PRs | Issues | Affiliation / Domain | Signal strength |
+|------|-----|--------|---------------------|----------------|
+| `terrygzhou` | 2 (1 open, 1 merged) | — | Prolific OSS contributor; also merged TOGAF ADM overlay Jun 30 | **High** — substantive feature PR open (#711) |
+| `gtonic` (Tom Geiger) | 1 merged (#707) | 3 | Austrian EA/GovTech; de facto at-overlay domain lead | **High** — paired issues + PRs, proposing new commands |
+| `anupamme` (Anupam Mediratta) | 1 merged (#703) | — | OSS security contributor | Medium — proactive CVE fix |
+| `chrismckelt` | — | 2 | Power user; found doc-types registry gap + Wardley bug | Medium — substantive bug reports |
+| `designlabdotcx` | — | 1 | End user | Low — install bug report |
+| `pacharanero` | — | 1 | NHS Clinical Informatics; DCB0129 domain expert | Medium — accurate standards fix request |
+| `johnfelipe` | — | 6 | LATAM enterprise architect; active ArcKit user on live project | Medium — power user, feature-request volume |
+
+*Full follower counts require individual profile API calls beyond what `search_users` returns. Notable affiliation: `pacharanero` is a known NHS open-source contributor; `gtonic`'s upside-down display name and Austrian law citation accuracy suggest domain expertise.*
+
+---
+
+## 6. Issues & PRs Activity (Last 30 Days)
+
+### Issues (Jul 1 – Aug 1)
+
+| Metric | Count |
+|--------|-------|
+| Total issues opened | **28** |
+| Opened by `tractorjuice` | ~15 |
+| Opened by external users | **13** |
+| Closed in period | **19** |
+| Open issues remaining from July | 9 |
+| External issue authors | **5 distinct users** |
+
+### Open backlog by label
+
+| Label | Open count |
+|-------|-----------|
+| `enhancement` | 9 |
+| `help wanted` | 3 |
+| `bug` | 3 |
+| `question` | 2 |
+| `architecture` | 2 |
+| `research` | 2 |
+| `security` / `priority:high` | 1 |
+
+### External issue authors (July)
+
+| User | Issues | Theme |
+|------|--------|-------|
+| `johnfelipe` | 6 | Eraser DSL, PlantUML rendering, multi-repo artifacts, sprint flow, audit output path |
+| `gtonic` | 3 | at-overlay: Austrian BVergG procurement, InfoSiG classification, new barrierefreiheit command |
+| `chrismckelt` | 2 | Doc-types registry (no GLOS code) + Wardley evolve-line bug |
+| `designlabdotcx` | 1 | Homebrew Python install path regression |
+| `pacharanero` | 1 | DCB0129 clinical-safety template fix |
+
+### PRs (Jul 1 – Aug 1)
+
+| Metric | Count |
+|--------|-------|
+| Total PRs opened | **50+** (API total_count: 76; 50 returned in page 1) |
+| By `tractorjuice` | ~96% |
+| External PR authors | **3** (`terrygzhou`, `gtonic`, `anupamme`) |
+| External PRs merged | **3** (#704, #707, #703) |
+| External PRs open | **1** (#711) |
+| PRs closed without merge | 0 external, unknown maintainer count |
+
+### External PR detail (July)
+
+| # | Author | Title | Outcome |
+|---|--------|-------|--------|
+| #711 | `terrygzhou` | feat: bring your own LLM — openai-compatible endpoint, build command, local config wizard | **Open** (substantial feature) |
+| #707 | `gtonic` | fix(at): correct Austrian overlay legal citations (NISG 2026, BVergG, DSG) + CODEOWNERS paths | Merged 2026-07-30 |
+| #704 | `terrygzhou` | chore: gitignore HANDOFF.md | Merged 2026-07-29 |
+| #703 | `anupamme` | fix: upgrade postcss to 8.5.18 (GHSA-r28c-9q8g-f849) | Merged 2026-07-30 |
+
+### Maintainer PR cadence (notable releases in July)
+
+| Release | Date | Highlights |
+|---------|------|-----------|
+| v6.7.5 | 2026-07-28 | Wardley evolve-line bug fix, contributors page update |
+| v6.7.4 | 2026-07-28 | Provenance stamp Markdown fix, RELEASING.md repair |
+| v6.7.3 | 2026-07-28 | Attribution + contributor credits |
+| v6.7.2 | 2026-07-27 | docs/manifest.json reverted (revert of #683) |
+| v6.7.1 | 2026-07-27 | Plugin namespace fixes, overlay command routing |
+| v6.7.0 | 2026-07-27 | **`/arckit:repo-audit`** new command; guide parity enforcement |
+| v6.6.0 | 2026-07-27 | Claude Code floor raised to v2.1.219; arckit-build wave fix |
+| v6.5.0 | 2026-07-27 | Kimi Code CLI distribution format (arckit-kimi) shipped |
+| v6.4.0 | 2026-07-25 | Kimi governance hooks, plugin manifest |
+| v6.3.x | Jul 16 area | (previous period) NHS DUAA 2025 |
+
+---
+
+## 7. Honest Read
+
+The "starred and forgot" to "actually using" conversion remains narrow but is measurably widening. Five distinct non-maintainer accounts contributed code or filed substantive domain-expert bug reports in July — the broadest single-month external participation since the April trending event. Three external PRs were merged and one significant feature PR (#711, BYOLLM support from `terrygzhou`) is open, which if landed would make ArcKit runtime-agnostic and meaningfully expand its addressable audience.
+
+Fork count grew from 254 to 263 (+9 in 12 days) but no fork-ahead evidence has emerged, and the zero-ahead baseline from May 2026 is likely still representative: most forks remain passive clones. The watcher metric is identical to stars on GitHub, so no independent watcher signal exists. Issue volume from non-maintainers is higher than prior months (13 external issues in July vs ~9 in the Jun 20–Jul 20 window per the previous report), with quality skewing toward domain-expert bug reports (`chrismckelt` finding registry gaps, `pacharanero` catching NHS clinical-safety errors) rather than generic "how does this work?" noise.
+
+The most concrete conversion signal is the emerging domain lead pattern: `gtonic` is now filing paired issues + PRs for the Austrian overlay without being asked, and `terrygzhou` has two merged contributions plus an open feature PR. The `johnfelipe` power-user signal remains at the feature-request tier (6 issues, 0 PRs) — watching whether that converts to a PR is the clearest leading indicator of deeper adoption. Organic star velocity (~1.5/day) is low but positive; re-spike potential would require a second trending or social amplification event, none of which is currently evidenced.
+
+---
+
+*Generated: 2026-08-01 by automated monthly traction routine*
+*Data source: GitHub MCP server (`mcp__github__*` tools)*
+*Star timestamp data (Sections 2–3) and fork divergence (Section 4) require `gh` CLI raw API access — not available in this MCP session. Commands to fill those gaps are provided inline.*

--- a/reports/traction/2026-08-01-traction.md
+++ b/reports/traction/2026-08-01-traction.md
@@ -34,6 +34,7 @@
 **Single-day spike flag:** No spike >50 stars detected in the Jul 20–Aug 1 window (+18 total over 12 days). The Apr 16–21 trending event remains the sole spike on record.
 
 *To compute exact 30/60/90-day deltas:*
+
 ```bash
 gh api repos/tractorjuice/arc-kit/stargazers \
   -H "Accept: application/vnd.github.star+json" \
@@ -48,7 +49,7 @@ The major trending event (2026-04-16 to 2026-04-21) peaked at **~221 stars/day**
 
 **ASCII sparkline — estimated stars/day for the last 30 days (Jul 2 – Aug 1)**
 
-```
+```text
 Day:  Jul02 05  08  11  14  17  20  23  26  29 Aug01
 Rate:  ▄▄▄▄  ▃▃  ▃▃  ▂▂  ▂▂  ▂▂  ▂▂  ▁▁  ▁▁  ▁▁  ▁
        ~3/d      ~2.5/d  ~2/d    ~1.5/d   (measured)
@@ -73,6 +74,7 @@ Rate:  ▄▄▄▄  ▃▃  ▃▃  ▂▂  ▂▂  ▂▂  ▂▂  ▁▁  ▁
 **⚠ ZERO-AHEAD BASELINE STATUS:** The 2026-05-01 baseline recorded **zero forks ahead of upstream**. This session cannot verify whether that has changed — the MCP server does not expose `GET /repos/.../forks`. No inbound PRs originating from a fork were detected in July issue/PR activity beyond the three external PRs already present in main (which came from personal fork branches). No evidence of divergent production deployments.
 
 *To verify programmatically:*
+
 ```bash
 gh api repos/tractorjuice/arc-kit/forks --paginate \
   | jq '.[] | {name: .full_name, stars: .stargazers_count, \


### PR DESCRIPTION
Adds the August 2026 monthly traction report to `reports/traction/2026-08-01-traction.md`.

## Summary

- **Stars at 2,111** (+18 vs Jul 20 report); organic rate ~1.5 stars/day — stabilised long-tail post-trending decay, no re-spike detected.
- **External participation at a monthly high**: 5 distinct non-maintainer contributors filed PRs or substantive issues in July (`terrygzhou`, `gtonic`, `anupamme`, `chrismckelt`, `pacharanero`); 3 external PRs merged; PR #711 (BYOLLM feature from `terrygzhou`) is open and scope-expanding.
- **Data gaps carried forward**: starred-at timestamps and per-fork `ahead_by` data remain unavailable via the GitHub MCP server; inline `gh` CLI commands are provided in each affected section so these can be filled manually.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C2HubNfD8piYwmscsFoocw)_