### PR TITLE
fix(eu): correct three SOV weights and the SEAL-3 name against the framework

### DIFF
--- a/.arckit/templates/eu-cloud-sovereignty-template.md
+++ b/.arckit/templates/eu-cloud-sovereignty-template.md
@@ -77,11 +77,11 @@
 
 | Level | Name | Definition |
 |-------|------|------------|
-| SEAL-0 | No Sovereignty | Service, technology or operations under exclusive control of non-EU third parties, governed entirely in non-EU jurisdictions |
+| SEAL-0 | No Sovereignty | Service, technology or operations under exclusive control of non-EU third parties, governed entirely by non-EU jurisdictions |
 | SEAL-1 | Jurisdictional Sovereignty | EU law formally applies with limited practical enforceability; service, technology or operations under exclusive control of non-EU third parties |
-| SEAL-2 | Data Sovereignty | EU law applicable and enforceable, with material non-EU dependencies remaining; under indirect control of non-EU third parties |
-| SEAL-3 | Digital Resilience | EU law applicable and enforceable, EU actors exercising meaningful but not full influence; under marginal control of non-EU third parties |
-| SEAL-4 | Full Digital Sovereignty | Technology and operations under complete EU control, subject only to EU law, with no critical non-EU dependencies |
+| SEAL-2 | Data Sovereignty | EU jurisdictions apply, with material dependencies remaining; service, technology or operations under indirect control of non-EU third parties |
+| SEAL-3 | Technological Sovereignty | EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties |
+| SEAL-4 | Full Digital Sovereignty | Technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies |
 
 **Formula**: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage.
 

--- a/.arckit/templates/eu-cloud-sovereignty-template.md
+++ b/.arckit/templates/eu-cloud-sovereignty-template.md
@@ -27,13 +27,13 @@
 
 | Objective | Weight | SEAL Claimed | SEAL Evidenced | Minimum SEAL (tender) | Meets Minimum? |
 |-----------|--------|-------------|-----------------|------------------------|-----------------|
-| SOV-1 Strategic Sovereignty | 15% | [SEAL-0 to SEAL-4] | [SEAL-0 to SEAL-4] | [SEAL / Not yet set] | ☐ |
+| SOV-1 Strategic Sovereignty | 20% | [SEAL-0 to SEAL-4] | [SEAL-0 to SEAL-4] | [SEAL / Not yet set] | ☐ |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-3 Data & AI Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-4 Operational Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
-| SOV-5 Supply Chain Sovereignty | 20% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
+| SOV-5 Supply Chain Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-6 Technology Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
-| SOV-7 Security & Compliance Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
+| SOV-7 Security & Compliance Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-8 Environmental Sustainability | 5% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 
 > ⚠️ This document is an **assessment record**, not a certification. There is no published EU list of providers assessed against this framework — no commercial cloud provider is named as sovereign, compliant, or achieving any SEAL level in this document.
@@ -89,13 +89,13 @@
 
 | Objective | Weight |
 |-----------|--------|
-| SOV-1 Strategic Sovereignty | 15% |
+| SOV-1 Strategic Sovereignty | 20% |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% |
 | SOV-3 Data & AI Sovereignty | 10% |
 | SOV-4 Operational Sovereignty | 15% |
-| SOV-5 Supply Chain Sovereignty | 20% |
+| SOV-5 Supply Chain Sovereignty | 10% |
 | SOV-6 Technology Sovereignty | 15% |
-| SOV-7 Security & Compliance Sovereignty | 10% |
+| SOV-7 Security & Compliance Sovereignty | 15% |
 | SOV-8 Environmental Sustainability | 5% |
 | **Total** | **100%** |
 
@@ -103,13 +103,13 @@
 
 | Objective | Score | Max Score | Weight | Weighted Contribution |
 |-----------|-------|-----------|--------|-------------------------|
-| SOV-1 Strategic Sovereignty | [Score] | [Max] | 15% | [%] |
+| SOV-1 Strategic Sovereignty | [Score] | [Max] | 20% | [%] |
 | SOV-2 Legal & Jurisdictional Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-3 Data & AI Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-4 Operational Sovereignty | [Score] | [Max] | 15% | [%] |
-| SOV-5 Supply Chain Sovereignty | [Score] | [Max] | 20% | [%] |
+| SOV-5 Supply Chain Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-6 Technology Sovereignty | [Score] | [Max] | 15% | [%] |
-| SOV-7 Security & Compliance Sovereignty | [Score] | [Max] | 10% | [%] |
+| SOV-7 Security & Compliance Sovereignty | [Score] | [Max] | 15% | [%] |
 | SOV-8 Environmental Sustainability | [Score] | [Max] | 5% | [%] |
 | **Sovereignty Score** | | | | **[N]%** |
 
@@ -117,7 +117,7 @@
 
 ## 4. Objective-by-Objective Assessment
 
-### 4.1 SOV-1 Strategic Sovereignty (Weight: 15%)
+### 4.1 SOV-1 Strategic Sovereignty (Weight: 20%)
 
 **SEAL claimed**: [SEAL-0 to SEAL-4] | **SEAL evidenced**: [SEAL-0 to SEAL-4]
 
@@ -173,7 +173,7 @@
 
 **Gaps**: [Gap description]
 
-### 4.5 SOV-5 Supply Chain Sovereignty (Weight: 20%)
+### 4.5 SOV-5 Supply Chain Sovereignty (Weight: 10%)
 
 **SEAL claimed**: [SEAL] | **SEAL evidenced**: [SEAL]
 
@@ -201,7 +201,7 @@
 
 **Gaps**: [Gap description]
 
-### 4.7 SOV-7 Security & Compliance Sovereignty (Weight: 10%)
+### 4.7 SOV-7 Security & Compliance Sovereignty (Weight: 15%)
 
 **SEAL claimed**: [SEAL] | **SEAL evidenced**: [SEAL]
 

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -162,6 +162,9 @@ jobs:
       - name: ArcKit FDE template consistency
         run: node scripts/tests/test-fde-templates.mjs
 
