### PR TITLE
feat(templates): convert 16 templates to the DOC-CONTROL-HEADER marker

### DIFF
--- a/plugins/arckit-agent-architecture/commands/agent-design.md
+++ b/plugins/arckit-agent-architecture/commands/agent-design.md
@@ -88,6 +88,7 @@ Before generating the agent design, use the **AskUserQuestion** tool to gather k
 - **First**, check if `.arckit/templates-custom/agent-design-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-design-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customize templates with `/arckit:customize agent-design`
 

--- a/plugins/arckit-agent-architecture/commands/agent-governance.md
+++ b/plugins/arckit-agent-architecture/commands/agent-governance.md
@@ -43,6 +43,7 @@ $ARGUMENTS
    - **First**, check if `.arckit/templates-custom/agent-governance-template.md` exists in the project root
    - **If found**: Read the user's customized template (user override takes precedence)
    - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-governance-template.md` (default)
+   - **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
    > **Tip**: Users can customize templates with `/arckit:customize agent-governance`
 

--- a/plugins/arckit-agent-architecture/commands/agent-integration.md
+++ b/plugins/arckit-agent-architecture/commands/agent-integration.md
@@ -70,6 +70,7 @@ $ARGUMENTS
    - **First**, check if `.arckit/templates-custom/agent-integration-template.md` exists in the project root
    - **If found**: Read the user's customized template (user override takes precedence)
    - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-integration-template.md` (default)
+   - **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
    > **Tip**: Users can customize templates with `/arckit:customize agent-integration`
 

--- a/plugins/arckit-agent-architecture/commands/agent-inventory.md
+++ b/plugins/arckit-agent-architecture/commands/agent-inventory.md
@@ -72,6 +72,7 @@ $ARGUMENTS
    - **First**, check if `.arckit/templates-custom/agent-inventory-template.md` exists in the project root
    - **If found**: Read the user's customized template (user override takes precedence)
    - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-inventory-template.md` (default)
+   - **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
    > **Tip**: Users can customize templates with `/arckit:customize agent-inventory`
 

--- a/plugins/arckit-agent-architecture/commands/agent-maturity.md
+++ b/plugins/arckit-agent-architecture/commands/agent-maturity.md
@@ -66,6 +66,7 @@ $ARGUMENTS
 - **First**, check if `.arckit/templates-custom/agent-maturity-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-maturity-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customize templates with `/arckit:customize agent-maturity`
 

--- a/plugins/arckit-agent-architecture/commands/agent-security.md
+++ b/plugins/arckit-agent-architecture/commands/agent-security.md
@@ -58,6 +58,7 @@ The user should specify:
 - **First**, check if `.arckit/templates-custom/agent-security-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-security-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customize templates with `/arckit:customize agent-security`
 

--- a/plugins/arckit-agent-architecture/templates/agent-governance-template.md
+++ b/plugins/arckit-agent-architecture/templates/agent-governance-template.md
@@ -8,9 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-[Standard: ID=ARC-{P}-AAOV-v{VERSION}]
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Oversight Model
 

--- a/plugins/arckit-agent-architecture/templates/agent-integration-template.md
+++ b/plugins/arckit-agent-architecture/templates/agent-integration-template.md
@@ -8,24 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | ARC-{P}-AAIN-v{VERSION} |
-| Document Type | AAIN — Agent Integration Architecture |
-| Project | {PROJECT_NAME} ({PROJECT_ID}) |
-| Classification | {CLASSIFICATION} |
-| Status | {STATUS} |
-| Version | {VERSION} |
-| Created | {DATE} |
-| Last Modified | {DATE} |
-| Review Cycle | Monthly |
-| Next Review | {NEXT_REVIEW_DATE} |
-| Owner | {OWNER_NAME_AND_ROLE} |
-| Reviewed By | — |
-| Approved By | — |
-| Distribution | Architecture Team, AI Programme Board |
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Integration Architecture
 

