### PR TITLE
feat(ca): wire the 12 Canadian federal doc-types into the quality checklist

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-ca/commands/ca-aia.md
+++ b/plugins/arckit-ca/commands/ca-aia.md
@@ -60,8 +60,9 @@ You are an enterprise architect generating a Canada Algorithmic Impact Assessmen
    - **Reassessment Triggers** — material change to data, model, decision boundary, or operating environment. Include a periodic reassessment cadence (annual default, accelerated for Level III/IV systems).
    - **Open Items** — explicit list of unresolved questionnaire scores, pending peer-review nominations, or downstream artefacts that must be produced before launch.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The TBS *Directive on Automated Decision-Making* and the *Algorithmic Impact Assessment Tool* MUST appear in the Document Register with their primary URLs and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the computed Impact Level, the headline mitigations triggered by that level, and any open peer-review or reassessment items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AIA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the computed Impact Level, the headline mitigations triggered by that level, and any open peer-review or reassessment items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-atip.md
+++ b/plugins/arckit-ca/commands/ca-atip.md
@@ -61,8 +61,9 @@ You are an enterprise architect generating a Canada ATIP (Access to Information 
    - **Annual Report Mapping** — alignment to TBS InfoSource, the departmental ATI / Privacy annual report, and the Office of the Information Commissioner / Office of the Privacy Commissioner reporting cycle. Identify what feeds which report and on what cadence.
    - **Open Issues** — explicit list of unresolved exemption rationales, missing PIB updates, pending consultation responses, and any severance rules that remain `<TBC>`.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Access to Information Act and the Privacy Act MUST appear in the Document Register with their primary URLs (Justice Laws Website) and verification dates. TBS directives and OIC / OPC guidance documents should be cited where relied on.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline exemption posture, the §8(2) letters in play, the severance design summary, and any open issues).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ATIP** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline exemption posture, the §8(2) letters in play, the severance design summary, and any open issues).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-charter.md
+++ b/plugins/arckit-ca/commands/ca-charter.md
@@ -64,8 +64,9 @@ You are an enterprise architect generating a Canada Charter Rights Design Review
    - **Mitigation Register** — per identified Charter risk, mitigation, residual.
    - **DOJ Counsel Sign-Off Block** — explicit field for departmental Justice counsel and the Department of Justice constitutional advisor where the risk warrants it; date and conditions of sign-off.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Canadian Charter of Rights and Freedoms MUST appear in the Document Register with its primary URL and the verification date. Cite the key jurisprudence below where applicable.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the engaged Charter sections, the headline risks per right, and any open DOJ-counsel sign-off items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CHRT** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the engaged Charter sections, the headline risks per right, and any open DOJ-counsel sign-off items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-cloud-residency.md
+++ b/plugins/arckit-ca/commands/ca-cloud-residency.md
@@ -53,8 +53,9 @@ You are an enterprise architect generating a Canada sovereign cloud residency as
    - **Operational Topology** — regions, availability zones, network paths (private link, transit gateway, peering), dedicated interconnects (Direct Connect / ExpressRoute / Cloud Interconnect), encryption-in-transit posture between zones, and the BYOK / HYOK / external-key-store custody decision per workload.
    - **Open Items** — outstanding sovereign-cloud option choices, pending Protected B authorisations on the candidate provider, unresolved sub-processor flags, exit-dry-run schedule, and any condition the security authority has placed on go-live.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The TBS *Direction on the Secure Use of Commercial Cloud Services*, the *Government of Canada Cloud Adoption Strategy*, CSE *ITSP.50.103*, and the SSC *Cloud Brokering Service* page MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen sovereign cloud option, the CLOUD-Act exposure posture, and any open Protected B authorisation or sub-processor flags).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CACR** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen sovereign cloud option, the CLOUD-Act exposure posture, and any open Protected B authorisation or sub-processor flags).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-fitaa.md
+++ b/plugins/arckit-ca/commands/ca-fitaa.md
@@ -55,8 +55,9 @@ You are an enterprise architect generating a Canada FITAA Compliance Assessment 
    - **Compliance Schedule (registrant-side)** — arrangement triggers, the 14-day clock, penalty exposures (cite specific FITAA offence sections where settled; otherwise `<TBC>`).
    - **Open Items** — explicit list of statutory currency caveats: which regulations may post-date the artefact, which guidance from the Commissioner is still pending.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Foreign Influence Transparency and Accountability Act (Bill C-70, 2024) MUST appear in the Document Register with its primary URL (Justice Laws Website) and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline Charter §2 risk findings and any open statutory-currency items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FITAA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline Charter §2 risk findings and any open statutory-currency items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-gc-digital-standards.md