+      - name: EU Cloud Sovereignty Framework weight guard
+        run: node scripts/tests/test-csf-weights.mjs
+
       - name: Command-reference notation (colon namespace)
         run: python3 scripts/standardise-colon.py --check
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **The EU Cloud Sovereignty Framework (EUCSF) assessment shipped three wrong objective weights** — `SOV-1 Strategic Sovereignty` **15%** (should be **20%**), `SOV-5 Supply Chain Sovereignty` **20%** (should be **10%**), `SOV-7 Security & Compliance Sovereignty` **10%** (should be **15%**) — verified against the European Commission's [Implementation guidance](https://commission.europa.eu/document/download/2ad80a48-166f-4c77-a513-80c53ca2a128_en?filename=Cloud+Sovereignty+Framework+-+Implementation+guidance.pdf) p.7 and the [Annex calculator](https://commission.europa.eu/document/download/3acb8fe8-8a4a-4339-ae74-f56138d913d1_en?filename=Annex+-+Sovereignty+assessment+calculator.xlsx) XLSX cells D4/D45/D76/D102/D133/D169/D195/D231. The other five objectives were already correct.
+
+  **The wrong set is a permutation of the correct one** — the same eight numbers, three of them assigned to the wrong objective — so it still sums to exactly 100%. That is why it survived two independent "totals 100%" checks: `quality-checklist.md`'s EUCSF item (*"Weight table reproduces the framework weights and totals exactly 100%"*) and this document's own predecessor guard both evaluate a sum, and a sum is invariant to a permutation of its addends. Neither check has ever verified a single objective's weight against its own known-correct value. `scripts/tests/test-csf-weights.mjs` closes that gap: it asserts each of the eight `SOV-N` weights individually, globbed across every canonical source and generated mirror (`plugins/arckit-eu/**`, `plugins/arckit-claude/plugins/eu/**`, `.arckit/templates/**`, `docs/guides/eu-cloud-sovereignty.md`, `plugins/arckit-claude/docs/guides/**`), and `quality-checklist.md`'s EUCSF check now lists all eight weights explicitly rather than only their total.
+
+  The guard's red run, before any data was corrected, named exactly the three wrong objectives across every file carrying the table (7 files, 48 individual weight-occurrence failures):
+
+  ```text
+  [FAIL] plugins/arckit-eu/commands/eu-cloud-sovereignty.md:198: SOV-1 weight is 15%, the framework says 20%
+  [FAIL] plugins/arckit-eu/commands/eu-cloud-sovereignty.md:202: SOV-5 weight is 20%, the framework says 10%
+  [FAIL] plugins/arckit-eu/commands/eu-cloud-sovereignty.md:204: SOV-7 weight is 10%, the framework says 15%
+  [FAIL] plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md:30: SOV-1 weight is 15%, the framework says 20%
+  [FAIL] plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md:34: SOV-5 weight is 20%, the framework says 10%
+  [FAIL] plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md:36: SOV-7 weight is 10%, the framework says 15%
+  ... (and the same three-objective pattern repeated across three tables and eight `(Weight: ...)` subsection headers per file, and across every generated mirror in `plugins/arckit-claude/plugins/eu/`, `.arckit/templates/`, and both `docs/guides/` trees)
+  ```
+
+  Also corrected in `plugins/arckit-eu/commands/eu-cloud-sovereignty.md`: `SEAL-3` was named **"Digital Resilience"**, which does not appear anywhere in the framework's SEAL scale — renamed to **"Technological Sovereignty"** per the Implementation guidance p.2-3. `SEAL-2` and `SEAL-4`'s wording was also drifting from that same normative rendering (*"EU law applicable and enforceable"* vs. the source's *"EU jurisdictions apply"*; *"subject only to EU law"* vs. *"subject only to EU jurisdiction"*) and is now verbatim.
+
 ## [6.10.0] — 2026-08-18
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   ... (and the same three-objective pattern repeated across three tables and eight `(Weight: ...)` subsection headers per file, and across every generated mirror in `plugins/arckit-claude/plugins/eu/`, `.arckit/templates/`, and both `docs/guides/` trees)
   ```
 
+  **The checklist item that states the eight weights is itself guarded**, after review found it was not. Replacing the sum-only check with an explicit eight-weight list is the right fix, but that list is *prose* — not a table row, not a `(Weight: ...)` header — and its 31 copies (one per plugin) sit outside the weight-table roots, so reverting `SOV-1` and `SOV-5` in the checklist alone still produced a green run. The guard now recognises a third shape, `SOV-<n> <objective name> <NN>%`, and collects `quality-checklist.md` by basename so a new plugin is covered the day it is added. Coverage goes from 128 occurrences across 7 files to 376 across 38.
+
+  Anchoring that shape on the objective's own name, rather than on a loose `SOV-<n>...<NN>%` scan, is load-bearing twice over. It avoids a false positive the same checklist line would otherwise produce (*"weights summing to 100%"* reads as SOV-8 being 100%), and it buys a second assertion: a code paired with **another objective's name** now fails too. That is the permutation defect wearing its other face — the same one that let `SEAL-3` ship as *"Digital Resilience"*.
+
+  `SEAL-2`'s *"EU jurisdictions apply, with material dependencies remain"* is ungrammatical in the Commission's own text and is now marked in the command as verbatim-on-purpose, so a later contributor does not silently repair it and put the artefact out of step with the normative wording a tender is assessed against.
+
   Also corrected in `plugins/arckit-eu/commands/eu-cloud-sovereignty.md`: `SEAL-3` was named **"Digital Resilience"**, which does not appear anywhere in the framework's SEAL scale — renamed to **"Technological Sovereignty"** per the Implementation guidance p.2-3. `SEAL-2` and `SEAL-4`'s wording was also drifting from that same normative rendering (*"EU law applicable and enforceable"* vs. the source's *"EU jurisdictions apply"*; *"subject only to EU law"* vs. *"subject only to EU jurisdiction"*) and is now verbatim.
 
 ## [6.10.0] — 2026-08-18

--- a/docs/guides/eu-cloud-sovereignty.md
+++ b/docs/guides/eu-cloud-sovereignty.md
@@ -35,16 +35,16 @@ Weights are set by the framework and sum to 100%. Treat them as the framework's 
 
 | Objective | Weight |
 |-----------|--------|
-| SOV-1 Strategic Sovereignty | 15% |
+| SOV-1 Strategic Sovereignty | 20% |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% |
 | SOV-3 Data & AI Sovereignty | 10% |
 | SOV-4 Operational Sovereignty | 15% |
-| SOV-5 Supply Chain Sovereignty | 20% |
+| SOV-5 Supply Chain Sovereignty | 10% |
 | SOV-6 Technology Sovereignty | 15% |
-| SOV-7 Security & Compliance Sovereignty | 10% |
+| SOV-7 Security & Compliance Sovereignty | 15% |
 | SOV-8 Environmental Sustainability | 5% |
 
-Supply chain carries the heaviest weight, and technology, strategic and operational sovereignty together carry 45% — the framework treats dependency as the core sovereignty question, not data location alone.
+Strategic sovereignty carries the heaviest weight, and together with technology and operational sovereignty accounts for 50% — the framework treats dependency as the core sovereignty question, not data location alone.
 
 ---
 

--- a/plugins/arckit-agent-architecture/references/quality-checklist.md
+++ b/plugins/arckit-agent-architecture/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-at/references/quality-checklist.md
+++ b/plugins/arckit-at/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-au-energy/references/quality-checklist.md
+++ b/plugins/arckit-au-energy/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-au/references/quality-checklist.md
+++ b/plugins/arckit-au/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-ca/references/quality-checklist.md
+++ b/plugins/arckit-ca/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/docs/guides/eu-cloud-sovereignty.md
+++ b/plugins/arckit-claude/docs/guides/eu-cloud-sovereignty.md
@@ -35,16 +35,16 @@ Weights are set by the framework and sum to 100%. Treat them as the framework's 
 
 | Objective | Weight |
 |-----------|--------|
-| SOV-1 Strategic Sovereignty | 15% |
+| SOV-1 Strategic Sovereignty | 20% |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% |
 | SOV-3 Data & AI Sovereignty | 10% |
 | SOV-4 Operational Sovereignty | 15% |
-| SOV-5 Supply Chain Sovereignty | 20% |
+| SOV-5 Supply Chain Sovereignty | 10% |
 | SOV-6 Technology Sovereignty | 15% |
-| SOV-7 Security & Compliance Sovereignty | 10% |
+| SOV-7 Security & Compliance Sovereignty | 15% |
 | SOV-8 Environmental Sustainability | 5% |
 
-Supply chain carries the heaviest weight, and technology, strategic and operational sovereignty together carry 45% — the framework treats dependency as the core sovereignty question, not data location alone.
+Strategic sovereignty carries the heaviest weight, and together with technology and operational sovereignty accounts for 50% — the framework treats dependency as the core sovereignty question, not data location alone.
 
 ---
 

--- a/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/agent/architecture/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/at/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/at/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/energy/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/au/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/au/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/ca/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/eu/commands/eu-cloud-sovereignty.md
+++ b/plugins/arckit-claude/plugins/eu/commands/eu-cloud-sovereignty.md
@@ -122,11 +122,11 @@ Show this scoping summary before generating the full document.
 
 5. **Section 3: Sovereignty Score — Methodology and Result**
    - Reproduce the five SEAL level definitions in full (do not paraphrase or abbreviate):
-     - **SEAL-0 No Sovereignty**: service, technology or operations under exclusive control of non-EU third parties, governed entirely in non-EU jurisdictions
+     - **SEAL-0 No Sovereignty**: service, technology or operations under exclusive control of non-EU third parties, governed entirely by non-EU jurisdictions
      - **SEAL-1 Jurisdictional Sovereignty**: EU law formally applies with limited practical enforceability; service, technology or operations under exclusive control of non-EU third parties
-     - **SEAL-2 Data Sovereignty**: EU law applicable and enforceable, with material non-EU dependencies remaining; under indirect control of non-EU third parties
-     - **SEAL-3 Digital Resilience**: EU law applicable and enforceable, EU actors exercising meaningful but not full influence; under marginal control of non-EU third parties
-     - **SEAL-4 Full Digital Sovereignty**: technology and operations under complete EU control, subject only to EU law, with no critical non-EU dependencies
+     - **SEAL-2 Data Sovereignty**: EU jurisdictions apply, with material dependencies remain; service, technology or operations under indirect control of non-EU third parties
+     - **SEAL-3 Technological Sovereignty**: EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties
+     - **SEAL-4 Full Digital Sovereignty**: technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies
    - State the formula: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage
    - Weight table for all eight objectives (must sum to exactly 100%)
    - Scored table: objective, Score, Max Score, Weight, Weighted Contribution
@@ -195,13 +195,13 @@ Sovereignty Score: {N}% (award-criterion contribution)
 
 | Objective | Weight | SEAL Claimed | SEAL Evidenced | Min. SEAL (tender) | Meets Min.? |
 |-----------|--------|-------------|-----------------|--------------------|-------------|
-| SOV-1 Strategic Sovereignty            | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
+| SOV-1 Strategic Sovereignty            | 20% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-3 Data & AI Sovereignty            | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-4 Operational Sovereignty          | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
-| SOV-5 Supply Chain Sovereignty         | 20% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
+| SOV-5 Supply Chain Sovereignty         | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-6 Technology Sovereignty           | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
-| SOV-7 Security & Compliance Sovereignty | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
+| SOV-7 Security & Compliance Sovereignty | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-8 Environmental Sustainability     |  5% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/plugins/arckit-claude/plugins/eu/commands/eu-cloud-sovereignty.md
+++ b/plugins/arckit-claude/plugins/eu/commands/eu-cloud-sovereignty.md
@@ -127,6 +127,7 @@ Show this scoping summary before generating the full document.
      - **SEAL-2 Data Sovereignty**: EU jurisdictions apply, with material dependencies remain; service, technology or operations under indirect control of non-EU third parties
      - **SEAL-3 Technological Sovereignty**: EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties
      - **SEAL-4 Full Digital Sovereignty**: technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies
+   - SEAL-2's *"with material dependencies remain"* is ungrammatical **in the source** (Implementation guidance p.2-3) and is reproduced verbatim on purpose. Do not correct it — "do not paraphrase" above governs, and a silent repair would put the artefact out of step with the normative text a tender is assessed against.
    - State the formula: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage
    - Weight table for all eight objectives (must sum to exactly 100%)
    - Scored table: objective, Score, Max Score, Weight, Weighted Contribution

--- a/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/eu/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/eu/templates/eu-cloud-sovereignty-template.md
+++ b/plugins/arckit-claude/plugins/eu/templates/eu-cloud-sovereignty-template.md
@@ -77,11 +77,11 @@
 
 | Level | Name | Definition |
 |-------|------|------------|
-| SEAL-0 | No Sovereignty | Service, technology or operations under exclusive control of non-EU third parties, governed entirely in non-EU jurisdictions |
+| SEAL-0 | No Sovereignty | Service, technology or operations under exclusive control of non-EU third parties, governed entirely by non-EU jurisdictions |
 | SEAL-1 | Jurisdictional Sovereignty | EU law formally applies with limited practical enforceability; service, technology or operations under exclusive control of non-EU third parties |
-| SEAL-2 | Data Sovereignty | EU law applicable and enforceable, with material non-EU dependencies remaining; under indirect control of non-EU third parties |
-| SEAL-3 | Digital Resilience | EU law applicable and enforceable, EU actors exercising meaningful but not full influence; under marginal control of non-EU third parties |
-| SEAL-4 | Full Digital Sovereignty | Technology and operations under complete EU control, subject only to EU law, with no critical non-EU dependencies |
+| SEAL-2 | Data Sovereignty | EU jurisdictions apply, with material dependencies remaining; service, technology or operations under indirect control of non-EU third parties |
+| SEAL-3 | Technological Sovereignty | EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties |
+| SEAL-4 | Full Digital Sovereignty | Technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies |
 
 **Formula**: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage.
 

--- a/plugins/arckit-claude/plugins/eu/templates/eu-cloud-sovereignty-template.md
+++ b/plugins/arckit-claude/plugins/eu/templates/eu-cloud-sovereignty-template.md
@@ -27,13 +27,13 @@
 
 | Objective | Weight | SEAL Claimed | SEAL Evidenced | Minimum SEAL (tender) | Meets Minimum? |
 |-----------|--------|-------------|-----------------|------------------------|-----------------|
-| SOV-1 Strategic Sovereignty | 15% | [SEAL-0 to SEAL-4] | [SEAL-0 to SEAL-4] | [SEAL / Not yet set] | ☐ |
+| SOV-1 Strategic Sovereignty | 20% | [SEAL-0 to SEAL-4] | [SEAL-0 to SEAL-4] | [SEAL / Not yet set] | ☐ |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-3 Data & AI Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-4 Operational Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
-| SOV-5 Supply Chain Sovereignty | 20% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
+| SOV-5 Supply Chain Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-6 Technology Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
-| SOV-7 Security & Compliance Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
+| SOV-7 Security & Compliance Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-8 Environmental Sustainability | 5% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 
 > ⚠️ This document is an **assessment record**, not a certification. There is no published EU list of providers assessed against this framework — no commercial cloud provider is named as sovereign, compliant, or achieving any SEAL level in this document.
@@ -89,13 +89,13 @@
 
 | Objective | Weight |
 |-----------|--------|
-| SOV-1 Strategic Sovereignty | 15% |
+| SOV-1 Strategic Sovereignty | 20% |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% |
 | SOV-3 Data & AI Sovereignty | 10% |
 | SOV-4 Operational Sovereignty | 15% |
-| SOV-5 Supply Chain Sovereignty | 20% |
+| SOV-5 Supply Chain Sovereignty | 10% |
 | SOV-6 Technology Sovereignty | 15% |
-| SOV-7 Security & Compliance Sovereignty | 10% |
+| SOV-7 Security & Compliance Sovereignty | 15% |
 | SOV-8 Environmental Sustainability | 5% |
 | **Total** | **100%** |
 
@@ -103,13 +103,13 @@
 
 | Objective | Score | Max Score | Weight | Weighted Contribution |
 |-----------|-------|-----------|--------|-------------------------|
-| SOV-1 Strategic Sovereignty | [Score] | [Max] | 15% | [%] |
+| SOV-1 Strategic Sovereignty | [Score] | [Max] | 20% | [%] |
 | SOV-2 Legal & Jurisdictional Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-3 Data & AI Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-4 Operational Sovereignty | [Score] | [Max] | 15% | [%] |
-| SOV-5 Supply Chain Sovereignty | [Score] | [Max] | 20% | [%] |
+| SOV-5 Supply Chain Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-6 Technology Sovereignty | [Score] | [Max] | 15% | [%] |
-| SOV-7 Security & Compliance Sovereignty | [Score] | [Max] | 10% | [%] |
+| SOV-7 Security & Compliance Sovereignty | [Score] | [Max] | 15% | [%] |
 | SOV-8 Environmental Sustainability | [Score] | [Max] | 5% | [%] |
 | **Sovereignty Score** | | | | **[N]%** |
 
@@ -117,7 +117,7 @@
 
 ## 4. Objective-by-Objective Assessment
 
-### 4.1 SOV-1 Strategic Sovereignty (Weight: 15%)
+### 4.1 SOV-1 Strategic Sovereignty (Weight: 20%)
 
 **SEAL claimed**: [SEAL-0 to SEAL-4] | **SEAL evidenced**: [SEAL-0 to SEAL-4]
 
@@ -173,7 +173,7 @@
 
 **Gaps**: [Gap description]
 
-### 4.5 SOV-5 Supply Chain Sovereignty (Weight: 20%)
+### 4.5 SOV-5 Supply Chain Sovereignty (Weight: 10%)
 
 **SEAL claimed**: [SEAL] | **SEAL evidenced**: [SEAL]
 
@@ -201,7 +201,7 @@
 
 **Gaps**: [Gap description]
 
-### 4.7 SOV-7 Security & Compliance Sovereignty (Weight: 10%)
+### 4.7 SOV-7 Security & Compliance Sovereignty (Weight: 15%)
 
 **SEAL claimed**: [SEAL] | **SEAL evidenced**: [SEAL]
 

--- a/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/fr/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/nl/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/nl/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/repo/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/togaf/adm/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uae/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/finance/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/uk/nhs/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/plugins/us/references/quality-checklist.md
+++ b/plugins/arckit-claude/plugins/us/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-claude/references/quality-checklist.md
+++ b/plugins/arckit-claude/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-eu/commands/eu-cloud-sovereignty.md
+++ b/plugins/arckit-eu/commands/eu-cloud-sovereignty.md
@@ -122,11 +122,11 @@ Show this scoping summary before generating the full document.
 
 5. **Section 3: Sovereignty Score — Methodology and Result**
    - Reproduce the five SEAL level definitions in full (do not paraphrase or abbreviate):
-     - **SEAL-0 No Sovereignty**: service, technology or operations under exclusive control of non-EU third parties, governed entirely in non-EU jurisdictions
+     - **SEAL-0 No Sovereignty**: service, technology or operations under exclusive control of non-EU third parties, governed entirely by non-EU jurisdictions
      - **SEAL-1 Jurisdictional Sovereignty**: EU law formally applies with limited practical enforceability; service, technology or operations under exclusive control of non-EU third parties
-     - **SEAL-2 Data Sovereignty**: EU law applicable and enforceable, with material non-EU dependencies remaining; under indirect control of non-EU third parties
-     - **SEAL-3 Digital Resilience**: EU law applicable and enforceable, EU actors exercising meaningful but not full influence; under marginal control of non-EU third parties
-     - **SEAL-4 Full Digital Sovereignty**: technology and operations under complete EU control, subject only to EU law, with no critical non-EU dependencies
+     - **SEAL-2 Data Sovereignty**: EU jurisdictions apply, with material dependencies remain; service, technology or operations under indirect control of non-EU third parties
+     - **SEAL-3 Technological Sovereignty**: EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties
+     - **SEAL-4 Full Digital Sovereignty**: technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies
    - State the formula: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage
    - Weight table for all eight objectives (must sum to exactly 100%)
    - Scored table: objective, Score, Max Score, Weight, Weighted Contribution
@@ -195,13 +195,13 @@ Sovereignty Score: {N}% (award-criterion contribution)
 
 | Objective | Weight | SEAL Claimed | SEAL Evidenced | Min. SEAL (tender) | Meets Min.? |
 |-----------|--------|-------------|-----------------|--------------------|-------------|
-| SOV-1 Strategic Sovereignty            | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
+| SOV-1 Strategic Sovereignty            | 20% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-3 Data & AI Sovereignty            | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-4 Operational Sovereignty          | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
-| SOV-5 Supply Chain Sovereignty         | 20% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
+| SOV-5 Supply Chain Sovereignty         | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-6 Technology Sovereignty           | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
-| SOV-7 Security & Compliance Sovereignty | 10% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
+| SOV-7 Security & Compliance Sovereignty | 15% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 | SOV-8 Environmental Sustainability     |  5% | {SEAL} | {SEAL} | {SEAL / not set} | {Y/N} |
 
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━

--- a/plugins/arckit-eu/commands/eu-cloud-sovereignty.md
+++ b/plugins/arckit-eu/commands/eu-cloud-sovereignty.md
@@ -127,6 +127,7 @@ Show this scoping summary before generating the full document.
      - **SEAL-2 Data Sovereignty**: EU jurisdictions apply, with material dependencies remain; service, technology or operations under indirect control of non-EU third parties
      - **SEAL-3 Technological Sovereignty**: EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties
      - **SEAL-4 Full Digital Sovereignty**: technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies
+   - SEAL-2's *"with material dependencies remain"* is ungrammatical **in the source** (Implementation guidance p.2-3) and is reproduced verbatim on purpose. Do not correct it — "do not paraphrase" above governs, and a silent repair would put the artefact out of step with the normative text a tender is assessed against.
    - State the formula: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage
    - Weight table for all eight objectives (must sum to exactly 100%)
    - Scored table: objective, Score, Max Score, Weight, Weighted Contribution

--- a/plugins/arckit-eu/references/quality-checklist.md
+++ b/plugins/arckit-eu/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md
+++ b/plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md
@@ -77,11 +77,11 @@
 
 | Level | Name | Definition |
 |-------|------|------------|
-| SEAL-0 | No Sovereignty | Service, technology or operations under exclusive control of non-EU third parties, governed entirely in non-EU jurisdictions |
+| SEAL-0 | No Sovereignty | Service, technology or operations under exclusive control of non-EU third parties, governed entirely by non-EU jurisdictions |
 | SEAL-1 | Jurisdictional Sovereignty | EU law formally applies with limited practical enforceability; service, technology or operations under exclusive control of non-EU third parties |
-| SEAL-2 | Data Sovereignty | EU law applicable and enforceable, with material non-EU dependencies remaining; under indirect control of non-EU third parties |
-| SEAL-3 | Digital Resilience | EU law applicable and enforceable, EU actors exercising meaningful but not full influence; under marginal control of non-EU third parties |
-| SEAL-4 | Full Digital Sovereignty | Technology and operations under complete EU control, subject only to EU law, with no critical non-EU dependencies |
+| SEAL-2 | Data Sovereignty | EU jurisdictions apply, with material dependencies remaining; service, technology or operations under indirect control of non-EU third parties |
+| SEAL-3 | Technological Sovereignty | EU jurisdictions apply, EU actors exercising meaningful but not full influence; service, technology or operations under marginal control of non-EU third parties |
+| SEAL-4 | Full Digital Sovereignty | Technology and operations under complete EU control, subject only to EU jurisdiction, with no critical non-EU dependencies |
 
 **Formula**: Sovereignty Score = Σ over the eight objectives of (Score(SOVn) / Max.Score(SOVn)) × Weight(SOVn), expressed as a percentage.
 

--- a/plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md
+++ b/plugins/arckit-eu/templates/eu-cloud-sovereignty-template.md
@@ -27,13 +27,13 @@
 
 | Objective | Weight | SEAL Claimed | SEAL Evidenced | Minimum SEAL (tender) | Meets Minimum? |
 |-----------|--------|-------------|-----------------|------------------------|-----------------|
-| SOV-1 Strategic Sovereignty | 15% | [SEAL-0 to SEAL-4] | [SEAL-0 to SEAL-4] | [SEAL / Not yet set] | ☐ |
+| SOV-1 Strategic Sovereignty | 20% | [SEAL-0 to SEAL-4] | [SEAL-0 to SEAL-4] | [SEAL / Not yet set] | ☐ |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-3 Data & AI Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-4 Operational Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
-| SOV-5 Supply Chain Sovereignty | 20% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
+| SOV-5 Supply Chain Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-6 Technology Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
-| SOV-7 Security & Compliance Sovereignty | 10% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
+| SOV-7 Security & Compliance Sovereignty | 15% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 | SOV-8 Environmental Sustainability | 5% | [SEAL] | [SEAL] | [SEAL / Not yet set] | ☐ |
 
 > ⚠️ This document is an **assessment record**, not a certification. There is no published EU list of providers assessed against this framework — no commercial cloud provider is named as sovereign, compliant, or achieving any SEAL level in this document.
@@ -89,13 +89,13 @@
 
 | Objective | Weight |
 |-----------|--------|
-| SOV-1 Strategic Sovereignty | 15% |
+| SOV-1 Strategic Sovereignty | 20% |
 | SOV-2 Legal & Jurisdictional Sovereignty | 10% |
 | SOV-3 Data & AI Sovereignty | 10% |
 | SOV-4 Operational Sovereignty | 15% |
-| SOV-5 Supply Chain Sovereignty | 20% |
+| SOV-5 Supply Chain Sovereignty | 10% |
 | SOV-6 Technology Sovereignty | 15% |
-| SOV-7 Security & Compliance Sovereignty | 10% |
+| SOV-7 Security & Compliance Sovereignty | 15% |
 | SOV-8 Environmental Sustainability | 5% |
 | **Total** | **100%** |
 
@@ -103,13 +103,13 @@
 
 | Objective | Score | Max Score | Weight | Weighted Contribution |
 |-----------|-------|-----------|--------|-------------------------|
-| SOV-1 Strategic Sovereignty | [Score] | [Max] | 15% | [%] |
+| SOV-1 Strategic Sovereignty | [Score] | [Max] | 20% | [%] |
 | SOV-2 Legal & Jurisdictional Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-3 Data & AI Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-4 Operational Sovereignty | [Score] | [Max] | 15% | [%] |
-| SOV-5 Supply Chain Sovereignty | [Score] | [Max] | 20% | [%] |
+| SOV-5 Supply Chain Sovereignty | [Score] | [Max] | 10% | [%] |
 | SOV-6 Technology Sovereignty | [Score] | [Max] | 15% | [%] |
-| SOV-7 Security & Compliance Sovereignty | [Score] | [Max] | 10% | [%] |
+| SOV-7 Security & Compliance Sovereignty | [Score] | [Max] | 15% | [%] |
 | SOV-8 Environmental Sustainability | [Score] | [Max] | 5% | [%] |
 | **Sovereignty Score** | | | | **[N]%** |
 
@@ -117,7 +117,7 @@
 
 ## 4. Objective-by-Objective Assessment
 
-### 4.1 SOV-1 Strategic Sovereignty (Weight: 15%)
+### 4.1 SOV-1 Strategic Sovereignty (Weight: 20%)
 
 **SEAL claimed**: [SEAL-0 to SEAL-4] | **SEAL evidenced**: [SEAL-0 to SEAL-4]
 
@@ -173,7 +173,7 @@
 
 **Gaps**: [Gap description]
 
-### 4.5 SOV-5 Supply Chain Sovereignty (Weight: 20%)
+### 4.5 SOV-5 Supply Chain Sovereignty (Weight: 10%)
 
 **SEAL claimed**: [SEAL] | **SEAL evidenced**: [SEAL]
 
@@ -201,7 +201,7 @@
 
 **Gaps**: [Gap description]
 
-### 4.7 SOV-7 Security & Compliance Sovereignty (Weight: 10%)
+### 4.7 SOV-7 Security & Compliance Sovereignty (Weight: 15%)
 
 **SEAL claimed**: [SEAL] | **SEAL evidenced**: [SEAL]
 

--- a/plugins/arckit-fr/references/quality-checklist.md
+++ b/plugins/arckit-fr/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-nl/references/quality-checklist.md
+++ b/plugins/arckit-nl/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-repo/references/quality-checklist.md
+++ b/plugins/arckit-repo/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-togaf-adm/references/quality-checklist.md
+++ b/plugins/arckit-togaf-adm/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-uae/references/quality-checklist.md
+++ b/plugins/arckit-uae/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-uk-finance/references/quality-checklist.md
+++ b/plugins/arckit-uk-finance/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-uk-gcloud/references/quality-checklist.md
+++ b/plugins/arckit-uk-gcloud/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-uk-nhs/references/quality-checklist.md
+++ b/plugins/arckit-uk-nhs/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/plugins/arckit-us/references/quality-checklist.md
+++ b/plugins/arckit-us/references/quality-checklist.md
@@ -465,7 +465,7 @@ All artifacts must pass these 10 checks:
 - Minimum SEAL per objective sourced **only** from the tender specification; where no tender specification exists, every objective is marked "Not yet set by contracting authority" rather than given an invented value
 - Document nowhere states or implies a framework-mandated minimum SEAL
 - All eight objectives (SOV-1 to SOV-8) assessed, none omitted
-- Weight table reproduces the framework weights and totals exactly 100%
+- Weight table reproduces the framework weights exactly, checked objective by objective (not only that the column totals 100%, which a permutation of the correct values would also pass): SOV-1 Strategic Sovereignty 20%, SOV-2 Legal & Jurisdictional Sovereignty 10%, SOV-3 Data & AI Sovereignty 10%, SOV-4 Operational Sovereignty 15%, SOV-5 Supply Chain Sovereignty 10%, SOV-6 Technology Sovereignty 15%, SOV-7 Security & Compliance Sovereignty 15%, SOV-8 Environmental Sustainability 5%
 - All five SEAL definitions (SEAL-0 to SEAL-4) reproduced in full, not paraphrased
 - Sovereignty Score computed from the stated formula, and the per-objective Score / Max Score basis is stated rather than assumed
 - Award criterion and rejection gate kept distinct: the weighted Sovereignty Score does not excuse a failed minimum SEAL on any single objective

--- a/scripts/tests/test-csf-weights.mjs
+++ b/scripts/tests/test-csf-weights.mjs
@@ -1,0 +1,204 @@
+#!/usr/bin/env node
+/**
+ * SOV weight guard for the EU Cloud Sovereignty Framework (EUCSF) assessment.
+ *
+ * Ground truth, verified against the European Commission's primary sources —
+ * NOT re-derived here:
+ *   - Implementation guidance, p.7:
+ *     https://commission.europa.eu/document/download/2ad80a48-166f-4c77-a513-80c53ca2a128_en?filename=Cloud+Sovereignty+Framework+-+Implementation+guidance.pdf
+ *   - Annex calculator XLSX, cells D4/D45/D76/D102/D133/D169/D195/D231:
+ *     https://commission.europa.eu/document/download/3acb8fe8-8a4a-4339-ae74-f56138d913d1_en?filename=Annex+-+Sovereignty+assessment+calculator.xlsx
+ *
+ * arc-kit previously shipped SOV-1 15%, SOV-5 20%, SOV-7 10% — wrong, but a
+ * PERMUTATION of the correct eight values, so it still summed to 100%. Two
+ * independent "totals exactly 100%" checks (this guard's predecessor and
+ * `quality-checklist.md`'s EUCSF checklist item) both passed against the
+ * wrong data, because a permutation of a correct set is invariant to a sum
+ * check. This guard exists so that can never happen again: every SOV-N is
+ * asserted INDIVIDUALLY against its own known-correct weight, never only as
+ * a sum.
+ *
+ * It globs every file that carries an SOV weight table — the canonical
+ * sources AND their generated mirrors — because the defect this guards
+ * against is exactly the kind that survives a sync: a wrong canonical value
+ * propagates byte-for-byte into every mirror, and per-file parity checks
+ * (`sync-shared-assets.py --check`, `sync-claude-plugin-layout.py --check`,
+ * `check-guide-parity.py`) all pass since the mirrors match their (wrong)
+ * source exactly.
+ *
+ * A "weight occurrence" is recognised in two shapes:
+ *   - a markdown table row whose first cell starts with `SOV-<n>` and some
+ *     later cell is exactly `<NN>%` (covers the Executive Summary table, the
+ *     Objective Weights table, and the Scored Result table, which all place
+ *     the weight in a different column position)
+ *   - a subsection header of the form `SOV-<n> ... (Weight: <NN>%)`
+ *
+ * Both shapes require the percentage to be either the entire content of its
+ * own table cell or captured inside `(Weight: ...)` — so prose that merely
+ * mentions "SOV-1 to SOV-8" alongside an unrelated "100%" (e.g. "weights
+ * summing to 100%") is never mistaken for a per-objective weight.
+ *
+ * Exit 0 = every SOV-N weight occurrence found under the guarded roots
+ * matches the framework, and no file carrying a weight table is missing an
+ * objective. Exit 1 = mismatch.
+ */
+
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve, relative, join } from 'node:path';
+import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(__dirname, '..', '..');
+
+// The eight EUCSF objective weights, per the primary sources cited above.
+const CORRECT_WEIGHTS = {
+  'SOV-1': 20, // Strategic Sovereignty
+  'SOV-2': 10, // Legal & Jurisdictional Sovereignty
+  'SOV-3': 10, // Data & AI Sovereignty
+  'SOV-4': 15, // Operational Sovereignty
+  'SOV-5': 10, // Supply Chain Sovereignty
+  'SOV-6': 15, // Technology Sovereignty
+  'SOV-7': 15, // Security & Compliance Sovereignty
+  'SOV-8': 5, // Environmental Sustainability
+};
+const EXPECTED_KEYS = Object.keys(CORRECT_WEIGHTS);
+
+// Canonical sources AND every generated mirror that can carry a copy of the
+// weight table. Neither `sync-shared-assets.py` nor `sync-claude-plugin-
+// layout.py` nor `check-guide-parity.py --sync` can fix a WRONG value that
+// is correctly propagated from a wrong canonical source — only this guard,
+// run against every root, can.
+const ROOTS = [
+  'plugins/arckit-eu',
+  'plugins/arckit-claude/plugins/eu',
+  '.arckit/templates',
+  'docs/guides/eu-cloud-sovereignty.md',
+  'plugins/arckit-claude/docs/guides',
+];
+
+function collectMarkdownFiles(root) {
+  const abs = resolve(repoRoot, root);
+  if (!existsSync(abs)) return [];
+  const stat = statSync(abs);
+  if (stat.isFile()) return abs.endsWith('.md') ? [abs] : [];
+  const out = [];
+  const stack = [abs];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(p);
+      else if (entry.isFile() && entry.name.endsWith('.md')) out.push(p);
+    }
+  }
+  return out;
+}
+
+// Matches subsection headers like `### 4.1 SOV-1 Strategic Sovereignty
+// (Weight: 15%)`. The percentage must be inside the `(Weight: ...)` group,
+// not merely present anywhere on the line.
+const HEADER_RE = /SOV-(\d)\b.*\(Weight:\s*(\d{1,3})%\)/;
+
+// Splits a markdown table row into trimmed cells, dropping the empty
+// leading/trailing cells produced by the row's outer pipes. Returns null for
+// lines that are not table rows.
+function parseRowCells(line) {
+  const trimmed = line.trim();
+  if (!trimmed.startsWith('|')) return null;
+  let cells = trimmed.split('|').map((c) => c.trim());
+  if (cells[0] === '') cells = cells.slice(1);
+  if (cells.length > 0 && cells[cells.length - 1] === '') cells = cells.slice(0, -1);
+  return cells;
+}
+
+let ok = true;
+let filesChecked = 0;
+let occurrencesChecked = 0;
+
+const files = new Set();
+for (const root of ROOTS) {
+  for (const f of collectMarkdownFiles(root)) files.add(f);
+}
+
+for (const file of [...files].sort()) {
+  const rel = relative(repoRoot, file);
+  const text = readFileSync(file, 'utf8');
+  const lines = text.split('\n');
+  const occurrences = [];
+
+  lines.forEach((line, idx) => {
+    const headerMatch = line.match(HEADER_RE);
+    if (headerMatch) {
+      occurrences.push({
+        lineNo: idx + 1,
+        sov: `SOV-${headerMatch[1]}`,
+        weight: Number(headerMatch[2]),
+      });
+      return;
+    }
+
+    const cells = parseRowCells(line);
+    if (!cells || cells.length < 2) return;
+    const firstCell = cells[0].replace(/\*\*/g, '');
+    const sovMatch = firstCell.match(/^SOV-(\d)\b/);
+    if (!sovMatch) return;
+
+    // The weight is whichever later cell is EXACTLY `<digits>%` — this
+    // correctly skips placeholder cells like `[Score]` or `[Max]` that
+    // precede the weight column in the Scored Result table.
+    const pctCell = cells.slice(1).find((c) => /^\d{1,3}%$/.test(c));
+    if (!pctCell) return;
+
+    occurrences.push({
+      lineNo: idx + 1,
+      sov: `SOV-${sovMatch[1]}`,
+      weight: Number(pctCell.slice(0, -1)),
+    });
+  });
+
+  if (occurrences.length === 0) continue; // no SOV weight table in this file — nothing to check
+
+  filesChecked += 1;
+
+  for (const occ of occurrences) {
+    occurrencesChecked += 1;
+    const expected = CORRECT_WEIGHTS[occ.sov];
+    if (expected === undefined) {
+      ok = false;
+      console.error(`[FAIL] ${rel}:${occ.lineNo}: unrecognised objective ${occ.sov} (not one of SOV-1..SOV-8)`);
+      continue;
+    }
+    if (occ.weight !== expected) {
+      ok = false;
+      console.error(
+        `[FAIL] ${rel}:${occ.lineNo}: ${occ.sov} weight is ${occ.weight}%, the framework says ${expected}%`,
+      );
+    }
+  }
+
+  const foundKeys = new Set(occurrences.map((o) => o.sov));
+  const missing = EXPECTED_KEYS.filter((k) => !foundKeys.has(k));
+  if (missing.length > 0) {
+    ok = false;
+    console.error(
+      `[FAIL] ${rel}: carries an SOV weight table but is missing objective(s) ${missing.join(', ')}`,
+    );
+  }
+}
+
+if (filesChecked === 0) {
+  ok = false;
+  console.error(
+    '[FAIL] no file under the guarded roots carries an SOV weight table — the guard\'s roots are broken:',
+  );
+  for (const root of ROOTS) console.error('  -', root);
+}
+
+if (ok) {
+  console.log(
+    `[PASS] ${occurrencesChecked} SOV weight occurrence(s) across ${filesChecked} file(s) all match the ` +
+      'framework (SOV-1 20%, SOV-2 10%, SOV-3 10%, SOV-4 15%, SOV-5 10%, SOV-6 15%, SOV-7 15%, SOV-8 5%).',
+  );
+  process.exit(0);
+}
+process.exit(1);