--- a/plugins/arckit-agent-architecture/templates/agent-inventory-template.md
+++ b/plugins/arckit-agent-architecture/templates/agent-inventory-template.md
@@ -8,24 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | ARC-{P}-AAGI-v{VERSION} |
-| Document Type | AAGI — AI Agent Inventory |
-| Project | {PROJECT_NAME} ({PROJECT_ID}) |
-| Classification | {CLASSIFICATION} |
-| Status | {STATUS} |
-| Version | {VERSION} |
-| Created | {DATE} |
-| Last Modified | {DATE} |
-| Review Cycle | Monthly |
-| Next Review | {NEXT_REVIEW_DATE} |
-| Owner | {OWNER_NAME_AND_ROLE} |
-| Reviewed By | — |
-| Approved By | — |
-| Distribution | Architecture Team, AI Programme Board |
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Agent Register
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-design.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-design.md
@@ -88,6 +88,7 @@ Before generating the agent design, use the **AskUserQuestion** tool to gather k
 - **First**, check if `.arckit/templates-custom/agent-design-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-design-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customize templates with `/arckit:customize agent-design`
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-governance.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-governance.md
@@ -43,6 +43,7 @@ $ARGUMENTS
    - **First**, check if `.arckit/templates-custom/agent-governance-template.md` exists in the project root
    - **If found**: Read the user's customized template (user override takes precedence)
    - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-governance-template.md` (default)
+   - **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
    > **Tip**: Users can customize templates with `/arckit:customize agent-governance`
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-integration.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-integration.md
@@ -70,6 +70,7 @@ $ARGUMENTS
    - **First**, check if `.arckit/templates-custom/agent-integration-template.md` exists in the project root
    - **If found**: Read the user's customized template (user override takes precedence)
    - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-integration-template.md` (default)
+   - **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
    > **Tip**: Users can customize templates with `/arckit:customize agent-integration`
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-inventory.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-inventory.md
@@ -72,6 +72,7 @@ $ARGUMENTS
    - **First**, check if `.arckit/templates-custom/agent-inventory-template.md` exists in the project root
    - **If found**: Read the user's customized template (user override takes precedence)
    - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-inventory-template.md` (default)
+   - **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
    > **Tip**: Users can customize templates with `/arckit:customize agent-inventory`
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-maturity.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-maturity.md
@@ -66,6 +66,7 @@ $ARGUMENTS
 - **First**, check if `.arckit/templates-custom/agent-maturity-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-maturity-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customize templates with `/arckit:customize agent-maturity`
 

--- a/plugins/arckit-claude/plugins/agent/architecture/commands/agent-security.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/commands/agent-security.md
@@ -58,6 +58,7 @@ The user should specify:
 - **First**, check if `.arckit/templates-custom/agent-security-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/agent-security-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customize templates with `/arckit:customize agent-security`
 

--- a/plugins/arckit-claude/plugins/agent/architecture/templates/agent-governance-template.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/templates/agent-governance-template.md
@@ -8,9 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-[Standard: ID=ARC-{P}-AAOV-v{VERSION}]
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Oversight Model
 

--- a/plugins/arckit-claude/plugins/agent/architecture/templates/agent-integration-template.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/templates/agent-integration-template.md
@@ -8,24 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | ARC-{P}-AAIN-v{VERSION} |
-| Document Type | AAIN — Agent Integration Architecture |
-| Project | {PROJECT_NAME} ({PROJECT_ID}) |
-| Classification | {CLASSIFICATION} |
-| Status | {STATUS} |
-| Version | {VERSION} |
-| Created | {DATE} |
-| Last Modified | {DATE} |
-| Review Cycle | Monthly |
-| Next Review | {NEXT_REVIEW_DATE} |
-| Owner | {OWNER_NAME_AND_ROLE} |
-| Reviewed By | — |
-| Approved By | — |
-| Distribution | Architecture Team, AI Programme Board |
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Integration Architecture
 

