### PR TITLE
feat(uae): wire the 12 UAE federal doc-types into the quality checklist

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/uae/commands/uae-ai-autonomy-tier.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-ai-autonomy-tier.md
@@ -43,8 +43,9 @@ You are an enterprise architect generating a three-tier AI Autonomy Posture for 
    - **Audit Obligations per Tier** — logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence, and reporting line.
    - **Tier-Promotion Criteria** — the criteria that must be evidenced before a use-case is promoted from Tier 1 to Tier 2, or Tier 2 to Tier 3.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Where the tier framing references the UAE AI Charter, cite the Charter directly.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of use-cases per tier and any tier-promotion proposals).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUTI** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of use-cases per tier and any tier-promotion proposals).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-ai-charter.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-ai-charter.md
@@ -39,8 +39,9 @@ You are an enterprise architect generating a UAE Charter for the Development and
    - **Bias & Fairness Assessment** — protected attributes, fairness metrics measured, dataset provenance, mitigation actions taken, residual risk.
    - **Human-in-the-Loop Design** — for each AI use-case, state the operator/reviewer role, the trigger for human review, the override mechanism, and the audit trail of human decisions.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE Charter for AI MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of principles fully compliant, partially compliant, and non-compliant).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AICH** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of principles fully compliant, partially compliant, and non-compliant).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-classification.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-classification.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a UAE Smart Data Classification Regis
    - Downstream INT requirements that consume it
    - The applicable PDPL lawful basis (if personal data is in scope — see `/arckit-uae:uae-pdpl`)
 8. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE Smart Data Classifications publication MUST appear in the Document Register with its primary URL and the verification date.
-9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-10. Show only a summary to the user (one paragraph plus a short list of datasets and their proposed classifications).
+9. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CLAS** per-type checks pass. Fix any failures before proceeding.
+10. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+11. Show only a summary to the user (one paragraph plus a short list of datasets and their proposed classifications).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-cloud-residency.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-cloud-residency.md
@@ -41,8 +41,9 @@ You are an enterprise architect assessing UAE sovereign cloud residency under th
    - **Shared-Responsibility Matrix** — per chosen CSP, division of security responsibilities across infrastructure, platform, application, data, identity, and operational layers.
    - **Exit and Portability Plan** — data egress strategy, format portability, identity migration, key custody on exit, contingency residency on regulatory change.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The National Cloud Security Policy v2 MUST appear in the Document Register with its primary URL and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (paragraph plus headline counts: datasets requiring UAE residency, datasets compliant, datasets non-compliant, chosen CSPs).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CRES** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (paragraph plus headline counts: datasets requiring UAE residency, datasets compliant, datasets non-compliant, chosen CSPs).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-data-sharing.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-data-sharing.md
@@ -42,8 +42,9 @@ You are an enterprise architect generating a Data Sharing Agreement under the UA
    - **Information-Security Safeguards** — encryption (transit + rest), key management, access controls, logging, and incident-response co-ordination between parties.
    - **Data-Subject Rights Implications** — how data subject rights (access, rectification, erasure, restriction, portability, object) flow across the sharing boundary, and which party owns each obligation.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Government Services Data Sharing Policy) MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of shares per direction and any unresolved lawful-basis gaps).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DSHR** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of shares per direction and any unresolved lawful-basis gaps).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-digital-records.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-digital-records.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a Digital Records Plan under the UAE 
    - **Records Lifecycle** — capture, classification (cross-reference to CLAS register), storage, access, retention, disposal. State where each lifecycle stage is implemented in the technology stack.
    - **Audit & Disposal procedures** — the operational procedure for periodic audit (sampling, integrity checks) and the controlled disposal procedure (approver, evidence of disposal).
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Government Services Digital Records Policy) MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of records under each lifecycle stage and any retention gaps).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DREC** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of records under each lifecycle stage and any retention gaps).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-ias.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-ias.md
@@ -38,8 +38,9 @@ You are an enterprise architect generating a UAE IAS Statement of Applicability 
    - **Risk Treatment Plan** — gaps surfaced from the SoA, target-state plan, owners, deadlines.
    - **CII Registration** (if applicable) — registration status with the UAE Cybersecurity Council, sector designation, sector regulator interactions.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE IAS publication MUST appear in the Document Register with its primary URL and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (paragraph plus headline counts: total controls applicable, % implemented per priority tier, critical gaps).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **IAS** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (paragraph plus headline counts: total controls applicable, % implemented per priority tier, critical gaps).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-pdpl.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-pdpl.md
@@ -44,8 +44,9 @@ You are an enterprise architect generating a UAE PDPL Compliance Assessment for 
    - **Breach notification playbook** — PDPL Article 9 obligations to the Data Office and to affected data subjects, with applicable timelines and the operational owner.
    - **Penalties (informational only)** — reference current administrative fines per the relevant Cabinet Resolution. This section is informational and is not used for compliance scoring.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Federal Decree-Law No. 45 of 2021 MUST appear in the Document Register with its primary URL and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline DPIA outcome and any cross-border transfers flagged).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PDPL** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline DPIA outcome and any cross-border transfers flagged).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-priorities-alignment.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-priorities-alignment.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a National Priorities Alignment State
    - **Resource-Efficiency Calculation** — quantitative comparison of the reused-capability baseline cost vs the build alternative, over the lifecycle of the project.
    - **Feasibility & Pilot Plan** — feasibility assessment per major capability and the pilot/phased rollout sequence required by the Federal Government Guide.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Federal Government Guide), We the UAE 2031, the UAE AI Strategy 2031, the National Investment Strategy 2031, and the Digital Economy Strategy MUST appear in the Document Register where cited.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline reuse decisions and the resource-efficiency outcome).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NPRA** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline reuse decisions and the resource-efficiency outcome).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-procurement.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-procurement.md
@@ -40,8 +40,9 @@ You are an enterprise architect generating a federal procurement strategy under 
    - **Evaluation Methodology** — score model (technical / commercial weights), pass/fail thresholds, panel composition (including independence from the bidding pool), conflict-of-interest declarations, evaluation report structure.
    - **Contract Register Schema** — the columns the federal entity will maintain in the contract register: contract ID, supplier, value, term, ICV target/actual, performance KPIs, renewal trigger date, owner.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Federal Decree-Law No. 11 of 2023 MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline route to market, ICV target, and evaluation weights).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FPRO** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline route to market, ICV target, and evaluation weights).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-uaepass.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-uaepass.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a UAE Pass integration design for a U
    - **Service Provider Onboarding Checklist** — TDRA / ICP onboarding artefacts (production credentials request, callback URL allow-list, branding pack, security review, go-live checklist).
    - **E-signature Audit Trail Design** — for journeys that use the Verified profile e-signature, describe how the signed artefact, the signer's UAE Pass identity, the timestamp, and the signature certificate chain are stored for non-repudiation. Cite the UAE Pass e-signature legal effect.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE Pass developer documentation MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline profile selection per journey and any onboarding gaps flagged).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **UPASS** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline profile selection per journey and any onboarding gaps flagged).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/commands/uae-zero-bureaucracy.md
+++ b/plugins/arckit-claude/plugins/uae/commands/uae-zero-bureaucracy.md
@@ -38,8 +38,9 @@ You are an enterprise architect generating a Service Catalogue Review under the 
    - **Customer Experience KPIs** — define and target the KPIs the service will report monthly: Customer Satisfaction (CSAT), Net Promoter Score (NPS), First-Time Right rate, Digital Adoption %, and Failure Demand %.
    - **Code Compliance Statement** — explicit statement against the UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast). For each principle, evidence how the redesigned service complies.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Code for Government Services + Zero Bureaucracy) MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline reduction commitments per service).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ZBUR** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline reduction commitments per service).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-uae/commands/uae-ai-autonomy-tier.md
+++ b/plugins/arckit-uae/commands/uae-ai-autonomy-tier.md
@@ -43,8 +43,9 @@ You are an enterprise architect generating a three-tier AI Autonomy Posture for 
    - **Audit Obligations per Tier** — logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence, and reporting line.
    - **Tier-Promotion Criteria** — the criteria that must be evidenced before a use-case is promoted from Tier 1 to Tier 2, or Tier 2 to Tier 3.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Where the tier framing references the UAE AI Charter, cite the Charter directly.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of use-cases per tier and any tier-promotion proposals).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUTI** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of use-cases per tier and any tier-promotion proposals).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-ai-charter.md
+++ b/plugins/arckit-uae/commands/uae-ai-charter.md
@@ -39,8 +39,9 @@ You are an enterprise architect generating a UAE Charter for the Development and
    - **Bias & Fairness Assessment** — protected attributes, fairness metrics measured, dataset provenance, mitigation actions taken, residual risk.
    - **Human-in-the-Loop Design** — for each AI use-case, state the operator/reviewer role, the trigger for human review, the override mechanism, and the audit trail of human decisions.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE Charter for AI MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of principles fully compliant, partially compliant, and non-compliant).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AICH** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of principles fully compliant, partially compliant, and non-compliant).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-classification.md
+++ b/plugins/arckit-uae/commands/uae-classification.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a UAE Smart Data Classification Regis
    - Downstream INT requirements that consume it
    - The applicable PDPL lawful basis (if personal data is in scope — see `/arckit:uae-pdpl`)
 8. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE Smart Data Classifications publication MUST appear in the Document Register with its primary URL and the verification date.
-9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-10. Show only a summary to the user (one paragraph plus a short list of datasets and their proposed classifications).
+9. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CLAS** per-type checks pass. Fix any failures before proceeding.
+10. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+11. Show only a summary to the user (one paragraph plus a short list of datasets and their proposed classifications).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-cloud-residency.md
+++ b/plugins/arckit-uae/commands/uae-cloud-residency.md
@@ -41,8 +41,9 @@ You are an enterprise architect assessing UAE sovereign cloud residency under th
    - **Shared-Responsibility Matrix** — per chosen CSP, division of security responsibilities across infrastructure, platform, application, data, identity, and operational layers.
    - **Exit and Portability Plan** — data egress strategy, format portability, identity migration, key custody on exit, contingency residency on regulatory change.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The National Cloud Security Policy v2 MUST appear in the Document Register with its primary URL and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (paragraph plus headline counts: datasets requiring UAE residency, datasets compliant, datasets non-compliant, chosen CSPs).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CRES** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (paragraph plus headline counts: datasets requiring UAE residency, datasets compliant, datasets non-compliant, chosen CSPs).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-data-sharing.md
+++ b/plugins/arckit-uae/commands/uae-data-sharing.md
@@ -42,8 +42,9 @@ You are an enterprise architect generating a Data Sharing Agreement under the UA
    - **Information-Security Safeguards** — encryption (transit + rest), key management, access controls, logging, and incident-response co-ordination between parties.
    - **Data-Subject Rights Implications** — how data subject rights (access, rectification, erasure, restriction, portability, object) flow across the sharing boundary, and which party owns each obligation.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Government Services Data Sharing Policy) MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of shares per direction and any unresolved lawful-basis gaps).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DSHR** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of shares per direction and any unresolved lawful-basis gaps).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-digital-records.md
+++ b/plugins/arckit-uae/commands/uae-digital-records.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a Digital Records Plan under the UAE 
    - **Records Lifecycle** — capture, classification (cross-reference to CLAS register), storage, access, retention, disposal. State where each lifecycle stage is implemented in the technology stack.
    - **Audit & Disposal procedures** — the operational procedure for periodic audit (sampling, integrity checks) and the controlled disposal procedure (approver, evidence of disposal).
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Government Services Digital Records Policy) MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the count of records under each lifecycle stage and any retention gaps).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DREC** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the count of records under each lifecycle stage and any retention gaps).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-ias.md
+++ b/plugins/arckit-uae/commands/uae-ias.md
@@ -38,8 +38,9 @@ You are an enterprise architect generating a UAE IAS Statement of Applicability 
    - **Risk Treatment Plan** — gaps surfaced from the SoA, target-state plan, owners, deadlines.
    - **CII Registration** (if applicable) — registration status with the UAE Cybersecurity Council, sector designation, sector regulator interactions.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE IAS publication MUST appear in the Document Register with its primary URL and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (paragraph plus headline counts: total controls applicable, % implemented per priority tier, critical gaps).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **IAS** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (paragraph plus headline counts: total controls applicable, % implemented per priority tier, critical gaps).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-pdpl.md
