### PR TITLE
fix(togaf): complete the Document Control block in all 9 templates

### DIFF
--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-repository.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-repository.md
@@ -328,7 +328,7 @@ Before completing the document, populate ALL document control fields in the head
 
 **Construct Document ID**:
 
-- **Document ID**: `ARC-000-REPO-v{VERSION}` (global) or `ARC-{PROJECT_ID}-REPO-v{VERSION}` (project-scoped)
+- **Document ID**: `ARC-000-REPO-v[VERSION]` (global) or `ARC-[PROJECT_ID]-REPO-v[VERSION]` (project-scoped)
 
 **Populate Required Fields**:
 

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/adm-preliminary-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/adm-preliminary-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
+| **Document Type** | Architecture Vision — Preliminary ADM |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/application-inventory-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/application-inventory-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
+| **Document Type** | Application Inventory |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-board-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-board-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
+| **Document Type** | Architecture Board Charter |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-change-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-change-template.md
@@ -13,18 +13,20 @@ templateVersion: "1.0"
 | **Document ID** | `ARC-[PROJECT_ID]-ACHG-[ACHG_NUM]-v[VERSION]` |
 | **Document Type** | Architecture Change Request |
 | **Project** | `[PROJECT_NAME]` |
-| **Change ID** | `ACHG-[ACHG_NUM]` |
 | **Classification** | `[CLASSIFICATION]` |
 | **Status** | DRAFT |
-| **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
-| **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |
+| **Version** | `[VERSION]` |
 | **Created Date** | `[YYYY-MM-DD]` |
 | **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Date** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
 | **Owner** | `[OWNER_NAME_AND_ROLE]` |
 | **Reviewed By** | `[REVIEWER_NAME]` |
 | **Approved By** | `[APPROVER_NAME]` |
 | **Distribution** | `[DISTRIBUTION_LIST]` |
+| **Change ID** | `ACHG-[ACHG_NUM]` |
+| **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
+| **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-repository-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-repository-template.md
@@ -10,19 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Standard ID | `ARC-000-REPO-v{VERSION}` |
-| Project | Global Repository |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
-| Review Cycle | Quarterly |
-| Next Review | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `Project Team, Architecture Team` |
+| **Document ID** | `ARC-000-REPO-v[VERSION]` |
+| **Document Type** | Architecture Repository |
+| **Project** | Global Repository |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | Quarterly |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `Project Team, Architecture Team` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/capability-map-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/capability-map-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
+| **Document Type** | Business Capability Map |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/gap-analysis-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/gap-analysis-template.md
@@ -10,14 +10,21 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Severity Weighting | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
+| **Document Type** | TOGAF Gap Analysis |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
+| **Severity Weighting** | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/rationalization-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/rationalization-template.md
@@ -10,20 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
-| Document Type | Application Rationalisation |
-| Project | `[PROJECT_NAME]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Version | `[VERSION]` |
-| Created | `[YYYY-MM-DD]` |
-| Last Modified | `[YYYY-MM-DD]` |
-| Review Cycle | Quarterly during active rationalisation programme |
-| Next Review Date | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `[DISTRIBUTION_LIST]` |
+| **Document ID** | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
+| **Document Type** | Application Rationalisation |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | Quarterly during active rationalisation programme |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/transition-architecture-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/transition-architecture-template.md
@@ -10,20 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
-| Document Type | Transition Architecture |
-| Project | `[PROJECT_NAME]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Version | `[VERSION]` |
-| Created | `[YYYY-MM-DD]` |
-| Last Modified | `[YYYY-MM-DD]` |
-| Review Cycle | Monthly during active migration, quarterly after migration |
-| Next Review Date | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `[DISTRIBUTION_LIST]` |
+| **Document ID** | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
+| **Document Type** | Transition Architecture |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | Monthly during active migration, quarterly after migration |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-togaf-adm/commands/architecture-repository.md
+++ b/plugins/arckit-togaf-adm/commands/architecture-repository.md
@@ -328,7 +328,7 @@ Before completing the document, populate ALL document control fields in the head
 
 **Construct Document ID**:
 