+++ b/plugins/arckit-ca/commands/ca-gc-digital-standards.md
@@ -55,8 +55,9 @@ You are an enterprise architect generating a Government of Canada Digital Standa
    - **Maturity Roadmap** — current vs target maturity per standard, milestones, owners, and dates. Maturity must be expressed dimension-by-dimension; do not collapse to a single overall score.
    - **Open Items** — outstanding decisions, blocked remediations, and deferred standards work with owners and review dates.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The TBS *Government of Canada Digital Standards*, the *Policy on Service and Digital*, the *Directive on Service and Digital*, and the *Accessible Canada Act* MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline conformance posture per standard, top three remediation actions, and any standards stuck at Initial maturity).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DIGSTD** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline conformance posture per standard, top three remediation actions, and any standards stuck at Initial maturity).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-itsg-33.md
+++ b/plugins/arckit-ca/commands/ca-itsg-33.md
@@ -51,8 +51,9 @@ You are an enterprise architect generating an ITSG-33 Statement of Applicability
    - **Authorisation Chain** — System Owner → Security Authority → Authorising Official, identified by role; specify the authorisation cycle, the conditions attaching to the authorisation, and the re-authorisation triggers.
    - **Open Items** — outstanding tailoring decisions, unfinished CMVP checks, unresolved supplier flags, and any condition the authorising official has placed on go-live.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. ITSG-33, the TBS *Standard on Security Categorization*, the *Direction on Vulnerable Suppliers*, and the CMVP active modules list MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen profile, the count of Compensating Controls, and any open lawful-authority or supplier-flag items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ITSG** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen profile, the count of Compensating Controls, and any open lawful-authority or supplier-flag items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-ocap.md
+++ b/plugins/arckit-ca/commands/ca-ocap.md
@@ -93,8 +93,9 @@ You are an enterprise architect generating a First Nations OCAP® sovereignty as
    10. **Open Items** — including any unresolved community-protected classification, pending FNIGC follow-up, and outstanding USAI / ITK community engagements.
 
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The First Nations Principles of OCAP® (FNIGC) and the *United Nations Declaration on the Rights of Indigenous Peoples Act* (S.C. 2021, c. 14) MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the FNIGC engagement status, the count of datasets mapped, and any open items). If the artefact is a planning scaffold, say so plainly in the summary.
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **OCAP** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the FNIGC engagement status, the count of datasets mapped, and any open items). If the artefact is a planning scaffold, say so plainly in the summary.
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-ola.md
+++ b/plugins/arckit-ca/commands/ca-ola.md
@@ -48,8 +48,9 @@ You are an enterprise architect generating an Official Languages Act review for 
    - **Risk and Mitigation Register** — per OLA risk: complaint exposure to the Commissioner of Official Languages, court remedies under Part X, reputational risk; mitigations.
    - **Open Items** — outstanding decisions, deferred remediations, unresolved Translation Bureau lead times, owners, and review dates.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The *Official Languages Act*, *An Act for the Substantive Equality of Canada's Official Languages* (Bill C-13, 2023), the TBS *Policy on Official Languages*, and the *Directive on the Implementation of the Official Languages (Communications with and Services to the Public) Regulations* MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline OLA posture per Part, top three remediation actions, any "translation lag" risks identified, and any surfaces where active offer is missing).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **OLA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline OLA posture per Part, top three remediation actions, any "translation lag" risks identified, and any surfaces where active offer is missing).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-pia.md
+++ b/plugins/arckit-ca/commands/ca-pia.md
@@ -50,8 +50,9 @@ You are an enterprise architect generating a Canada Privacy Impact Assessment (P
    - **PIA Approval Chain** — departmental ATIP coordinator → ADM → head of institution, with TBS notification and OPC consultation positioned at the right gates.
    - **Action Tracker** — open mitigations with owner, due date, status, and the link back to the privacy-risk register entry.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Privacy Act and the TBS Directive on Privacy Impact Assessment MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline privacy risks, OPC notification decision, and any open lawful-authority items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PIA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline privacy risks, OPC notification decision, and any open lawful-authority items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-pspc.md
+++ b/plugins/arckit-ca/commands/ca-pspc.md
@@ -54,8 +54,9 @@ You are an enterprise architect generating a federal Canadian procurement strate
    - **Risks** — including but not limited to: insufficient supplier pool (especially for set-aside or niche services), security-clearance bottleneck on critical path, threshold disputes with bidders, ITQ vs ITT vs RFP shape confusion, contract-award challenge under CFTA Chapter 5 / CITT, sub-processor residency conflict (cross-reference `ca-cloud-residency`), and OLA / accessibility obligations on the supplier delivery surface.
    - **Open Items** — outstanding decisions, pending instrument confirmations, deferred risk treatments, owners, and review dates.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The PSPC *Supply Manual*, the *Canadian Free Trade Agreement* (CFTA), CETA, CPTPP, the WTO Agreement on Government Procurement (WTO-AGP), the Indigenous Services Canada *Procurement Strategy for Indigenous Business*, and the Canadian International Trade Tribunal (CITT) procurement complaint regime MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the recommended route, the binding trade agreements, the PSAB contribution posture, the longest clearance lead time on the critical path, and any open items that block solicitation posting).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PROC** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the recommended route, the binding trade agreements, the PSAB contribution posture, the longest clearance lead time on the critical path, and any open items that block solicitation posting).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/commands/ca-soia.md
