### PR TITLE
feat(us): wire the 10 US federal doc-types into the quality checklist

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/plugins/us/commands/us-ai-impact.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-ai-impact.md
@@ -80,9 +80,10 @@ Appendix I of M-24-10 lists **presumed-impacting** use cases (those agencies mus
    - **Public Disclosure Obligations** — confirm the entry has been (or will be) submitted to the agency AI Use Case Inventory (federal.ai.gov); note any redactions required for sensitive law-enforcement or national-security carve-outs.
    - **CAIO Sign-Off Block** — agency Chief AI Officer review and approval section: reviewer, date, scope of approval, conditions, next review.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AIIA** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — impact verdict (rights-impacting / safety-impacting / both / neither), Appendix I match (Y/N), minimum-practice satisfaction percentage, waiver count, AI Use Case Inventory ID (or "pending"), and CAIO review status. Do not echo the full artefact.
+8. Emit a short summary to the user — impact verdict (rights-impacting / safety-impacting / both / neither), Appendix I match (Y/N), minimum-practice satisfaction percentage, waiver count, AI Use Case Inventory ID (or "pending"), and CAIO review status. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-ai-rmf.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-ai-rmf.md
@@ -81,9 +81,10 @@ The AI RMF underpins the federal policy stack: OMB M-24-10 requires agencies to 
    - **Residual Risk Register** — risks remaining after Manage actions, prioritised; each linked to a target review date.
    - **Control Crosswalk** — table mapping AI RMF subcategories to NIST 800-53 Rev 5 controls and to OMB M-24-10 minimum-practice items, so the assurance posture is traceable.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AIRMF** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — AI system type, GenAI in scope (Y/N), top 5 residual risks, M-24-10 impact-class hint (rights-impacting / safety-impacting / neither), and CAIO review status. Do not echo the full artefact.
+8. Emit a short summary to the user — AI system type, GenAI in scope (Y/N), top 5 residual risks, M-24-10 impact-class hint (rights-impacting / safety-impacting / neither), and CAIO review status. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-fedramp-readiness.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-fedramp-readiness.md
@@ -75,9 +75,10 @@ This command produces an **internal** RAR-equivalent: a self-assessment in the s
    - **3PAO Engagement Readiness** — go / no-go assessment with the top 5 blockers if no-go.
    - **POA&M Pre-Population** — gaps converted to draft POA&M rows in FedRAMP POA&M template format (Weakness, Source, Asset, Severity, Status, Original Detection Date, Scheduled Completion Date).
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FRRR** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — readiness verdict (Ready / Conditionally Ready / Not Ready), gap counts by severity, recommended authorization path, and the top 3 blockers. Do not echo the full artefact.
+8. Emit a short summary to the user — readiness verdict (Ready / Conditionally Ready / Not Ready), gap counts by severity, recommended authorization path, and the top 3 blockers. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-fedramp-ssp.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-fedramp-ssp.md
@@ -85,9 +85,10 @@ Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** basel
    15. **Network Architecture** — boundary diagram, internal network topology, public-facing components, management plane separation
    16. **Continuous Monitoring (ConMon) Strategy** — monthly vulnerability scans (authenticated / unauthenticated / web app / container / database), annual assessment, POA&M cadence, ATO drift management
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FRSSP** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — CSO name, baseline (Moderate / High), authorization path (Agency / JAB), boundary component count, interconnection count, and any sections marked `<TBC>`. Do not echo the full artefact.
+8. Emit a short summary to the user — CSO name, baseline (Moderate / High), authorization path (Agency / JAB), boundary component count, interconnection count, and any sections marked `<TBC>`. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-fisma-categorization.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-fisma-categorization.md
@@ -73,9 +73,10 @@ The methodology decomposes the system into its constituent **information types**
    - **Agency-Specific Overlays** — note any agency-specific information-type overlays (e.g. CUI categories per 32 CFR Part 2002, HHS-specific health information types, IRS Publication 1075 FTI overlays) that apply.
    - **Rationale and Open Issues** — narrative justification for the water-mark and a register of any provisional or contested classifications requiring SISO/AO review.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FIPS199** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — system name, derived water-mark (e.g. `MODERATE / MODERATE / LOW → MODERATE`), count of information types, and any open issues. Do not echo the full artefact.
+8. Emit a short summary to the user — system name, derived water-mark (e.g. `MODERATE / MODERATE / LOW → MODERATE`), count of information types, and any open issues. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-icam.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-icam.md
@@ -83,9 +83,10 @@ Federal employees and contractors authenticate using **PIV** (Personal Identity 
    - **Credential Lifecycle** — issuance, suspension, revocation, re-issuance, renewal; PIV-specific lifecycle per FIPS 201-3 §5.
    - **Authorization Model** — RBAC / ABAC / ReBAC choice with rationale; policy decision point (PDP), policy information point (PIP), policy enforcement point (PEP) placement; integration with the Zero Trust policy engine.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ICAM** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — user-population count, highest IAL/AAL/FAL required, selected identity providers (login.gov, PIV, agency IdP), and any open architecture decisions. Do not echo the full artefact.
+8. Emit a short summary to the user — user-population count, highest IAL/AAL/FAL required, selected identity providers (login.gov, PIV, agency IdP), and any open architecture decisions. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-nist-800-53.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-nist-800-53.md
@@ -78,9 +78,10 @@ For systems pursuing FedRAMP authorization, the FedRAMP Rev 5 Baselines (Low / M
    - **CUI Overlay (if applicable)** — for systems handling Controlled Unclassified Information, layer NIST SP 800-171 Rev 3 requirements per 32 CFR Part 2002.
    - **OSCAL Readiness** — note whether the implementation is published in OSCAL machine-readable format (FedRAMP increasingly mandates OSCAL SSP submission); flag as a roadmap item if not yet.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NIST** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — baseline selected, control counts (Implemented / Inherited / Hybrid / Planned / N/A), open compensating controls, and OSCAL readiness. Do not echo the full artefact.
+8. Emit a short summary to the user — baseline selected, control counts (Implemented / Inherited / Hybrid / Planned / N/A), open compensating controls, and OSCAL readiness. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-privacy-pia.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-privacy-pia.md
@@ -81,9 +81,10 @@ This US PIA is distinct from the Canadian PIA (`/arckit-ca:ca-pia`), Australian 
    - **Privacy Risk Register and Mitigations** — risks scored by likelihood and impact, with mitigations and residual risk; cross-reference the project risk register.
    - **SAOP Sign-Off Block** — agency SAOP reviewer, date, scope of approval, publication URL (post-redaction), and re-assessment cadence.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **USPIA** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — PII element count, SORN verdict, M-03-22 checklist satisfaction, top three privacy risks, SAOP review status, and intended publication date. Do not echo the full artefact.
+8. Emit a short summary to the user — PII element count, SORN verdict, M-03-22 checklist satisfaction, top three privacy risks, SAOP review status, and intended publication date. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-sbom-eo-14028.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-sbom-eo-14028.md
@@ -81,9 +81,10 @@ Alongside the attestation, agencies may require an **SBOM** conforming to the NT
    - **Exception Request** — if a self-attestation cannot be made for one or more items, document the M-22-18 exception process: which items, why, compensating controls, agency CIO + OMB notification status, expiry of the exception.
    - **Distribution Plan** — where the attestation will be lodged (CISA Repository for Software Attestations and Artifacts), where the SBOM will be distributed (agency CSO portal, supplier portal), and the access-control posture for SBOM consumers.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SBOM** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — attestation status (Full / Partial / Exception), SBOM format and component count, SLSA level claim, open exceptions, and the lodging date target. Do not echo the full artefact.
+8. Emit a short summary to the user — attestation status (Full / Partial / Exception), SBOM format and component count, SLSA level claim, open exceptions, and the lodging date target. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/commands/us-zero-trust.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-zero-trust.md
@@ -74,9 +74,10 @@ NIST SP 800-207 is the foundational Zero Trust Architecture specification (logic
    - **OMB M-22-09 End-State Alignment** — explicit mapping of current posture to the five M-22-09 strategic goals (Identity, Devices, Networks, Applications & Workloads, Data) and the specific action items in the memo.
    - **800-53 Control Linkage** — table mapping each ZTMM function to the NIST 800-53 Rev 5 controls that evidence it (e.g. Identity / Authentication → IA-2, IA-2(1), IA-2(2), IA-5, IA-8; Networks / Network Segmentation → SC-7, SC-7(4), SC-7(5), SC-7(8); Data / Data Encryption → SC-13, SC-28, SC-28(1)).
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ZTA** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — overall maturity (e.g. "Initial across Identity and Networks; Traditional elsewhere"), top three gaps, target FY for Advanced posture, and the count of M-22-09 action items unaddressed. Do not echo the full artefact.
+8. Emit a short summary to the user — overall maturity (e.g. "Initial across Identity and Networks; Traditional elsewhere"), top three gaps, target FY for Advanced posture, and the count of M-22-09 action items unaddressed. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers

--- a/plugins/arckit-us/commands/us-ai-impact.md
+++ b/plugins/arckit-us/commands/us-ai-impact.md
@@ -80,9 +80,10 @@ Appendix I of M-24-10 lists **presumed-impacting** use cases (those agencies mus
    - **Public Disclosure Obligations** — confirm the entry has been (or will be) submitted to the agency AI Use Case Inventory (federal.ai.gov); note any redactions required for sensitive law-enforcement or national-security carve-outs.
    - **CAIO Sign-Off Block** — agency Chief AI Officer review and approval section: reviewer, date, scope of approval, conditions, next review.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AIIA** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — impact verdict (rights-impacting / safety-impacting / both / neither), Appendix I match (Y/N), minimum-practice satisfaction percentage, waiver count, AI Use Case Inventory ID (or "pending"), and CAIO review status. Do not echo the full artefact.
+8. Emit a short summary to the user — impact verdict (rights-impacting / safety-impacting / both / neither), Appendix I match (Y/N), minimum-practice satisfaction percentage, waiver count, AI Use Case Inventory ID (or "pending"), and CAIO review status. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-ai-rmf.md
+++ b/plugins/arckit-us/commands/us-ai-rmf.md
@@ -81,9 +81,10 @@ The AI RMF underpins the federal policy stack: OMB M-24-10 requires agencies to 
    - **Residual Risk Register** — risks remaining after Manage actions, prioritised; each linked to a target review date.
    - **Control Crosswalk** — table mapping AI RMF subcategories to NIST 800-53 Rev 5 controls and to OMB M-24-10 minimum-practice items, so the assurance posture is traceable.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AIRMF** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — AI system type, GenAI in scope (Y/N), top 5 residual risks, M-24-10 impact-class hint (rights-impacting / safety-impacting / neither), and CAIO review status. Do not echo the full artefact.
+8. Emit a short summary to the user — AI system type, GenAI in scope (Y/N), top 5 residual risks, M-24-10 impact-class hint (rights-impacting / safety-impacting / neither), and CAIO review status. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-fedramp-readiness.md
+++ b/plugins/arckit-us/commands/us-fedramp-readiness.md
@@ -75,9 +75,10 @@ This command produces an **internal** RAR-equivalent: a self-assessment in the s
    - **3PAO Engagement Readiness** — go / no-go assessment with the top 5 blockers if no-go.
    - **POA&M Pre-Population** — gaps converted to draft POA&M rows in FedRAMP POA&M template format (Weakness, Source, Asset, Severity, Status, Original Detection Date, Scheduled Completion Date).
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FRRR** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — readiness verdict (Ready / Conditionally Ready / Not Ready), gap counts by severity, recommended authorization path, and the top 3 blockers. Do not echo the full artefact.
+8. Emit a short summary to the user — readiness verdict (Ready / Conditionally Ready / Not Ready), gap counts by severity, recommended authorization path, and the top 3 blockers. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-fedramp-ssp.md
+++ b/plugins/arckit-us/commands/us-fedramp-ssp.md
@@ -85,9 +85,10 @@ Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** basel
    15. **Network Architecture** — boundary diagram, internal network topology, public-facing components, management plane separation
    16. **Continuous Monitoring (ConMon) Strategy** — monthly vulnerability scans (authenticated / unauthenticated / web app / container / database), annual assessment, POA&M cadence, ATO drift management
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FRSSP** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — CSO name, baseline (Moderate / High), authorization path (Agency / JAB), boundary component count, interconnection count, and any sections marked `<TBC>`. Do not echo the full artefact.
+8. Emit a short summary to the user — CSO name, baseline (Moderate / High), authorization path (Agency / JAB), boundary component count, interconnection count, and any sections marked `<TBC>`. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-fisma-categorization.md
+++ b/plugins/arckit-us/commands/us-fisma-categorization.md
@@ -73,9 +73,10 @@ The methodology decomposes the system into its constituent **information types**
    - **Agency-Specific Overlays** — note any agency-specific information-type overlays (e.g. CUI categories per 32 CFR Part 2002, HHS-specific health information types, IRS Publication 1075 FTI overlays) that apply.
    - **Rationale and Open Issues** — narrative justification for the water-mark and a register of any provisional or contested classifications requiring SISO/AO review.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FIPS199** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — system name, derived water-mark (e.g. `MODERATE / MODERATE / LOW → MODERATE`), count of information types, and any open issues. Do not echo the full artefact.
+8. Emit a short summary to the user — system name, derived water-mark (e.g. `MODERATE / MODERATE / LOW → MODERATE`), count of information types, and any open issues. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-icam.md
+++ b/plugins/arckit-us/commands/us-icam.md
@@ -83,9 +83,10 @@ Federal employees and contractors authenticate using **PIV** (Personal Identity 
    - **Credential Lifecycle** — issuance, suspension, revocation, re-issuance, renewal; PIV-specific lifecycle per FIPS 201-3 §5.
    - **Authorization Model** — RBAC / ABAC / ReBAC choice with rationale; policy decision point (PDP), policy information point (PIP), policy enforcement point (PEP) placement; integration with the Zero Trust policy engine.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ICAM** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — user-population count, highest IAL/AAL/FAL required, selected identity providers (login.gov, PIV, agency IdP), and any open architecture decisions. Do not echo the full artefact.
+8. Emit a short summary to the user — user-population count, highest IAL/AAL/FAL required, selected identity providers (login.gov, PIV, agency IdP), and any open architecture decisions. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-nist-800-53.md
+++ b/plugins/arckit-us/commands/us-nist-800-53.md
@@ -78,9 +78,10 @@ For systems pursuing FedRAMP authorization, the FedRAMP Rev 5 Baselines (Low / M
    - **CUI Overlay (if applicable)** — for systems handling Controlled Unclassified Information, layer NIST SP 800-171 Rev 3 requirements per 32 CFR Part 2002.
    - **OSCAL Readiness** — note whether the implementation is published in OSCAL machine-readable format (FedRAMP increasingly mandates OSCAL SSP submission); flag as a roadmap item if not yet.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NIST** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — baseline selected, control counts (Implemented / Inherited / Hybrid / Planned / N/A), open compensating controls, and OSCAL readiness. Do not echo the full artefact.
+8. Emit a short summary to the user — baseline selected, control counts (Implemented / Inherited / Hybrid / Planned / N/A), open compensating controls, and OSCAL readiness. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-privacy-pia.md
+++ b/plugins/arckit-us/commands/us-privacy-pia.md
@@ -81,9 +81,10 @@ This US PIA is distinct from the Canadian PIA (`/arckit:ca-pia`), Australian PIA
    - **Privacy Risk Register and Mitigations** — risks scored by likelihood and impact, with mitigations and residual risk; cross-reference the project risk register.
    - **SAOP Sign-Off Block** — agency SAOP reviewer, date, scope of approval, publication URL (post-redaction), and re-assessment cadence.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **USPIA** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — PII element count, SORN verdict, M-03-22 checklist satisfaction, top three privacy risks, SAOP review status, and intended publication date. Do not echo the full artefact.
+8. Emit a short summary to the user — PII element count, SORN verdict, M-03-22 checklist satisfaction, top three privacy risks, SAOP review status, and intended publication date. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-sbom-eo-14028.md
+++ b/plugins/arckit-us/commands/us-sbom-eo-14028.md
@@ -81,9 +81,10 @@ Alongside the attestation, agencies may require an **SBOM** conforming to the NT
    - **Exception Request** — if a self-attestation cannot be made for one or more items, document the M-22-18 exception process: which items, why, compensating controls, agency CIO + OMB notification status, expiry of the exception.
    - **Distribution Plan** — where the attestation will be lodged (CISA Repository for Software Attestations and Artifacts), where the SBOM will be distributed (agency CSO portal, supplier portal), and the access-control posture for SBOM consumers.
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SBOM** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — attestation status (Full / Partial / Exception), SBOM format and component count, SLSA level claim, open exceptions, and the lodging date target. Do not echo the full artefact.
+8. Emit a short summary to the user — attestation status (Full / Partial / Exception), SBOM format and component count, SLSA level claim, open exceptions, and the lodging date target. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/commands/us-zero-trust.md
+++ b/plugins/arckit-us/commands/us-zero-trust.md
@@ -74,9 +74,10 @@ NIST SP 800-207 is the foundational Zero Trust Architecture specification (logic
    - **OMB M-22-09 End-State Alignment** — explicit mapping of current posture to the five M-22-09 strategic goals (Identity, Devices, Networks, Applications & Workloads, Data) and the specific action items in the memo.
    - **800-53 Control Linkage** — table mapping each ZTMM function to the NIST 800-53 Rev 5 controls that evidence it (e.g. Identity / Authentication → IA-2, IA-2(1), IA-2(2), IA-5, IA-8; Networks / Network Segmentation → SC-7, SC-7(4), SC-7(5), SC-7(8); Data / Data Encryption → SC-13, SC-28, SC-28(1)).
 
-6. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
+6. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ZTA** per-type checks pass. Fix any failures before proceeding.
+7. Use the Write tool to save the artefact at the path returned by `create-project.sh` + `generate-document-id.mjs`.
 
-7. Emit a short summary to the user — overall maturity (e.g. "Initial across Identity and Networks; Traditional elsewhere"), top three gaps, target FY for Advanced posture, and the count of M-22-09 action items unaddressed. Do not echo the full artefact.
+8. Emit a short summary to the user — overall maturity (e.g. "Initial across Identity and Networks; Traditional elsewhere"), top three gaps, target FY for Advanced posture, and the count of M-22-09 action items unaddressed. Do not echo the full artefact.
 
 ## Handoffs
 

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -847,3 +847,134 @@ All artifacts must pass these 10 checks:
 - No dimension scored above L3 without documented, repeatable process evidence
 - Improvement actions given per dimension where a gap exists
 - Overall maturity consistent with the dimension scores — not above the lowest scored dimension without justification
+
+### FIPS199 -- FISMA Security Categorization
+
+- System type recorded (General Support System / Major Application / Minor Application / Subsystem)
+- Every information type carries an SP 800-60 Vol 2 reference (e.g. `C.2.8.12`), not a prose name alone
+- Confidentiality, Integrity and Availability each scored Low / Moderate / High for every information type
+- SP 800-60 provisional values recorded alongside the adjusted values, with rationale for every deviation
+- System security category derived by the high-water-mark rule with the calculation shown — each objective equals the maximum across all information types, and none falls below its highest constituent
+- Aggregation-driven upward adjustments stated explicitly; any downward adjustment justified against SP 800-60 §3.2
+- Agency-specific overlays assessed (CUI per 32 CFR Part 2002, IRS Publication 1075 FTI, agency health types) or recorded as not applicable
+- Provisional or contested classifications listed for SISO/AO review rather than silently resolved
+
+### NIST -- NIST SP 800-53 Control Tailoring
+
+- Baseline derived from the FIPS 199 water-mark and matching it, not chosen independently
+- FedRAMP baseline recorded where FedRAMP applies (Low / Moderate / High / LI-SaaS) with the Rev 5 source cited
+- Every control in the selected baseline appears in the tailoring matrix — no silent omissions
+- Each control records an implementation status (Implemented / Inherited / Hybrid / Planned / Not Applicable) and a responsible party
+- Every Inherited or Hybrid control names the CSP and links its Customer Responsibility Matrix
+- Control enhancements carried at their own IDs (e.g. `AC-2(1)`), not folded into the base control
+- Every `[Assignment:` and `[Selection:` parameter has an assigned agency value; FedRAMP-specified values honoured, with deviations called out
+- Compensating controls record rationale, residual risk and AO acceptance posture
+- Privacy control overlay (PT family, SP 800-53B) tailored wherever PII is processed, cross-referenced to the PIA
+- SP 800-171 Rev 3 layered where CUI is in scope
+- OSCAL publication status recorded, flagged as a roadmap item if not yet met
+
+### FRSSP -- FedRAMP System Security Plan
+
+- Every section of the SSP structure present, with sections lacking content marked `<TBC>` and surfaced rather than left silently incomplete
+- Categorization pulled verbatim from the FIPS 199 artefact, with the CIA water-mark matching it exactly
+- Control baseline consistent with that categorization — a Moderate system carries the Moderate baseline
+- Every control records a Control Origination from the permitted set (Service Provider Corporate / SP System Specific / Configured by Customer / Provided by Customer / Shared / Inherited)
+- Every Shared control states the customer responsibility
+- Authorization boundary describes components inside and outside, with explicit in-scope / out-of-scope justification for external services per the ABG
+- Every interconnection records name, FedRAMP package ID, agreement type (ICA / MOU / ISA), data direction, ports and protocols, and sensitivity
+- Types of Users records privilege level, clearance or citizenship requirement, and authentication mechanism per population
+- Applicable laws include FISMA, the Privacy Act and E-Gov Act §208 as a minimum, plus agency-specific statutes, with M-24-10 cited where AI is in scope
+- ConMon strategy states scan cadence by type (authenticated, unauthenticated, web application, container, database), annual assessment and POA&M cadence
+
+### FRRR -- FedRAMP Readiness Assessment
+
+- The SSP and NIST 800-53 artefacts both exist — the control delta cannot be enumerated without them
+- Capability statement says why a federal agency would use the CSO, not only what it does
+- Ready-capabilities checklist assessed item by item: FIPS 140-3 validated cryptography at rest and in transit, MFA for privileged access, audit logging, vulnerability-management cadence, incident response with US-CERT reporting, supply-chain controls, ConMon, and US-Persons staffing where required
+- Every gap records a severity per the 3PAO RAR rubric (Critical / High / Moderate / Low), an owner and a target date
+- Gap register reconciles with the Planned entries in the NIST 800-53 artefact
+- Every gap has a corresponding draft POA&M row in FedRAMP POA&M format
+- Evidence inventory identifies control claims with no supporting artefact, rather than listing only the evidence that exists
+- Customer Responsibility Matrix drafted for SaaS and PaaS offerings
+- Authorization path recommended with rationale against the JAB prioritization criteria
+- Readiness verdict consistent with the gaps — no Ready verdict while Critical or High gaps remain open
+
+### ZTA -- Zero Trust Architecture Maturity
+
+- All five pillars assessed: Identity, Devices, Networks, Applications & Workloads, Data
+- All three cross-cuts assessed: Visibility & Analytics, Automation & Orchestration, Governance
+- Every function scored Current and Target on the ZTMM v2.0 four-stage scale (Traditional / Initial / Advanced / Optimal)
+- Current-stage claims carry evidence rather than assertion
+- Heatmap cell codes (T/I/A/O) reconcile with the per-function scores, with a parallel target-state heatmap present
+- No target stage set below its own current stage
+- Every function with a gap appears in the uplift roadmap; roadmap sequencing respects the stated dependencies
+- M-22-09 alignment maps posture to all five strategic goals and names the action items still unaddressed
+- Control linkage maps each ZTMM function to specific 800-53 Rev 5 control IDs
+
+### ICAM -- Identity, Credential and Access Management
+
+- Every user population enumerated with its use cases (Federal Employees, Contractors, Citizens, Partner Agencies, Privileged Administrators, Service Accounts)
+- IAL, AAL and FAL each scored 1/2/3 per use case, with SP 800-63-3 rationale referencing the impact categories
+- AAL consistent with the FIPS 199 water-mark — a higher water-mark cannot carry a lower AAL without stated justification
+- Authenticators selected for each tier are permitted by SP 800-63B for that tier; AAL3 uses multi-factor cryptographic hardware with verifier impersonation resistance
+- Identity proofing documented for every IAL2/IAL3 use case: evidence strength (FAIR / STRONG / SUPERIOR), remote versus in-person, provider, retention and disposal
+- Federal employee and contractor pattern uses PIV as primary credential per HSPD-12 and FIPS 201-3, with Derived PIV (SP 800-157 Rev 1) for mobile
+- Public-facing citizen pattern documents login.gov per M-19-17, or justifies an alternative
+- Federation pattern specifies protocol (SAML 2.0 / OIDC), initiation direction, assertion encryption and single-logout handling
+- Privileged access covers break-glass accounts, just-in-time elevation, session recording and separation of duties
+- Credential lifecycle covers issuance, suspension, revocation, re-issuance and renewal
+- Authorization model chosen (RBAC / ABAC / ReBAC) with PDP, PIP and PEP placement identified
+- Identity-proofing PII flows cross-referenced to the PIA
+
+### USPIA -- Privacy Impact Assessment (US Federal)
+
+- Document ID uses `USPIA`, not `PIA` — `PIA` is registered to the Canadian Privacy Impact Assessment
+- Every PII element records category (sensitive / non-sensitive per SP 800-122), source, purpose, lawful authority, retention period and disposal method
+- Any PII element without a clear lawful authority flagged as a blocker rather than left blank
+- Lifecycle map covers Collection → Use → Disclosure → Retention → Disposal, each flow annotated with its authority and any Privacy Act §552a(b) exception relied upon
+- System-of-records determination made explicitly — records about individuals retrieved by personal identifier
+- SORN verdict stated as New required / Modify existing (citing the SORN number) / None required, with reasoning
+- Where a SORN is required, routine uses, retention schedule and Federal Register timeline captured, including the 30-day period before operational use
+- All eight FIPPs assessed (Transparency, Individual Participation, Purpose Specification, Data Minimisation, Use Limitation, Data Quality and Integrity, Security, Accountability and Auditing)
+- All seven M-03-22 required topics covered
+- Sector overlays assessed where applicable (HIPAA, FERPA, IRS Publication 1075, CJIS, GLBA, COPPA)
+- Privacy risks scored by likelihood and impact with mitigations and residual risk, cross-referenced to the project risk register
+- SAOP sign-off block present with reviewer, scope, publication URL and re-assessment cadence
+
+### AIRMF -- NIST AI Risk Management Framework
+
+- All four functions assessed: Govern, Map, Measure, Manage
+- Govern subcategories covered across 1.1–1.7, 2.1–2.3, 3.1–3.2, 4.1–4.3, 5.1–5.2 and 6.1–6.2, each with outcome, current state, evidence and gap action
+- Lifecycle stages in scope identified per AI RMF §3, with TEVV responsibilities named
+- Measure function selects metrics per trustworthiness characteristic (valid and reliable, safe, secure and resilient, accountable and transparent, explainable and interpretable, privacy-enhanced, fair with harmful bias managed), each with test method and frequency
+- Generative AI addendum present wherever the system uses generative AI, assessing all 12 NIST AI 600-1 risks with applicability, controls, residual risk and actions
+- Absence of the GenAI addendum justified by an explicit not-generative determination, never omitted silently
+- Residual risk register lists risks remaining after Manage actions, each with a target review date
+- Control crosswalk maps AI RMF subcategories to 800-53 Rev 5 controls and to M-24-10 minimum practices
+- Manage function cross-references the IR controls in the NIST 800-53 artefact
+
+### AIIA -- AI Impact Assessment (OMB M-24-10)
+
+- Appendix I presumed-impacting lists checked for both rights and safety, with matched items quoted verbatim and cited to their M-24-10 section, or an explicit "no Appendix I match"
+- Rights-impacting determination applies the M-24-10 principal-basis test and names both the decision and the affected population
+- Safety-impacting determination names the decision flow, not a verdict alone
+- An Appendix I match not carried through to a Yes verdict recorded as a documented rebuttal of presumption, never as a silent No
+- All eight minimum risk-management practices assessed with status (Met / Partial / Not Met / Not Applicable), evidence reference and action
+- Every practice not Met carries a waiver record with CAIO determination, waiver period and compensating measures
+- M-25-21 acquisition controls documented for vendor-supplied AI: AI RMF alignment, model provenance, training-data disclosure, bias-testing access, fairness reporting, incident reporting, exit and portability
+- AI Use Case Inventory submission confirmed or scheduled, with any law-enforcement or national-security redactions noted
+- CAIO sign-off block present with scope, conditions and next review
+
+### SBOM -- Software Bill of Materials (EO 14028 / M-22-18)
+
+- Applicability determined against the M-22-18 §2 covered-software definition, citing the post-14-September-2022 development test
+- Producer of record identified for every open-source component
+- Every CISA attestation item recorded with status (Yes / No / Partial), evidence reference and remediation plan
+- Attestation items crosswalked to SP 800-218 SSDF practices (PO, PS, PW, RV) and to 800-53 SR and SA controls
+- SBOM format stated with its version (e.g. CycloneDX 1.6, SPDX 2.3) and the tooling used to generate it
+- All seven NTIA minimum data fields present: supplier name, component name, version, other unique identifiers (PURL / CPE), dependency relationships, author of SBOM data, timestamp
+- NTIA automation and practice elements addressed: machine-readable format, frequency, depth, known unknowns, distribution and delivery, access control, accommodation of mistakes
+- SLSA level claimed with rationale, and a signing strategy stated
+- VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
+- Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
+- Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers


### PR DESCRIPTION
First regime of the 61 in #748. Chosen as the starting point because `arckit-us` is the cleanest: one plugin, 10 codes, 10 commands, every one templated and structurally identical — the right place to prove the pattern before the messier regimes.

**Remaining after this: 51** — UK (15), UAE (12), CA (12), AU (12).

## Two edits per doc-type, not one

This is the important difference from #750. There, the reference already existed and only the section was missing. Here the commands reference `references/quality-checklist.md` in **no phrasing at all**, so a section on its own would be inert — nothing would ever read it.

So each doc-type gets:

1. a `### <CODE>` section in the canonical checklist (90 → 100 sections)
2. a checklist step in the command, immediately before the Write step

Worth being explicit about what these artefacts were missing: not just their per-type checks, but the **10 Common Checks** too. No Document Control completeness check, no placeholder detection, no classification validation, on every US federal artefact ArcKit produced.

## Where the content came from

Not `## Success Criteria` — this overlay has none (0/10), which is the premise #748 gets wrong. The source is each command's "Generate the following sections" list, which is unusually good material: it names the standards, the enums and the derived values directly.

The checks lean on that. Where a value is derived, the check asserts it **agrees with its inputs** rather than merely existing:

- the FIPS 199 water-mark must equal the maximum across information types, with the calculation shown
- the 800-53 baseline must match that water-mark rather than being chosen independently
- the SSP categorization must match the FIPS 199 artefact verbatim
- no FedRAMP **Ready** verdict may stand while Critical or High gaps are open
- no ZTMM target stage may sit below its own current stage

A few encode silent-failure modes the commands imply but never state: an Appendix I presumed-impacting match that does not reach a Yes verdict must be a recorded **rebuttal of presumption**, never a silent No; and a missing GenAI addendum must rest on an explicit not-generative determination rather than simple omission.

`USPIA` carries an explicit check that the document ID is `USPIA` and not `PIA` — `PIA` is registered to the Canadian assessment, and the command itself flags the collision risk.

## The mechanical edit

All 10 commands shared one step shape (write at 6, emit at 7, no step 8), verified before touching anything, so the insertion was applied uniformly and renumbered. Confirmed 1–8 with no duplicates or gaps in every file afterwards.

## Verification

- Guard reports **91 references across 5 plugins, all resolving** — `arckit-us: 10` is new
- Regime-carrying codes with no section: **61 → 51**
- `check-doc-type-registry.py`, `check_references.py` (836 files), `sync-shared-assets.py --check` all clean
- `markdownlint-cli2` clean over 1,211 plugin files
- Converter regenerated all 7 extensions
- Full suite: 1297 passed, 225 skipped
- Canonical checklist diff is additive only (+131, −0)

## Found while reading, not fixed here

`us-fedramp-ssp.md` step 5 says **"Generate the 15-section FedRAMP SSP structure"** and then lists **16** numbered sections. The count and the list disagree. I did not touch it — it is a command-body defect rather than a checklist gap, and folding it in would mix two concerns. The `FRSSP` section is written against section *names*, so it does not depend on the wrong count. Happy to fix it separately if you want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
