### PR TITLE
docs(contributors): correct @umag's card to their actual merged work

### DIFF
--- a/docs/contributors.html
+++ b/docs/contributors.html
@@ -326,11 +326,11 @@
                             <span class="app-contributor-card__role app-contributor-card__role--code">Code Contributor</span>
                         </div>
                     </div>
-                    <p class="govuk-body-s">First external code contributor to ArcKit. Fixed document generation issues and improved output quality across multiple commands.</p>
+                    <p class="govuk-body-s">First external code contributor to ArcKit, six months before the next one. Brought ArcKit to Gemini CLI and wrote the original converter script, the ancestor of the engine that now generates every non-Claude distribution format.</p>
                     <ul class="app-contributor-card__highlights">
-                        <li>Fixed stakeholder analysis generation</li>
-                        <li>Improved template formatting consistency</li>
-                        <li>Multiple merged pull requests</li>
+                        <li>Built the initial Gemini CLI support, 21 commands</li>
+                        <li>Authored the first converter script</li>
+                        <li>Fixed markdown packaging into the built wheel</li>
                     </ul>
                 </div>
 


### PR DESCRIPTION
@umag's contributor card credited work that is not theirs, and omitted the work that is.

## What the card said

> Fixed document generation issues and improved output quality across multiple commands.
>
> - Fixed stakeholder analysis generation
> - Improved template formatting consistency
> - Multiple merged pull requests

Neither highlight matches anything in their merged PRs.

## What they actually did

| PR | Merged | Files |
|---|---|---|
| [#3](https://github.com/tractorjuice/arc-kit/pull/3) | 2025-10-23 | `pyproject.toml`, `src/arckit_cli/__init__.py` — markdown packaging into the built wheel |
| [#5](https://github.com/tractorjuice/arc-kit/pull/5) | 2025-10-27 | 21 × `.gemini/commands/arckit/*.toml`, **`converter.py`**, `pyproject.toml`, `src/arckit_cli/__init__.py` |

The omission worth fixing is the converter. `converter.py` was **added** by @umag in commit `33d3363e` (2025-10-26) at 48 lines — the ancestor of the engine that now generates all seven non-Claude distribution formats. The card credited none of it.

"First external code contributor to ArcKit" was the one accurate claim and is kept. The card now says how far ahead they were, because it is a striking gap: the next external merged PR is [#333](https://github.com/tractorjuice/arc-kit/pull/333) (@gtonic, 2026-04-20), six months later.

## Deliberately not credited

[#739](https://github.com/tractorjuice/arc-kit/pull/739) (Netherlands overlay) and [#740](https://github.com/tractorjuice/arc-kit/pull/740) (`/arckit:eu-cloud-sovereignty`) are both open. Crediting unmerged work on a public page would be inaccurate — worth a follow-up once they land.

## Checked, unchanged

- **The hero's "21 Open Source Contributors" is correct.** A first count suggested 24 and was wrong: `grep -c` was matching three CSS selector lines alongside the cards. There are exactly 21 contributor cards.
- `scripts/check-contributor-credits.py` passes both before and after — all 11 CHANGELOG-credited handles have cards, so there is no release-time drift to clear here.

Content-only change to one card; no structural, CSS, or count changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE