### PR TITLE
fix(quality-checklist): add the 15 missing per-type sections for togaf-adm and agent-architecture

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -669,3 +669,181 @@ All artifacts must pass these 10 checks:
 - BVwG / LVwG review venue documented with the tiered Pauschalgebühren (Vergaberechtsgesetz 2026) reference
 - Vergabeakt structure defined for Rechnungshof / EU audit defensibility
 - Items requiring practitioner verification marked `[NEEDS VERIFICATION]`
+
+### ADMP -- TOGAF ADM Preliminary Phase
+
+- Architecture Vision stated as an outcome, not a restatement of scope
+- Scope split into explicit In Scope and Out of Scope lists, with Out of Scope non-empty
+- Drivers captured across all four categories (strategic, operational, compliance, technology)
+- Every success criterion has both a measure and a target value, not a qualitative aspiration
+- Stakeholder map records interest and influence per entry, each with an engagement strategy
+- ADM Scope table marks each of Phases A–H in or out of scope with a note
+- Constraints distinguished from risks (constraints are fixed; risks are probabilistic)
+- Traceability to REQ, STKE and PRIN artefacts where those exist
+
+### BPCM -- Business Capability Map
+
+- Capability hierarchy is three levels deep with a consistent dotted ID scheme (C1.0 → C1.1 → C1.1.1)
+- Capabilities named as abilities, not as processes, systems or organisational units
+- No capability appears in more than one branch of the hierarchy
+- Every value stream (VS-xxx) has a trigger, an outcome, and the capabilities it consumes
+- Maturity assessed on L1–L5 for both current and target, with the gap derived from the two
+- Heatmap plots strategic importance against maturity; every plotted point exists in the hierarchy
+- Requirement coverage rated Full / Partial / Gap for each mapped requirement
+- Principle alignment recorded against entries in the PRIN artefact
+
+### APP -- Application Inventory
+
+- Every application has a unique APP-xxx ID used consistently across all sections
+- Strategic fit scored on both axes (Business Value 1–5, Technical Debt 1–5) with a derived quadrant
+- Quadrant assignment consistent with the two scores
+- Lifecycle status set per application (Active / Deprecated / Planned)
+- Technology diversity counts recorded against a target, with over-target dimensions flagged
+- Vendor lock-in risk rated, with a named exit strategy for every High rating
+- Applications mapped to capabilities (C-x.x.x) where a capability map exists
+- Dependencies directional and resolvable to APP-xxx IDs in the register
+
+### APPR -- Application Rationalisation
+
+- Every application carries exactly one decision (KEEP / MERGE / REPLACE / RETIRE)
+- Summary counts reconcile with the per-application decisions
+- Every MERGE names its target application
+- Every REPLACE and RETIRE states the disposition of its data and its dependent applications
+- Rationale given per decision, traceable to the strategic fit scores in the APP inventory
+- Consolidation benefits quantified (cost, licence, headcount or risk reduction), not asserted
+- Implementation sequencing respects dependencies — nothing retired before its replacement lands
+- Decisions awaiting board approval listed separately and not presented as agreed
+
+### GAPA -- Gap Analysis
+
+- Every gap references a capability ID from the capability map (C-x.x.x)
+- Gap Size derived from the maturity delta per the classification table (Small Δ=1, Medium Δ=2, Large Δ≥3)
+- Urgency set with its timeframe (High 0–3 months, Medium 3–12 months, Low 12–24 months)
+- Severity read from the Size × Urgency matrix rather than chosen independently — every row matches the matrix
+- Capabilities already at target recorded with gap size None and severity Informational, not omitted
+- Heatmap quadrant counts reconcile with the rows of the gap matrix
+- Every gap assigned to a workstream (WS-xxx), or explicitly marked unassigned with a reason
+- Workstream dependencies acyclic and consistent with the dependency diagram
+- Severe gaps mapped to entries in the RISK artefact
+
+### TRANS -- Transition Architecture
+
+- Baseline and target architectures both defined, with intermediate states numbered sequentially
+- Every transition state is independently viable — the enterprise can operate if the programme stops there
+- Every work package has a WP-xxx ID, a duration and named resources
+- Work package dependencies acyclic and consistent with the dependency diagram
+- Each work package traces to the capability gaps (C-x.x.x / WS-xxx) it closes
+- Acceptance criteria per work package are measurable and testable
+- Migration waves sequenced so that no wave depends on a later wave
+- Investment stated per transition state and summing to a programme total
+- Contingency identified for the critical path
+
+### BORD -- Architecture Board Charter
+
+- Authority levels defined and distinguished (Advisory / Mandatory / Exception)
+- Every member has a named role and an explicit vote type (Voting or Observer)
+- Quorum stated as a rule that can be evaluated against the membership list
+- Voting model specified (consensus, majority, chair casting vote) including tie-breaking
+- Compliance scorecard criteria measurable, each with a scoring scale
+- Exception process defines who may grant a waiver, for how long, and what triggers review
+- Review cadence stated for the board itself and for the charter
+- Decision register present with a stable ID scheme for board decisions
+
+### ACHG -- Architecture Change Request
+
+- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE with justification
+- Priority set (CRITICAL / HIGH / MEDIUM / LOW) and consistent with the impact assessment
+- Impact assessed across all four dimensions: capability, application, technology, governance
+- Affected artefacts listed by document ID, each with the action required
+- ADM re-entry point determined per phase (A–H) with the scope of re-entry, not just YES/NO
+- Re-entry point consistent with the change type — transformational changes re-enter at Phase A or B
+- Cost and benefit both quantified
+- Approval workflow names the approving authority for the assessed priority
+
+### REPO -- Architecture Repository
+
+- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
+- Deprecated standards name their superseding standard
+- Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram
+- Building blocks (BB-xxx) carry a maturity rating (Prototype / Proven / Standard) and a documentation link
+- Lessons learned (LL-xxx) categorised (Technical / Process / People) with an impact rating
+- Search index covers every registered entry ID
+- No project-specific content in what is a global artefact
+
+### AAGI -- AI Agent Inventory
+
+- Every agent has a unique AGT-xxx ID used consistently across all sections
+- Model and deployment environment recorded per agent (Prod / Staging / Dev / Planned)
+- Risk level assigned (Critical / High / Medium / Low)
+- Oversight stated as human-in-the-loop, human-on-the-loop or human-out-of-loop — no other values
+- No Critical-risk agent left at human-out-of-loop without a documented justification
+- Capability matrix lists tools, memory types and output types per agent
+- Security classification records data sensitivity, access level and isolation for every agent
+- Audit requirement set per agent, and set to Yes wherever data sensitivity is High
+- Lifecycle status set (Active / In Development / Deprecating / Retired)
+- Agent dependencies resolve to AGT-xxx IDs in the register
+
+### AAGR -- AI Agent Design
+
+- Architecture pattern selected from Single Agent / Chain / Multi-Agent / Hierarchical with a rationale
+- Pattern consistent with the component diagram — a hierarchical design shows a supervisor
+- Every tool has a T-xxx ID, a type (MCP / REST / Function) and an explicit permission level
+- Input and output schemas defined for every tool contract, not described in prose
+- Tool permissions least-privilege: no Execute granted where Read suffices
+- Tool dependency graph acyclic
+- All three memory layers addressed (Session, Durable, Vector), or explicitly ruled out with a reason
+- Retention and access rules stated per memory layer
+- LLM configuration records model, temperature and context limits with rationale
+- Guardrails specified for both the input and the output path
+
+### AASE -- AI Agent Security
+
+- Attack surface enumerated before threats are assessed
+- Every threat has a severity, a frequency and a named mitigation
+- Sandboxing defined for all five boundaries: agent process, tool execution, memory access, network access, data I/O
+- Isolation layers carry an escape-risk rating
+- Tool permission matrix grants least privilege, with a mitigation for every High-risk grant
+- Data handling policy covers PII, sensitive, public and model weights, with retention per class
+- PII masked in prompts and encrypted at rest, or its absence explicitly asserted
+- Prompt injection defences cover direct prompts, indirect injection and output validation — all three
+- Indirect injection via tool output and retrieved content specifically addressed, not only user input
+- Egress controls defined for network access
+- Output validation names the schema or filter applied, not merely that validation occurs
+
+### AAIN -- AI Agent Integration
+
+- Integration pattern selected (Event-Driven / Request-Response / Message Queue / Shared State) with a rationale
+- Every inter-agent contract has a CNT-xxx ID naming source agent, target agent and protocol
+- Source and target agents resolve to AGT-xxx IDs in the agent inventory
+- SLA stated per contract as a measurable latency or throughput target
+- Message protocol defines schema, versioning and compatibility rules
+- Delivery semantics stated (at-least-once / at-most-once / exactly-once) with matching duplicate handling
+- Failure isolation defined per boundary, each with a failure mode and a recovery action
+- No shared mutable state without a documented access pattern and concurrency control
+- Observability defines a metric and an alert threshold per component
+- Cascading failure across agents explicitly addressed
+
+### AAOV -- AI Agent Governance
+
+- Three oversight tiers defined, with the human role stated for each
+- Every agent from the inventory (AGT-xxx) assigned a tier with a justification
+- Tier assignment consistent with the agent's risk level — Critical risk maps to Tier 1
+- Approval matrix names an approver and an SLA for every risk tier, plus an escalation path
+- Escalation path terminates in a named human authority, never in an agent
+- Audit requirements state frequency, scope and retention period per audit type
+- Retention periods meet the longest applicable regulatory requirement
+- Monitoring KPIs have numeric targets and a current value
+- Escalation procedures define the trigger condition, not only the route
+- Compliance mapping present where a regulatory regime applies (EU AI Act, sector rules)
+
+### AAMT -- AI Agent Maturity Assessment
+
+- All five dimensions assessed: design, governance, security, integration, operations
+- Level assigned on the L1–L5 scale using the framework's own definitions (Ad-hoc, Reactive, Defined, Managed, Optimized)
+- Each level assignment supported by named evidence rather than asserted
+- Target level set per dimension with a stated timeframe
+- Gap between current and target derived, not restated
+- No dimension scored above L3 without documented, repeatable process evidence
+- Improvement actions given per dimension where a gap exists
+- Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification


### PR DESCRIPTION
Closes #749. Part of the split of #748.

## What was broken

15 commands ended with an instruction to verify per-type checks for a doc-type that has no section in `references/quality-checklist.md`:

```
... read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all
**Common Checks** plus the **GAPA** per-type checks pass.
```

There was no `### GAPA` section, nor one for the other 14. The instruction was emitted, resolved to nothing, and left the model to invent the criteria for the artefact it was about to write.

| Plugin | Codes |
|---|---|
| `arckit-togaf-adm` | `ADMP` `BPCM` `APP` `APPR` `GAPA` `TRANS` `BORD` `ACHG` `REPO` |
| `arckit-agent-architecture` | `AAGI` `AAGR` `AASE` `AAIN` `AAOV` `AAMT` |

Both overlays landed 2026-06-30 and have shipped this way since. These are the only codes in the repo where the symptom reported in #748 actually occurs; its other 61 are a different defect (commands that never reference the checklist at all), tracked separately.

## Where the content came from

#748 proposes deriving this from each command's `## Success Criteria`. That source does not exist here — neither overlay has one, and repo-wide only 30 of 190 commands do, concentrated in exactly the regimes whose checklist sections are already written (`arckit-eu` 7/7, `arckit-fr` 12/12, `arckit-at` 3/3).