-- **Document ID**: `ARC-000-REPO-v{VERSION}` (global) or `ARC-{PROJECT_ID}-REPO-v{VERSION}` (project-scoped)
+- **Document ID**: `ARC-000-REPO-v[VERSION]` (global) or `ARC-[PROJECT_ID]-REPO-v[VERSION]` (project-scoped)
 
 **Populate Required Fields**:
 

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-togaf-adm/templates/adm-preliminary-template.md
+++ b/plugins/arckit-togaf-adm/templates/adm-preliminary-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
+| **Document Type** | Architecture Vision — Preliminary ADM |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/application-inventory-template.md
+++ b/plugins/arckit-togaf-adm/templates/application-inventory-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
+| **Document Type** | Application Inventory |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/architecture-board-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-board-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
+| **Document Type** | Architecture Board Charter |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/architecture-change-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-change-template.md
@@ -13,18 +13,20 @@ templateVersion: "1.0"
 | **Document ID** | `ARC-[PROJECT_ID]-ACHG-[ACHG_NUM]-v[VERSION]` |
 | **Document Type** | Architecture Change Request |
 | **Project** | `[PROJECT_NAME]` |
-| **Change ID** | `ACHG-[ACHG_NUM]` |
 | **Classification** | `[CLASSIFICATION]` |
 | **Status** | DRAFT |
-| **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
-| **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |
+| **Version** | `[VERSION]` |
 | **Created Date** | `[YYYY-MM-DD]` |
 | **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Date** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
 | **Owner** | `[OWNER_NAME_AND_ROLE]` |
 | **Reviewed By** | `[REVIEWER_NAME]` |
 | **Approved By** | `[APPROVER_NAME]` |
 | **Distribution** | `[DISTRIBUTION_LIST]` |
+| **Change ID** | `ACHG-[ACHG_NUM]` |
+| **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
+| **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/architecture-repository-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-repository-template.md
@@ -10,19 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Standard ID | `ARC-000-REPO-v{VERSION}` |
-| Project | Global Repository |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
-| Review Cycle | Quarterly |
-| Next Review | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `Project Team, Architecture Team` |
+| **Document ID** | `ARC-000-REPO-v[VERSION]` |
+| **Document Type** | Architecture Repository |
+| **Project** | Global Repository |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | Quarterly |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `Project Team, Architecture Team` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/capability-map-template.md
+++ b/plugins/arckit-togaf-adm/templates/capability-map-template.md
@@ -10,13 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
+| **Document Type** | Business Capability Map |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/gap-analysis-template.md
+++ b/plugins/arckit-togaf-adm/templates/gap-analysis-template.md
@@ -10,14 +10,21 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Severity Weighting | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Document ID** | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
+| **Document Type** | TOGAF Gap Analysis |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
+| **Severity Weighting** | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/rationalization-template.md
+++ b/plugins/arckit-togaf-adm/templates/rationalization-template.md
@@ -10,20 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
-| Document Type | Application Rationalisation |
-| Project | `[PROJECT_NAME]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Version | `[VERSION]` |
-| Created | `[YYYY-MM-DD]` |
-| Last Modified | `[YYYY-MM-DD]` |
-| Review Cycle | Quarterly during active rationalisation programme |
-| Next Review Date | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `[DISTRIBUTION_LIST]` |
+| **Document ID** | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
+| **Document Type** | Application Rationalisation |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | Quarterly during active rationalisation programme |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/transition-architecture-template.md
+++ b/plugins/arckit-togaf-adm/templates/transition-architecture-template.md
@@ -10,20 +10,20 @@ templateVersion: "1.0"
 
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
-| Document Type | Transition Architecture |
-| Project | `[PROJECT_NAME]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Version | `[VERSION]` |
-| Created | `[YYYY-MM-DD]` |
-| Last Modified | `[YYYY-MM-DD]` |
-| Review Cycle | Monthly during active migration, quarterly after migration |
-| Next Review Date | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `[DISTRIBUTION_LIST]` |
+| **Document ID** | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
+| **Document Type** | Transition Architecture |
+| **Project** | `[PROJECT_NAME]` |
+| **Classification** | `[CLASSIFICATION]` |
+| **Status** | DRAFT |
+| **Version** | `[VERSION]` |
+| **Created Date** | `[YYYY-MM-DD]` |
+| **Last Modified** | `[YYYY-MM-DD]` |
+| **Review Cycle** | Monthly during active migration, quarterly after migration |
+| **Next Review Date** | `[YYYY-MM-DD]` |
+| **Owner** | `[OWNER_NAME_AND_ROLE]` |
+| **Reviewed By** | `[REVIEWER_NAME]` |
+| **Approved By** | `[APPROVER_NAME]` |
+| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -762,7 +762,7 @@ All artifacts must pass these 10 checks:
 
 ### REPO -- Architecture Repository
 
