### PR TITLE
feat(uk): wire the final 15 UK doc-types into the quality checklist (closes #748)

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/agents/arckit-competitors-writer.md
+++ b/plugins/arckit-claude/agents/arckit-competitors-writer.md
@@ -286,10 +286,12 @@ Notes on optional groups:
    value is not actual spend …`) must always be present. Render any
    additional entries from `caveats[]` as further blockquote lines beneath it.
 
-6. **Write the CMPT artefact.** Use the `Write` tool to save the completed
+6. **Verify quality checks.** Read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **CMPT** per-type checks pass. Fix any failures before writing. Every figure you correct must come from the orchestrator payload — never introduce a supplier, value or buyer at render time.
+
+7. **Write the CMPT artefact.** Use the `Write` tool to save the completed
    document to `{project_path}/research/{document_id}.md`.
 
-7. **Spawn / enrich vendor profiles (mirror datascout-writer Step B).** For
+8. **Spawn / enrich vendor profiles (mirror datascout-writer Step B).** For
    each rival in `suppliers[]` whose award data is present (it has
    `sample_notices[]` and/or `awarded_value_total_gbp` / `award_count`):
 
@@ -339,7 +341,7 @@ Notes on optional groups:
       writer. Record this rival in the Spawned Knowledge note as "award
       history available, no profile yet".
 
-8. **Append a `## Spawned Knowledge` section to the CMPT artefact** (use
+9. **Append a `## Spawned Knowledge` section to the CMPT artefact** (use
    `Edit` on the file you wrote in step 6) listing the outcome per rival:
 
    ```markdown

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-consumer-duty.md
+++ b/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-consumer-duty.md
@@ -163,6 +163,8 @@ target market, and the firm's operational capability even where those harms have
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSCD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSCD-v1.0.md`
 

--- a/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-ctp-dependency.md
+++ b/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-ctp-dependency.md
@@ -163,6 +163,8 @@ with board sign-off).
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSCTP** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSCTP-v1.0.md`
 

--- a/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-safeguarding.md
+++ b/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-safeguarding.md
@@ -178,6 +178,8 @@ Populate the **Failure scenarios and recovery** section (§8) with at least thre
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSSAFE** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSSAFE-v1.0.md`
 

--- a/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-sca-rts.md
+++ b/plugins/arckit-claude/plugins/uk/finance/commands/uk-fs-sca-rts.md
@@ -150,6 +150,8 @@ Populate the **Audit Trail Requirements** section (§6) with:
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSSCA** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSSCA-v1.0.md`
 

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/declaration.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/declaration.md
@@ -161,6 +161,8 @@ question as `[PENDING]` rather than assuming a "No" — the supplier must confir
 explicitly. Record any "Yes" answers and their mitigating detail in the Mitigating Information
 section (Part 8) of the template.
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DECL** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed declaration to:
 
 `projects/000-global/supplier/ARC-000-DECL-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/gcloud-competitors.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/gcloud-competitors.md
@@ -245,6 +245,8 @@ overwriting at v1.0.
 
 ### 10. Write the benchmark report
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GCMP** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed benchmark to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-GCMP-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/pricing.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/pricing.md
@@ -252,6 +252,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 9. Write the pricing document
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PRIC** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-PRIC-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/review.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/review.md
@@ -287,6 +287,8 @@ Document Control footer:
 
 ### 6. Write the review report
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GCRV** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed report to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-GCRV-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/sdd-lot1.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/sdd-lot1.md
@@ -209,6 +209,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the SDD
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SDD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SDD-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/sdd-lot2.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/sdd-lot2.md
@@ -190,6 +190,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the SDD
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SDD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SDD-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/sdd-lot3.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/sdd-lot3.md
@@ -184,6 +184,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the SDD
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SDD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SDD-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/security.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/security.md
@@ -275,6 +275,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the security document
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SECA** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SECA-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/service-design.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/service-design.md
@@ -208,6 +208,8 @@ footer at the end of the document:
 
 ### 10. Write the service-design document
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SVCD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{project_dir}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SVCD-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/commands/supplier-profile.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/commands/supplier-profile.md
@@ -180,6 +180,8 @@ increment for an update and add a Revision History row describing what changed).
 
 ### 7. Write the supplier profile
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SUPP** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `projects/000-global/supplier/ARC-000-SUPP-v1.0.md`

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/uk/nhs/commands/uk-mdr-classification.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/commands/uk-mdr-classification.md
@@ -135,9 +135,10 @@ This command focuses on **software-as-medical-device** (SaMD) and **AI-as-medica
 
 7. **Populate the External References section** per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. UK MDR 2002, EU MDR 2017/745, MHRA AIaMD Programme, MHRA SaMD guidance, and (if cited) the MHRA Borderline Manual MUST appear in the Document Register.
 