+++ b/plugins/arckit-ca/commands/ca-soia.md
@@ -58,8 +58,9 @@ You are an enterprise architect generating a Canada Security of Information Act 
    - **Personnel Reliability** — clearance prerequisites (Reliability, Secret, Top Secret, Top Secret SCI), update cycle, briefing and debriefing protocol, and indoctrination for compartments. Clearance is per-task, not per-role.
    - **Open Items** — explicit list of statutory currency caveats: which CSIS Act amendments under Bill C-26 / Bill C-70 are still settling, which Ministerial Directives are pending, which compartment MOUs with CSIS or RCMP are still in negotiation, and a reminder that the artefact itself is likely classified and must be stored, marked, and handled accordingly.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The *Security of Information Act* (R.S.C., 1985, c. O-5) and the *Canadian Security Intelligence Service Act* (R.S.C., 1985, c. C-23) MUST appear in the Document Register with their primary URLs (Justice Laws Website) and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline SOI inventory count, compartment count, and any open statutory-currency or MOU items). Remind the user that the artefact may itself be classified.
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SOIA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline SOI inventory count, compartment count, and any open statutory-currency or MOU items). Remind the user that the artefact may itself be classified.
 
 ## Authoritative anchor
 

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/ca/commands/ca-aia.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-aia.md
@@ -60,8 +60,9 @@ You are an enterprise architect generating a Canada Algorithmic Impact Assessmen
    - **Reassessment Triggers** — material change to data, model, decision boundary, or operating environment. Include a periodic reassessment cadence (annual default, accelerated for Level III/IV systems).
    - **Open Items** — explicit list of unresolved questionnaire scores, pending peer-review nominations, or downstream artefacts that must be produced before launch.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The TBS *Directive on Automated Decision-Making* and the *Algorithmic Impact Assessment Tool* MUST appear in the Document Register with their primary URLs and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the computed Impact Level, the headline mitigations triggered by that level, and any open peer-review or reassessment items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AIA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the computed Impact Level, the headline mitigations triggered by that level, and any open peer-review or reassessment items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-atip.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-atip.md
@@ -61,8 +61,9 @@ You are an enterprise architect generating a Canada ATIP (Access to Information 
    - **Annual Report Mapping** — alignment to TBS InfoSource, the departmental ATI / Privacy annual report, and the Office of the Information Commissioner / Office of the Privacy Commissioner reporting cycle. Identify what feeds which report and on what cadence.
    - **Open Issues** — explicit list of unresolved exemption rationales, missing PIB updates, pending consultation responses, and any severance rules that remain `<TBC>`.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Access to Information Act and the Privacy Act MUST appear in the Document Register with their primary URLs (Justice Laws Website) and verification dates. TBS directives and OIC / OPC guidance documents should be cited where relied on.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline exemption posture, the §8(2) letters in play, the severance design summary, and any open issues).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ATIP** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline exemption posture, the §8(2) letters in play, the severance design summary, and any open issues).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-charter.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-charter.md
@@ -64,8 +64,9 @@ You are an enterprise architect generating a Canada Charter Rights Design Review
    - **Mitigation Register** — per identified Charter risk, mitigation, residual.
    - **DOJ Counsel Sign-Off Block** — explicit field for departmental Justice counsel and the Department of Justice constitutional advisor where the risk warrants it; date and conditions of sign-off.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Canadian Charter of Rights and Freedoms MUST appear in the Document Register with its primary URL and the verification date. Cite the key jurisprudence below where applicable.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the engaged Charter sections, the headline risks per right, and any open DOJ-counsel sign-off items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CHRT** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the engaged Charter sections, the headline risks per right, and any open DOJ-counsel sign-off items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-cloud-residency.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-cloud-residency.md
@@ -53,8 +53,9 @@ You are an enterprise architect generating a Canada sovereign cloud residency as
    - **Operational Topology** — regions, availability zones, network paths (private link, transit gateway, peering), dedicated interconnects (Direct Connect / ExpressRoute / Cloud Interconnect), encryption-in-transit posture between zones, and the BYOK / HYOK / external-key-store custody decision per workload.
    - **Open Items** — outstanding sovereign-cloud option choices, pending Protected B authorisations on the candidate provider, unresolved sub-processor flags, exit-dry-run schedule, and any condition the security authority has placed on go-live.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The TBS *Direction on the Secure Use of Commercial Cloud Services*, the *Government of Canada Cloud Adoption Strategy*, CSE *ITSP.50.103*, and the SSC *Cloud Brokering Service* page MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen sovereign cloud option, the CLOUD-Act exposure posture, and any open Protected B authorisation or sub-processor flags).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CACR** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen sovereign cloud option, the CLOUD-Act exposure posture, and any open Protected B authorisation or sub-processor flags).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-fitaa.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-fitaa.md