+++ b/plugins/arckit-uae/commands/uae-pdpl.md
@@ -44,8 +44,9 @@ You are an enterprise architect generating a UAE PDPL Compliance Assessment for 
    - **Breach notification playbook** — PDPL Article 9 obligations to the Data Office and to affected data subjects, with applicable timelines and the operational owner.
    - **Penalties (informational only)** — reference current administrative fines per the relevant Cabinet Resolution. This section is informational and is not used for compliance scoring.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Federal Decree-Law No. 45 of 2021 MUST appear in the Document Register with its primary URL and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline DPIA outcome and any cross-border transfers flagged).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PDPL** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline DPIA outcome and any cross-border transfers flagged).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-priorities-alignment.md
+++ b/plugins/arckit-uae/commands/uae-priorities-alignment.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a National Priorities Alignment State
    - **Resource-Efficiency Calculation** — quantitative comparison of the reused-capability baseline cost vs the build alternative, over the lifecycle of the project.
    - **Feasibility & Pilot Plan** — feasibility assessment per major capability and the pilot/phased rollout sequence required by the Federal Government Guide.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Federal Government Guide), We the UAE 2031, the UAE AI Strategy 2031, the National Investment Strategy 2031, and the Digital Economy Strategy MUST appear in the Document Register where cited.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline reuse decisions and the resource-efficiency outcome).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NPRA** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline reuse decisions and the resource-efficiency outcome).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-procurement.md
+++ b/plugins/arckit-uae/commands/uae-procurement.md
@@ -40,8 +40,9 @@ You are an enterprise architect generating a federal procurement strategy under 
    - **Evaluation Methodology** — score model (technical / commercial weights), pass/fail thresholds, panel composition (including independence from the bidding pool), conflict-of-interest declarations, evaluation report structure.
    - **Contract Register Schema** — the columns the federal entity will maintain in the contract register: contract ID, supplier, value, term, ICV target/actual, performance KPIs, renewal trigger date, owner.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Federal Decree-Law No. 11 of 2023 MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline route to market, ICV target, and evaluation weights).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FPRO** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline route to market, ICV target, and evaluation weights).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-uaepass.md
+++ b/plugins/arckit-uae/commands/uae-uaepass.md
@@ -41,8 +41,9 @@ You are an enterprise architect generating a UAE Pass integration design for a U
    - **Service Provider Onboarding Checklist** — TDRA / ICP onboarding artefacts (production credentials request, callback URL allow-list, branding pack, security review, go-live checklist).
    - **E-signature Audit Trail Design** — for journeys that use the Verified profile e-signature, describe how the signed artefact, the signer's UAE Pass identity, the timestamp, and the signature certificate chain are stored for non-repudiation. Cite the UAE Pass e-signature legal effect.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The UAE Pass developer documentation MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline profile selection per journey and any onboarding gaps flagged).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **UPASS** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline profile selection per journey and any onboarding gaps flagged).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/commands/uae-zero-bureaucracy.md
+++ b/plugins/arckit-uae/commands/uae-zero-bureaucracy.md
@@ -38,8 +38,9 @@ You are an enterprise architect generating a Service Catalogue Review under the 
    - **Customer Experience KPIs** — define and target the KPIs the service will report monthly: Customer Satisfaction (CSAT), Net Promoter Score (NPS), First-Time Right rate, Digital Adoption %, and Failure Demand %.
    - **Code Compliance Statement** — explicit statement against the UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast). For each principle, evidence how the redesigned service complies.
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The 23 April 2026 UAE Cabinet meeting announcement (Code for Government Services + Zero Bureaucracy) MUST appear in the Document Register with its primary URL and the verification date.
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-9. Show only a summary to the user (one paragraph plus the headline reduction commitments per service).
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ZBUR** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+10. Show only a summary to the user (one paragraph plus the headline reduction commitments per service).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -978,3 +978,118 @@ All artifacts must pass these 10 checks:
 - VEX production cadence, CVE disclosure policy, coordinated-disclosure contact and mean-time-to-patch targets recorded
 - Any item that cannot be attested carries an M-22-18 exception record: which items, rationale, compensating controls, agency CIO and OMB notification status, and expiry
 - Distribution plan names the CISA Repository lodging target and the access-control posture for SBOM consumers
