### PR TITLE
feat(au): wire the 12 Australian doc-types into the quality checklist

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-au-energy/commands/au-aescsf.md
+++ b/plugins/arckit-au-energy/commands/au-aescsf.md
@@ -108,9 +108,10 @@ The Australian Energy Sector Cyber Security Framework is an energy-sector cyber 
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. AEMO AESCSF, the verified AESCSF version / publication date, access date, and any AEMO availability issue MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUAESCSF** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: AESCSF scope, target maturity, highest-risk gaps, architecture evidence gaps, and top five uplift actions.
+10. Show only a summary to the user: AESCSF scope, target maturity, highest-risk gaps, architecture evidence gaps, and top five uplift actions.
 
 ## Important Notes
 

--- a/plugins/arckit-au-energy/commands/au-energy-compliance.md
+++ b/plugins/arckit-au-energy/commands/au-energy-compliance.md
@@ -107,9 +107,10 @@ Australian energy projects may need architecture evidence for **AER ring-fencing
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Current AER, AEMC NER/NGR, AEMO, CISC / SOCI, and access dates MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUENERGY** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: applicability position, key ring-fencing boundaries, AEMO interface risks, SOCI escalation gaps, and top evidence recommendations.
+10. Show only a summary to the user: applicability position, key ring-fencing boundaries, AEMO interface risks, SOCI escalation gaps, and top evidence recommendations.
 
 ## Important Notes
 

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-au/commands/au-ai-assurance.md
+++ b/plugins/arckit-au/commands/au-ai-assurance.md
@@ -129,9 +129,10 @@ Australia's AI assurance landscape combines several frameworks that together gov
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. DTA AI Policy v2.0, AU AI Ethics Principles, AU Essential AI Practices (AI6) — Foundations + Implementation Guidance, ISO 42001 (Australian Standard), and Privacy Act 1988 MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUAIA** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the DTA + Ethics Principles compliance summary table).
+10. Show only a summary to the user (one paragraph plus the DTA + Ethics Principles compliance summary table).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-disp-attestation.md
+++ b/plugins/arckit-au/commands/au-disp-attestation.md
@@ -114,9 +114,10 @@ The Defence Industry Security Program (DISP) is the security accreditation frame
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The DISP Membership Pack (with edition) MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUDISP** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the Four Security Domains coverage table).
+10. Show only a summary to the user (one paragraph plus the Four Security Domains coverage table).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-dss.md
+++ b/plugins/arckit-au/commands/au-dss.md
@@ -110,9 +110,10 @@ The Digital Transformation Agency (DTA) Digital Service Standard sets the mandat
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The DTA Digital Service Standard MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUDSS** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the compliance summary table showing status per criterion).
+10. Show only a summary to the user (one paragraph plus the compliance summary table showing status per criterion).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-e8-posture.md
+++ b/plugins/arckit-au/commands/au-e8-posture.md
@@ -95,9 +95,10 @@ The Australian Signals Directorate (ASD) Essential Eight is the baseline cyber-s
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The ASD Essential Eight Maturity Model MUST appear in the Document Register with its primary URL and verification date.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUE8** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the maturity summary matrix showing current ML vs target ML per strategy).
+10. Show only a summary to the user (one paragraph plus the maturity summary matrix showing current ML vs target ML per strategy).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-ism-controls.md
+++ b/plugins/arckit-au/commands/au-ism-controls.md
@@ -122,9 +122,10 @@ The Australian Signals Directorate (ASD) Information Security Manual (ISM) is th
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The ASD ISM (with edition / publication date) MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUISM** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the Compliance Summary table showing per-domain status).
+10. Show only a summary to the user (one paragraph plus the Compliance Summary table showing per-domain status).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-ndb-playbook.md
+++ b/plugins/arckit-au/commands/au-ndb-playbook.md
@@ -115,9 +115,10 @@ A working NDB playbook is operational — it must be executable under time press
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Privacy Act 1988 + OAIC NDB scheme guidance MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUNDB** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the 30-day timeline summary).
+10. Show only a summary to the user (one paragraph plus the 30-day timeline summary).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-ot-security.md
+++ b/plugins/arckit-au/commands/au-ot-security.md
@@ -110,9 +110,10 @@ ASD operational technology guidance is reusable beyond any one industry sector. 
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. ASD OT guidance documents and the verification date MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUOT** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: overall OT posture, highest-risk connectivity gaps, and the top five recommended actions.
+10. Show only a summary to the user: overall OT posture, highest-risk connectivity gaps, and the top five recommended actions.
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-pia.md
+++ b/plugins/arckit-au/commands/au-pia.md
@@ -112,9 +112,10 @@ Australian Government agencies covered by the Privacy Act 1988 must conduct PIAs
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Privacy Act 1988 and OAIC PIA Guide MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUPIA** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the APP compliance summary table).
+10. Show only a summary to the user (one paragraph plus the APP compliance summary table).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-pspf.md
+++ b/plugins/arckit-au/commands/au-pspf.md
@@ -128,9 +128,10 @@ PSPF is structured around **four security outcomes** with **16 core requirements
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. PSPF (with edition) MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUPSPF** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the four-outcome compliance summary table).
+10. Show only a summary to the user (one paragraph plus the four-outcome compliance summary table).
 
 ## Important Notes
 

--- a/plugins/arckit-au/commands/au-soci-cirmp.md
+++ b/plugins/arckit-au/commands/au-soci-cirmp.md
@@ -115,9 +115,10 @@ SOCI is a cross-sector Australian critical-infrastructure regime, not an energy-
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The SOCI Act, current CIRMP Rules / regulator guidance, and verification date MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUSOCI** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: likely SOCI applicability position, CIRMP readiness, top material risks, and immediate evidence gaps.
+10. Show only a summary to the user: likely SOCI applicability position, CIRMP readiness, top material risks, and immediate evidence gaps.
 
 ## Important Notes
 

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/au/commands/au-ai-assurance.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-ai-assurance.md
@@ -129,9 +129,10 @@ Australia's AI assurance landscape combines several frameworks that together gov
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. DTA AI Policy v2.0, AU AI Ethics Principles, AU Essential AI Practices (AI6) — Foundations + Implementation Guidance, ISO 42001 (Australian Standard), and Privacy Act 1988 MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUAIA** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the DTA + Ethics Principles compliance summary table).
+10. Show only a summary to the user (one paragraph plus the DTA + Ethics Principles compliance summary table).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-disp-attestation.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-disp-attestation.md
@@ -114,9 +114,10 @@ The Defence Industry Security Program (DISP) is the security accreditation frame
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The DISP Membership Pack (with edition) MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUDISP** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the Four Security Domains coverage table).
+10. Show only a summary to the user (one paragraph plus the Four Security Domains coverage table).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-dss.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-dss.md
@@ -110,9 +110,10 @@ The Digital Transformation Agency (DTA) Digital Service Standard sets the mandat
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The DTA Digital Service Standard MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUDSS** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the compliance summary table showing status per criterion).
+10. Show only a summary to the user (one paragraph plus the compliance summary table showing status per criterion).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-e8-posture.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-e8-posture.md
@@ -95,9 +95,10 @@ The Australian Signals Directorate (ASD) Essential Eight is the baseline cyber-s
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The ASD Essential Eight Maturity Model MUST appear in the Document Register with its primary URL and verification date.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUE8** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the maturity summary matrix showing current ML vs target ML per strategy).
+10. Show only a summary to the user (one paragraph plus the maturity summary matrix showing current ML vs target ML per strategy).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-ism-controls.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-ism-controls.md
@@ -122,9 +122,10 @@ The Australian Signals Directorate (ASD) Information Security Manual (ISM) is th
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The ASD ISM (with edition / publication date) MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUISM** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the Compliance Summary table showing per-domain status).
+10. Show only a summary to the user (one paragraph plus the Compliance Summary table showing per-domain status).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-ndb-playbook.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-ndb-playbook.md
@@ -115,9 +115,10 @@ A working NDB playbook is operational — it must be executable under time press
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Privacy Act 1988 + OAIC NDB scheme guidance MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUNDB** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the 30-day timeline summary).
+10. Show only a summary to the user (one paragraph plus the 30-day timeline summary).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-ot-security.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-ot-security.md
@@ -110,9 +110,10 @@ ASD operational technology guidance is reusable beyond any one industry sector. 
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. ASD OT guidance documents and the verification date MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUOT** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: overall OT posture, highest-risk connectivity gaps, and the top five recommended actions.
+10. Show only a summary to the user: overall OT posture, highest-risk connectivity gaps, and the top five recommended actions.
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-pia.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-pia.md
@@ -112,9 +112,10 @@ Australian Government agencies covered by the Privacy Act 1988 must conduct PIAs
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The Privacy Act 1988 and OAIC PIA Guide MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUPIA** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the APP compliance summary table).
+10. Show only a summary to the user (one paragraph plus the APP compliance summary table).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-pspf.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-pspf.md
@@ -128,9 +128,10 @@ PSPF is structured around **four security outcomes** with **16 core requirements
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. PSPF (with edition) MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUPSPF** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user (one paragraph plus the four-outcome compliance summary table).
+10. Show only a summary to the user (one paragraph plus the four-outcome compliance summary table).
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/commands/au-soci-cirmp.md
+++ b/plugins/arckit-claude/plugins/au/commands/au-soci-cirmp.md
@@ -115,9 +115,10 @@ SOCI is a cross-sector Australian critical-infrastructure regime, not an energy-
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. The SOCI Act, current CIRMP Rules / regulator guidance, and verification date MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUSOCI** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: likely SOCI applicability position, CIRMP readiness, top material risks, and immediate evidence gaps.
+10. Show only a summary to the user: likely SOCI applicability position, CIRMP readiness, top material risks, and immediate evidence gaps.
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/energy/commands/au-aescsf.md
+++ b/plugins/arckit-claude/plugins/au/energy/commands/au-aescsf.md
@@ -108,9 +108,10 @@ The Australian Energy Sector Cyber Security Framework is an energy-sector cyber 
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. AEMO AESCSF, the verified AESCSF version / publication date, access date, and any AEMO availability issue MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUAESCSF** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: AESCSF scope, target maturity, highest-risk gaps, architecture evidence gaps, and top five uplift actions.
+10. Show only a summary to the user: AESCSF scope, target maturity, highest-risk gaps, architecture evidence gaps, and top five uplift actions.
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/energy/commands/au-energy-compliance.md
+++ b/plugins/arckit-claude/plugins/au/energy/commands/au-energy-compliance.md
@@ -107,9 +107,10 @@ Australian energy projects may need architecture evidence for **AER ring-fencing
 
 7. Populate the External References section per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. Current AER, AEMC NER/NGR, AEMO, CISC / SOCI, and access dates MUST appear in the Document Register.
 