--- a/scripts/tests/test-csf-weights.mjs
+++ b/scripts/tests/test-csf-weights.mjs
@@ -32,11 +32,27 @@
  *     Objective Weights table, and the Scored Result table, which all place
  *     the weight in a different column position)
  *   - a subsection header of the form `SOV-<n> ... (Weight: <NN>%)`
+ *   - a PROSE pair `SOV-<n> <objective name> <NN>%`, which is how
+ *     `references/quality-checklist.md` states the eight weights. That item
+ *     is the checklist's own defence against the permutation bug, and it was
+ *     itself unguarded: it is neither a table row nor a `(Weight: ...)`
+ *     header, and its 31 copies live outside the weight-table roots, so the
+ *     two shapes above could not see it. Reverting the checklist's SOV-1 and
+ *     SOV-5 values by hand still produced a green run.
  *
- * Both shapes require the percentage to be either the entire content of its
- * own table cell or captured inside `(Weight: ...)` — so prose that merely
+ * The first two shapes require the percentage to be either the entire
+ * content of its own table cell or captured inside `(Weight: ...)`. The
+ * prose shape instead requires a literal match on the objective's OWN name
+ * from `OBJECTIVES` below. All three therefore ignore prose that merely
  * mentions "SOV-1 to SOV-8" alongside an unrelated "100%" (e.g. "weights
- * summing to 100%") is never mistaken for a per-objective weight.
+ * summing to 100%", which appears in that same checklist line) — a loose
+ * `SOV-<n>...<NN>%` scan reads that as SOV-8 being 100%.
+ *
+ * Anchoring the prose shape on the name buys a second assertion for free:
+ * a code paired with the WRONG objective name is caught too. That is the
+ * same defect class as the weights themselves — the shipped weights were a
+ * permutation, and `SEAL-3` was shipped under a name ("Digital Resilience")
+ * that appears nowhere in the framework.
  *
  * Exit 0 = every SOV-N weight occurrence found under the guarded roots
  * matches the framework, and no file carrying a weight table is missing an
@@ -50,18 +66,24 @@ import { existsSync, readdirSync, readFileSync, statSync } from 'node:fs';
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(__dirname, '..', '..');
 
-// The eight EUCSF objective weights, per the primary sources cited above.
-const CORRECT_WEIGHTS = {
-  'SOV-1': 20, // Strategic Sovereignty
-  'SOV-2': 10, // Legal & Jurisdictional Sovereignty
-  'SOV-3': 10, // Data & AI Sovereignty
-  'SOV-4': 15, // Operational Sovereignty
-  'SOV-5': 10, // Supply Chain Sovereignty
-  'SOV-6': 15, // Technology Sovereignty
-  'SOV-7': 15, // Security & Compliance Sovereignty
-  'SOV-8': 5, // Environmental Sustainability
+// The eight EUCSF objectives — weight AND name — per the primary sources
+// cited above. The name is ground truth in its own right: it is what the
+// prose shape matches on, and a code paired with another objective's name is
+// the same permutation defect as a code paired with another's weight.
+const OBJECTIVES = {
+  'SOV-1': { weight: 20, name: 'Strategic Sovereignty' },
+  'SOV-2': { weight: 10, name: 'Legal & Jurisdictional Sovereignty' },
+  'SOV-3': { weight: 10, name: 'Data & AI Sovereignty' },
+  'SOV-4': { weight: 15, name: 'Operational Sovereignty' },
+  'SOV-5': { weight: 10, name: 'Supply Chain Sovereignty' },
+  'SOV-6': { weight: 15, name: 'Technology Sovereignty' },
+  'SOV-7': { weight: 15, name: 'Security & Compliance Sovereignty' },
+  'SOV-8': { weight: 5, name: 'Environmental Sustainability' },
 };
-const EXPECTED_KEYS = Object.keys(CORRECT_WEIGHTS);
+const EXPECTED_KEYS = Object.keys(OBJECTIVES);
+const CORRECT_WEIGHTS = Object.fromEntries(
+  Object.entries(OBJECTIVES).map(([k, v]) => [k, v.weight]),
+);
 
 // Canonical sources AND every generated mirror that can carry a copy of the
 // weight table. Neither `sync-shared-assets.py` nor `sync-claude-plugin-
@@ -75,6 +97,30 @@ const ROOTS = [
   'docs/guides/eu-cloud-sovereignty.md',
   'plugins/arckit-claude/docs/guides',
 ];
+
+// `references/quality-checklist.md` is a shared asset copied into EVERY
+// plugin, so its EUCSF weight list exists 31 times over, all but two of them
+// outside the roots above. Collected by basename rather than by listing the
+// copies, so a new plugin is covered the day it is added — the enumeration
+// drift this guard exists to catch should not be reintroduced in the guard.
+const CHECKLIST_ROOTS = ['plugins', '.arckit'];
+const CHECKLIST_BASENAME = 'quality-checklist.md';
+
+function collectByBasename(root, basename) {
+  const abs = resolve(repoRoot, root);
+  if (!existsSync(abs) || !statSync(abs).isDirectory()) return [];
+  const out = [];
+  const stack = [abs];
+  while (stack.length > 0) {
+    const dir = stack.pop();
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const p = join(dir, entry.name);
+      if (entry.isDirectory()) stack.push(p);
+      else if (entry.isFile() && entry.name === basename) out.push(p);
+    }
+  }
+  return out;
+}
 
 function collectMarkdownFiles(root) {
   const abs = resolve(repoRoot, root);
@@ -99,6 +145,16 @@ function collectMarkdownFiles(root) {
 // not merely present anywhere on the line.
 const HEADER_RE = /SOV-(\d)\b.*\(Weight:\s*(\d{1,3})%\)/;
 
+// Matches the checklist's prose pairs, e.g. `SOV-1 Strategic Sovereignty
+// 20%`. Built from OBJECTIVES so the alternation cannot drift from the
+// ground truth, and deliberately anchored on the NAME: a bare
+// `SOV-(\d)[^,]*?(\d{1,3})%` scan matches "SOV-1 to SOV-8 ... 100%" in the
+// same checklist line and reports SOV-8 as 100%.
+const NAME_ALTERNATION = Object.values(OBJECTIVES)
+  .map((o) => o.name.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'))
+  .join('|');
+const PROSE_RE = new RegExp(`SOV-(\\d)\\s+(${NAME_ALTERNATION})\\s+(\\d{1,3})%`, 'g');
+
 // Splits a markdown table row into trimmed cells, dropping the empty
 // leading/trailing cells produced by the row's outer pipes. Returns null for
 // lines that are not table rows.
@@ -119,6 +175,13 @@ const files = new Set();
 for (const root of ROOTS) {
   for (const f of collectMarkdownFiles(root)) files.add(f);
 }
+let checklistsFound = 0;
+for (const root of CHECKLIST_ROOTS) {
+  for (const f of collectByBasename(root, CHECKLIST_BASENAME)) {
+    files.add(f);
+    checklistsFound += 1;
+  }
+}
 
 for (const file of [...files].sort()) {
   const rel = relative(repoRoot, file);
@@ -127,6 +190,23 @@ for (const file of [...files].sort()) {
   const occurrences = [];
 
   lines.forEach((line, idx) => {
+    // Prose pairs are scanned first and are cumulative: one line carries all
+    // eight, so this cannot `return` after the first hit the way the two
+    // single-occurrence-per-line table shapes do.
+    PROSE_RE.lastIndex = 0;
+    let proseMatch;
+    let sawProse = false;
+    while ((proseMatch = PROSE_RE.exec(line)) !== null) {
+      sawProse = true;
+      occurrences.push({
+        lineNo: idx + 1,
+        sov: `SOV-${proseMatch[1]}`,
+        weight: Number(proseMatch[3]),
+        name: proseMatch[2],
+      });
+    }
+    if (sawProse) return;
+
     const headerMatch = line.match(HEADER_RE);
     if (headerMatch) {
       occurrences.push({
@@ -174,6 +254,15 @@ for (const file of [...files].sort()) {
         `[FAIL] ${rel}:${occ.lineNo}: ${occ.sov} weight is ${occ.weight}%, the framework says ${expected}%`,
       );
     }
+    // Only the prose shape carries a name to check. A wrong pairing here is
+    // the permutation defect wearing its other face.
+    if (occ.name !== undefined && occ.name !== OBJECTIVES[occ.sov].name) {
+      ok = false;
+      console.error(
+        `[FAIL] ${rel}:${occ.lineNo}: ${occ.sov} is named "${occ.name}", the framework says ` +
+          `"${OBJECTIVES[occ.sov].name}"`,
+      );
+    }
   }
 
   const foundKeys = new Set(occurrences.map((o) => o.sov));
@@ -194,10 +283,23 @@ if (filesChecked === 0) {
   for (const root of ROOTS) console.error('  -', root);
 }
 
+// The same self-defence for the checklist half. If the shared asset is ever
+// moved or renamed, the prose list must fail loudly rather than fall out of
+// coverage the silent way it was in until now.
+if (checklistsFound === 0) {
+  ok = false;
+  console.error(
+    `[FAIL] no ${CHECKLIST_BASENAME} found under ${CHECKLIST_ROOTS.join(', ')} — the guard\'s ` +
+      'checklist roots are broken',
+  );
+}
+
 if (ok) {
   console.log(
-    `[PASS] ${occurrencesChecked} SOV weight occurrence(s) across ${filesChecked} file(s) all match the ` +
-      'framework (SOV-1 20%, SOV-2 10%, SOV-3 10%, SOV-4 15%, SOV-5 10%, SOV-6 15%, SOV-7 15%, SOV-8 5%).',
+    `[PASS] ${occurrencesChecked} SOV weight occurrence(s) across ${filesChecked} file(s) ` +
+      `(including ${checklistsFound} ${CHECKLIST_BASENAME} copies) all match the framework ` +
+      '(SOV-1 20%, SOV-2 10%, SOV-3 10%, SOV-4 15%, SOV-5 10%, SOV-6 15%, SOV-7 15%, SOV-8 5%), ' +
+      'and every prose pair names its own objective.',
   );
   process.exit(0);
 }


### PR DESCRIPTION
Three of the eight Sovereignty Objective weights, and the name of SEAL-3, contradict the framework this command implements. Both shipped in #740 — mine to fix.

Sources: [Implementation guidance](https://commission.europa.eu/document/download/2ad80a48-166f-4c77-a513-80c53ca2a128_en?filename=Cloud+Sovereignty+Framework+-+Implementation+guidance.pdf) p.7 and the [Annex — Sovereignty assessment calculator](https://commission.europa.eu/document/download/3acb8fe8-8a4a-4339-ae74-f56138d913d1_en?filename=Annex+-+Sovereignty+assessment+calculator.xlsx) cells `D4`–`D231`. Both agree.

## The weights

| Objective | Shipped | Framework | |
|---|---|---|---|
| SOV-1 Strategic | 15% | **20%** | ✗ |
| SOV-2 Legal & Jurisdictional | 10% | 10% | ✓ |
| SOV-3 Data & AI | 10% | 10% | ✓ |
| SOV-4 Operational | 15% | 15% | ✓ |
| SOV-5 Supply Chain | 20% | **10%** | ✗ |
| SOV-6 Technology | 15% | 15% | ✓ |
| SOV-7 Security & Compliance | 10% | **15%** | ✗ |
| SOV-8 Environmental | 5% | 5% | ✓ |

## Why it survived two independent verifications

**The defect is a permutation.** The wrong set also sums to 100.

My PR body on #740 said "weights verified programmatically to sum to 100". You independently confirmed "15 + 10 + 10 + 15 + 20 + 15 + 10 + 5 = 100". Both statements were true. Both were invariant to the error.

So the guard added here asserts each weight **individually**, across canonical files *and* generated mirrors — and it was run on unfixed `main` **before** the correction:

```
[FAIL] plugins/arckit-eu/commands/eu-cloud-sovereignty.md:198: SOV-1 weight is 15%, the framework says 20%
[FAIL] plugins/arckit-eu/commands/eu-cloud-sovereignty.md:202: SOV-5 weight is 20%, the framework says 10%
[FAIL] plugins/arckit-eu/commands/eu-cloud-sovereignty.md:204: SOV-7 weight is 10%, the framework says 15%
… 48 [FAIL] lines across 7 files, all naming exactly those three objectives
```

A guard written after the fix has never been observed to fail. The existing sum-to-100 assertion stays, but demoted — it passed throughout the defect's life.

`scripts/tests/test-csf-weights.mjs` is wired into `lint-markdown.yml` with its own `run:` step, beside the three existing mjs guards. A guard with only a path filter never executes.

## SEAL-3 is "Technological Sovereignty"

Guidance p.2–3, and again in the p.10 table. We shipped **"Digital Resilience"** — inside the block instructing *"do not paraphrase or abbreviate"*. SEAL-0, SEAL-2 and SEAL-4 wording had also drifted (`governed entirely in` → `by`; `EU law applicable and enforceable` → `EU jurisdictions apply`; `subject only to EU law` → `EU jurisdiction`). All five rows now match p.2–3 verbatim, in both the command's definition block and the template's own SEAL table — correcting only the command would have left the two disagreeing about the name of the level being assessed, which is worse than being uniformly wrong.

p.2–3 is treated as normative for the definition block; p.10 gives a second, non-identical rendering and is the per-objective requirements view.

## Two things the correction dragged with it

**The template carries the weights in 12 places, not 2.** Three tables (Executive Summary, Objective Weights, Scored Result) plus eight inline `(Weight: NN%)` subsection headers. Fixing a subset would have left the document contradicting itself.

**A derived claim in the guide went stale.** It read *"Supply chain carries the heaviest weight, and technology, strategic and operational sovereignty together carry 45%"* — both halves false once corrected: Strategic Sovereignty is heaviest at 20%, and the three-objective sum is 50%. Corrected in your voice rather than left to contradict the table above it. That sentence traces back to my framing in #740, built on the wrong number.

## Verification

```
test-csf-weights.mjs               PASS (128 occurrences, 7 files)
Full Python suite                  1512 passed, 225 skipped
12 check scripts                   all pass
4 mjs guards                       all pass
sync-shared-assets --check         clean
sync-claude-plugin-layout --check  clean
converter.py                       zero drift
markdownlint-cli2                  0 issues, 3764 files
```

`check-guide-parity.py --sync` was needed after editing `docs/guides/` — the converter copies plugin→extensions, not root→plugin, so the mirror drifts otherwise.

## Merge order

Companion to the overall-SEAL and scoring PRs. All three touch the command, template, checklist and CHANGELOG. This one should land **first** — its weight values are load-bearing for the scoring PR's data file.