-8. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSMDR-v1.0.md`.
+8. **Before writing the file**, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NHSMDR** per-type checks pass. Fix any failures before proceeding.
+9. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSMDR-v1.0.md`.
 
-9. **Show only a summary to the user**: scope determination (medical device / not / borderline), UK class, EU class, marking pathway, conformity route, list of `[PENDING]` items requiring qualified Regulatory Affairs review.
+10. **Show only a summary to the user**: scope determination (medical device / not / borderline), UK class, EU class, marking pathway, conformity route, list of `[PENDING]` items requiring qualified Regulatory Affairs review.
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/uk/nhs/commands/uk-nhs-dtac.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/commands/uk-nhs-dtac.md
@@ -129,9 +129,10 @@ DTAC was introduced by NHSX (now part of NHS England's Transformation Directorat
 
 7. **Populate the External References section** per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. DTAC v3, NHS DCB0129, NHS DCB0160, UK GDPR, DSPT, WCAG 2.2, and ATRS (if AI) MUST appear in the Document Register.
 
-8. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSDTAC-v1.0.md`.
+8. **Before writing the file**, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NHSDTAC** per-type checks pass. Fix any failures before proceeding.
+9. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSDTAC-v1.0.md`.
 
-9. **Show only a summary to the user**: pass / partial / fail counts per section, list of `[PENDING]` items requiring human input, recommended next commands.
+10. **Show only a summary to the user**: pass / partial / fail counts per section, list of `[PENDING]` items requiring human input, recommended next commands.
 
 ## Important Notes
 

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-uk-finance/commands/uk-fs-consumer-duty.md
+++ b/plugins/arckit-uk-finance/commands/uk-fs-consumer-duty.md
@@ -163,6 +163,8 @@ target market, and the firm's operational capability even where those harms have
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSCD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSCD-v1.0.md`
 

--- a/plugins/arckit-uk-finance/commands/uk-fs-ctp-dependency.md
+++ b/plugins/arckit-uk-finance/commands/uk-fs-ctp-dependency.md
@@ -163,6 +163,8 @@ with board sign-off).
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSCTP** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSCTP-v1.0.md`
 

--- a/plugins/arckit-uk-finance/commands/uk-fs-safeguarding.md
+++ b/plugins/arckit-uk-finance/commands/uk-fs-safeguarding.md
@@ -178,6 +178,8 @@ Populate the **Failure scenarios and recovery** section (§8) with at least thre
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSSAFE** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSSAFE-v1.0.md`
 

--- a/plugins/arckit-uk-finance/commands/uk-fs-sca-rts.md
+++ b/plugins/arckit-uk-finance/commands/uk-fs-sca-rts.md
@@ -150,6 +150,8 @@ Populate the **Audit Trail Requirements** section (§6) with:
 Create the output directory if it does not already exist:
 `<project_dir>/payments-compliance/`
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **FSSCA** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 `projects/<NNN>-<slug>/payments-compliance/ARC-<NNN>-FSSCA-v1.0.md`
 

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-uk-gcloud/commands/declaration.md
+++ b/plugins/arckit-uk-gcloud/commands/declaration.md
@@ -161,6 +161,8 @@ question as `[PENDING]` rather than assuming a "No" — the supplier must confir
 explicitly. Record any "Yes" answers and their mitigating detail in the Mitigating Information
 section (Part 8) of the template.
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **DECL** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed declaration to:
 
 `projects/000-global/supplier/ARC-000-DECL-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/gcloud-competitors.md
+++ b/plugins/arckit-uk-gcloud/commands/gcloud-competitors.md
@@ -245,6 +245,8 @@ overwriting at v1.0.
 
 ### 10. Write the benchmark report
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GCMP** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed benchmark to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-GCMP-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/pricing.md
+++ b/plugins/arckit-uk-gcloud/commands/pricing.md
@@ -252,6 +252,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 9. Write the pricing document
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **PRIC** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-PRIC-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/review.md
+++ b/plugins/arckit-uk-gcloud/commands/review.md
@@ -287,6 +287,8 @@ Document Control footer:
 
 ### 6. Write the review report
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **GCRV** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed report to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-GCRV-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/sdd-lot1.md
+++ b/plugins/arckit-uk-gcloud/commands/sdd-lot1.md
@@ -209,6 +209,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the SDD
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SDD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SDD-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/sdd-lot2.md
+++ b/plugins/arckit-uk-gcloud/commands/sdd-lot2.md
@@ -190,6 +190,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the SDD
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SDD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SDD-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/sdd-lot3.md
+++ b/plugins/arckit-uk-gcloud/commands/sdd-lot3.md
@@ -184,6 +184,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the SDD
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SDD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SDD-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/security.md
+++ b/plugins/arckit-uk-gcloud/commands/security.md
@@ -275,6 +275,8 @@ History, and append the standard ArcKit Document Control footer:
 
 ### 8. Write the security document
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SECA** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{path}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SECA-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/service-design.md
+++ b/plugins/arckit-uk-gcloud/commands/service-design.md
@@ -208,6 +208,8 @@ footer at the end of the document:
 
 ### 10. Write the service-design document
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SVCD** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `{project_dir}/{filename}` — e.g. `projects/004-secure-case-mgmt/ARC-004-SVCD-v1.0.md`

--- a/plugins/arckit-uk-gcloud/commands/supplier-profile.md
+++ b/plugins/arckit-uk-gcloud/commands/supplier-profile.md
@@ -180,6 +180,8 @@ increment for an update and add a Revision History row describing what changed).
 
 ### 7. Write the supplier profile
 