--- a/plugins/arckit-claude/plugins/agent/architecture/templates/agent-inventory-template.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/templates/agent-inventory-template.md
@@ -8,24 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | ARC-{P}-AAGI-v{VERSION} |
-| Document Type | AAGI — AI Agent Inventory |
-| Project | {PROJECT_NAME} ({PROJECT_ID}) |
-| Classification | {CLASSIFICATION} |
-| Status | {STATUS} |
-| Version | {VERSION} |
-| Created | {DATE} |
-| Last Modified | {DATE} |
-| Review Cycle | Monthly |
-| Next Review | {NEXT_REVIEW_DATE} |
-| Owner | {OWNER_NAME_AND_ROLE} |
-| Reviewed By | — |
-| Approved By | — |
-| Distribution | Architecture Team, AI Programme Board |
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Agent Register
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/adm-preliminary.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/adm-preliminary.md
@@ -59,6 +59,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/adm-preliminary-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/adm-preliminary-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize adm-preliminary`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/application-inventory.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/application-inventory.md
@@ -60,6 +60,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/application-inventory-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/application-inventory-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize application-inventory`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/application-rationalization.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/application-rationalization.md
@@ -65,6 +65,7 @@ Identify the target project from the hook context or user input. Extract the pro
 - **First**, check if `.arckit/templates-custom/rationalization-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/rationalization-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize application-rationalization`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-board.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-board.md
@@ -56,6 +56,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/architecture-board-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/architecture-board-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize architecture-board`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-change.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-change.md
@@ -71,6 +71,7 @@ Change requests are **multi-instance** documents (like ADRs). Find the next avai
 - **First**, check if `.arckit/templates-custom/architecture-change-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/architecture-change-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize architecture-change`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-repository.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/architecture-repository.md
@@ -75,6 +75,7 @@ This command operates at **global scope** by default. The repository synthesises
 - **First**, check if `.arckit/templates-custom/architecture-repository-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/architecture-repository-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize architecture-repository`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/business-capability-map.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/business-capability-map.md
@@ -64,6 +64,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/capability-map-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/capability-map-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize capability-map`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/gap-analysis.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/gap-analysis.md
@@ -63,6 +63,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/gap-analysis-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/gap-analysis-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize gap-analysis`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/commands/transition-architecture.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/commands/transition-architecture.md
@@ -63,6 +63,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/transition-architecture-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/transition-architecture-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize transition-architecture`
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/adm-preliminary-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/adm-preliminary-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
-| **Document Type** | Architecture Vision — Preliminary ADM |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/application-inventory-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/application-inventory-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
-| **Document Type** | Application Inventory |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-board-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-board-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
-| **Document Type** | Architecture Board Charter |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-change-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-change-template.md
@@ -8,22 +8,13 @@ templateVersion: "1.0"
 
 ## Document Control
 
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
+
 | Field | Value |
 |-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-ACHG-[ACHG_NUM]-v[VERSION]` |
-| **Document Type** | Architecture Change Request |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
 | **Change ID** | `ACHG-[ACHG_NUM]` |
 | **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
 | **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-repository-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/architecture-repository-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-000-REPO-v[VERSION]` |
-| **Document Type** | Architecture Repository |
-| **Project** | Global Repository |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | Quarterly |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `Project Team, Architecture Team` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/capability-map-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/capability-map-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
-| **Document Type** | Business Capability Map |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/gap-analysis-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/gap-analysis-template.md
@@ -8,22 +8,13 @@ templateVersion: "1.0"
 
 ## Document Control
 
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
+
 | Field | Value |
 |-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
-| **Document Type** | TOGAF Gap Analysis |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
 | **Severity Weighting** | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
 
 ### Revision History

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/rationalization-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/rationalization-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
-| **Document Type** | Application Rationalisation |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | Quarterly during active rationalisation programme |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/togaf/adm/templates/transition-architecture-template.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/templates/transition-architecture-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
-| **Document Type** | Transition Architecture |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | Monthly during active migration, quarterly after migration |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-consumer-duty-template.md
+++ b/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-consumer-duty-template.md
@@ -4,27 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document contains specific
-     pricing models, fraud-rate data, or vulnerable-customer cohort breakdowns that could
-     be exploited if disclosed to competitors or bad actors. Driven by
-     user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | FCA Consumer Duty Annual Board Report |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Annual (Board sign-off required before each anniversary of the Duty in-force date) |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Reporting Period** | {{REPORTING_PERIOD_START}} to {{REPORTING_PERIOD_END}} |
 | **Firm Legal Name** | {{FIRM_LEGAL_NAME}} |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |

--- a/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-ctp-dependency-template.md
+++ b/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-ctp-dependency-template.md
@@ -4,26 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document reveals specific contractual
-     exit terms, proprietary resilience-test outcomes, or provider-specific vulnerabilities that
-     could be exploited if disclosed. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK FS CTP Dependency Assessment |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED_DATE}} |
-| **Review Cycle** | Annual (minimum); review immediately on any new HMT designation or material change to provider relationship |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation / Registration Type** | {{FIRM_AUTHORISATION_TYPE}} |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 | **SMF Holder (Operational Resilience)** | {{SMF_HOLDER_NAME}} — {{SMF_HOLDER_FUNCTION}} |

--- a/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-safeguarding-template.md
+++ b/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-safeguarding-template.md
@@ -4,26 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document reveals the specific
-     safeguarding bank account numbers, policy reference numbers, or shortfall thresholds that
-     could be exploited if disclosed. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK EMI / PI Safeguarding Assessment |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Annual (minimum); review immediately on change of safeguarding bank, insurer, or product scope |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation / Registration Type** | {{FIRM_AUTHORISATION_TYPE}} (EMI — authorised / API — authorised / SPI — registered) |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 | **SMF Holder (Safeguarding)** | {{SMF_HOLDER_NAME}} — {{SMF_HOLDER_FUNCTION}} |