+
+### PDPL -- UAE Personal Data Protection Law Assessment
+
+- Scope states the carve-outs: DIFC DPL and ADGM DPR free-zone regimes fall outside the federal PDPL, and ADHICS is flagged where healthcare data is in scope
+- Every processing activity cites a PDPL Article 5 lawful basis, or Article 6 where consent is relied upon
+- All five Article 21 DPIA triggers assessed (new technology, large-scale processing, profiling or automated decisions, systematic monitoring, Article 7 sensitive categories), each triggered category carrying an impact assessment, residual risk and mitigations
+- Data-subject rights procedure covers all eight rights (access, rectification, erasure, restriction, portability, object, withdraw consent, complain to the Data Office), each with channel, response SLA and operational owner
+- Every cross-border transfer assessed against Article 22 adequacy or Article 23 derogations; transfers to countries with no UAE adequacy designation record both a written agreement and an explicit derogation
+- Breach notification playbook states the Article 9 obligations to the Data Office and to data subjects, with timelines and a named owner
+- Penalties section marked informational and excluded from compliance scoring
+
+### IAS -- UAE Information Assurance Standards
+
+- Federal entity identified, with CII sector designated where applicable (energy, water, telecoms, finance, transport, government, health, food and agriculture, emergency services)
+- Statement of Applicability covers every control family: 60 management controls (M1–M6) and 128 technical controls (T1–T9)
+- Applicable and not-applicable counts reconcile against that full set of 188 — no control silently absent
+- Every SoA row carries Control ID, description, priority tier (P1–P4), applicability, implementation status (Implemented / Partial / Not Implemented / Not Applicable), owner and evidence reference
+- Every Not Applicable control carries a justification rather than a blank
+- Risk treatment plan derived from the SoA gaps, each with target state, owner and deadline
+- CII registration status with the UAE Cybersecurity Council recorded where the entity is designated, including sector regulator interactions
+
+### CRES -- UAE Cloud Residency
+
+- Every dataset assessed by its Dataset ID from the CLAS register rather than re-enumerated
+- Classification, required residency, chosen CSP, region and compliance check recorded per dataset
+- Confidential, Secret and Top Secret datasets resolve to UAE-resident sovereign infrastructure under the National Cloud Security Policy v2, with any exception raised rather than left implicit
+- CSP due diligence recorded per candidate (Core42 / G42, Microsoft UAE North and UAE Central, TDRA FedNet, e& Sovereign Launchpad on AWS) covering certification posture (DESC for Dubai entities, CSC accreditation), regional footprint, sovereign-data scope and documented limitations
+- Shared-responsibility matrix divides responsibility across infrastructure, platform, application, data, identity and operational layers for each chosen CSP
+- Shared platform components (identity, observability, backups) assessed for residency, not only the primary services
+- Exit and portability plan covers data egress, format portability, identity migration, key custody on exit and contingency residency on regulatory change
+
+### CLAS -- UAE Smart Data Classification Register
+
+- Every dataset assigned exactly one Smart Data level (Open / Shared / Confidential / Secret / Top Secret) — no other values
+- Level definitions cited to the UAE Smart Data Classifications publication, which appears in the Document Register with its primary URL and verification date
+- Handling, storage and declassification rules stated per dataset, not per level alone
+- Each dataset cross-referenced upstream to the BR / DR requirements that drove its capture and downstream to the INT requirements that consume it
+- PDPL lawful basis referenced for every dataset containing personal data
+- Dataset IDs stable and reusable — the CRES and DSHR artefacts reference this register by ID
+- Document Control carries the UAE block (Federal Entity, Cabinet Instrument, Sovereign Cloud Region, AI Autonomy Tier)
+
+### UPASS -- UAE Pass Integration
+
+- In-scope user journeys enumerated with their user populations (citizens, residents, visitors) and the Service Provider category being onboarded
+- Authentication flow shown as an OIDC Authorization Code flow with PKCE, covering user agent, Service Provider, UAE Pass IdP, claim issuance and session establishment
+- Profile selection justified per journey — Basic for login only, Verified for KYC and e-signature — with the Emirates ID verification prerequisite stated for Verified
+- Any journey relying on e-signature uses the Verified profile; a Basic-profile journey cannot claim e-signature capability
+- Claim mapping covers the UAE Pass claims in use (`sub`, `idn`, `fullnameAR`, `fullnameEN`, `mobile`, `email`, `nationalityEN`, `nationalityAR`, `gender`, `dob`, `profileType`) against the Service Provider schema, with consent and privacy notes per claim
+- E-signature audit trail records the signed artefact, signer identity, timestamp and certificate chain for non-repudiation, citing the legal effect
+- Onboarding checklist covers the TDRA / ICP artefacts: production credentials, callback URL allow-list, branding pack, security review and go-live
+
+### ZBUR -- UAE Zero Bureaucracy
+
+- Every service mapped to its federal entity service catalogue ID where one is published, with its customer journey and current Zero Bureaucracy status
+- Baseline captures current and target values for all four metrics per service: process steps, customer-supplied fields, end-to-end time to outcome, total customer cost
+- Every metric shows a reduction trajectory — a target equal to or worse than its baseline is flagged rather than recorded silently
+- All five customer-experience KPIs defined with monthly targets: CSAT, NPS, First-Time Right rate, Digital Adoption %, Failure Demand %
+- Compliance stated against each of the five UAE Code for Government Services principles (proactive, omni-channel, personalised, simple, fast), with evidence per principle
+
+### DREC -- UAE Digital Records
+
+- Every record type designates an authoritative system, a custodian entity and a stable record identifier scheme
+- Retention schedule states period, legal or regulatory basis, disposal trigger and disposal method per record type — no retention period without a cited basis
+- Records carrying the official-source designation named explicitly, with the evidence supporting it (audit trail, integrity controls, signature)
+- Lifecycle covers capture, classification, storage, access, retention and disposal, each mapped to where it is implemented in the technology stack
+- Classification stage cross-references the CLAS register rather than restating levels
+- Audit procedure states sampling approach and integrity checks; disposal procedure names the approver and the evidence of disposal
+
+### DSHR -- UAE Data Sharing Agreement
+
+- Sharing parties identified with joint-controller status and service-level commitments
+- Every shared dataset referenced by its Dataset ID from the CLAS register, with classification level, volume, frequency and direction
+- Every share involving personal data cites its PDPL Article 5 lawful basis (or Article 6 consent) and references the PDPL artefact entry that justifies it
+- Technical mechanism stated per share (REST API, event stream, file drop, federated query) with authentication, integrity and rate-limiting controls
+- Safeguards cover encryption in transit and at rest, key management, access control, logging, and incident-response co-ordination between the parties
+- All six data-subject rights traced across the sharing boundary (access, rectification, erasure, restriction, portability, object), each with a named owning party
+- No dataset shared at a classification its residency posture forbids — cross-checked against the CRES assessment
+
+### NPRA -- UAE National Priorities Alignment
+
+- All four federal strategies assessed with their relevant pillars: We the UAE 2031, National Investment Strategy 2031, UAE Strategy for Artificial Intelligence 2031, Digital Economy Strategy
+- Every major capability (identity, payments, hosting, notifications, data exchange) tested against the federally-provided shared service (UAE Pass, FedNet, government cloud, federal payment gateway)
+- Every rejected reuse carries an explicit justification — a build decision cannot rest on silence
+- Capability reuse register records the federal provider, integration mode and cost-saving evidence per adopted capability
+- Resource-efficiency calculation compares the reuse baseline against the build alternative quantitatively, over the project lifecycle
+- Feasibility assessment and pilot or phased rollout sequence present per major capability, per the Federal Government Guide
+
+### AICH -- UAE AI Ethics Charter Assessment
+
+- Every AI capability inventoried with model family, vendor, deployment mode (on-prem / sovereign-cloud / hosted-API) and primary user population
+- All 12 Charter principles assessed: Human-Machine Ties, Safety, Bias Mitigation, Data Privacy, Transparency, Human Oversight, Governance and Accountability, Technological Excellence, Human Commitment, Peaceful Coexistence, Inclusive Access, Lawful Compliance
+- Each principle records applicability, evidence of compliance, gap and mitigation — a principle marked applicable with no evidence is a gap, not a pass
+- Bias and fairness assessment names the protected attributes, the fairness metrics measured, dataset provenance, mitigations taken and residual risk
+- Human-in-the-loop design states the reviewer role, review trigger, override mechanism and audit trail of human decisions per use case
+- AI Autonomy Tier in the Document Control header consistent with the AUTI assessment where one exists
+
+### AUTI -- UAE AI Autonomy Tier
+
+- Every AI use-case mapped to exactly one tier with rationale: Tier 1 internal productivity, Tier 2 external-facing with mandatory human approval, Tier 3 regulated or financial decisions
+- Tier assignment consistent with blast radius — a use-case driving eligibility, payment or risk-scoring decisions cannot sit below Tier 3
+- Guard-rail matrix states the technical controls per tier: input filtering, output filtering, retrieval grounding, hallucination controls, refusal policy, prompt-injection defences
+- Approval gates named per tier for both deployment and each release, including the regulator-facing approval where Tier 3 applies
+- Audit obligations per tier state logging detail (prompt, response, model version, retrieval context, human reviewer), retention, audit cadence and reporting line
+- Tier-promotion criteria stated as evidence requirements, so promotion is testable rather than discretionary
+- AI Autonomy Tier in the Document Control header matches the highest tier in the inventory
+
+### FPRO -- UAE Federal Procurement
+
+- Route to market selected (open / restricted / direct award) with justification under the Decree-Law, alongside value bracket and any framework-agreement use
+- ITT/RFP pack outline aligned to the MoF Digital Procurement Platform templates: cover page, instructions to bidders, scope of work, technical specification, mandatory and desirable requirements, ICV obligations, evaluation criteria and weights, contract terms, response forms
+- Technical specification traceable to REQ (FR / NFR / INT) rather than written afresh
+- ICV plan states scoring criteria, target score, supplier evidence requirements and the post-award reporting obligation
+- Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
+- Evaluation weights sum to 100%, with the stated thresholds reachable under them
+- Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner


### PR DESCRIPTION
Second regime of the 61 in #748, following #754 (US). Same defect, same two-part fix: these commands referenced `references/quality-checklist.md` in no phrasing at all, so the artefacts skipped the **10 Common Checks** as well as their per-type checks. Each doc-type gets a `### <CODE>` section *and* a checklist step in the command, since a section alone would never be read.

`PDPL` `IAS` `CRES` `CLAS` `UPASS` `ZBUR` `DREC` `DSHR` `NPRA` `AICH` `AUTI` `FPRO`. Sections 100 → 112.

**Remaining after this: 39** — UK (15), CA (12), AU (12).

## The mechanical edit was not mechanical here

This is the part worth reviewing. `arckit-us` had one uniform step shape, so the insertion was a fixed-position replace. `arckit-uae` does not: commands run to 8, 9 or 10 steps and the Write step sits at 7, 8 or 9 depending on the file.

So the insertion is anchored on the Write line itself, with every following top-level step renumbered. I verified contiguous `1..N` numbering in all 12 afterwards rather than trusting the transform.

`uae-classification.md` departs further still — it carries its content across a prose step and a separate cross-reference step instead of a single "Generate the following sections" list, so its checks were derived by hand from both.

## Cross-artefact checks

No `## Success Criteria` here either (0/12), so content again comes from each command's own section list. What makes this overlay different from US is how interconnected it is, and several checks now enforce that rather than leaving it to chance:

- `CRES` and `DSHR` must reference datasets by **Dataset ID from the CLAS register**, not re-enumerate them
- `DREC` must cross-reference CLAS for its classification stage rather than restating levels
- `DSHR` must not share a dataset at a classification its **CRES residency posture forbids**
- the AI Autonomy Tier in a Document Control header must match the **highest tier in the AUTI inventory**

Others enforce a threshold the commands state but never check:

- `IAS` applicable-plus-not-applicable counts must reconcile against the full **188 controls** (60 management M1–M6 + 128 technical T1–T9)
- Confidential, Secret and Top Secret datasets must resolve to **UAE-resident sovereign infrastructure** under the National Cloud Security Policy v2
- an **e-signature journey cannot run on a Basic UAE Pass profile** — it needs Verified
- a use-case driving eligibility, payment or risk-scoring decisions **cannot sit below AI Autonomy Tier 3**
- `FPRO` evaluation weights must sum to 100% with thresholds reachable under them

## Verification

- Guard reports **103 references across 6 plugins, all resolving** — `arckit-uae: 12` is new
- Regime-carrying codes with no section: **51 → 39**
- Contiguous step numbering confirmed in all 12 commands post-edit
- `check-doc-type-registry.py`, `check_references.py` (836 files), `sync-shared-assets.py --check` clean
- `markdownlint-cli2` clean; converter regenerated all 7 extensions
- Full suite: 1297 passed, 225 skipped

## Still outstanding from #754

The `us-fedramp-ssp.md` "15-section" heading over a 16-item list is still unfixed — flagged there, not carried into this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