Content is derived instead from each command's `## Instructions` and its template, both of which are specific enough to check against:

- **ID schemes** the templates already establish: `APP-xxx`, `WP-xxx`, `WS-xxx`, `AGT-xxx`, `CNT-xxx`, `T-xxx`, `STD/REF/BB/LL-xxx`, and the `C1.0 → C1.1 → C1.1.1` capability hierarchy
- **Decision enums**: `KEEP / MERGE / REPLACE / RETIRE`, `EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE`, the three oversight tiers, `Prototype / Proven / Standard`
- **Derived-value rules**, where the template defines how one field follows from others: gap size from the maturity delta (Small Δ=1, Medium Δ=2, Large Δ≥3), severity from the Size × Urgency matrix, quadrant from the two strategic-fit scores

The last group is where most of the value is. Rather than asserting a field is present, those checks assert it agrees with its inputs — for example, that every severity in the gap matrix matches what the Size × Urgency table produces, and that summary counts in the rationalisation artefact reconcile with the per-application decisions. A few encode judgements the templates imply but never state, such as no Critical-risk agent sitting at human-out-of-loop without justification, and every transition state being independently viable.

Sections follow the established `### CODE -- Name` shape at 8 to 11 bullets each, in line with the EU/FR/AT sections rather than the terser 3-bullet core ones.

## Files

Only `plugins/arckit-claude/references/quality-checklist.md` is hand-edited: 75 sections to 90, 178 lines added, nothing removed.

`references/` is in `SHARED_DIRS`, so the other 28 changed files are regenerated, not authored:

- 14 overlay copies via `python3 scripts/sync-shared-assets.py`
- 14 publish-layout mirror copies under `plugins/arckit-claude/plugins/` via `python3 scripts/sync-claude-plugin-layout.py`

The mirror is easy to miss. `sync-shared-assets.py` alone leaves it stale, and `tests/plugin/test_release_process.py` and `test_claude_overlay_namespacing.py` both fail until the second script runs.

## Verification

- **0 dangling per-type references** across every plugin command tree, down from 15 (script in #749)
- `npx markdownlint-cli2` clean over all 15 checklist files
- `python3 scripts/sync-shared-assets.py --check` clean
- `python3 scripts/check-doc-type-registry.py` passes
- `python scripts/converter.py` regenerates all 7 extensions
- `python -m pytest` 1267 passed, 225 skipped

## Not included

A CI guard for the invariant *"if a command emits `**<CODE>** per-type checks`, a `### <CODE>` section must exist"*. It passes as of this PR and would prevent recurrence, but it is a separate concern from the content fix and is left for a follow-up so this stays reviewable. Note it is a different rule from the one #748 suggests, which would miss all 15 of these (neither plugin's codes carry a `regime`) and false-positive on `WVCH`, `MMOD`, `WGAM` and `WCLM`.

## Observed, not fixed

Four `arckit-togaf-adm` templates (`adm-preliminary`, `application-inventory`, `architecture-board`, `architecture-repository`) carry a reduced Document Control block, roughly 7 fields against the 14 that Common Check 1 requires. That predates this PR and affects the Common Checks rather than the per-type ones, so it is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
