### PR TITLE
docs(mcp): add a keyless web search example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Optional Parallel Search MCP setup.** The MCP guide now includes a
+  project-local, keyless remote configuration for live web search and URL
+  fetching. It does not change ArcKit's bundled MCP servers or agent defaults.
+
 - **Every command now declares the doc-type it writes as data, and the registry gate asserts each recipe `output.type` matches it.** `check-doc-type-registry.py` could previously only tell whether a code *resolved*, not whether it named the *right* artefact. That blind spot was one plausible fix away from shipping: `UAE-PROC` de-prefixed to `PROC`, which **is** registered, to Canada's Federal Procurement Strategy. It would have passed every existing check while keying `.arckit/state.json` to the wrong type (#715).
 
   The declaration is a `doc-type:` field in command frontmatter: a single code, a `[A, B]` list where a command writes more than one governed artefact, or `none` where it writes no `ARC-*` artefact at all (20 commands, including `/arckit:search`, `/arckit:health`, `/arckit:impact` and `/arckit:pages`, all of which produce console output or a docs site rather than a governed artefact). It sits on the **command** even where the command delegates to an agent holding the Write call: `/arckit:framework` declares `FWRK` although `arckit-framework` writes it. The declaration describes what running the command produces, which is what a recipe target names, and it keeps the gate from having to follow delegation.

--- a/docs/guides/mcp-servers.md
+++ b/docs/guides/mcp-servers.md
@@ -256,6 +256,30 @@ ArcKit also supports integration with third-party MCP servers that are **not bun
 | MCP | Purpose | Guide |
 |-----|---------|-------|
 | Pinecone | Vector search across architecture artifacts and Wardley Mapping knowledge base | [Pinecone MCP Guide](pinecone-mcp.md) |
+| Parallel Search | Keyless live web search and URL fetching | Setup below |
+
+### Parallel Search
+
+Parallel Search MCP is a remote server for current web search and clean
+Markdown extraction from specific URLs. The default endpoint requires no
+account, API key, or OAuth setup.
+
+Add it to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+Reload the project's MCP configuration. The server exposes `web_search` for
+live search and `web_fetch` for extracting content from a known URL. It remains
+project-local and is not bundled with ArcKit.
 
 ---
 

--- a/plugins/arckit-claude/docs/guides/mcp-servers.md
+++ b/plugins/arckit-claude/docs/guides/mcp-servers.md
@@ -256,6 +256,30 @@ ArcKit also supports integration with third-party MCP servers that are **not bun
 | MCP | Purpose | Guide |
 |-----|---------|-------|
 | Pinecone | Vector search across architecture artifacts and Wardley Mapping knowledge base | [Pinecone MCP Guide](pinecone-mcp.md) |
+| Parallel Search | Keyless live web search and URL fetching | Setup below |
+
+### Parallel Search
+
+Parallel Search MCP is a remote server for current web search and clean
+Markdown extraction from specific URLs. The default endpoint requires no
+account, API key, or OAuth setup.
+
+Add it to your project's `.mcp.json`:
+
+```json
+{
+  "mcpServers": {
+    "parallel-search": {
+      "type": "http",
+      "url": "https://search.parallel.ai/mcp"
+    }
+  }
+}
+```
+
+Reload the project's MCP configuration. The server exposes `web_search` for
+live search and `web_fetch` for extracting content from a known URL. It remains
+project-local and is not bundled with ArcKit.
 
 ---
 


### PR DESCRIPTION
ArcKit's optional MCP section currently points readers to vector search, but its research workflows can also benefit from current web results. This adds a project-local, keyless remote example for live search and URL fetching without changing ArcKit's bundled servers or agent defaults.

## What changed

- Added a `parallel-search` `.mcp.json` example using the existing remote HTTP configuration shape
- Documented the `web_search` and `web_fetch` tools
- Kept the canonical and plugin guide copies in sync and added an Unreleased changelog entry

## Validation

- `python3 scripts/check-guide-parity.py --check`
- Markdown lint on all three changed files
- `python3 scripts/check_references.py` (791 Markdown files, no broken references)
- `git diff --check`

Disclosure: I work at Parallel.ai, which operates this MCP endpoint.