-8. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
+8. Before writing the file, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **AUENERGY** per-type checks pass. Fix any failures before proceeding.
+9. Write the artefact via the Write tool to `projects/<project-id>/<filename>`.
 
-9. Show only a summary to the user: applicability position, key ring-fencing boundaries, AEMO interface risks, SOCI escalation gaps, and top evidence recommendations.
+10. Show only a summary to the user: applicability position, key ring-fencing boundaries, AEMO interface risks, SOCI escalation gaps, and top evidence recommendations.
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -1242,3 +1242,150 @@ All artifacts must pass these 10 checks:
 - Repatriation plan covers return-or-destroy with format portability wherever data was historically taken without informed consent
 - Co-governance records Indigenous representation, decision-making authority and appeal pathway
 - Risk register covers misuse of traditional knowledge, secondary analysis without consent, breach of trust and *UNDA* / UNDRIP implications
+
+### AUE8 -- Essential Eight Maturity Assessment
+
+- All eight mitigation strategies assessed: application control, patch applications, Office macro settings, user application hardening, restrict administrative privileges, patch operating systems, multi-factor authentication, regular backups
+- Each strategy records current maturity (ML0 / ML1 / ML2 / ML3) with evidence, target maturity with its regulatory or risk-appetite rationale, gap, remediation with owner and target date, and residual risk
+- Maturity summary matrix carries one row per strategy and reconciles with the per-strategy assessments
+- Where the entity is a DISP member, any strategy below ML2 is flagged as a DISP non-compliance risk rather than reported as a neutral gap
+- Cloud-hosted systems state which controls are shared-responsibility, which are vendor-managed, and any IRAP-assessed service alignment
+- System classification recorded (UNOFFICIAL / OFFICIAL / OFFICIAL:Sensitive / PROTECTED / SECRET) alongside deployment model and data sovereignty position
+- Recommendations grouped by Quick Wins (<30 days), Short-Term (30–90) and Medium-Term (90–180), each naming its strategy and target ML
+
+### AUISM -- ISM Control Applicability
+
+- Applicability driven by system classification — the control set at OFFICIAL:Sensitive is a subset of that at PROTECTED, and the artefact states which classification it is assessing
+- Applicability matrix covers all 17 ISM control areas (the 15 chapter domains plus Cloud/IaaS and Working-Off-Site)
+- Each in-scope domain records applicability rationale, implementation status, evidence, gap with specific ISM control IDs, remediation with owner and date, and any compensating controls
+- Gaps name the specific ISM control IDs not met rather than describing the domain in general terms
+- ISM-to-E8 cross-reference present, showing E8 as a mitigation subset rather than an alternative
+- Compliance summary states an applicability score as controls implemented over controls applicable, reconciling with the per-domain assessments
+- IRAP position records scope, assessment date, accepted residual risks and re-assessment cadence; inherited posture noted where integrating with IRAP-assessed cloud services
+
+### AUPIA -- Australian Privacy Impact Assessment
+
+- All 13 Australian Privacy Principles assessed, each with applicability and rationale, compliance status, evidence, privacy risk where non-compliant, and mitigation with owner and date
+- Information flows shown as a diagram marking collection, storage, processing, disclosure, cross-border transfer and disposal, with each flow marked against the APP that governs it
+- Sensitive information tested against the s 6 Privacy Act definition (racial or ethnic origin, political opinions, religious beliefs, sexual orientation, criminal record, health, genetic, biometric, trade union membership); where present, the additional APP 3.3 consent requirement is addressed
+- Cross-border disclosures assessed under APP 8, with the accountability consequence stated
+- Privacy risks scored by likelihood and impact with mitigations and residual risk
+- Automated decisions affecting individuals record the December 2026 notification requirement, the human review mechanism and a fairness assessment, cross-referenced to the AI assurance artefact
+- APP 11 security posture cross-referenced to the E8 and ISM artefacts rather than asserted independently
+
+### AUNDB -- Notifiable Data Breaches Playbook
+
+- Eligibility test stated as an explicit decision tree over the three statutory limbs: unauthorised access, disclosure or loss; serious harm likely; remediable by reasonable steps
+- The eligibility conclusion follows the logic — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible data breach requiring notification within 30 days
+- 30-day timeline planned day by day from Day 0 awareness through Day 30 notification, with the intermediate phases named
+- RACI covers Privacy Officer, Security Officer, CISO, Legal, Communications and the accountable executive
+- Detection and containment procedures name the channels by which breaches become known, the immediate containment steps and evidence preservation
+- Serious-harm assessment criteria stated (financial loss, identity theft, emotional distress, physical safety, reputational harm), together with the reasonable-steps mitigation that can remove eligibility
+- OAIC notification content covers the statutory form fields: nature of breach, kind of information, recommendations for individuals, contact details
+- Individual notification approach chooses between direct and publication-based, with content, channel, language and accessibility considerations
+- Coordination with other obligations addressed — SOCI 12-hour and 72-hour, DISP incident reporting, and sectoral regulators — recognising that one incident can trigger several timelines
+- Post-incident review feeds control updates back into the E8, ISM and PIA artefacts
+- Annual tabletop exercise planned with evidence retention and a lessons-learned cycle
+
+### AUOT -- Operational Technology Security
+
+- OT environment context records operational function, safety impact, availability requirements, the OT/IT boundary, third-party access, classification and critical-infrastructure relevance
+- Assessment made against ASD OT principles, definitive OT architecture guidance and secure connectivity principles
+- Definitive OT architecture view records whether an authoritative asset, data-flow, trust-boundary, dependency, owner and connectivity picture exists — absence recorded as a finding
+- Architecture evidence cross-referenced to diagram, DFD and data-model artefacts per OT zone, with missing diagrams, missing DFD levels, stale entities or unowned dependencies called out explicitly as evidence gaps
+- Segmentation documents zones, conduits, boundary controls, admin pathways, jump hosts, protocol gateways, DMZs and monitoring points
+- Remote access assessed for business case, exposure, brokered and just-in-time access, privileged access workstations, vendor access, obsolete-device compensating controls and logging
+- Safety, availability and recovery constraints identify where cyber controls must be adapted for safety, uptime, legacy devices, maintenance windows and manual fallback
+- AI-in-OT assessed where AI is present; where absent, recorded as not applicable with the trigger conditions for reassessment stated rather than silently omitted
+- Findings cross-referenced to the E8 and ISM artefacts, showing where evidence is reused or qualified
+- Recommendations grouped Immediate / 30–90 days / 90–180 days / strategic, each with owner, evidence artefact and residual risk
+
+### AUSOCI -- SOCI Critical Infrastructure Risk Management Programme
+
+- Critical asset context identifies asset, sector, responsible entity, operator, direct interest holders, regulator, and whether the asset is declared or suspected in scope
+- Applicability assessment covers sector, asset class, thresholds, responsible-entity obligations, register obligations, incident reporting and government assistance, with any uncertainty flagged for legal confirmation rather than resolved by assumption
+- All five CIRMP hazard domains assessed: cyber and information security, personnel, supply chain, physical security, natural hazards — each with material risk, relevant impact, current controls, evidence, gaps and a named risk owner
+- Cyber evidence consolidated from the E8, ISM, OT, PIA and NDB artefacts rather than restated
+- Governance model records accountable owner, governing-body oversight, annual report owner, risk committee, review cadence and evidence repository
+- Incident reporting documents the 12-hour and 72-hour pathways where applicable, escalation roles, regulator contact points and record-keeping
+- Annual report and attestation readiness assessed against the required timeframe, including governing-body approval
+- Sector-specific obligations (AESCSF, AER ring-fencing, NER/NGR, AEMO) explicitly deferred to the sector recipes rather than partially duplicated here
+- Architecture and data evidence cross-referenced, with missing or stale evidence called out explicitly
+
+### AUAESCSF -- Australian Energy Sector Cyber Security Framework
+
+- AESCSF source text is not quoted verbatim — the assessment describes maturity in its own words to respect the framework's licensing
+- Energy sub-sector, asset or platform, market role, operational environment and criticality identified, with AESCSF applicability assumptions stated
+- Target maturity profile justified against business criticality, safety and market impacts, with legal or regulatory assumptions flagged for qualified review
+- Maturity assessed per AESCSF capability domain with current evidence, target state, gaps, owners and uplift actions
+- OT/IT zone and conduit diagrams required, alongside DERMS / DOE / CSIP-AUS flows where applicable, field telemetry, metering, control-room and grid-edge dependency evidence
+- Market and system-operator interfaces documented (AEMO interfaces, settlement or metering flows, telemetry, APIs, file transfers, protocol gateways)
+- Asset and interface inventory names a source-of-truth register per class, with owners, criticality and inventory gaps identified
+- Anti-pattern register calls out flat OT networks, undocumented market interfaces, unmanaged vendor remote access, stale DER integration assumptions, missing data ownership and unsupported control-room dependencies
+- Findings mapped to the federal baseline artefacts (E8, ISM, OT security, SOCI CIRMP)
+- Maturity gaps converted into risk treatments with owner, due date, evidence artefact and residual risk
+
+### AUENERGY -- Australian Energy Regulatory Compliance
+
+- Energy sub-sector, regulated services, market participant roles, asset classes and system-operator touchpoints identified
+- AER ring-fencing assessment covers the regulated and unregulated boundary, shared services, staff access, data access, branding, affiliate interactions and waivers, with items requiring qualified legal review marked as such rather than asserted
+- NER, NGR and AEMO obligations mapped at architecture level and explicitly positioned for specialist confirmation
+- SOCI applicability cross-referenced to the CIRMP artefact rather than re-derived
+- Market and system-operator interface register identifies AEMO portals, APIs, B2B/B2M, file transfers, telemetry, dispatch, outage and settlement interfaces
+- Regulated and unregulated data flows document permitted and prohibited flows with controls, approvals, logging, retention, affiliate access and evidence owners
+- Prohibited flows stated explicitly — a permitted-flow list alone does not evidence ring-fencing
+- Inventory names source-of-truth registers across regulated and unregulated services, critical assets, CMDB CIs, interfaces, telemetry, vendor access, customer and metering data, with owners, criticality and gaps
+- Architecture decision seeds proposed for ring-fencing boundaries, shared services, market interface design, DER integration, customer data sharing and SOCI escalation
+- Gaps prioritised with owner, artefact, decision, review requirement and due date
+
+### AUDSS -- Digital Service Standard Assessment
+
+- All 13 Digital Service Standard criteria assessed, each with status, evidence summary, gap description and remediation with owner and target date
+- Service phase recorded (Discovery / Alpha / Beta / Live) alongside user base and transaction volume
+- Accessibility assessed against WCAG 2.2 AA with assistive-technology testing and a published accessibility statement
+- Privacy criterion evidenced by a completed PIA and APP compliance rather than an assertion
+- Security criterion cross-referenced to the E8 posture rather than described independently
+- Open-source criterion states the strategy, repository and licence, or records the exemption
+- Performance measures name the KPIs (completion rate, user satisfaction, cost per transaction, digital take-up)
+- Non-digital experience addressed with assisted digital, phone and in-person channel design — not deferred as out of scope
+- Compliance summary table reconciles with the per-criterion assessments
+- Services approaching an assessment gate identify the top three risks to passing, with mitigations
+
+### AUPSPF -- Protective Security Policy Framework
+
+- All four PSPF outcomes assessed: security governance, information security, personnel security, physical security
+- All 16 core requirements (CR1–CR16) assessed individually, each with compliance status, supporting evidence, gap description, remediation with owner and date, and the self-assessment level achieved
+- Compliance summary carries 16 rows and reconciles with the individual core-requirement assessments
+- Entity type recorded (non-corporate Commonwealth, corporate Commonwealth, contractor, panel member, state government under flow-down) together with the applicability driver — direct or contractual flow-down
+- Chief Security Officer designated
+- Evidence cites the ISM, E8, PIA and DISP artefacts where they exist rather than restating their content
+- Non-corporate Commonwealth entities record Annual Self-Assessment status, last submission to AGD and current self-assessed maturity
+- Recommendations grouped Quick Wins / Short-Term / Medium-Term, each tagged to a specific core requirement
+
+### AUDISP -- Defence Industry Security Programme Attestation
+
+- DISP level sought stated (Level 1 / 2 / 3) with its regulatory driver and a justification for the level chosen
+- A named Chief Security Officer designated with role, authority across all four security domains, deputy, contact details and vetting status
+- All four security domains covered — governance, personnel security, physical security, information and cyber security — each with current state, evidence references, gap, remediation with target dates and an accountable-officer sign-off
+- Essential Eight evidence summarised per strategy against the ML2 minimum, citing the E8 artefact directly
+- Any strategy below ML2 surfaced as a DISP attestation risk rather than recorded as a routine gap
+- ISM applicability highlights identify gaps that materially affect the attestation, citing the ISM artefact
+- FOCI declaration discloses foreign ownership above 5%, foreign board arrangements, foreign supply-chain dependencies and foreign personnel access, with mitigation plans where Level 2 or 3 applies
+- Supply chain discloses Tier 1 suppliers and the attestations they hold (SOC 2, ISO 27001, IRAP)
+- Incident response evidences a 24-hour rapid notification capability for Defence-relevant incidents and integration with the NDB scheme
+- Annual self-audit plan states scope, methodology and evidence retention
+- Attestation statement carries CSO and Director sign-off blocks, date and re-attestation cadence
+
+### AUAIA -- Australian AI Assurance
+
+- AI capability type, deployment phase, foundation model, training and inference data sources and human-in-the-loop posture recorded, with decisions affecting individuals stated explicitly
+- All six DTA Responsible AI Policy accountabilities assessed: accountability, transparency, risk-based approach, quality data and design integrity, privacy and security, human oversight and redress
+- All eight AU AI Ethics Principles assessed with status, evidence, gap and mitigation
+- All six Essential AI Practices (AI6) assessed with status, evidence, gap and action, cross-referenced to the DTA accountabilities without conflating the two — the DTA policy is a Commonwealth mandate, AI6 is adoption guidance
+- Substantially-automated decisions significantly affecting individuals document the December 2026 notification mechanism, what individuals are told and any opt-out pathway, cross-referenced to APP 6 and APP 11
+- Fairness assessment names the bias evaluation methodology, protected attributes, fairness metrics, test results across population segments and residual fairness risks
+- Training-data classification assessed on the basis that models can memorise personal information, so the classification may exceed that of the source system
+- Prompt-injection and model-extraction defences documented, cross-referenced to the E8 posture and ISM applicability
+- Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
+- Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
+- ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated


### PR DESCRIPTION
Fourth regime of the 61 in #748, after #754 (US), #755 (UAE) and #756 (CA). Same defect and same two-part fix.

`AUE8` `AUISM` `AUPIA` `AUNDB` `AUOT` `AUSOCI` `AUDSS` `AUPSPF` `AUAIA` `AUDISP` in `arckit-au`, plus `AUAESCSF` and `AUENERGY` in `arckit-au-energy`. Sections 124 → 136.

**Remaining after this: 15 — all UK, the last regime.**

## First regime spanning two plugins

The guard now counts `arckit-au: 10` and `arckit-au-energy: 2` separately. That is the per-plugin resolution working as designed: each plugin reads its own `references/` copy, so they are genuinely two independent resolutions rather than one bucket.

## The file that needed care

`au-ndb-playbook.md` carries a *second* top-level numbered list — the three-limb eligibility test — in its `## Context` section, ahead of the Process list. A naive file-wide renumber would have corrupted it.

The transform only walks lines after the Write step, so it was untouched. I verified that directly, and checked Process-list numbering from the `## Process` heading rather than file-wide, since a file-wide check would have reported a false mismatch here.

## Checks that encode the derived conclusion

**`AUNDB` is the clearest.** The eligibility conclusion must follow the three statutory limbs — limbs 1 and 2 satisfied with limb 3 unsatisfied yields an eligible breach requiring notification within 30 days. It also has to recognise that one incident can trigger SOCI 12/72-hour, DISP and sectoral obligations on *different clocks*, which is the failure mode where a team notifies OAIC correctly and misses everything else.

