### PR TITLE
feat(ci): guard that every per-type quality-checklist reference resolves

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -16,6 +16,7 @@ on:
       - "package-lock.json"
       - "scripts/check-guide-site-links.py"
       - "scripts/check-contributor-credits.py"
+      - "scripts/check-quality-checklist-refs.py"
       - "docs/contributors.html"
       - "docs/guides.html"
       - "docs/roles.html"
@@ -43,6 +44,7 @@ on:
       - "package-lock.json"
       - "scripts/check-guide-site-links.py"
       - "scripts/check-contributor-credits.py"
+      - "scripts/check-quality-checklist-refs.py"
       - "docs/contributors.html"
       - "docs/guides.html"
       - "docs/roles.html"
@@ -97,6 +99,9 @@ jobs:
 
       - name: Contributor credit check (CHANGELOG credits vs contributors page)
         run: python3 scripts/check-contributor-credits.py
+
+      - name: Quality-checklist references resolve (closes #749)
+        run: python3 scripts/check-quality-checklist-refs.py
 
       - uses: actions/setup-node@v4
         with:

--- a/scripts/check-quality-checklist-refs.py
+++ b/scripts/check-quality-checklist-refs.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Assert every per-type quality-checklist reference resolves to a real section.
+
+Commands and agents end by telling the model to verify quality checks:
+
+    read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all
+    **Common Checks** plus the **GAPA** per-type checks pass.
+
+If `references/quality-checklist.md` has no `### GAPA` section, that instruction
+resolves to nothing. Nothing errors, nothing is logged; the model is simply left
+to invent the criteria for the artefact it is about to write. That was live for
+15 codes across `arckit-togaf-adm` and `arckit-agent-architecture` from
+2026-06-30 until PR #750 (issue #749).
+
+Resolution is PER PLUGIN, not against the core copy. `${CLAUDE_PLUGIN_ROOT}`
+resolves to each plugin's own root with no cross-plugin fallback, so a command in
+`arckit-togaf-adm` reads that plugin's copy. Checking against core would pass a
+plugin that carries no checklist at all — `arckit-fde` is sync-exempt and has
+none today, and would silently fail open the moment it gained a governance
+command. `sync-shared-assets.py --check` separately guarantees the copies are
+byte-identical; this guard does not assume it has run.
+
+Deliberately NOT checked here:
+
+  * Commands that reference no per-type code at all. `wardley.value-chain` and
+    `maturity-model` ask for Common Checks only, by design. Distinguishing those
+    from the ~61 commands that never invoke the checklist despite writing a
+    governed artefact needs the doc-type registry and a judgement call per
+    command — a different defect, tracked on #748.
+  * Sections that no command references. Dead weight, not a broken instruction.
+  * `plugins/arckit-claude/plugins/**`, the generated publish-layout mirror.
+    Drift there is a sync failure and `tests/plugin/test_release_process.py`
+    already catches it.
+
+Exit 0 when clean, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PLUGINS_DIR = ROOT / "plugins"
+
+# Generated publish-layout mirror — see module docstring.
+MIRROR_DIR = PLUGINS_DIR / "arckit-claude/plugins"
+
+CHECKLIST_REL = Path("references/quality-checklist.md")
+
+# "**GAPA** per-type checks" — the code is bold, hyphens allowed (e.g. FIPS199,
+# two-part codes). Matches every phrasing in the tree: "plus the **X**",
+# "plus **X**", and "plus any applicable **X**".
+REF_RE = re.compile(r"\*\*([A-Z0-9][A-Z0-9-]*)\*\*\s+per-type checks")
+
+SECTION_RE = re.compile(r"^### ([A-Z0-9][A-Z0-9-]*)\s", re.M)
+
+
+def plugin_dirs() -> list[Path]:
+    return sorted(
+        p for p in PLUGINS_DIR.iterdir() if p.is_dir() and (p / ".claude-plugin").is_dir()
+    )
+
+
+def sections_for(plugin: Path) -> set[str] | None:
+    """Codes with a `### CODE` section in this plugin's checklist, or None if it
+    carries no checklist file at all."""
+    checklist = plugin / CHECKLIST_REL
+    if not checklist.is_file():
+        return None
+    return set(SECTION_RE.findall(checklist.read_text(encoding="utf-8")))
+
+
+def references_for(plugin: Path) -> list[tuple[Path, str]]:
+    """(file, code) for every per-type reference emitted anywhere in the plugin."""
+    found: list[tuple[Path, str]] = []
+    for path in sorted(plugin.rglob("*.md")):
+        if MIRROR_DIR in path.parents:
+            continue
+        for code in sorted(set(REF_RE.findall(path.read_text(encoding="utf-8")))):
+            found.append((path, code))
+    return found
+
+
+def main() -> int:
+    if not PLUGINS_DIR.is_dir():
+        print(f"ERROR: {PLUGINS_DIR} not found", file=sys.stderr)
+        return 1
+
+    plugins = plugin_dirs()
+    if not plugins:
+        print(f"ERROR: no plugins found under {PLUGINS_DIR.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+
+    dangling: list[tuple[Path, str, str]] = []  # (file, code, plugin)
+    no_checklist: list[tuple[Path, str, str]] = []
+    total_refs = 0
+    per_plugin: dict[str, set[str]] = {}
+
+    for plugin in plugins:
+        sections = sections_for(plugin)
+        for path, code in references_for(plugin):
+            total_refs += 1
+            per_plugin.setdefault(plugin.name, set()).add(code)
+            rel = path.relative_to(ROOT)
+            if sections is None:
+                no_checklist.append((rel, code, plugin.name))
+            elif code not in sections:
+                dangling.append((rel, code, plugin.name))
+
+    if total_refs == 0:
+        print(
+            "ERROR: no per-type references found at all — the phrasing in commands "
+            "has probably changed and REF_RE no longer matches it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failed = False
+
+    if no_checklist:
+        failed = True
+        print(
+            f"FAIL {len(no_checklist)} per-type reference(s) in a plugin that carries "
+            f"no {CHECKLIST_REL}:",
+            file=sys.stderr,
+        )
+        for rel, code, plugin in no_checklist:
+            print(f"  {rel}  ->  **{code}**  (plugin {plugin})", file=sys.stderr)
+        print(
+            "\n  ${CLAUDE_PLUGIN_ROOT} resolves to the plugin's OWN root, so this read\n"
+            "  fails silently at runtime. Either remove the plugin from SYNC_EXEMPT_PLUGINS\n"
+            "  in scripts/sync-shared-assets.py and re-run it, or drop the reference.",
+            file=sys.stderr,
+        )
+
+    if dangling:
+        failed = True
+        print(
+            f"\nFAIL {len(dangling)} per-type reference(s) with no matching "
+            f"`### <CODE>` section:",
+            file=sys.stderr,
+        )
+        for rel, code, plugin in dangling:
+            print(f"  {rel}  ->  **{code}**  (plugin {plugin})", file=sys.stderr)
+        print(
+            "\n  The instruction resolves to nothing and the model invents the criteria.\n"
+            "  Add a `### <CODE> -- <Name>` section to\n"
+            "  plugins/arckit-claude/references/quality-checklist.md (the canonical copy),\n"
+            "  then run: python3 scripts/sync-shared-assets.py\n"
+            "         and python3 scripts/sync-claude-plugin-layout.py\n"
+            "  Derive the checks from the command's Instructions and its template — assert\n"
+            "  that derived values agree with their inputs, not merely that fields exist.",
+            file=sys.stderr,
+        )
+
+    if failed:
+        return 1
+
+    breakdown = ", ".join(f"{name}: {len(codes)}" for name, codes in sorted(per_plugin.items()))
+    print(
+        f"Quality-checklist reference check OK: {total_refs} per-type reference(s) "
+        f"across {len(per_plugin)} plugin(s), all resolve ({breakdown})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugin/test_quality_checklist_refs.py
+++ b/tests/plugin/test_quality_checklist_refs.py
@@ -1,0 +1,169 @@
+"""Tests for scripts/check-quality-checklist-refs.py.
+
+The guard exists because a per-type reference to a section that does not exist
+fails silently: the model reads the checklist, finds no `### <CODE>` heading, and
+invents the criteria for the artefact it is about to write. Nothing errors and
+nothing is logged. That shipped for 15 codes across arckit-togaf-adm and
+arckit-agent-architecture from 2026-06-30 until PR #750 (issue #749).
+
+The tests that matter most here are the negative ones. A guard that cannot fail
+is worse than no guard, because it reads as coverage.
+"""
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / "scripts/check-quality-checklist-refs.py"
+
+# The 15 codes that were dangling until PR #750.
+REGRESSION_CODES = {
+    "arckit-togaf-adm": [
+        "ADMP", "BPCM", "APP", "APPR", "GAPA", "TRANS", "BORD", "ACHG", "REPO",
+    ],
+    "arckit-agent-architecture": [
+        "AAGI", "AAGR", "AASE", "AAIN", "AAOV", "AAMT",
+    ],
+}
+
+
+def load_guard():
+    spec = importlib.util.spec_from_file_location("check_quality_checklist_refs", GUARD)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_plugin(root: Path, name: str, *, ref_code: str | None, sections: list[str] | None):
+    """Build a minimal plugin tree. sections=None means no checklist file at all."""
+    plugin = root / name
+    (plugin / ".claude-plugin").mkdir(parents=True)
+    (plugin / ".claude-plugin/plugin.json").write_text(json.dumps({"name": name}))
+    if ref_code is not None:
+        (plugin / "commands").mkdir()
+        (plugin / "commands/thing.md").write_text(
+            "---\ndoc-type: X\n---\n\nBefore writing the file, read the checklist and verify "
+            f"all **Common Checks** plus the **{ref_code}** per-type checks pass.\n"
+        )
+    if sections is not None:
+        (plugin / "references").mkdir()
+        body = "# Quality Checklist\n\n## Per-Type Checks\n\n"
+        body += "".join(f"### {c} -- Thing\n\n- a check\n\n" for c in sections)
+        (plugin / "references/quality-checklist.md").write_text(body)
+    return plugin
+
+
+def run_against(module, plugins_dir: Path) -> int:
+    module.PLUGINS_DIR = plugins_dir
+    module.ROOT = plugins_dir.parent
+    module.MIRROR_DIR = plugins_dir / "__no_mirror__"
+    return module.main()
+
+
+def test_guard_exists():
+    assert GUARD.is_file(), "quality-checklist reference guard missing"
+
+
+def test_guard_passes_on_current_tree():
+    result = subprocess.run(
+        ["python3", str(GUARD)], capture_output=True, text=True, cwd=REPO_ROOT
+    )
+    assert result.returncode == 0, f"guard failed:\n{result.stdout}\n{result.stderr}"
+
+
+def test_guard_is_wired_into_ci():
+    workflow = (REPO_ROOT / ".github/workflows/lint-markdown.yml").read_text()
+    assert "check-quality-checklist-refs.py" in workflow, "guard not run in CI"
+
+
+def test_guard_fails_on_dangling_reference(tmp_path, capsys):
+    # The defect the guard exists for: reference emitted, no matching section.
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", ref_code="GAPA", sections=["REQ", "ADR"])
+    assert run_against(load_guard(), plugins) == 1
+    assert "GAPA" in capsys.readouterr().err
+
+
+def test_guard_fails_when_plugin_has_no_checklist_at_all(tmp_path, capsys):
+    # ${CLAUDE_PLUGIN_ROOT} has no cross-plugin fallback, so a sync-exempt plugin
+    # that emits a reference reads a file that does not exist. Resolving against
+    # the core copy instead would pass this and fail open.
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", ref_code="REQ", sections=None)
+    assert run_against(load_guard(), plugins) == 1
+    assert "no references/quality-checklist.md" in capsys.readouterr().err
+
+
+def test_guard_passes_when_section_present(tmp_path):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", ref_code="GAPA", sections=["GAPA"])
+    assert run_against(load_guard(), plugins) == 0
+
+
+def test_guard_fails_if_phrasing_stops_matching(tmp_path, capsys):
+    # If the instruction wording is reworded tree-wide, REF_RE silently matches
+    # nothing and every reference "resolves". Guard must refuse to pass empty.
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", ref_code=None, sections=["REQ"])
+    assert run_against(load_guard(), plugins) == 1
+    assert "no per-type references found" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize(
+    "text,expected",
+    [
+        ("plus the **GAPA** per-type checks pass", ["GAPA"]),
+        ("plus **SECD** per-type checks pass", ["SECD"]),
+        ("plus any applicable **WARD** per-type checks pass", ["WARD"]),
+        ("plus the **FIPS199** per-type checks pass", ["FIPS199"]),
+        ("plus the **NHS-DTAC** per-type checks pass", ["NHS-DTAC"]),
+        ("all **Common Checks** pass", []),
+    ],
+)
+def test_ref_regex_handles_every_phrasing_in_the_tree(text, expected):
+    # All five shapes occur in plugins/ today; the last is the Common-Checks-only
+    # form that must NOT be read as a per-type reference.
+    assert load_guard().REF_RE.findall(text) == expected
+
+
+def test_section_regex_matches_real_heading_shape():
+    guard = load_guard()
+    checklist = (
+        REPO_ROOT / "plugins/arckit-claude/references/quality-checklist.md"
+    ).read_text()
+    found = set(guard.SECTION_RE.findall(checklist))
+    assert "GAPA" in found and "REQ" in found
+    assert len(found) >= 90, f"expected >=90 sections, found {len(found)}"
+
+
+@pytest.mark.parametrize(
+    "plugin,code",
+    [(p, c) for p, codes in REGRESSION_CODES.items() for c in codes],
+)
+def test_pr750_codes_still_resolve_in_their_own_plugin(plugin, code):
+    # Explicit regression for the 15 that motivated the guard, checked against
+    # each plugin's OWN copy — the file the command actually reads at runtime.
+    checklist = REPO_ROOT / "plugins" / plugin / "references/quality-checklist.md"
+    assert checklist.is_file(), f"{plugin} carries no quality-checklist.md"
+    guard = load_guard()
+    sections = set(guard.SECTION_RE.findall(checklist.read_text()))
+    assert code in sections, f"### {code} missing from {plugin}'s checklist again"
+
+
+def test_generated_mirror_is_excluded():
+    # plugins/arckit-claude/plugins/** is regenerated by sync-claude-plugin-layout.py.
+    # Scanning it would double-report every core finding.
+    guard = load_guard()
+    assert guard.MIRROR_DIR == REPO_ROOT / "plugins/arckit-claude/plugins"
+    core = REPO_ROOT / "plugins/arckit-claude"
+    scanned = {path for path, _ in guard.references_for(core)}
+    assert scanned, "no references found in core plugin"
+    assert not any(guard.MIRROR_DIR in p.parents for p in scanned)


### PR DESCRIPTION
Follow-up to #750, which fixed the 15 dangling references but left nothing to stop them recurring. Refs #748.

## The invariant

> If a command or agent emits `**<CODE>** per-type checks`, a `### <CODE>` section must exist in the checklist **that file will actually read**.

The failure this catches is silent. The model reads `references/quality-checklist.md`, finds no matching heading, and invents the criteria for the artefact it is about to write. No error, no log line, no test failure — which is why 15 codes shipped that way from 2026-06-30 until #750.

## Design decisions worth reviewing

**Resolution is per plugin, not against the core copy.** `${CLAUDE_PLUGIN_ROOT}` resolves to each plugin's own root with no cross-plugin fallback, so a command in `arckit-togaf-adm` reads *that plugin's* file. Checking against core would fail open for a plugin carrying no checklist at all — `arckit-fde` is sync-exempt and has none today, so the moment it gained a governance command the reference would break at runtime while the guard stayed green. That case is reported as its own distinct failure with a pointer to `SYNC_EXEMPT_PLUGINS`.

This does not assume `sync-shared-assets.py --check` has run. The two guards are independent on purpose.

**Agents are covered, not just commands.** 8 agent files emit per-type references. My first pass scanned only `commands/` and would have missed them — worth knowing if you ever extend this.

**Empty match is a failure, not a pass.** If the instruction wording is reworded tree-wide, `REF_RE` matches nothing and every reference trivially "resolves". The guard refuses to pass on zero references. This is the failure mode that would otherwise turn the whole thing into decoration.

**The generated mirror is skipped.** `plugins/arckit-claude/plugins/**` is rebuilt by `sync-claude-plugin-layout.py`; drift there is a sync failure and `tests/plugin/test_release_process.py` already catches it. Scanning it would double-report every core finding.

## Not the invariant #748 proposes

#748 suggests asserting that every regime-carrying doc-type has a section. That is wrong in both directions:

- It **misses all 15** codes fixed in #750 — neither `arckit-togaf-adm` nor `arckit-agent-architecture` codes carry a `regime`, which is exactly why the original scan never saw them.
- It **false-positives on four**: `WVCH` and `MMOD` ask for Common Checks only by design, and `WGAM`/`WCLM` deliberately point at the shared `WARD` section.

Keying on what files actually emit avoids both.

## Deliberately out of scope

Commands that reference no per-type code at all. Separating the two intentional cases from the ~61 commands that never invoke the checklist despite writing a governed artefact needs the doc-type registry and a judgement call per command. That is the other half of #748 and wants its own change.

## Verification

The test that matters is the negative one — a guard that cannot fail reads as coverage while providing none.

- Passes on `main`: 81 references across 4 plugins, all resolve
- **Fails as intended** when a section is deleted, naming the file, the code and the plugin
- 30 new tests in `tests/plugin/test_quality_checklist_refs.py`, including negative cases for a dangling reference, a plugin with no checklist file, and the empty-match failure mode; a regression case per PR #750 code, checked against each plugin's own copy
- Full suite: 1297 passed, 225 skipped
- `markdownlint-cli2` clean, `sync-shared-assets.py --check` and `check-doc-type-registry.py` unaffected

No `${{ }}` interpolation is introduced in the workflow — the change is one static path trigger and one static run step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
