### PR TITLE
docs: drop the stale jurisdiction count from the Guides card

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -991,7 +991,7 @@
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="guides.html" class="govuk-link">Guides</a></h3>
-                    <p class="govuk-body-s">A usage guide for every command across 6 jurisdictions plus topical guides on discovery, planning, architecture, governance, compliance, and operations.</p>
+                    <p class="govuk-body-s">A usage guide for every command across every jurisdictional and sector overlay, plus topical guides on discovery, planning, architecture, governance, compliance, and operations.</p>
                 </div>
                 <div class="app-explore-card">
                     <h3 class="govuk-heading-m"><a href="roles.html" class="govuk-link">Role Guides</a></h3>


### PR DESCRIPTION
The Guides card on the homepage claims **"a usage guide for every command across 6 jurisdictions"**.

The real figure is **8** — AU, AT, CA, EU, FR, UAE, UK, US — and it becomes 9 when the Netherlands overlay in #739 lands.

## Why not just change 6 to 8

The number has been wrong since the sentence was introduced in `6b39a932`, and has survived several overlay additions since. Correcting it to 8 buys a few days: #739 is already `MERGEABLE` and makes it 9.

It also never resolved *what* it was counting. The sector overlays (UK Finance, UK NHS, Australian Energy, UK G-Cloud) and the method overlays (TOGAF ADM, AI Agent Architecture) all ship guides too, and are neither clearly in nor clearly out of "jurisdictions". That ambiguity is the likely reason it drifted in the first place.

So this drops the number and covers both axes instead:

> A usage guide for every command across **every jurisdictional and sector overlay**, plus topical guides on discovery, planning, architecture, governance, compliance, and operations.

The neighbouring Commands card is already written this way — *"the official baseline plus community jurisdictional overlay categories"* — so this makes the pair consistent.

## Scope

One line. No other count on the page needs the same treatment: the `8 jurisdictions` strings in `docs/articles.html` are alt text describing historical release hero images, and are accurate for the releases they depict.

## Verification

- `check-guide-site-links.py` — 239 guides on disk, all reachable
- `markdownlint-cli2` — 0 issues

## Related

Found while reviewing #739. Separately, `docs/llms.txt` is materially staler than this — 136 of 239 guides and 48 commands missing, and 2 of the 9 distribution formats unlisted — because nothing generates or guards it. That is a follow-up PR, with a CI guard so it cannot drift again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE