### PR TITLE
docs(contributing): name all four doc files a new command must update

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -77,9 +77,15 @@ To add a new ArcKit command:
 4. **Multi-AI support**:
    - Run `python scripts/converter.py` to generate Gemini TOML and Codex Markdown from the plugin command
 
-5. **Update documentation**:
-   - Update `CHANGELOG.md`
-   - Add to `README.md` if major feature
+5. **Update documentation** — four files, not one:
+   - `CHANGELOG.md` — an entry under `## [Unreleased]`.
+   - `README.md` — a bullet in the relevant command table or overlay section. Not optional for an overlay command: those section headers carry counts (`The 21 commands below …`) that go stale the moment you add one.
+   - `docs/index.html` — the published site. Overlay commands appear both in a jurisdiction card's instrument list and in the community-overlay paragraph, each enumerating instruments by name.
+   - `docs/DEPENDENCY-MATRIX.md` — a dependency entry alongside the command's siblings, and its place in that overlay's flow block.
+
+   The last two were previously documented only in `CLAUDE.md`, which contributors do not read, so PRs kept arriving without them. That was our omission, not the contributors'.
+
+6. **Watch the counts.** A new overlay command changes a stated number in **five** places: the overlay's `README.md` (`N slash commands`), its `.claude-plugin/plugin.json` description, **both** marketplace manifests, and the root `README.md` section header. Grep for the old number before pushing — nothing checks these.
 
 ### 5. Code Improvements
 


### PR DESCRIPTION
`CONTRIBUTING.md` step 5 told contributors to update `CHANGELOG.md` and to add to `README.md` **"if major feature"**. `docs/index.html` and `docs/DEPENDENCY-MATRIX.md` appeared only in `CLAUDE.md` step 7 — a maintainer-facing file contributors do not read.

The result is that PRs arrive without them and then get reviewed against a requirement that was never written down. [#739](https://github.com/tractorjuice/arc-kit/pull/739) and [#740](https://github.com/tractorjuice/arc-kit/pull/740) both did exactly this. That is our omission, and the PR says so in as many words.

## Changes

**Step 5** now names all four files with what each one actually needs, rather than a bare list:

| File | What a new command needs there |
|---|---|
| `CHANGELOG.md` | entry under `## [Unreleased]` |
| `README.md` | a bullet in the command table or overlay section |
| `docs/index.html` | the jurisdiction card's instrument list **and** the community-overlay paragraph |
| `docs/DEPENDENCY-MATRIX.md` | a dependency entry alongside its siblings, plus its place in the flow block |

The `README.md` line drops "if major feature". For an overlay command it is not discretionary: those section headers carry counts (`The 21 commands below …`) that go stale the moment one is added.

**New step 6** covers the count claims, which are the part people miss even when they remember the four files. A new overlay command changes a stated number in **five** places:

- the overlay's `README.md` (`N slash commands`)
- its `.claude-plugin/plugin.json` description
- **both** marketplace manifests
- the root `README.md` section header

Nothing checks any of them.

## Verification

```
npx markdownlint-cli2 CONTRIBUTING.md    0 issues
scripts/check_references.py              no broken references
```

Docs-only; no commands, config, or scripts touched.

Follows [#741](https://github.com/tractorjuice/arc-kit/pull/741), which covered the overlay *registration* points. Same root cause: integration requirements recorded somewhere contributors never see.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE