### PR TITLE
fix(templates): guard the CLI template mirror by content, and resync 23 drifted copies

### DIFF
--- a/.arckit/templates/adm-preliminary-template.md
+++ b/.arckit/templates/adm-preliminary-template.md
@@ -8,15 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-ADMP-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/agent-governance-template.md
+++ b/.arckit/templates/agent-governance-template.md
@@ -8,9 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-[Standard: ID=ARC-{P}-AAOV-v{VERSION}]
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Oversight Model
 

--- a/.arckit/templates/agent-integration-template.md
+++ b/.arckit/templates/agent-integration-template.md
@@ -8,24 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | ARC-{P}-AAIN-v{VERSION} |
-| Document Type | AAIN — Agent Integration Architecture |
-| Project | {PROJECT_NAME} ({PROJECT_ID}) |
-| Classification | {CLASSIFICATION} |
-| Status | {STATUS} |
-| Version | {VERSION} |
-| Created | {DATE} |
-| Last Modified | {DATE} |
-| Review Cycle | Monthly |
-| Next Review | {NEXT_REVIEW_DATE} |
-| Owner | {OWNER_NAME_AND_ROLE} |
-| Reviewed By | — |
-| Approved By | — |
-| Distribution | Architecture Team, AI Programme Board |
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Integration Architecture
 

--- a/.arckit/templates/agent-inventory-template.md
+++ b/.arckit/templates/agent-inventory-template.md
@@ -8,24 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | ARC-{P}-AAGI-v{VERSION} |
-| Document Type | AAGI — AI Agent Inventory |
-| Project | {PROJECT_NAME} ({PROJECT_ID}) |
-| Classification | {CLASSIFICATION} |
-| Status | {STATUS} |
-| Version | {VERSION} |
-| Created | {DATE} |
-| Last Modified | {DATE} |
-| Review Cycle | Monthly |
-| Next Review | {NEXT_REVIEW_DATE} |
-| Owner | {OWNER_NAME_AND_ROLE} |
-| Reviewed By | — |
-| Approved By | — |
-| Distribution | Architecture Team, AI Programme Board |
-
----
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ## 1. Agent Register
 

--- a/.arckit/templates/application-inventory-template.md
+++ b/.arckit/templates/application-inventory-template.md
@@ -8,15 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-APP-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/architecture-board-template.md
+++ b/.arckit/templates/architecture-board-template.md
@@ -8,15 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-BORD-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/architecture-change-template.md
+++ b/.arckit/templates/architecture-change-template.md
@@ -8,23 +8,16 @@ templateVersion: "1.0"
 
 ## Document Control
 
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
+
 | Field | Value |
 |-------|-------|
-| **Document ID** | `ARC-[PROJECT_ID]-ACHG-[ACHG_NUM]-v[VERSION]` |
-| **Document Type** | Architecture Change Request |
-| **Project** | `[PROJECT_NAME]` |
 | **Change ID** | `ACHG-[ACHG_NUM]` |
-| **Classification** | `[CLASSIFICATION]` |
-| **Status** | DRAFT |
 | **Change Type** | `[EVOLUTIONARY / TRANSFORMATIONAL / CORRECTIVE]` |
 | **Priority** | `[CRITICAL / HIGH / MEDIUM / LOW]` |
-| **Created Date** | `[YYYY-MM-DD]` |
-| **Last Modified** | `[YYYY-MM-DD]` |
-| **Review Date** | `[YYYY-MM-DD]` |
-| **Owner** | `[OWNER_NAME_AND_ROLE]` |
-| **Reviewed By** | `[REVIEWER_NAME]` |
-| **Approved By** | `[APPROVER_NAME]` |
-| **Distribution** | `[DISTRIBUTION_LIST]` |
 
 ### Revision History
 

--- a/.arckit/templates/architecture-repository-template.md
+++ b/.arckit/templates/architecture-repository-template.md
@@ -8,21 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Standard ID | `ARC-000-REPO-v{VERSION}` |
-| Project | Global Repository |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
-| Review Cycle | Quarterly |
-| Next Review | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `Project Team, Architecture Team` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/capability-map-template.md
+++ b/.arckit/templates/capability-map-template.md
@@ -8,15 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-BPCM-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/fr-anssi-carto-template.md
+++ b/.arckit/templates/fr-anssi-carto-template.md
@@ -141,7 +141,9 @@ The network view maps physical and logical network segments and interconnections
 
 | ID | Interconnection | Remote Party | Protocol | Encryption | Authentication | Direction |
 |----|----------------|-------------|---------|-----------|----------------|-----------|
-| INT-01 | [Name] | [Partner / Provider] | [MPLS / VPN / Internet] | [Yes / No] | [Certificate / PSK] | [In / Out / Both] |
+| ECX-01 | [Name] | [Partner / Provider] | [MPLS / VPN / Internet] | [Yes / No] | [Certificate / PSK] | [In / Out / Both] |
+
+> **Note**: This template uses `ECX-NN` (External Connection) rather than `INT-NN` because the universal requirement-ID pattern in `arckit-claude/hooks/hook-utils.mjs` reserves `INT-\d{1,3}` for Integration Requirements (REQ document IDs). Using `INT-NN` here would make every interconnection row appear as a "missed requirement" in `/arckit:traceability` and `/arckit:health` scans. Same pattern as the Azure-research template renaming `BR-N` → `BCK-N` (Backup & Recovery).
 
 ### 4.3 Internet Entry Points
 
@@ -173,7 +175,7 @@ Sensitive flows are data flows that cross trust boundaries, carry classified dat
 |--------------|-------------|--------------------|--------------------|
 | External web | [URL / IP] | [WAF, CDN, firewall] | [Low / Medium / High] |
 | VPN / remote access | [VPN endpoint] | [MFA, certificate] | |
-| Third-party interconnections | [INT-xx] | [Encryption, auth] | |
+| Third-party interconnections | [ECX-xx] | [Encryption, auth] | |
 | Supply chain (SaaS) | [Service] | [Contract, access control] | |
 | Physical | [DC / Office] | [Badge, CCTV] | |
 

--- a/.arckit/templates/gap-analysis-template.md
+++ b/.arckit/templates/gap-analysis-template.md
@@ -8,16 +8,14 @@ templateVersion: "1.0"
 
 ## Document Control
 
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
+
 | Field | Value |
 |-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-GAPA-v[VERSION]` |
-| Project | `[PROJECT_NAME]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Severity Weighting | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
-| Created | `[YYYY-MM-DD]` |
-| Review Date | `[YYYY-MM-DD]` |
+| **Severity Weighting** | `[BALANCED / STRATEGIC-RISK / OPERATIONAL]` |
 
 ### Revision History
 

--- a/.arckit/templates/rationalization-template.md
+++ b/.arckit/templates/rationalization-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-APPR-v[VERSION]` |
-| Document Type | Application Rationalisation |
-| Project | `[PROJECT_NAME]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Version | `[VERSION]` |
-| Created | `[YYYY-MM-DD]` |
-| Last Modified | `[YYYY-MM-DD]` |
-| Review Cycle | Quarterly during active rationalisation programme |
-| Next Review Date | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/transition-architecture-template.md
+++ b/.arckit/templates/transition-architecture-template.md
@@ -8,22 +8,8 @@ templateVersion: "1.0"
 
 ## Document Control
 
-| Field | Value |
-|-------|-------|
-| Document ID | `ARC-[PROJECT_ID]-TRANS-v[VERSION]` |
-| Document Type | Transition Architecture |
-| Project | `[PROJECT_NAME]` |
-| Classification | `[CLASSIFICATION]` |
-| Status | DRAFT |
-| Version | `[VERSION]` |
-| Created | `[YYYY-MM-DD]` |
-| Last Modified | `[YYYY-MM-DD]` |
-| Review Cycle | Monthly during active migration, quarterly after migration |
-| Next Review Date | `[YYYY-MM-DD]` |
-| Owner | `[OWNER_NAME_AND_ROLE]` |
-| Reviewed By | `[REVIEWER_NAME]` |
-| Approved By | `[APPROVER_NAME]` |
-| Distribution | `[DISTRIBUTION_LIST]` |
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
 
 ### Revision History
 

--- a/.arckit/templates/uk-fs-consumer-duty-template.md
+++ b/.arckit/templates/uk-fs-consumer-duty-template.md
@@ -4,27 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document contains specific
-     pricing models, fraud-rate data, or vulnerable-customer cohort breakdowns that could
-     be exploited if disclosed to competitors or bad actors. Driven by
-     user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | FCA Consumer Duty Annual Board Report |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Annual (Board sign-off required before each anniversary of the Duty in-force date) |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Reporting Period** | {{REPORTING_PERIOD_START}} to {{REPORTING_PERIOD_END}} |
 | **Firm Legal Name** | {{FIRM_LEGAL_NAME}} |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |

--- a/.arckit/templates/uk-fs-ctp-dependency-template.md
+++ b/.arckit/templates/uk-fs-ctp-dependency-template.md
@@ -4,26 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document reveals specific contractual
-     exit terms, proprietary resilience-test outcomes, or provider-specific vulnerabilities that
-     could be exploited if disclosed. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK FS CTP Dependency Assessment |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED_DATE}} |
-| **Review Cycle** | Annual (minimum); review immediately on any new HMT designation or material change to provider relationship |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation / Registration Type** | {{FIRM_AUTHORISATION_TYPE}} |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 | **SMF Holder (Operational Resilience)** | {{SMF_HOLDER_NAME}} — {{SMF_HOLDER_FUNCTION}} |

--- a/.arckit/templates/uk-fs-safeguarding-template.md
+++ b/.arckit/templates/uk-fs-safeguarding-template.md
@@ -4,26 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Upgrade to OFFICIAL-SENSITIVE if this document reveals the specific
-     safeguarding bank account numbers, policy reference numbers, or shortfall thresholds that
-     could be exploited if disclosed. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK EMI / PI Safeguarding Assessment |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Annual (minimum); review immediately on change of safeguarding bank, insurer, or product scope |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{DOCUMENT_OWNER_ROLE}} — {{DOCUMENT_OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation / Registration Type** | {{FIRM_AUTHORISATION_TYPE}} (EMI — authorised / API — authorised / SPI — registered) |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 | **SMF Holder (Safeguarding)** | {{SMF_HOLDER_NAME}} — {{SMF_HOLDER_FUNCTION}} |

--- a/.arckit/templates/uk-fs-sca-rts-template.md
+++ b/.arckit/templates/uk-fs-sca-rts-template.md
@@ -4,24 +4,13 @@
 
 ## Document Control
 
-<!-- Default: OFFICIAL. Use OFFICIAL-SENSITIVE if the document reveals proprietary fraud model parameters or detection thresholds. Driven by user_config.default_classification. -->
+<!-- DOC-CONTROL-HEADER -->
+<!-- Resolved at command-execution time to _partials/document-control-uk.md or _partials/document-control-uae.md based on plugin userConfig classification_scheme + governance_framework. See _partials/RENDERING.md (when present). -->
+
+<!-- Domain-specific fields, retained after the resolved header per the Document Control Standard. -->
 
 | Field | Value |
 |-------|-------|
-| **Document ID** | {{DOCUMENT_ID}} |
-| **Document Type** | UK PSD2 SCA-RTS Exemption Design |
-| **Project** | {{PROJECT_NAME}} |
-| **Classification** | {{CLASSIFICATION}} |
-| **Status** | DRAFT |
-| **Version** | 1.0 |
-| **Created Date** | {{CREATED_DATE}} |
-| **Last Modified** | {{LAST_MODIFIED}} |
-| **Review Cycle** | Quarterly |
-| **Next Review Date** | {{NEXT_REVIEW_DATE}} |
-| **Owner** | {{OWNER_ROLE}} — {{OWNER_NAME}} |
-| **Reviewed By** | PENDING |
-| **Approved By** | PENDING |
-| **Distribution** | {{DISTRIBUTION}} |
 | **Firm Authorisation Type** | {{FIRM_AUTHORISATION_TYPE}} (PSP / EMI / PI / ASPSP / TPP) |
 | **FCA Firm Reference Number** | {{FCA_FRN}} |
 

--- a/.arckit/templates/uk-nhs-dcb0129-case-template.md
+++ b/.arckit/templates/uk-nhs-dcb0129-case-template.md
@@ -180,6 +180,21 @@ Evidence:
 
 [CSO's overall judgment that the product, with controls in place, is acceptably safe for its intended use. One paragraph.]
 
+### Re-review triggers
+
+This safety case must be re-reviewed by the Clinical Safety Officer when a change touches any of the following. Record the change and the re-review outcome in the Revision History.
+
+- Calculation, threshold, score, rounding, unit, or clinical rule
+- Patient identity, record matching, demographics, or clinical context
+- Data model, terminology, coding, validation, migration, or persistence
+- API, integration, interoperability, cache, queue, sync, or source-of-truth behaviour
+- Alerting, notification, escalation, prioritisation, or acknowledgement
+- User workflow, UI copy, warnings, confirmations, or accessibility
+- Authentication, authorisation, legitimate relationship, audit logging, or break-glass
+- Deployment configuration, feature flags, environment, infrastructure, failover, or backups
+- Monitoring, incident response, support, downtime, or decommissioning
+- AI/ML model, prompt, training data, calibration, drift, or human oversight
+
 ---
 
 ## 6. CSO Sign-off

--- a/.arckit/templates/uk-nhs-dcb0129-safety-template.md
+++ b/.arckit/templates/uk-nhs-dcb0129-safety-template.md
@@ -58,6 +58,36 @@
 
 ---
 
+## Applicable standards and assurance domains
+
+Clinical safety evidence sits alongside wider information-standard evidence. Under the Data (Use and Access) Act 2025 (amending the Health and Social Care Act 2012 Part 9 information-standards framework), standards can reach IT, software, interoperability, portability, information access, and security. This register records which domains apply, where the evidence lives, and who owns it. The Clinical Safety Officer owns the clinical-safety row and cross-references the others where a failure in that domain could cause patient harm; the CSO does not own every domain below.
+
+| Domain | Standard / framework | Applies? | Evidence location | Owner |
+|---|---|---|---|---|
+| Clinical risk management (manufacture) | DCB0129 | [YES] | `SAFETY-CASE.md` | Manufacturer CSO |
+| Clinical risk management (deployment/use) | DCB0160 | [YES/NO/TBD] | Deployment safety case | Deployer CSO |
+| Health/care information standards | HSC Act 2012 Part 9 as amended (DUAA 2025) | [TBD] | Evidence pack | Responsible owner |
+| Interoperability / connectivity | [e.g. FHIR UK Core, NHS Number, SNOMED CT] | [TBD] | [TBD] | Technical owner |
+| Data protection / secondary use | UK GDPR / DPA 2018 / DUAA 2025 context | [TBD] | DPIA / IG evidence | IG lead |
+| Information security | [e.g. DSPT, NCSC CAF, Cyber Essentials] | [TBD] | [TBD] | Security owner |
+| Portability / storage / access | [TBD] | [TBD] | [TBD] | [TBD] |
+
+---
+
+## Roles and responsibilities
+
+The Data (Use and Access) Act 2025 "relevant IT provider" concept can bring suppliers, operators, and maintainers into the information-standards compliance picture, not only the deploying organisation. Record who holds each role so that clinical-risk ownership across the lifecycle is unambiguous.
+
+| Role | Applies? | Organisation / person | Evidence |
+|---|---|---|---|
+| Manufacturer / supplier | [YES/NO] | [ORGANISATION] | `SAFETY-CASE.md` |
+| Deployer / health organisation | [YES/NO] | [ORGANISATION] | Deployment safety case |
+| Operator | [YES/NO] | [ORGANISATION] | [TBD] |
+| Maintainer | [YES/NO] | [ORGANISATION] | [TBD] |
+| Relevant IT provider (DUAA 2025) | [YES/NO] | [ORGANISATION] | Evidence pack |
+
+---
+
 ## Tier
 
 This product is assessed as Marcus Baw SAFETY.md **Tier 2** by default (3-file set). Adjust to Tier 1 (consolidate into this single file) for low-risk reference or information-only tools where the CSO judges a separate case + hazard log to be disproportionate. Adjust to Tier 3 (add `SAFETY-PLAN.md`) for SaMD products and any product where the manufacturer needs to evidence a separate Clinical Risk Management Plan to MHRA or a Notified Body.

--- a/.arckit/templates/uk-nhs-dcb0129-template.md
+++ b/.arckit/templates/uk-nhs-dcb0129-template.md
@@ -8,6 +8,6 @@ This wrapper exists only for `/arckit:customize list` and the documentation site
 2. [`uk-nhs-dcb0129-case-template.md`](./uk-nhs-dcb0129-case-template.md) — renders to `clinical-safety/SAFETY-CASE.md`
 3. [`uk-nhs-dcb0129-hazard-template.md`](./uk-nhs-dcb0129-hazard-template.md) — renders to `clinical-safety/HAZARD-LOG.md`
 
-The three files together implement the NHS DCB0129 manufacturer-side documentation expected by NHS England under the Health and Social Care Act 2012 s250. They follow Dr Marcus Baw's [SAFETY.md spec v2.0.0-draft](https://github.com/pacharanero/SAFETY.md) for filenames and YAML-frontmatter structure, prefixed with an ArcKit Document Control block.
+The three files together implement the NHS DCB0129 manufacturer-side documentation expected by NHS England under section 250 of the Health and Social Care Act 2012 (Part 9 information-standards framework, as amended by the Data (Use and Access) Act 2025). They follow Dr Marcus Baw's [SAFETY.md spec v2.0.0-draft](https://github.com/pacharanero/SAFETY.md) for filenames and YAML-frontmatter structure, prefixed with an ArcKit Document Control block.
 
 To customise: run `/arckit:customize uk-nhs-dcb0129-safety` (or `-case`, or `-hazard`) to copy individual sub-templates into `.arckit/templates-custom/` for editing.

--- a/.arckit/templates/uk-nhs-dcb0160-deployment-case-template.md
+++ b/.arckit/templates/uk-nhs-dcb0160-deployment-case-template.md
@@ -174,6 +174,21 @@ Evidence:
 
 [Deploying organisation CSO's overall judgment that the deployment, with controls in place, is acceptably safe.]
 
+### Re-review triggers
+
+This safety case must be re-reviewed by the Clinical Safety Officer when a change touches any of the following. Record the change and the re-review outcome in the Revision History.
+
+- Calculation, threshold, score, rounding, unit, or clinical rule
+- Patient identity, record matching, demographics, or clinical context
+- Data model, terminology, coding, validation, migration, or persistence
+- API, integration, interoperability, cache, queue, sync, or source-of-truth behaviour
+- Alerting, notification, escalation, prioritisation, or acknowledgement
+- User workflow, UI copy, warnings, confirmations, or accessibility
+- Authentication, authorisation, legitimate relationship, audit logging, or break-glass
+- Deployment configuration, feature flags, environment, infrastructure, failover, or backups
+- Monitoring, incident response, support, downtime, or decommissioning
+- AI/ML model, prompt, training data, calibration, drift, or human oversight
+
 ---
 
 ## 7. Deploying-Organisation CSO Sign-off

--- a/.arckit/templates/uk-nhs-dcb0160-deployment-safety-template.md
+++ b/.arckit/templates/uk-nhs-dcb0160-deployment-safety-template.md
@@ -59,6 +59,36 @@
 
 ---
 
+## Applicable standards and assurance domains
+
+Clinical safety evidence sits alongside wider information-standard evidence. Under the Data (Use and Access) Act 2025 (amending the Health and Social Care Act 2012 Part 9 information-standards framework), standards can reach IT, software, interoperability, portability, information access, and security. This register records which domains apply, where the evidence lives, and who owns it. The Clinical Safety Officer owns the clinical-safety row and cross-references the others where a failure in that domain could cause patient harm; the CSO does not own every domain below.
+
+| Domain | Standard / framework | Applies? | Evidence location | Owner |
+|---|---|---|---|---|
+| Clinical risk management (manufacture) | DCB0129 | [YES/NO] | received from manufacturer (see `../SAFETY-CASE.md`) | Manufacturer CSO |
+| Clinical risk management (deployment/use) | DCB0160 | [YES] | this deployment safety case | Deployer CSO |
+| Health/care information standards | HSC Act 2012 Part 9 as amended (DUAA 2025) | [TBD] | Evidence pack | Responsible owner |
+| Interoperability / connectivity | [e.g. FHIR UK Core, NHS Number, SNOMED CT] | [TBD] | [TBD] | Technical owner |
+| Data protection / secondary use | UK GDPR / DPA 2018 / DUAA 2025 context | [TBD] | DPIA / IG evidence | IG lead |
+| Information security | [e.g. DSPT, NCSC CAF, Cyber Essentials] | [TBD] | [TBD] | Security owner |
+| Portability / storage / access | [TBD] | [TBD] | [TBD] | [TBD] |
+
+---
+
+## Roles and responsibilities
+
+The Data (Use and Access) Act 2025 "relevant IT provider" concept can bring suppliers, operators, and maintainers into the information-standards compliance picture, not only the deploying organisation. Record who holds each role so that clinical-risk ownership across the lifecycle is unambiguous.
+
+| Role | Applies? | Organisation / person | Evidence |
+|---|---|---|---|
+| Manufacturer / supplier | [YES/NO] | [ORGANISATION] | `SAFETY-CASE.md` |
+| Deployer / health organisation | [YES] | [ORGANISATION] | Deployment safety case |
+| Operator | [YES/NO] | [ORGANISATION] | [TBD] |
+| Maintainer | [YES/NO] | [ORGANISATION] | [TBD] |
+| Relevant IT provider (DUAA 2025) | [YES/NO] | [ORGANISATION] | Evidence pack |
+
+---
+
 ## Relationship to manufacturer case
 
 The deploying organisation has reviewed the manufacturer's DCB0129 Clinical Safety Case Report and accepted its residual risks **in the context of this specific deployment**. Deployment-specific hazards (training inadequacy, workflow integration, business continuity, local configuration) are documented in this case and are **not** covered by the manufacturer case.

--- a/.arckit/templates/uk-nhs-dcb0160-template.md
+++ b/.arckit/templates/uk-nhs-dcb0160-template.md
@@ -8,6 +8,6 @@ This wrapper exists only for `/arckit:customize list` and the documentation site
 2. [`uk-nhs-dcb0160-deployment-case-template.md`](./uk-nhs-dcb0160-deployment-case-template.md) — renders to `clinical-safety/deployment/DEPLOYMENT-SAFETY-CASE.md`
 3. [`uk-nhs-dcb0160-deployment-hazard-template.md`](./uk-nhs-dcb0160-deployment-hazard-template.md) — renders to `clinical-safety/deployment/DEPLOYMENT-HAZARD-LOG.md`
 
-The three files together implement the NHS DCB0160 deployer-side documentation expected by NHS England under the Health and Social Care Act 2012 s250. They follow Dr Marcus Baw's [SAFETY.md spec v2.0.0-draft](https://github.com/pacharanero/SAFETY.md) for filenames and YAML-frontmatter structure, prefixed with an ArcKit Document Control block.
+The three files together implement the NHS DCB0160 deployer-side documentation expected by NHS England under section 250 of the Health and Social Care Act 2012 (Part 9 information-standards framework, as amended by the Data (Use and Access) Act 2025). They follow Dr Marcus Baw's [SAFETY.md spec v2.0.0-draft](https://github.com/pacharanero/SAFETY.md) for filenames and YAML-frontmatter structure, prefixed with an ArcKit Document Control block.
 
 DCB0160 sits alongside DCB0129 — neither replaces the other. The manufacturer's DCB0129 case is the input; the deployer's DCB0160 case argues that *this specific deployment* of the product, with this organisation's clinicians, workflows, integrations, training, and business continuity, is acceptably safe.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **23 templates had drifted between the plugin tree and the `.arckit/templates/` CLI mirror, because the test guarding the two trees compared filenames and not contents** (#784). `test_plugin_and_cli_templates_are_in_sync` built two sets of `os.path.basename(p)` and asserted the symmetric difference was empty, so a template present in both trees passed however far the copies had diverged. `test_plugin_and_cli_partials_are_in_sync` already used `filecmp.cmp`, and its docstring records the same bug being fixed one scope down for `_partials/RENDERING.md`; the fix was applied to the partials and not to the templates beside them.
+
+  This reaches users rather than being tidy-up. `.arckit/templates/` ships as CLI package data and is scaffolded by `arckit init`, and commands resolve the project-root `.arckit/templates/<name>` **before** falling back to `${CLAUDE_PLUGIN_ROOT}/templates/`. In a CLI-scaffolded project the drifted copy is the one that renders and the plugin copy is never read.
+
+  Sixteen of the 23 still carried the frozen, fully-expanded Document Control table that `<!-- DOC-CONTROL-HEADER -->` replaced. With no marker there is nothing for `_partials/RENDERING.md` to resolve, so the regime routing added in #744 never fired for those templates at all, across `arckit-togaf-adm` (9), `arckit-uk-finance` (4) and `arckit-agent-architecture` (3). They also still used `{{DOCUMENT_ID}}` mustache placeholders against the tree's `[PLACEHOLDER]` convention.
+
+  The remaining seven were content staleness, and the sharpest was `fr-anssi-carto-template.md`: the CLI copy still numbered interconnection rows `INT-01`, which collides with the `INT-\d{1,3}` Integration Requirement pattern reserved in `hooks/hook-utils.mjs`, so every row surfaced as a missed requirement in `/arckit:traceability` and `/arckit:health` scans. The plugin copy had already renamed these to `ECX-NN`. The NHS DCB0129/DCB0160 copies were missing the Data (Use and Access) Act 2025 amendment to the Health and Social Care Act 2012 Part 9 citation, plus a re-review-triggers section and an applicable-standards register.
+
+  `test_plugin_and_cli_templates_have_identical_content` now compares contents with `filecmp.cmp`, matching the partials test. All 23 copies are resynced from the plugin tree, which stays the source of truth. Note there is still no sync script for this mirror: `sync-shared-assets.py` writes into plugin directories only, so the copy remains manual and is now merely guarded.
+
 - **Every scripted project-creation path in the overlay commands called `create-project.sh` in a form it rejects** (#775, #777). 41 files across eight plugins, in two spellings, neither of which can produce a project:
 
   ```text

--- a/tests/plugin/test_template_consistency.py
+++ b/tests/plugin/test_template_consistency.py
@@ -117,6 +117,41 @@ def test_plugin_and_cli_templates_are_in_sync():
     assert not messages, "\n".join(messages)
 
 
+def test_plugin_and_cli_templates_have_identical_content():
+    """Every template present in both trees must be byte-identical.
+
+    Filenames are not enough. The sibling test above compares basenames only,
+    and 23 templates had drifted in content while it passed (#784) — the same
+    bug test_plugin_and_cli_partials_are_in_sync already documents for
+    _partials/, one scope down. Sixteen of the 23 still carried the frozen
+    Document Control table that <!-- DOC-CONTROL-HEADER --> replaced, so the
+    RENDERING.md regime routing never fired for them at all.
+
+    This matters because commands resolve .arckit/templates/<name> in the
+    project root BEFORE falling back to ${CLAUDE_PLUGIN_ROOT}/templates/. In a
+    CLI-scaffolded project the mirror is the copy that actually renders, and
+    the plugin copy is never read.
+
+    The plugin tree is the source of truth; the CLI tree is its mirror. There
+    is no sync script for it (sync-shared-assets.py writes into plugin dirs
+    only), so the copy is manual.
+    """
+    drifted = []
+    for plugin in PLUGIN_SOURCES:
+        for path in sorted(glob.glob(os.path.join(REPO_ROOT, plugin, "templates", "*.md"))):
+            name = os.path.basename(path)
+            cli_path = os.path.join(CLI_TEMPLATES_DIR, name)
+            if not os.path.exists(cli_path):
+                continue  # absence is the sibling test's job, not this one
+            if not filecmp.cmp(path, cli_path, shallow=False):
+                drifted.append(f"{plugin}/templates/{name}")
+    assert not drifted, (
+        "Content differs between the plugin tree and .arckit/templates/ for "
+        f"{len(drifted)} template(s):\n  " + "\n  ".join(drifted) + "\n"
+        "Copy the plugin copy over the CLI copy — the plugin tree is the source of truth."
+    )
+
+
 def test_plugin_and_cli_partials_are_in_sync():
     """Every _partials file in the core plugin must exist in .arckit/templates/_partials/
     with identical content.


### PR DESCRIPTION
Closes #784.

`tests/plugin/test_template_consistency.py` compared the plugin tree and the `.arckit/templates/` CLI mirror by **filename**, not content, so 23 templates had drifted while the suite stayed green.

`test_plugin_and_cli_partials_are_in_sync` already used `filecmp.cmp`, and its own docstring records this exact bug being fixed one scope down for `_partials/RENDERING.md`. The fix never reached the templates sitting beside it.

## Why it reaches users

`.arckit/templates/` ships as CLI package data via `pyproject.toml` shared-data and is scaffolded by `arckit init`. Commands resolve the project-root `.arckit/templates/<name>` **before** falling back to `${CLAUDE_PLUGIN_ROOT}/templates/`, so in a CLI-scaffolded project the drifted copy is the one that actually renders and the plugin copy is never read.

## What had drifted

Direction was confirmed per file. The plugin copy was newer in all 23, and the seven content-drift cases were read by hand rather than assumed.

**16 CLI copies predated the Document Control partial refactor**, still carrying the frozen, fully-expanded table that `<!-- DOC-CONTROL-HEADER -->` replaced. With no marker there is nothing for `_partials/RENDERING.md` to resolve, so the regime routing added in #744 never fired for those templates at all. `arckit-togaf-adm` (9), `arckit-uk-finance` (4), `arckit-agent-architecture` (3). They also still used `{{DOCUMENT_ID}}` mustache placeholders against the tree's `[PLACEHOLDER]` convention.

**7 were content staleness.** The sharpest is `fr-anssi-carto-template.md`: the CLI copy numbered interconnection rows `INT-01`, which collides with the `INT-\d{1,3}` Integration Requirement pattern reserved in `hooks/hook-utils.mjs`, so every interconnection row surfaced as a missed requirement in `/arckit:traceability` and `/arckit:health` scans. The plugin copy had already renamed them to `ECX-NN` for exactly that reason. The NHS DCB0129/DCB0160 copies were missing the Data (Use and Access) Act 2025 amendment to the Health and Social Care Act 2012 Part 9 citation, a re-review-triggers section, and an applicable-standards register.

## Changes

1. Added `test_plugin_and_cli_templates_have_identical_content`, comparing with `filecmp.cmp` exactly as the partials test does. Written and confirmed failing on all 23 **before** the resync, so the fix is verified by the guard rather than by eye.
2. Resynced all 23 CLI copies from the plugin tree, which stays the source of truth.
3. CHANGELOG entry under Unreleased → Fixed.

`arckit-uk-gcloud` is unaffected: it is proprietary and none of its 8 templates are mirrored into the CLI tree, which the new guard respects by skipping absent counterparts (absence remains the sibling test's job).

## Verification

```
pytest tests/                 1478 passed, 225 skipped
9 Python guard scripts        PASS
3 node guard scripts          PASS
sync-shared-assets --check    PASS
converter.py                  no drift
markdownlint-cli2             0 issues
independent diff sweep        0 remaining drift
```

## Note for the reviewer

There is still **no sync script** for this mirror. `sync-shared-assets.py` writes into plugin directories only and `converter.py` does not touch `.arckit/`, so the copy remains manual and is now merely guarded. Point 3 of #784 suggested a `--sync` mode in the shape of `check-guide-parity.py --sync`; I have deliberately left that out of this PR to keep the fix and the guard reviewable on their own. Happy to follow up if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