--- a/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-sca-rts-template.md
+++ b/plugins/arckit-claude/plugins/uk/finance/templates/uk-fs-sca-rts-template.md
@@ -4,24 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Use OFFICIAL-SENSITIVE if the document reveals proprietary fraud model parameters or detection thresholds. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK PSD2 SCA-RTS Exemption Design |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Quarterly |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{OWNER_ROLE}} — {{OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation Type** | {{FIRM_AUTHORISATION_TYPE}} (PSP / EMI / PI / ASPSP / TPP) |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 

--- a/plugins/arckit-togaf-adm/commands/adm-preliminary.md
+++ b/plugins/arckit-togaf-adm/commands/adm-preliminary.md
@@ -59,6 +59,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/adm-preliminary-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/adm-preliminary-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize adm-preliminary`
 

--- a/plugins/arckit-togaf-adm/commands/application-inventory.md
+++ b/plugins/arckit-togaf-adm/commands/application-inventory.md
@@ -60,6 +60,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/application-inventory-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/application-inventory-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize application-inventory`
 

--- a/plugins/arckit-togaf-adm/commands/application-rationalization.md
+++ b/plugins/arckit-togaf-adm/commands/application-rationalization.md
@@ -65,6 +65,7 @@ Identify the target project from the hook context or user input. Extract the pro
 - **First**, check if `.arckit/templates-custom/rationalization-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/rationalization-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize application-rationalization`
 

--- a/plugins/arckit-togaf-adm/commands/architecture-board.md
+++ b/plugins/arckit-togaf-adm/commands/architecture-board.md
@@ -56,6 +56,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/architecture-board-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/architecture-board-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize architecture-board`
 

--- a/plugins/arckit-togaf-adm/commands/architecture-change.md
+++ b/plugins/arckit-togaf-adm/commands/architecture-change.md
@@ -71,6 +71,7 @@ Change requests are **multi-instance** documents (like ADRs). Find the next avai
 - **First**, check if `.arckit/templates-custom/architecture-change-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/architecture-change-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize architecture-change`
 

--- a/plugins/arckit-togaf-adm/commands/architecture-repository.md
+++ b/plugins/arckit-togaf-adm/commands/architecture-repository.md
@@ -75,6 +75,7 @@ This command operates at **global scope** by default. The repository synthesises
 - **First**, check if `.arckit/templates-custom/architecture-repository-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/architecture-repository-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize architecture-repository`
 

--- a/plugins/arckit-togaf-adm/commands/business-capability-map.md
+++ b/plugins/arckit-togaf-adm/commands/business-capability-map.md
@@ -64,6 +64,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/capability-map-template.md` exists in the project root
 - **If found**: Read the user's customized template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/capability-map-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize capability-map`
 

--- a/plugins/arckit-togaf-adm/commands/gap-analysis.md
+++ b/plugins/arckit-togaf-adm/commands/gap-analysis.md
@@ -63,6 +63,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/gap-analysis-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/gap-analysis-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize gap-analysis`
 

--- a/plugins/arckit-togaf-adm/commands/transition-architecture.md
+++ b/plugins/arckit-togaf-adm/commands/transition-architecture.md
@@ -63,6 +63,7 @@ Identify the target project from the hook context. If the user specifies a proje
 - **First**, check if `.arckit/templates-custom/transition-architecture-template.md` exists in the project root
 - **If found**: Read the user's customised template (user override takes precedence)
 - **If not found**: Read `${CLAUDE_PLUGIN_ROOT}/templates/transition-architecture-template.md` (default)
+- **Then**, read `${CLAUDE_PLUGIN_ROOT}/templates/_partials/RENDERING.md` and resolve the template's `<!-- DOC-CONTROL-HEADER -->` marker to the Document Control partial it selects, applying the `${user_config.organisation_name}` and `${user_config.default_classification}` substitutions. Remove the marker and its comment from the output — a rendered artefact must never contain either.
 
 > **Tip**: Users can customise templates with `/arckit:customize transition-architecture`
 

--- a/plugins/arckit-togaf-adm/templates/adm-preliminary-template.md
+++ b/plugins/arckit-togaf-adm/templates/adm-preliminary-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
-| **Document Type** | Architecture Vision — Preliminary ADM |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/application-inventory-template.md
+++ b/plugins/arckit-togaf-adm/templates/application-inventory-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
-| **Document Type** | Application Inventory |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/architecture-board-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-board-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
-| **Document Type** | Architecture Board Charter |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/architecture-change-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-change-template.md
@@ -8,22 +8,13 @@ templateVersion: "1.0"
 
 ## Document Control
 
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
+
 | Field | Value |
 |-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-ACHG-[ACHG_NUM]-v[VERSION]` |
-| **Document Type** | Architecture Change Request |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
 | **Change ID** | `ACHG-[ACHG_NUM]` |
 | **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
 | **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |

--- a/plugins/arckit-togaf-adm/templates/architecture-repository-template.md
+++ b/plugins/arckit-togaf-adm/templates/architecture-repository-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-000-REPO-v[VERSION]` |
-| **Document Type** | Architecture Repository |
-| **Project** | Global Repository |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | Quarterly |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `Project Team, Architecture Team` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/capability-map-template.md
+++ b/plugins/arckit-togaf-adm/templates/capability-map-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
-| **Document Type** | Business Capability Map |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/gap-analysis-template.md
+++ b/plugins/arckit-togaf-adm/templates/gap-analysis-template.md
@@ -8,22 +8,13 @@ templateVersion: "1.0"
 
 ## Document Control
 
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
+
 | Field | Value |
 |-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
-| **Document Type** | TOGAF Gap Analysis |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | `[Monthly / Quarterly / Annual / On-Demand]` |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
 | **Severity Weighting** | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
 
 ### Revision History

--- a/plugins/arckit-togaf-adm/templates/rationalization-template.md
+++ b/plugins/arckit-togaf-adm/templates/rationalization-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
-| **Document Type** | Application Rationalisation |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | Quarterly during active rationalisation programme |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-togaf-adm/templates/transition-architecture-template.md
+++ b/plugins/arckit-togaf-adm/templates/transition-architecture-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
-| **Document Type** | Transition Architecture |
-| **Project** | `[PROJECT_NAME]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
-| **Version** | `[VERSION]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Cycle** | Monthly during active migration, quarterly after migration |
-| **Next Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/plugins/arckit-uk-finance/templates/uk-fs-consumer-duty-template.md
+++ b/plugins/arckit-uk-finance/templates/uk-fs-consumer-duty-template.md
@@ -4,27 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document contains specific
-     pricing models, fraud-rate data, or vulnerable-customer cohort breakdowns that could
-     be exploited if disclosed to competitors or bad actors. Driven by
-     user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | FCA Consumer Duty Annual Board Report |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Annual (Board sign-off required before each anniversary of the Duty in-force date) |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Reporting Period** | {{REPORTING_PERIOD_START}} to {{REPORTING_PERIOD_END}} |
 | **Firm Legal Name** | {{FIRM_LEGAL_NAME}} |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |

--- a/plugins/arckit-uk-finance/templates/uk-fs-ctp-dependency-template.md
+++ b/plugins/arckit-uk-finance/templates/uk-fs-ctp-dependency-template.md
@@ -4,26 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document reveals specific contractual
-     exit terms, proprietary resilience-test outcomes, or provider-specific vulnerabilities that
-     could be exploited if disclosed. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK FS CTP Dependency Assessment |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED_DATE}} |
-| **Review Cycle** | Annual (minimum); review immediately on any new HMT designation or material change to provider relationship |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation / Registration Type** | {{FIRM_AUTHORISATION_TYPE}} |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 | **SMF Holder (Operational Resilience)** | {{SMF_HOLDER_NAME}} — {{SMF_HOLDER_FUNCTION}} |

--- a/plugins/arckit-uk-finance/templates/uk-fs-safeguarding-template.md
+++ b/plugins/arckit-uk-finance/templates/uk-fs-safeguarding-template.md
@@ -4,26 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document reveals the specific
-     safeguarding bank account numbers, policy reference numbers, or shortfall thresholds that
-     could be exploited if disclosed. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK EMI / PI Safeguarding Assessment |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Annual (minimum); review immediately on change of safeguarding bank, insurer, or product scope |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation / Registration Type** | {{FIRM_AUTHORISATION_TYPE}} (EMI — authorised / API — authorised / SPI — registered) |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 | **SMF Holder (Safeguarding)** | {{SMF_HOLDER_NAME}} — {{SMF_HOLDER_FUNCTION}} |

--- a/plugins/arckit-uk-finance/templates/uk-fs-sca-rts-template.md
+++ b/plugins/arckit-uk-finance/templates/uk-fs-sca-rts-template.md
@@ -4,24 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Use OFFICIAL-SENSITIVE if the document reveals proprietary fraud model parameters or detection thresholds. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK PSD2 SCA-RTS Exemption Design |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Quarterly |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{OWNER_ROLE}} — {{OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation Type** | {{FIRM_AUTHORISATION_TYPE}} (PSP / EMI / PI / ASPSP / TPP) |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 

--- a/scripts/python/apply_doc_control_marker.py
+++ b/scripts/python/apply_doc_control_marker.py
@@ -1,50 +1,139 @@
 #!/usr/bin/env python3
 """
-Replace each template's `## Document Control` table with a marker that the
-command runtime resolves to the UK or UAE partial. Idempotent — running twice
-leaves the file unchanged.
+Replace a template's hand-maintained `## Document Control` table with the
+`<!-- DOC-CONTROL-HEADER -->` marker, which the command runtime resolves to the
+partial selected by `_partials/RENDERING.md`. Idempotent — running twice leaves
+the file unchanged.
 
 Usage:
-  python scripts/python/apply_doc_control_marker.py <template-dir>
+  python scripts/python/apply_doc_control_marker.py <template-dir> [--check]
 
-Exits 0 with a count of files modified.
+`--check` reports what would change and exits 1 if anything would, without
+writing. Exits 0 with a count of files modified otherwise.
+
+## Why this preserves rows
+
+The original version of this script replaced the whole Document Control section.
+That is lossy: several templates carry domain-specific rows the shared partial
+does not supply, and the Document Control Standard explicitly allows them after
+the standard fields. Running the old script over `arckit-uk-finance` would have
+dropped `Firm Legal Name`, `Firm Authorisation / Registration Type` and
+`FCA Firm Reference Number` — firm-identity fields that exist nowhere else in
+those artefacts (#760).
+
+So: standard fields (and their known aliases) are dropped, because the partial
+supplies them. Anything else is re-appended after the marker as an addendum
+table, and the file records that the addendum is deliberate.
 """
+
+from __future__ import annotations
+
 import re
 import sys
 from pathlib import Path
 
-MARKER = "<!-- DOC-CONTROL-HEADER -->\n<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->\n"
+MARKER = (
+    "<!-- DOC-CONTROL-HEADER -->\n"
+    "<!-- Resolved at command-execution time to _partials/document-control-uk.md or "
+    "_partials/document-control-uae.md based on plugin userConfig classification_scheme + "
+    "governance_framework. See _partials/RENDERING.md (when present). -->\n"
+)
 
-# Match from "## Document Control" up to (but not including) the next "## " heading.
-PATTERN = re.compile(r"## Document Control\n.*?(?=\n## )", re.DOTALL)
+# The 14 fields the partial supplies. Anything else in a Document Control block
+# is domain-specific and must survive the conversion.
+STANDARD = {
+    "Document ID", "Document Type", "Project", "Classification", "Status", "Version",
+    "Created Date", "Last Modified", "Review Cycle", "Next Review Date", "Owner",
+    "Reviewed By", "Approved By", "Distribution",
+}
 
-def transform(path: Path) -> bool:
+# Non-canonical spellings seen in the wild. These ARE standard fields under a
+# different name, so the partial covers them and they must not be re-appended.
+ALIASES = {
+    "Created": "Created Date",
+    "Review Date": "Next Review Date",
+    "Next Review": "Next Review Date",
+    "Standard ID": "Document ID",
+    "Last Updated": "Last Modified",
+}
+
+# Stop at the NEXT HEADING OF ANY LEVEL, not just `## `. Several templates put
+# `### Revision History` immediately after Document Control; a `## `-only
+# lookahead runs straight past it and swallows the revision table.
+SECTION = re.compile(r"## Document Control\n.*?(?=\n#{2,6} )", re.DOTALL)
+ROW = re.compile(r"^\|\s*\*{0,2}(.+?)\*{0,2}\s*\|\s*(.*?)\s*\|\s*$", re.M)
+
+
+def extra_rows(block: str) -> list[tuple[str, str]]:
+    """Domain-specific rows: everything that is not a standard field, an alias of
+    one, or the table header/separator."""
+    out = []
+    for name, value in ROW.findall(block):
+        name = name.strip()
+        if name in ("Field", "") or set(name) <= set("- "):
+            continue
+        if name in STANDARD or name in ALIASES:
+            continue
+        out.append((name, value.strip()))
+    return out
+
+
+def build(block: str) -> str:
+    new = "## Document Control\n\n" + MARKER
+    extras = extra_rows(block)
+    if extras:
+        new += (
+            "\n<!-- Domain-specific fields, retained after the resolved header per the "
+            "Document Control Standard. -->\n\n"
+            "| Field | Value |\n|-------|-------|\n"
+        )
+        new += "".join(f"| **{k}** | {v} |\n" for k, v in extras)
+    return new
+
+
+def transform(path: Path) -> tuple[bool, list[str]]:
     text = path.read_text(encoding="utf-8")
     if MARKER in text:
-        return False  # already migrated
-    if not PATTERN.search(text):
-        return False  # no Document Control section to migrate
-    new = PATTERN.sub("## Document Control\n\n" + MARKER, text)
+        return False, []
+    m = SECTION.search(text)
+    if not m:
+        return False, []
+    extras = [k for k, _ in extra_rows(m.group(0))]
+    new = text[: m.start()] + build(m.group(0)) + text[m.end():]
     if new == text:
-        return False
+        return False, []
     path.write_text(new, encoding="utf-8")
-    return True
+    return True, extras
+
 
 def main() -> int:
-    if len(sys.argv) != 2:
-        print("usage: apply_doc_control_marker.py <template-dir>", file=sys.stderr)
+    args = [a for a in sys.argv[1:] if not a.startswith("-")]
+    check = "--check" in sys.argv
+    if len(args) != 1:
+        print("usage: apply_doc_control_marker.py <template-dir> [--check]", file=sys.stderr)
         return 2
-    target = Path(sys.argv[1])
+    target = Path(args[0])
     if not target.is_dir():
         print(f"not a directory: {target}", file=sys.stderr)
         return 2
+
     modified = 0
     for md in sorted(target.glob("*.md")):
-        if transform(md):
+        if check:
+            text = md.read_text(encoding="utf-8")
+            if MARKER not in text and SECTION.search(text):
+                print(f"would modify: {md}")
+                modified += 1
+            continue
+        changed, extras = transform(md)
+        if changed:
             modified += 1
-            print(f"modified: {md}")
-    print(f"\nTotal modified: {modified}")
-    return 0
+            kept = f"  (kept: {', '.join(extras)})" if extras else ""
+            print(f"modified: {md}{kept}")
+
+    print(f"\nTotal {'to modify' if check else 'modified'}: {modified}")
+    return 1 if (check and modified) else 0
+
 
 if __name__ == "__main__":
     sys.exit(main())


### PR DESCRIPTION
Fixes the conversion described in #760. Marker adoption for templates carrying a Document Control block: **16/16** across `arckit-togaf-adm` (9), `arckit-uk-finance` (4) and `arckit-agent-architecture` (3).

These three hand-maintained their tables, so they sat outside the regime routing added in #744 and re-drifted freely — #759 had just finished repairing one such drift by hand.

## Template and command move together

A template carrying the marker whose command does not resolve it emits a literal HTML comment and **no Document Control block at all** — strictly worse than a short one. `arckit-uk-finance` already resolved (4/4); the 9 togaf and 6 agent-architecture commands did not, so all 15 gain the resolution step beside their template read.

## `arckit-uk-nhs` deliberately excluded

Stays at 2/8. Its six DCB0129/DCB0160 templates carry:

```
| **Document ID** | `SAFETY.md` (Marcus Baw SAFETY.md spec convention; no ARC- prefix) |
```

That deviation is documented in the commands, and those templates already hold all 14 fields with a constrained `[PUBLIC / OFFICIAL / OFFICIAL-SENSITIVE]` ladder. Converting them would impose an `ARC-…` ID and break the convention on purpose.

## The script had two defects, both found by running it

Worth reviewing, because the first would have destroyed data silently:

**1. Lossy.** It replaced the entire Document Control section, discarding domain-specific rows the Document Control Standard explicitly permits after the standard fields. **Six firm-identity rows existed only there** and would have been destroyed:

- `Firm Legal Name`
- `Firm Authorisation / Registration Type` (×2)
- `FCA Firm Reference Number` (×2)
- `Firm Authorisation Type`

It now re-appends non-standard rows as an addendum table, dropping only the 14 standard fields and their known aliases (`Created`, `Review Date`, `Next Review`, `Standard ID`, `Last Updated`).

**2. It swallowed the Revision History.** The section regex stopped at the next `## ` heading. Nine togaf templates put `### Revision History` immediately after Document Control, so the lookahead ran straight past it and consumed the revision table.

This surfaced only because the first run reported keeping a bogus `` `[VERSION]` `` field — which was the revision row. Fixed to stop at any heading level; verified 18 templates had a Revision History both before and after.

The script also gains `--check` for a non-writing report, and is idempotent — re-running all three directories reports 0 modified.

## Not included: a guard

The obvious invariant — *template has the marker ⇒ its command reads RENDERING.md* — **does not hold**.

`arckit-claude` is **64/64** on markers and **0/75** on RENDERING.md. Core commands resolve the header through inline "Auto-Populate Document Control Fields" instructions plus a worked example, not by reading the partial rules. So there are two working mechanisms, and a guard needs a crisper invariant than either alone expresses.

I've left that on #760 rather than shipping something weak that passes on the current mixed state — the same reasoning that shaped the invariant in #751.

## Verification

- 16/16 adoption in the three plugins; every marker-carrying template's command resolves it
- Revision History preserved: 18 templates before, 18 after
- Domain-specific rows preserved and visible in the converted output
- Script idempotent; `--check` mode reports cleanly
- `check-quality-checklist-refs.py` 144 references / 12 plugins, `check-doc-type-registry.py`, `check_references.py` (836 files), `test-regime-registration.mjs` all clean
- Converter regenerated all 7 extensions; `markdownlint-cli2` clean across 3,146 files — one MD032 from my own insertion (agent-architecture uses indented bullets) caught and fixed before commit
- Full suite: 1297 passed, 225 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