Others:

- any E8 strategy below **ML2 is a DISP non-compliance risk**, not a neutral gap — asserted from both the `AUE8` and `AUDISP` sides so neither artefact can quietly disagree with the other
- `AUISM` applicability is driven by classification (OFFICIAL:Sensitive is a subset of PROTECTED), and gaps must name specific ISM control IDs rather than describing a domain
- `AUPSPF` must carry all **16 core requirements** with a 16-row summary that reconciles against them
- `AUPIA` must test sensitive information against the **s 6** definition and apply APP 3.3 where present
- `AUOT` must record AI-in-OT as *not applicable with reassessment triggers* rather than omitting the section — absence and inapplicability are different findings
- `AUSOCI` must **defer** AESCSF, AER ring-fencing, NER/NGR and AEMO obligations to the sector recipes instead of partially duplicating them

`AUAESCSF` carries a licensing-driven check that the others don't: the assessment must describe maturity in its own words and **not quote AESCSF source text verbatim**. The command says so; nothing else enforced it.

## Verification

- Guard reports **127 references across 9 plugins, all resolving**
- Regime-carrying codes with no section: **27 → 15**
- `au-ndb-playbook.md` Context list confirmed unchanged; Process numbering contiguous in all 12
- `check-doc-type-registry.py`, `check_references.py` (836 files), `sync-shared-assets.py --check` clean
- `markdownlint-cli2` clean; converter regenerated all 7 extensions
- Full suite: 1297 passed, 225 skipped

## Note on what remains

UK's 15 is the awkward one: 4 plugins, 17 commands for 15 codes (`SDD` is written by three), and `GCMP` and `GCRV` have **no template**, so their checks must come from command Instructions alone.

Still outstanding: the `us-fedramp-ssp.md` "15-section" heading over a 16-item list, flagged in #754.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