@@ -55,8 +55,9 @@ You are an enterprise architect generating a Canada FITAA Compliance Assessment 
    - **Compliance Schedule (registrant-side)** — arrangement triggers, the 14-day clock, penalty exposures (cite specific FITAA offence sections where settled; otherwise `<TBC>`).
    - **Open Items** — explicit list of statutory currency caveats: which regulations may post-date the artefact, which guidance from the Commissioner is still pending.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Foreign Influence Transparency and Accountability Act (Bill C-70, 2024) MUST appear in the Document Register with its primary URL (Justice Laws Website) and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline Charter §2 risk findings and any open statutory-currency items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FITAA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline Charter §2 risk findings and any open statutory-currency items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-gc-digital-standards.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-gc-digital-standards.md
@@ -55,8 +55,9 @@ You are an enterprise architect generating a Government of Canada Digital Standa
    - **Maturity Roadmap** — current vs target maturity per standard, milestones, owners, and dates. Maturity must be expressed dimension-by-dimension; do not collapse to a single overall score.
    - **Open Items** — outstanding decisions, blocked remediations, and deferred standards work with owners and review dates.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The TBS *Government of Canada Digital Standards*, the *Policy on Service and Digital*, the *Directive on Service and Digital*, and the *Accessible Canada Act* MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline conformance posture per standard, top three remediation actions, and any standards stuck at Initial maturity).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DIGSTD** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline conformance posture per standard, top three remediation actions, and any standards stuck at Initial maturity).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-itsg-33.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-itsg-33.md
@@ -51,8 +51,9 @@ You are an enterprise architect generating an ITSG-33 Statement of Applicability
    - **Authorisation Chain** — System Owner → Security Authority → Authorising Official, identified by role; specify the authorisation cycle, the conditions attaching to the authorisation, and the re-authorisation triggers.
    - **Open Items** — outstanding tailoring decisions, unfinished CMVP checks, unresolved supplier flags, and any condition the authorising official has placed on go-live.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. ITSG-33, the TBS *Standard on Security Categorization*, the *Direction on Vulnerable Suppliers*, and the CMVP active modules list MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen profile, the count of Compensating Controls, and any open lawful-authority or supplier-flag items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **ITSG** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the system-level categorisation, the chosen profile, the count of Compensating Controls, and any open lawful-authority or supplier-flag items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-ocap.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-ocap.md
@@ -93,8 +93,9 @@ You are an enterprise architect generating a First Nations OCAP® sovereignty as
    10. **Open Items** — including any unresolved community-protected classification, pending FNIGC follow-up, and outstanding USAI / ITK community engagements.
 
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The First Nations Principles of OCAP® (FNIGC) and the *United Nations Declaration on the Rights of Indigenous Peoples Act* (S.C. 2021, c. 14) MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the FNIGC engagement status, the count of datasets mapped, and any open items). If the artefact is a planning scaffold, say so plainly in the summary.
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **OCAP** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the FNIGC engagement status, the count of datasets mapped, and any open items). If the artefact is a planning scaffold, say so plainly in the summary.
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-ola.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-ola.md
@@ -48,8 +48,9 @@ You are an enterprise architect generating an Official Languages Act review for 
    - **Risk and Mitigation Register** — per OLA risk: complaint exposure to the Commissioner of Official Languages, court remedies under Part X, reputational risk; mitigations.
    - **Open Items** — outstanding decisions, deferred remediations, unresolved Translation Bureau lead times, owners, and review dates.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The *Official Languages Act*, *An Act for the Substantive Equality of Canada's Official Languages* (Bill C-13, 2023), the TBS *Policy on Official Languages*, and the *Directive on the Implementation of the Official Languages (Communications with and Services to the Public) Regulations* MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline OLA posture per Part, top three remediation actions, any "translation lag" risks identified, and any surfaces where active offer is missing).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **OLA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline OLA posture per Part, top three remediation actions, any "translation lag" risks identified, and any surfaces where active offer is missing).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-pia.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-pia.md
@@ -50,8 +50,9 @@ You are an enterprise architect generating a Canada Privacy Impact Assessment (P
    - **PIA Approval Chain** — departmental ATIP coordinator → ADM → head of institution, with TBS notification and OPC consultation positioned at the right gates.
    - **Action Tracker** — open mitigations with owner, due date, status, and the link back to the privacy-risk register entry.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Privacy Act and the TBS Directive on Privacy Impact Assessment MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline privacy risks, OPC notification decision, and any open lawful-authority items).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PIA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline privacy risks, OPC notification decision, and any open lawful-authority items).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-pspc.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-pspc.md
@@ -54,8 +54,9 @@ You are an enterprise architect generating a federal Canadian procurement strate
    - **Risks** — including but not limited to: insufficient supplier pool (especially for set-aside or niche services), security-clearance bottleneck on critical path, threshold disputes with bidders, ITQ vs ITT vs RFP shape confusion, contract-award challenge under CFTA Chapter 5 / CITT, sub-processor residency conflict (cross-reference `ca-cloud-residency`), and OLA / accessibility obligations on the supplier delivery surface.
    - **Open Items** — outstanding decisions, pending instrument confirmations, deferred risk treatments, owners, and review dates.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The PSPC *Supply Manual*, the *Canadian Free Trade Agreement* (CFTA), CETA, CPTPP, the WTO Agreement on Government Procurement (WTO-AGP), the Indigenous Services Canada *Procurement Strategy for Indigenous Business*, and the Canadian International Trade Tribunal (CITT) procurement complaint regime MUST appear in the Document Register with their primary URLs and verification dates.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the recommended route, the binding trade agreements, the PSAB contribution posture, the longest clearance lead time on the critical path, and any open items that block solicitation posting).
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PROC** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the recommended route, the binding trade agreements, the PSAB contribution posture, the longest clearance lead time on the critical path, and any open items that block solicitation posting).
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/commands/ca-soia.md
+++ b/plugins/arckit-claude/plugins/ca/commands/ca-soia.md
@@ -58,8 +58,9 @@ You are an enterprise architect generating a Canada Security of Information Act 
    - **Personnel Reliability** — clearance prerequisites (Reliability, Secret, Top Secret, Top Secret SCI), update cycle, briefing and debriefing protocol, and indoctrination for compartments. Clearance is per-task, not per-role.
    - **Open Items** — explicit list of statutory currency caveats: which CSIS Act amendments under Bill C-26 / Bill C-70 are still settling, which Ministerial Directives are pending, which compartment MOUs with CSIS or RCMP are still in negotiation, and a reminder that the artefact itself is likely classified and must be stored, marked, and handled accordingly.
 6. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The *Security of Information Act* (R.S.C., 1985, c. O-5) and the *Canadian Security Intelligence Service Act* (R.S.C., 1985, c. C-23) MUST appear in the Document Register with their primary URLs (Justice Laws Website) and the verification date.
-7. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
-8. Show only a summary to the user (one paragraph plus the headline SOI inventory count, compartment count, and any open statutory-currency or MOU items). Remind the user that the artefact may itself be classified.
+7. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SOIA** per-type checks pass. Fix any failures before proceeding.
+8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+9. Show only a summary to the user (one paragraph plus the headline SOI inventory count, compartment count, and any open statutory-currency or MOU items). Remind the user that the artefact may itself be classified.
 
 ## Authoritative anchor
 

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -1093,3 +1093,152 @@ All artifacts must pass these 10 checks:
 - Evaluation methodology states technical and commercial weights, pass/fail thresholds, panel composition independent of the bidding pool, conflict-of-interest declarations and report structure
 - Evaluation weights sum to 100%, with the stated thresholds reachable under them
 - Contract register schema defines its columns: contract ID, supplier, value, term, ICV target and actual, performance KPIs, renewal trigger date, owner
+
+### FITAA -- Foreign Influence Transparency Registry
+
+- Activity scoping states the statutory triggers (covered arrangements with foreign principals to influence government, political processes or public discourse) and the excluded categories (journalism, academic research)
+- Decision tree maps the project's own activities against those triggers rather than restating the statute
+- Provisions cited only where numbering is settled; anything pending marked `<TBC at draft time>` rather than asserted
+- Arrangement register separates public-facing transparency fields from protected national-security fields, with the 14-day material-change cadence stated
+- Registration workflow bilingual per the OLA assessment, with identity verification, acknowledgement and registration ID issuance
+- Public-register versus protected-investigative data flow shown, with severance rules cross-referenced to the ATIP assessment
+- Commissioner liaison protocol covers reporting cadence for suspected non-registration and falsification, plus RCMP and CSIS touchpoints
+- Charter risks registered against s.2(b) chilling effect and s.2(d) association, cross-referenced to the CHRT assessment
+- Open Items record which regulations may post-date the artefact and which Commissioner guidance is still pending
+
+### PIA -- Privacy Impact Assessment (Canada)
+
+- Document ID uses `PIA` — the US federal assessment is registered as `USPIA`
+- Privacy Act §4 collection authority cited to the enabling statute or regulation; unclear authority marked `<TBC>` and flagged as an OPC blocker rather than left implicit
+- Every personal information element records source, purpose, sensitivity, retention period, disclosure recipients and its Personal Information Bank entry where applicable
+- Necessity and proportionality run as the four-step Oakes-derived analysis: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- §7 use limited to the purpose of collection or a consistent use; §8 disclosures analysed per routine use, with §8(2)(a)–(m) letters treated individually rather than aggregated
+- Cross-border transfer flags cross-referenced to the cloud-residency assessment
+- Individual rights cover §12 access, §13 PIB registration with TBS InfoSource, correction and annotation, and the OPC complaint pathway
+- OPC notification trigger analysed, honouring the 30-day pre-launch requirement for new programmes and substantial modifications
+- Approval chain named through ATIP coordinator, ADM and head of institution, with TBS notification and OPC consultation at the correct gates
+- Action tracker links every open mitigation back to its privacy-risk register entry
+
+### ATIP -- Access to Information and Privacy
+
+- Information holdings inventory categorises every holding as Public, Protected or Classified, accounting for every data element in the data model rather than personal information alone
+- Each holding maps to its Personal Information Bank where applicable, with owner and lifecycle stage
+- Every claimed ATI Act exemption explained rather than merely cited (§13, §14, §15, §16 including §16.1–§16.6, §19, §21, §23, §24)
+- §19 not treated as a blanket exemption — §8(2) routine-use disclosures still assessed
+- Privacy Act register tables every collection, use and disclosure against its section authority (§4, §5 with the §5(2)/(3) exceptions, §7 and §7(a) consistent use, §8)
+- §8(2)(a)–(m) routine-use letters analysed individually; dissimilar disclosures not aggregated under a single letter
+- Severance design states field-level rules, an audit-log schema capturing reviewer, exemption claimed, justification and output, and a re-identification risk analysis against adjacent open data
+- Request workflow covers the §7 30-day clock, §9 extensions with written reasons, §27 third-party consultation and publication of refusals, with an SLA per step
+- Annual report mapping identifies what feeds TBS InfoSource, the departmental report and the OIC / OPC cycle, and on what cadence
+
+### AIA -- Algorithmic Impact Assessment
+
+- All six questionnaire dimensions scored with evidence cited: Project, System, Algorithm, Decision, Impact, Data
+- Impact Level (I–IV) computed from the questionnaire per the TBS Directive threshold matrix with the workings shown — never self-declared
+- Mitigations applied match the computed Level rather than a lower one
+- Peer review scoped to the Level (internal at II, external at III/IV) with named reviewers and lead time
+- Transparency notice bilingual per the OLA assessment, published 30 days pre-launch for Level III/IV
+- Human-in-the-loop design states override paths, escalation thresholds and reviewer training
+- Recourse mechanism provides an appeal path to a human decision-maker and explanation rights for affected individuals
+- Algorithmic risks register covers bias (selection, label, deployment), data and concept drift, proxy variables, contestability gaps and distributional fairness across protected grounds
+- Training-data provenance records source, licence and vintage per dataset, with refresh cadence, drift triggers and a named steward
+- Disclosure plan assumes publication unless a stated exemption applies, with the national-security cross-reference and any Protected B/C severance noted
+- Reassessment triggers stated for material change to data, model, decision boundary or operating environment, with cadence accelerated for Level III/IV
+
+### CHRT -- Charter of Rights and Freedoms Analysis
+
+- Engagement surface states which Charter sections are engaged with reasoning per section; "Not engaged" carries a stated justification rather than silence
+- Sections 2(b), 2(d), 7, 8 and 15 addressed as the default engaged set for FITAA-class systems
+- s.8 analysis addresses reasonable expectation of privacy, the warrant requirement and production-order interfaces against the *Hunter v Southam* and *R v Spencer* lines
+- s.15 analysis names the protected grounds and applies the substantive equality test with a differential-impact assessment
+- Oakes proportionality run through all four steps for every engaged right: pressing and substantial objective, rational connection, minimal impairment, proportional effects
+- Mitigation register records residual risk per identified Charter risk
+- DOJ counsel sign-off block present with date and conditions, escalating to the Department of Justice constitutional advisor where the risk warrants
+
+### ITSG -- ITSG-33 Security Control Profile
+
+- Every information asset scored Confidentiality, Integrity and Availability as Low / Medium / High using the TBS injury-based matrix, with the reasoning recorded
+- System-level categorisation derived as the high-water mark across the asset inventory with the working shown, mapped to UNCLASSIFIED / Protected A / Protected B / Protected C / CONFIDENTIAL / SECRET / TOP SECRET
+- Control profile matches that categorisation (PBMM, PBMM-Cloud, Secret-High, Top-Secret-High) with rationale and a named approver
+- Every tailoring deviation from the published profile justified rather than merely preferred
+- Statement of Applicability covers all 16 control families (AC, AU, CA, CM, CP, IA, IR, MA, MP, PE, PL, PS, RA, SA, SC, SI), each control marked Applicable / Not Applicable / Compensating with justification
+- Every compensating control names its substitute and the residual-risk acceptance rationale
+- Every cryptographic module lists its CMVP / FIPS 140-3 certificate number, validation level and algorithm scope; non-validated cryptography protecting Protected B or above recorded as a finding, not a discussion item
+- Supply chain assessed against the TBS Direction on Vulnerable Suppliers and the sanctioned-entities list, flagging vendors, sub-processors and PSPC-restricted telecommunications equipment
+- Continuous monitoring states assessment frequency per family, the evidence tooling, reporting cadence, and explicit re-categorisation triggers
+- Authorisation chain identified by role (System Owner, Security Authority, Authorising Official) with cycle, conditions and re-authorisation triggers
+
+### SOIA -- Security of Information Act Handling
+
+- SOI inventory qualifies material against the s.8 statutory definition — departmental designation cannot create or remove SOI status
+- Marking matrix records classification level, caveats (CANADIAN EYES ONLY, NOFORN, FVEY, releasability tags) and compartments per asset
+- Foreign-shared product carries originator caveats, with the Third-Party Rule applied and redistribution conditioned on originator consent
+- Handling rules tiered by classification across at rest (storage approval, CMVP / CSE-approved encryption), in transit and in use
+- Transmission channel matrix states allowed channels per categorisation, unencrypted-link prohibitions, and caveat-driven restrictions — CEO and NOFORN material is not transmissible over allied-shared infrastructure
+- Compartment register defaults to deny, with every access an explicit need-to-know determination; owner, access-list size, indoctrination requirements and audit-log rotation recorded per compartment
+- Destruction and sanitisation use approved routes (CSE / RCMP-approved shredders, degaussers, incineration) per CSE ITSP.40.006 across the media lifecycle
+- CSIS Act §16 and §19 coordination identifies the system's role and the coordinating contact and artefact for each
+- Breach response prioritises containment within minutes (revoke access, isolate the system, suspend the account) ahead of forensic completeness, with the escalation path and PCO reporting where Cabinet confidence is implicated
+- Personnel reliability treated as per-task rather than per-role, with clearance prerequisites, update cycle and compartment indoctrination stated
+- The artefact itself marked, stored and handled at its own classification
+
+### CACR -- Canadian Cloud Residency
+
+- Workload categorisation drawn from the ITSG-33 artefact where present, otherwise performed here against the TBS Standard on Security Categorization with the working shown
+- Residency requirements stated separately for data at rest, in transit and in processing, including backup and disaster-recovery locations
+- Managed-service processing routed through a foreign region treated as a residency event rather than an implementation detail
+- Sovereign cloud options matrix records per candidate the in-region offering, Protected B authorisation status with verification date, foreign-government access exposure (US CLOUD Act, EO 12333 / FISA 702), cost band and managed-services gaps
+- SSC cloud-brokering path documented without treating it as transferring the departmental ATO obligation
+- Foreign sub-processor analysis identifies any sub-processor whose primary jurisdiction sits outside Canada, with the exposure documented
+- Every cross-border transfer cites a lawful authority, and CLOUD Act exposure noted as persisting for US-incorporated CSPs even in Canadian regions
+- Exit and portability plan states bulk-export approach, format portability, an annual-minimum dry-run cadence, and a budget for egress fees and runbook rebuild
+- Operational topology records regions, zones, network paths, interconnects, in-transit encryption posture and the BYOK / HYOK / external-key-store custody decision per workload
+- Indigenous data constraints cross-referenced to the OCAP assessment where such data is in scope
+
+### DIGSTD -- GC Digital Standards Scorecard
+
+- All 10 GC Digital Standards named in the artefact so the scorecard reads without leaving it
+- Each standard assessed with evidence citing artefacts, test reports, retrospectives or user research rather than assertion
+- Each standard records gaps, remediation actions, owner, target date and maturity (Initial / Repeatable / Defined / Measured / Optimising)
+- Maturity expressed per standard, never collapsed to a single overall score
+- Cross-cutting themes addressed: accessibility against WCAG 2.1 AA / 2.2 AA and the *Accessible Canada Act*, open data and code, ethical AI cross-referenced to the AIA, and user-research practice
+- Roadmap states current versus target maturity per standard with milestones, owners and dates
+
+### OLA -- Official Languages Act Assessment
+
+- Service surface inventory covers every user-facing surface: screens, forms, notifications, error messages, public registers, accessibility statements, printed correspondence, IVR scripts and social media
+- Each surface records its language posture with justification wherever unilingual, plus audience and channel
+- Part IV obligations state the rationale per surface (significant demand, public travel, head office, designated bilingual office), active offer at first contact, and bilingual capacity at time of service
+- Part V covers internal tooling availability for designated bilingual regions, the National Capital Region and New Brunswick, including language of supervision
+- Part VI addresses staffing impact, equitable participation, and non-discrimination on language grounds
+- Equivalent quality assessed per surface across content depth, usability, response time and release cadence — no translation-lag releases
+- Translation pipeline states the Translation Bureau engagement model, lead time per content class, and a workflow that holds release until both languages are ready
+- OQLF considerations acknowledged where there is a material Quebec audience, noting it does not bind federal entities but may apply to suppliers
+- Risk register covers complaint exposure to the Commissioner of Official Languages and Part X court remedies
+
+### PROC -- Federal Procurement Strategy (Canada)
+
+- Procurement scope aggregates to a single estimated value, used consistently for threshold analysis
+- Thresholds assessed against CFTA, CETA, CPTPP and WTO-AGP, each stating the current threshold, whether the value crosses it, the coverage scope and the open-tendering obligation attaching
+- Route selection assesses every candidate with fit, risk posture and timeline (Standing Offer / Supply Arrangement, AgileIQ, bespoke RFP/RFSO/RFSA, PSAB set-aside)
+- Any Standing Offer or Supply Arrangement named is confirmed current and in scope per its scope notice
+- PSAB contribution documented explicitly so the departmental rolling 5% target can roll it up, with the set-aside type stated and the supplier pool identified through the ISC directory
+- The 5% treated as a department-level rolling target — no single procurement judged in isolation
+- Security clearance requirements stated per role with level, holder count, PSPC processing lead time, and the operational risk where clearance sits on the critical path
+- Evaluation framework sets mandatory, point-rated and financial dimensions with a weight envelope traceable to requirements, leaving the detailed rubric to the evaluation artefact
+- Bid solicitation schedule runs market notice through award including CanadaBuys posting, standstill periods and post-award PSAB reporting, each with owner and dependency
+- Risks cover supplier-pool sufficiency, clearance bottleneck on the critical path, threshold disputes, CFTA Chapter 5 / CITT challenge, sub-processor residency conflict, and supplier-side OLA and accessibility obligations
+
+### OCAP -- OCAP® Indigenous Data Governance
+
+- FNIGC pre-engagement confirmed before any substantive section is generated — the gate is structural, not advisory
+- Where engagement is absent and not in progress, the artefact is a planning scaffold only: status marked `PLANNING SCAFFOLD — INCOMPLETE`, an engagement-letter shape provided, and no self-declared OCAP register, DSA terms or co-governance arrangement generated
+- An `N/A` answer carries a written justification that no Indigenous data is in scope, cross-referenced to the data requirements and data model
+- Indigenous data inventory records First Nation(s) of origin, nature of data, current custodianship, transfer history and sensitivity tier per dataset
+- All four OCAP principles mapped per dataset: Ownership, Control, Access, Possession
+- USAI principles applied separately where Métis populations are in scope — never collapsed into OCAP
+- ITK principles applied separately where Inuit populations are in scope — never collapsed into OCAP
+- Data-sharing agreement terms include Indigenous co-signatory, purpose limitation, time bounding, revocability, audit rights and sub-processor restrictions
+- Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
+- Co-governance records Indigenous representation, decision-making authority and appeal pathway
+- Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications


### PR DESCRIPTION
Third regime of the 61 in #748, after #754 (US) and #755 (UAE). Same defect and same two-part fix: these commands referenced `references/quality-checklist.md` in no phrasing at all, so the artefacts skipped the **10 Common Checks** as well as their per-type checks.

`FITAA` `PIA` `ATIP` `AIA` `CHRT` `ITSG` `SOIA` `CACR` `DIGSTD` `OLA` `PROC` `OCAP`. Sections 112 → 124.

**Remaining after this: 27** — UK (15), AU (12).

## Step editing

Uniform here (Write at step 7 in all 12), so simpler than UAE. The one file needing care is `ca-ocap.md`, which carries a nested 1–10 list inside step 5. The renumbering anchors on `^\d+\. ` so the indented list is untouched — I verified that by diffing the file down to its three changed lines rather than trusting the pattern.

## Checks that encode a gate the command states but nothing enforces

This regime had the most of these, and they're the ones worth reviewing:

**`OCAP` is the sharpest.** FNIGC pre-engagement is a *structural* gate: without it the artefact must be a planning scaffold marked `PLANNING SCAFFOLD — INCOMPLETE`, with no self-declared OCAP register, DSA terms or co-governance arrangement generated. The checks also hold USAI (Métis) and ITK (Inuit) principles as separate assessments rather than letting them collapse into OCAP, which the command is explicit about and which is exactly the kind of thing a hurried generation would flatten.