+Before writing, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **SUPP** per-type checks pass. Fix any failures before proceeding.
+
 Use the **Write tool** to save the completed document to:
 
 `projects/000-global/supplier/ARC-000-SUPP-v1.0.md`

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-uk-nhs/commands/uk-mdr-classification.md
+++ b/plugins/arckit-uk-nhs/commands/uk-mdr-classification.md
@@ -135,9 +135,10 @@ This command focuses on **software-as-medical-device** (SaMD) and **AI-as-medica
 
 7. **Populate the External References section** per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. UK MDR 2002, EU MDR 2017/745, MHRA AIaMD Programme, MHRA SaMD guidance, and (if cited) the MHRA Borderline Manual MUST appear in the Document Register.
 
-8. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSMDR-v1.0.md`.
+8. **Before writing the file**, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NHSMDR** per-type checks pass. Fix any failures before proceeding.
+9. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSMDR-v1.0.md`.
 
-9. **Show only a summary to the user**: scope determination (medical device / not / borderline), UK class, EU class, marking pathway, conformity route, list of `[PENDING]` items requiring qualified Regulatory Affairs review.
+10. **Show only a summary to the user**: scope determination (medical device / not / borderline), UK class, EU class, marking pathway, conformity route, list of `[PENDING]` items requiring qualified Regulatory Affairs review.
 
 ## Important Notes
 

--- a/plugins/arckit-uk-nhs/commands/uk-nhs-dtac.md
+++ b/plugins/arckit-uk-nhs/commands/uk-nhs-dtac.md
@@ -129,9 +129,10 @@ DTAC was introduced by NHSX (now part of NHS England's Transformation Directorat
 
 7. **Populate the External References section** per `${CLAUDE_PLUGIN_ROOT}/references/citation-instructions.md`. DTAC v3, NHS DCB0129, NHS DCB0160, UK GDPR, DSPT, WCAG 2.2, and ATRS (if AI) MUST appear in the Document Register.
 
-8. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSDTAC-v1.0.md`.
+8. **Before writing the file**, read `${CLAUDE_PLUGIN_ROOT}/references/quality-checklist.md` and verify all **Common Checks** plus the **NHSDTAC** per-type checks pass. Fix any failures before proceeding.
+9. **Write the artefact via the Write tool** to `projects/{NNN}-<slug>/ARC-{NNN}-NHSDTAC-v1.0.md`.
 
-9. **Show only a summary to the user**: pass / partial / fail counts per section, list of `[PENDING]` items requiring human input, recommended next commands.
+10. **Show only a summary to the user**: pass / partial / fail counts per section, list of `[PENDING]` items requiring human input, recommended next commands.
 
 ## Important Notes
 

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -1389,3 +1389,180 @@ All artifacts must pass these 10 checks:
 - Model lifecycle governance covers version control, change management for model updates, drift detection and retirement criteria
 - Third-party foundation models disclose vendor, model version, vendor policy compliance, training-data provenance, inference data residency and the IP position
 - ISO 42001 readiness assessed clause by clause where certification is pursued or anticipated
+
+### CMPT -- Competitor Landscape
+
+- Rival suppliers ranked by awarded-value share with award counts and key buyers
+- The mandatory awarded-value caveat present — figures are awarded contract value, not actual spend
+- On a supplier-focus run the focal supplier is pulled out of the set with its awarded value, award count and share; on a capability-focus run the head-to-head section renders explicitly not-applicable rather than being omitted
+- Concentration reported as top-1 and top-3 share with a HIGH / MEDIUM / LOW flag, and the flag consistent with the shares it is derived from
+- Every representative notice carries its `notice_url`
+- Data freshness and source health reported, or a freshness-unavailable note given rather than silence
+- Per-rival buyer relationships and recent wins present for each rival in the set
+- Government Award History enrichment only merged into pre-existing vendor profiles — no new profiles created
+- Figures traceable to the reader payload; no supplier, value or buyer introduced at render time
+
+### SUPP -- G-Cloud Supplier Profile
+
+- Company details complete: registered name, company registration number, DUNS, VAT, registered address, trading name, website, year established
+- Every certification records status, certificate number, expiry and certification body — a named certification without a number or expiry is incomplete
+- Security clearances recorded as staff counts per level (BPSS, CTC, SC, DV, eDV) with sponsoring organisation and renewal process
+- Every data centre records location, operator, UK data sovereignty position, certifications, and backup or DR location with distance from primary
+- Insurance recorded per policy with provider, coverage amount and expiry
+- Modern Slavery position states whether the £36m turnover threshold is met and, where it is, the published statement URL
+- Environmental credentials record ISO 14001 status, carbon-neutral position and net-zero target year
+- Subcontracting position stated, with policy and key subcontractors where used
+- SME status recorded (Micro / Small / Medium / Large) consistent with the stated employee count and turnover
+
+### DECL -- G-Cloud Supplier Declaration
+
+- Every mandatory exclusion ground answered explicitly and reproduced verbatim — never paraphrased or skipped
+- All seven mandatory exclusion categories addressed: conspiracy, corruption and bribery, fraud and theft, organised crime, terrorism, money laundering, tax evasion
+- All seven discretionary exclusion grounds answered: bankruptcy or insolvency, grave professional misconduct, distorting competition, conflict of interest, significant deficiencies in prior contracts, serious misrepresentation, undue influence
+- Company information complete, including contract notice contact details as distinct from the primary contact
+- Service offerings confirm day-one availability, absence of prohibited items and the subcontracting position
+- Modern Slavery, Equality Act 2010, environmental and labour law compliance each answered
+- All three insurance types declared: employers liability, professional indemnity, public liability
+- Tax compliance covers current obligations, GAAR compliance and absence of evasion convictions
+- Framework terms accepted, including the 10-working-day response commitment
+- No question left blank or answered `N/A` where a positive or negative declaration is required
+
+### SVCD -- G-Cloud Service Design
+
+- Lot selected and recorded (Lot 1 Cloud Hosting, Lot 2 Cloud Software, Lot 3 Cloud Support)
+- Lot-specific information gathered for the selected lot rather than the generic set alone
+- Service name within 100 characters and service description within 50 words for the marketplace fields
+- Features and benefits each capped at 10 items, every item within 100 characters
+- Target buyer segments named
+- Technical details cover hosting locations and data residency, backup and DR, scalability, and security controls cross-referenced to the supplier profile certifications
+- Support model states hours, channels, response targets and escalation
+- Pricing model outlined consistently with the pricing artefact where one exists
+- Differentiation states competitive advantages and target use cases rather than marketing claims
+
+### SDD -- G-Cloud Service Definition Document
+
+- Every mandatory marketplace question answered — an unanswered question causes rejection
+- Lot-specific categories completed for the document's own lot, and no other lot's categories substituted
+- Service name within 100 characters; description within 50 words and 500 characters
+- Features and benefits each within 10 items and 100 characters per item
+- Data centre details cover physical locations, tier, power redundancy, cooling, physical security and environmental certifications
+- Multi-tenancy separation described across resource, network and data isolation
+- Public sector network connectivity addressed where relevant (PSN, HSCN)
+- Support availability, channels, response times and documentation availability stated
+- Data locations, import and export formats, and the end-of-contract data-extraction process all specified
+- Content consistent with the supplier profile and service design artefacts — company name, certifications, data-centre locations, features, benefits and lot must agree
+
+### PRIC -- G-Cloud Pricing Document
+
+- Pricing model chosen and appropriate to the lot — day rates or fixed price for Lot 3, per-user, consumption, flat fee or tiered for Lots 1 and 2
+- All prices stated in GBP; no other currency present
+- Base pricing states minimum, standard and enterprise or volume price points
+- What is included at base price stated explicitly (features, support level, storage, users, transactions, training)
+- What costs extra stated explicitly, so the total cost of the service is derivable rather than implied
+- Education and charity pricing addressed
+- Free trial or free version position stated
+- SFIA rate card used for Lot 3 day rates, with remote, on-site and out-of-hours rates distinguished
+- Pricing consistent with the SDD's stated pricing model, included features and support level
+
+### SECA -- G-Cloud Security Evidence
+
+- All 14 NCSC Cloud Security Principles addressed
+- Every certification records certificate number, scope, certification body, last audit date and next recertification date
+- Cyber Essentials or Cyber Essentials Plus recorded with certificate number, certification date and expiry
+- SOC 2 Type II records report date, trust service criteria covered and any exceptions noted — exceptions are not omitted
+- Penetration testing records frequency, last test date, provider, scope coverage and remediation process
+- Vulnerability scanning records frequency, tooling and remediation SLAs
+- Data protection covered both in transit and at rest, with key management stated
+- Access management and audit capabilities described
+- Evidence register maps each claim to its supporting artefact
+- Certifications consistent with those declared in the supplier profile
+
+### GCMP -- G-Cloud Competitor Benchmark
+
+- Competitors identified from real market evidence, with the search basis recorded rather than assumed
+- Feature, pricing, certification and support comparisons each presented as a like-for-like table
+- Pricing comparison states market low, average and high alongside the service's own price
+- Certification comparison expresses the market position as a proportion rather than an assertion
+- SWOT covers all four quadrants, each grounded in the comparison tables rather than introduced fresh
+- Strengths and weaknesses stated relative to named competitors, not in the abstract
+- Recommendations follow from the comparisons — a pricing recommendation must be consistent with the pricing comparison
+- Where award evidence is available, the benchmark is anchored to it and the awarded-value caveat carried
+- Citation traceability applied, with every external claim referenced
+
+### GCRV -- G-Cloud Submission Review
+
+- Every expected document checked for existence by its ARC-ID (SUPP, DECL, SVCD, SDD, PRIC, SECA)
+- Overall status set to READY, NEEDS WORK or NOT READY, and consistent with the findings — no READY status while a mandatory field is missing
+- Mandatory field status reported per document rather than in aggregate
+- Character and word limits validated numerically and reported as actual against limit: service name against 100 characters, description against 50 words and 500 characters, each feature and benefit against 100 characters
+- Consistency checks run across every pair the review names: supplier profile against SDD, service design against SDD, SDD against pricing, SDD against security
+- Common rejection reasons checked explicitly: placeholder text, `N/A` where an answer is required, contradictory statements, unsubstantiated claims, competitor mentions, non-GBP pricing
+- Actions required listed with enough specificity to be actioned without re-reading the source documents
+- Evidence status reported per claim requiring evidence
+
+### FSSCA -- SCA-RTS Exemption Assessment
+
+- All nine in-scope exemptions assessed (Articles 10, 10A, 11, 13, 14, 15, 16, 17, 18), each with a decision of APPLY, DO_NOT_APPLY or CONDITIONAL
+- Article 12 explicitly excluded as out of scope — AISP payment account access is covered by Article 10A post-PS21/19
+- Every decision justified against the firm's actual payment channels and risk profile rather than asserted
+- Where Article 18 TRA is applied, the firm's current fraud rate per payment category is stated
+- The applicable reference fraud-rate band cited, and the targeted exemption threshold consistent with that band — a threshold cannot be claimed while the corresponding fraud-rate condition is unmet
+- The continuous nature of the TRA fraud-rate condition stated, not treated as a one-off test
+- Exemption decisions consistent with each other where they interact
+
+### FSSAFE -- Safeguarding Arrangements
+
+- Authorisation type recorded (authorised EMI, authorised API, registered SPI) with the applicable regulation cited
+- Safeguarding method stated with justification: segregation, insurance, or comparable guarantee
+- SPI safeguarding correctly characterised as voluntary — registered SPIs are not required to safeguard, and where elected the Reg 23 mechanics and insolvency priority follow
+- Designated accounts record institution name, FCA FRN, account type, sort code or IBAN, and date designated
+- Segregation trigger stated against the correct deadline for the authorisation type — end of business on the day of receipt under PSRs 2017 Reg 23(2), or within five business days of issuance for EMIs under EMR 2011 Reg 20(4)
+- Controls preventing commingling with operational funds documented, along with the controls keeping the designated account to safeguarding use only
+- Where insurance or a comparable guarantee is used, the insurer or guarantor, coverage amount, sublimits and insolvency trigger are recorded, with confirmation the cover was in place before any relevant funds were received
+- Reconciliation approach documented with frequency and break-resolution process
+
+### FSCD -- Consumer Duty Assessment
+
+- All four outcomes assessed with an evidence status, and thin evidence flagged as Amber or Red rather than presented as compliant
+- Price and Value states total cost to the consumer broken down by fee type, including FX spread and ancillary charges
+- Fair-value methodology stated, with benchmarking against at least two comparable competitors or market indices
+- Any cross-subsidisation disclosed and tested against the fair-value obligation
+- Consumer Support evidenced with service-level data across every contact channel, complaint volumes with root-cause analysis and trend direction, and escalation and FOS referral rates
+- Vulnerable customer cohorts identified from evidence rather than assumed demographics, covering all four FG22/5 drivers: health, life events, resilience, capability
+- Each cohort records estimated proportion of the customer base, identification method, and evidence that the additional support offered is effective
+- Foreseeable harms register populated, with each harm linked to the outcome it engages
+
+### FSCTP -- Critical Third Party Dependency
+
+- Every provider classified as designated CTP, material non-CTP, or non-material, with the current HMT designation status verified rather than assumed
+- Designated CTPs record the specific services consumed, mapped to the firm's Important Business Services
+- Substitution time estimate and substitution complexity stated per designated CTP
+- Last resilience test recorded as an actual date — "planned" or "TBD" is not an acceptable value
+- Nth-party sub-contractor dependencies identified, on the basis that these are often the real failure mode
+- Materiality scored across all four dimensions (IBS dependency, substitution difficulty, recovery time impact, concentration risk contribution) on the 1–5 scale
+- Concentration assessed across all three axes: geographic, vendor and functional
+- Concentration findings consistent with the materiality scores that produced them
+
+### NHSDTAC -- NHS Digital Technology Assessment Criteria
+
+- All five DTAC sections assessed, each with an explicit pass, partial or fail status and supporting evidence
+- Clinical safety records DCB0129 manufacturer and DCB0160 deployer case status, CSO name and registration, and hazard log status with open-hazard count and highest open risk level
+- Absent safety case files marked `[PENDING DCB0129/0160]` clearly rather than passed over
+- Data protection states the UK GDPR Article 6 lawful basis, and Article 9 where special-category data is processed
+- Sub-processor list records locations and the SCCs or UK addendum relied upon
+- DSPT submission status stated, marked as an organisation responsibility where external
+- Technical assurance covers cloud hosting and UK region status, Cyber Essentials, software lifecycle including SBOM, encryption in transit and at rest with key management, penetration test status, business continuity with RTO and RPO, and vulnerability management SLAs
+- Every `[PENDING]` item requiring human input surfaced in the summary rather than left in the body
+- Cross-references resolve to the DPIA, DATA and clinical-safety artefacts where they exist
+
+### NHSMDR -- UK MDR Classification
+
+- Intended purpose statement quoted verbatim — it is the load-bearing input, and paraphrase changes the classification
+- Medical device determination applies both the UK MDR 2002 regulation 2 definition test and the MHRA stand-alone software decision tree
+- A "Not a Medical Device" determination carries rationale drawn from the MHRA Borderline Manual and a responsible-person sign-off, and the remainder of the assessment is then explicitly N/A rather than partially completed
+- Borderline cases record the borderline rationale and recommend MHRA pre-submission review rather than resolving the question unilaterally
+- UK MDR 2002 class determined (I / IIa / IIb / III) with the applicable rule cited, plus sterile, measuring and reusable-surgical subclass flags
+- Self-certification eligibility stated, and consistent with the determined class — only Class I non-sterile, non-measuring qualifies
+- EU MDR 2017/745 classification determined separately with Rule 11 reasoning shown for software
+- Divergence between the UK and EU classifications flagged explicitly, on the basis that EU MDR is typically the more conservative reading
+- Marking pathway recommended across UKCA, UKNI and CE with Notified Body involvement and registration obligations stated per market


### PR DESCRIPTION
**Closes #748.** Last regime, after #754 (US), #755 (UAE), #756 (CA) and #757 (AU).

Regime-carrying doc-types with no per-type section: **61 → 0**. Sections 136 → 151. The guard now reports **144 references across 12 plugins, all resolving**.

`CMPT` (core) · `SUPP` `SVCD` `SDD` `DECL` `PRIC` `SECA` `GCMP` `GCRV` (G-Cloud) · `FSSCA` `FSSAFE` `FSCD` `FSCTP` (Finance) · `NHSDTAC` `NHSMDR` (NHS)

## Four different edits, not one transform

This regime was heterogeneous enough that the approach from the previous four did not carry over:

**`CMPT` goes in the agent, not the command.** `/arckit:competitors` is a three-tier orchestrator that never writes the artefact — `arckit-competitors-writer` does. A command-side check would be verifying a document the command cannot see. The invocation is in `agents/arckit-competitors-writer.md`, immediately before its Write step, and the guard picks it up because it scans agents as well as commands. Worth noting the other four writer agents (`grants`, `datascout`, `gov-reuse`, `tenders`) are in the same position and out of scope here.

**G-Cloud and Finance needed no renumbering.** Those 14 commands use `### N. Write the X` headings rather than a numbered process list, so the invocation is a paragraph inside the existing write section — lower risk than renumbering headings.

**NHS did.** Those 2 use numbered steps, so inserted and renumbered.

**`SDD` is written by three commands** (`sdd-lot1/2/3`), so 15 codes needed **17 edits**.

`GCMP` and `GCRV` have no template at all, so their checks derive from command Instructions alone.

## Checks

These lean on the marketplace's hard limits, because those are the actual rejection causes: service name ≤100 chars, description ≤50 words and ≤500 chars, features and benefits ≤10 items at ≤100 chars each, pricing in GBP only. `GCRV` must report them **numerically as actual against limit**, and its overall verdict cannot read READY while a mandatory field is missing.

Others encode a statutory boundary the command states but nothing enforces:

- **`FSSAFE`** segregation deadlines differ by authorisation type — end of business on receipt under PSRs 2017 Reg 23(2), five business days from issuance for EMIs under EMR 2011 Reg 20(4) — and SPI safeguarding is *voluntary*, which is easy to get wrong in the opposite direction
- **`FSSCA`** must exclude Article 12 as out of scope, and cannot claim a TRA threshold whose fraud-rate condition is unmet
- **`FSCTP`** resilience tests need an actual date; "planned" or "TBD" is not a value
- **`NHSMDR`** must quote the intended-purpose statement **verbatim**, because paraphrase changes the classification, and self-certification eligibility must agree with the determined class
- **`DECL`** exclusion grounds must be reproduced verbatim and never left blank or `N/A`

## Verification

- **0** regime-carrying codes without a section, down from 61
- Guard: 144 references across 12 plugins, all resolving
- NHS step numbering contiguous post-edit; canonical diff additive only (+177, −0)
- `check-doc-type-registry.py`, `check_references.py` (836 files), `check_recipes.py`, `sync-shared-assets.py --check` all clean
- `markdownlint-cli2` clean across **3,146** files — one MD012 from my own insertion was caught and fixed before commit
- Converter regenerated all 7 extensions; full suite 1297 passed, 225 skipped

## What #748 leaves behind

The issue is closed by this, but two things noted along the way are not:

- `us-fedramp-ssp.md` says "Generate the **15-section** FedRAMP SSP structure" over a **16**-item list (flagged in #754)
- Four `arckit-togaf-adm` templates carry a reduced Document Control block, ~7 fields against the 14 Common Check 1 requires (flagged in #750)

Both are pre-existing and independent of the checklist work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
