### PR TITLE
fix(us): remove the contradictory SSP section count from us-fedramp-ssp

### DIFF
--- a/plugins/arckit-claude/plugins/us/commands/us-fedramp-ssp.md
+++ b/plugins/arckit-claude/plugins/us/commands/us-fedramp-ssp.md
@@ -36,7 +36,7 @@ $ARGUMENTS
 
 The FedRAMP SSP is the central artefact of a FedRAMP authorization package. It documents the CSO at a level of detail sufficient for an Authorizing Official (AO) — agency-level for Agency ATO, or the FedRAMP PMO / JAB for Joint Authorization — to make a risk-based authorization decision. The SSP cross-references the FedRAMP SAP (Security Assessment Plan), SAR (Security Assessment Report), and POA&M, and is updated continuously through ConMon (Continuous Monitoring).
 
-Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** baselines and is progressively requiring **OSCAL** machine-readable submission. The SSP template (Word and OSCAL) is published on fedramp.gov; the structure below reflects the current 15-section layout. Authorization Boundary Guidance (ABG) defines what is in-scope; getting the boundary right is the most common cause of FedRAMP delays.
+Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** baselines and is progressively requiring **OSCAL** machine-readable submission. The SSP template (Word and OSCAL) is published on fedramp.gov. The structure below follows its layout, flattened into a single numbered list: the published template nests Types of Users and Network Architecture beneath General System Description, so the list below runs longer than the template's top-level section count. Authorization Boundary Guidance (ABG) defines what is in-scope; getting the boundary right is the most common cause of FedRAMP delays.
 
 **Authoritative anchors**:
 
@@ -66,7 +66,7 @@ Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** basel
 
 4. Use `node scripts/generate-document-id.mjs <PROJECT_ID> FRSSP --filename` for the artefact filename. The type code for this command is `FRSSP`.
 
-5. Generate the 15-section FedRAMP SSP structure:
+5. Generate the following FedRAMP SSP sections:
 
    1. **Information System Name and Title** — CSO name, CSP company, FedRAMP package ID (if assigned)
    2. **Information System Categorization** — pull verbatim from FIPS 199 artefact (CIA water-mark)

--- a/plugins/arckit-us/commands/us-fedramp-ssp.md
+++ b/plugins/arckit-us/commands/us-fedramp-ssp.md
@@ -36,7 +36,7 @@ $ARGUMENTS
 
 The FedRAMP SSP is the central artefact of a FedRAMP authorization package. It documents the CSO at a level of detail sufficient for an Authorizing Official (AO) — agency-level for Agency ATO, or the FedRAMP PMO / JAB for Joint Authorization — to make a risk-based authorization decision. The SSP cross-references the FedRAMP SAP (Security Assessment Plan), SAR (Security Assessment Report), and POA&M, and is updated continuously through ConMon (Continuous Monitoring).
 
-Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** baselines and is progressively requiring **OSCAL** machine-readable submission. The SSP template (Word and OSCAL) is published on fedramp.gov; the structure below reflects the current 15-section layout. Authorization Boundary Guidance (ABG) defines what is in-scope; getting the boundary right is the most common cause of FedRAMP delays.
+Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** baselines and is progressively requiring **OSCAL** machine-readable submission. The SSP template (Word and OSCAL) is published on fedramp.gov. The structure below follows its layout, flattened into a single numbered list: the published template nests Types of Users and Network Architecture beneath General System Description, so the list below runs longer than the template's top-level section count. Authorization Boundary Guidance (ABG) defines what is in-scope; getting the boundary right is the most common cause of FedRAMP delays.
 
 **Authoritative anchors**:
 
@@ -66,7 +66,7 @@ Since 2024, FedRAMP requires all new SSP submissions against the **Rev 5** basel
 
 4. Use `node scripts/generate-document-id.mjs <PROJECT_ID> FRSSP --filename` for the artefact filename. The type code for this command is `FRSSP`.
 
-5. Generate the 15-section FedRAMP SSP structure:
+5. Generate the following FedRAMP SSP sections:
 
    1. **Information System Name and Title** — CSO name, CSP company, FedRAMP package ID (if assigned)
    2. **Information System Categorization** — pull verbatim from FIPS 199 artefact (CIA water-mark)


### PR DESCRIPTION
`us-fedramp-ssp.md` claimed a **"15-section FedRAMP SSP structure"** in two places while listing **16** numbered sections. I flagged this during #754 and it stayed unfixed through #755–#761; this clears it.

## The count wasn't simply wrong

FedRAMP's published template nests **Types of Users** and **Network Architecture** beneath General System Description. This command flattens them out into a single numbered list, which is exactly why the list runs longer than the template's top-level section count.

So the prose was describing FedRAMP correctly, the list was describing something else, and nothing said so. Reading it, you'd assume one of the two was a typo.

## Why not just change 15 → 16

That would assert a top-level section count for FedRAMP's own template. This repo has no authoritative source for that number, and the 2024 Rev 5 and OSCAL submission changes make it a moving target — precisely the kind of claim that goes stale silently in a compliance tool.

Instead both count claims are removed and the flattening is explained. A reader comparing the list against the published Word template now knows why the numbering differs, which is more useful than either number would have been.

## Consistency

Step 5 now reads `Generate the following FedRAMP SSP sections:`, matching its nine sibling `us-*` commands, which all use `Generate the following sections:`. It was the only one asserting a count at all.

## Scope

- **No change to the 16 listed sections** — content is untouched
- **No change needed to the `FRSSP` per-type checks.** They were written against section *names* rather than a count, so they were already immune to this. That was deliberate in #754, and it held up

## Verification

- 0 count claims remain; list still 16 items
- `check-quality-checklist-refs.py` 144 references / 12 plugins, `check-doc-type-registry.py`, `check_references.py` (836 files), `sync-shared-assets.py --check` all clean
- Converter regenerated all 7 extensions; `markdownlint-cli2` clean
- Full suite: 1297 passed, 225 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