Others:

- an **`AIA` Impact Level must be computed** from the six questionnaire dimensions with workings shown, never self-declared — and its mitigations must match the *computed* Level, not a lower one
- **`ITSG`** categorisation is the high-water mark across the asset inventory, and non-CMVP-validated cryptography protecting Protected B or above is a finding, not a discussion item
- **`SOIA`** compartments default to deny, and departmental designation cannot create or remove s.8 SOI status — it's a statutory category
- **`ATIP`** §19 is not a blanket exemption, and §8(2)(a)–(m) routine-use letters must be analysed individually rather than aggregated under one letter
- **`PROC`** treats the PSAB 5% as a department-level rolling target that no single procurement is judged against in isolation
- **`CHRT`** runs all four Oakes steps for every engaged right, and "Not engaged" requires a stated justification rather than silence

`PIA` carries the mirror of the check added in #754: its document ID is `PIA`, and the US federal assessment is `USPIA`. The two now assert each other's boundary from both sides.

## Verification

- Guard reports **115 references across 7 plugins, all resolving** — `arckit-ca: 12` is new
- Regime-carrying codes with no section: **39 → 27**
- Contiguous step numbering confirmed in all 12; `ca-ocap.md` nested list confirmed intact
- `check-doc-type-registry.py`, `check_references.py` (836 files), `sync-shared-assets.py --check` clean
- `markdownlint-cli2` clean; converter regenerated all 7 extensions
- Full suite: 1297 passed, 225 skipped

## Still outstanding

The `us-fedramp-ssp.md` "15-section" heading over a 16-item list, flagged in #754 and not yet fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
