### PR TITLE
docs(au-energy): generalise fixture reference in methodology notes

### DIFF
--- a/tests/fixtures/au-energy/REFERENCES_AND_METHODOLOGY.md
+++ b/tests/fixtures/au-energy/REFERENCES_AND_METHODOLOGY.md
@@ -11,7 +11,7 @@ This document explains **how the synthetic test data was created**, lists **ever
 
 ## 1. Purpose
 
-The `au-energy` recipe (`plugins/arckit-au/recipes/au-energy.yaml`) shipped two community commands — `au-aescsf` and `au-soci-cirmp` — that are mechanically clean but were **not validated end-to-end** because the existing federal test fixture (MBB Group) is an advisory firm, not an energy market participant or SOCI-designated critical-asset operator. The recipe YAML explicitly states that *"validation against an [energy-sector / SOCI] test fixture is required before merge."*
+The `au-energy` recipe (`plugins/arckit-au/recipes/au-energy.yaml`) shipped two community commands — `au-aescsf` and `au-soci-cirmp` — that are mechanically clean but were **not validated end-to-end** because the existing federal test fixture is an advisory-sector composite, not an energy market participant or SOCI-designated critical-asset operator. The recipe YAML explicitly states that *"validation against an [energy-sector / SOCI] test fixture is required before merge."*
 
 These fixtures provide that test data: an energy-sector entity that **triggers** the energy regulatory paths (Fixture A) and a supplier that **deliberately does not** trigger SOCI (Fixture B), so the recipe's applicability logic can be validated in both directions.
 


### PR DESCRIPTION
One-word documentation tidy: the au-energy methodology notes described the existing federal test fixture more specifically than the fixture documentation itself does. This aligns the wording with the composite framing used throughout the fixture set. No fixture data or command behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FSJo4PiejPB1mdpsjsNhvc