-- Document ID uses the global form `ARC-000-REPO-v{VERSION}`, not a project-scoped ID
+- Document ID uses `ARC-000-REPO-v[VERSION]` for a global repository or `ARC-[PROJECT_ID]-REPO-v[VERSION]` for a project-scoped one, and the Project field agrees with the form chosen
 - Every standard has an STD-xxx ID, a domain, a status (Active / Deprecated) and a source artefact
 - Deprecated standards name their superseding standard
 - Every reference architecture (REF-xxx) links to a DIAG artefact rather than embedding the diagram


### PR DESCRIPTION
Common Check 1 requires **14** Document Control fields. Seven of the nine `arckit-togaf-adm` templates carried fewer — five had only **7** — so every artefact from those commands failed that check the moment #758 wired the per-type checks in.

Not a regression from #758. The templates have always been short; nothing read the checklist for these types before, so nothing surfaced it.

## Correction to what I told you earlier

I flagged this on #750 and again on #758 as "four templates". **It is seven.** I had only eyeballed the ones I happened to open while deriving checklist sections, and reported that as the count rather than auditing all nine.

| Template | Before | Missing |
|---|---|---|
| `adm-preliminary` | 7 | Document Type, Version, Last Modified, Review Cycle, Reviewed By, Approved By, Distribution |
| `application-inventory` | 7 | same seven |
| `architecture-board` | 7 | same seven |
| `capability-map` | 7 | same seven |
| `gap-analysis` | 8 | same seven |
| `architecture-repository` | 13 | Document ID, Document Type, Version, Last Modified |
| `architecture-change` | 15 | Version, Review Cycle |
| `rationalization` | 14 | — |
| `transition-architecture` | 14 | — |

## What changed

All nine normalised to the canonical 14 fields in the order `templates/_partials/document-control-uk.md` defines, with bold field names — the plugin was carrying three different shapes. Domain-specific fields move *after* the standard block per the Document Control Standard: `Change ID` / `Change Type` / `Priority` on architecture-change, `Severity Weighting` on gap-analysis.

Per-template values preserved: the repository stays global-scoped with its own distribution list, and the rationalisation and transition review cycles keep their programme-specific wording rather than being flattened to the generic placeholder.

`architecture-repository` had two defects beyond missing fields — its ID row was labelled **`Standard ID`** rather than `Document ID`, and **`Owner` appeared twice**.

## Two corrections to my own earlier work

Both from #750:

1. **The REPO per-type check was wrong.** It asserted the Document ID "uses the global form `ARC-000-REPO-v{VERSION}`, **not** a project-scoped ID". The command explicitly permits either form, so that check would have failed a legitimate project-scoped repository artefact. It now accepts both and asserts the Project field agrees with the form chosen — which is the actual invariant.
2. Placeholder style normalised from `{VERSION}` to `[VERSION]` across the REPO template, command and checklist, matching every other template.

## Deliberately not changed

`arckit-togaf-adm` remains the only plugin whose templates do not use the `<!-- DOC-CONTROL-HEADER -->` marker — **0/9**, against 64/64 in core and 100% in most overlays. Converting it needs a marker-resolution step added to all nine commands, none of which read `RENDERING.md` today.

That is a larger change and a different concern from making the blocks complete, so it is not in this PR. Worth its own issue: until it lands, these nine blocks are hand-maintained duplicates of the shared partial and can drift again. Two other plugins are in the same position — `arckit-uk-finance` at 0/8 and `arckit-uk-nhs` at 2/10.

## Verification

- All 9 templates carry the 14 standard fields **in canonical order, no duplicates** — asserted programmatically, including an ordering check
- Guard: 144 references across 12 plugins, all resolving
- `check-doc-type-registry.py`, `check_references.py` (836 files), `check_recipes.py`, `sync-shared-assets.py --check` clean
- Converter regenerated all 7 extensions; `markdownlint-cli2` clean across 3,146 files
- Full suite: 1297 passed, 225 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
