### PR TITLE
docs(release): push the version tag by name, not every local tag

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -84,9 +84,11 @@ done
 claude plugin prune --dry-run
 
 # 9. Tag the umbrella release and push — this triggers
-#    .github/workflows/release.yml, which creates the GitHub Release:
+#    .github/workflows/release.yml, which creates the GitHub Release.
+#    Push the tag BY NAME: `git push --tags` pushes every local tag, and
+#    published a stray `pre-rebase-*` backup tag during v6.8.0.
 git tag -a vX.Y.Z -m "vX.Y.Z"
-git push && git push --tags
+git push && git push origin vX.Y.Z
 
 # 10. Create native per-plugin tags (arckit--vX.Y.Z, arckit-uae--vX.Y.Z, …).
 #    Auto-discovers plugins; idempotent (skips existing tags):

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -94,9 +94,11 @@ claude plugin tag plugins/arckit-claude --dry-run
 # 10. (optional) Prune orphaned plugin dependencies
 claude plugin prune --dry-run
 
-# 11. Tag, push — GitHub Release created automatically
+# 11. Tag, push — GitHub Release created automatically.
+#     Push the one tag by name. `git push --tags` pushes EVERY local tag,
+#     which published a stray `pre-rebase-*` backup tag during v6.8.0.
 git tag -a vX.Y.Z -m "vX.Y.Z"
-git push && git push --tags
+git push && git push origin vX.Y.Z
 
 # 12. Push to standalone repos (Claude, Gemini, Codex, etc.).
 #     This also publishes each standalone repo's vX.Y.Z tag and GitHub Release.


### PR DESCRIPTION
Cutting **v6.8.0** published a stray tag. Step 11 of the release flow prescribes `git push --tags`, which pushes *every* tag in the local repo, not just the one just created:

```
* [new tag]  pre-rebase-251256b9 -> pre-rebase-251256b9
* [new tag]  v6.8.0 -> v6.8.0
```

`pre-rebase-251256b9` was a local backup tag from May 2026 that had never been pushed. It is now deleted from the remote, and this stops the next release recreating the problem.

## Change

`docs/RELEASING.md` step 11 and the matching step 9 in `.claude/skills/release/SKILL.md` both become:

```bash
git push && git push origin vX.Y.Z
```

Both carry a comment naming the v6.8.0 incident, so the shorter form does not get restored as a tidy-up later.

## Scope

`git push --tags` appeared in exactly two places repo-wide, both fixed here. `scripts/tag-plugins.sh` was already correct — it pushes each native plugin tag by name.

## Note on the deleted tag

Checked before deleting: the commit `251256b9` was an ancestor of no branch and referenced by no other tag, so that tag was its only reference. The work it backed up ("read `desktop_notifications` from env var, not `user_config` substitution") did survive its rebase and is live on `main` — `plugins/arckit-claude/hooks/notify-stale-artifacts.mjs:39` reads `CLAUDE_PLUGIN_OPTION_DESKTOP_NOTIFICATIONS`, and the plugin CHANGELOG records it. Nothing unique was lost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WdKpn9PEjXtYiyRoG3Y7or