### PR TITLE
feat(ci): guard per-type quality checks against the artefact's own regime ladder (#790)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -22,6 +22,7 @@ on:
       - "scripts/check-llms-txt.py"
       - "docs/llms.txt"
       - "scripts/check-quality-checklist-refs.py"
+      - "scripts/check-quality-checklist-ladders.py"
       - "scripts/check-doc-control-resolution.py"
       - "scripts/check-common-parity.py"
       - "scripts/check-create-project-invocations.py"
@@ -62,6 +63,7 @@ on:
       - "scripts/check-llms-txt.py"
       - "docs/llms.txt"
       - "scripts/check-quality-checklist-refs.py"
+      - "scripts/check-quality-checklist-ladders.py"
       - "scripts/check-doc-control-resolution.py"
       - "scripts/check-common-parity.py"
       - "scripts/check-create-project-invocations.py"
@@ -129,6 +131,9 @@ jobs:
 
       - name: Quality-checklist references resolve (closes #749)
         run: python3 scripts/check-quality-checklist-refs.py
+
+      - name: Quality-checklist checks match the artefact's own regime ladder (#790)
+        run: python3 scripts/check-quality-checklist-ladders.py
 
       - name: DOC-CONTROL-HEADER markers have a command that resolves them (#760)
         run: python3 scripts/check-doc-control-resolution.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A guard that per-type quality-checklist checks match the artefact's own regime ladder** (#790, follow-up to #787). `scripts/check-quality-checklist-ladders.py` asserts that a section for a doc-type whose regime hard-routes — AT, AU, CA, FR, NL, UAE — never demands a classification from a different regime's ladder. That state is invisible at runtime: the artefact renders `Diffusion Restreinte` from `document-control-fr.md`, the check demands `OFFICIAL-SENSITIVE`, and a correctly classified artefact fails the check its own command gates on. Seven sections were in it until #788, every one from copying a UK section when adding an overlay type.
+
+  Derived end to end from `config/doc-types.mjs` (`DOC_TYPES`, `REGIME_PARTIALS`, `UK_FALLBACK_BY_DESIGN`) and each partial's own `**Classification**` row, so a new regime extends the guard with no edit here. Enumerating the schemes by hand is the defect #788 fixed *in the checklist itself*, where a list of three had drifted from a registry of six, and a test asserts no ladder value is hardcoded in the guard.
+
+  Anchored on the two assertion phrasings actually in use rather than scanning for ladder tokens. A bare token scan cannot work: `OFFICIAL` and `SECRET` sit on three ladders at once, and `Open`, `Shared`, `Secret` and `Confidential` are ordinary English — the #787 detection pass false-positived on FITAA's *"Open Items"*. The four fall-through regimes (UK, MOD, EU, US) are deliberately not policed, because they resolve through user config and can legitimately render a UAE or AT ladder.
+
+  Resolution is per plugin, matching `check-quality-checklist-refs.py`: `${CLAUDE_PLUGIN_ROOT}` has no cross-plugin fallback, so each overlay is checked against its own checklist and its own partials. Run against the tree as it stood before #788 it reports all seven, in each of the 16 copies; `tests/plugin/test_quality_checklist_ladders.py` reproduces that failure against the real registry, because a guard that cannot demonstrate a failure reads as coverage.
+
 - **Two new `arckit-uk-gcloud` templates**: `gcloud-competitors-template.md` (`GCMP`) and `review-template.md` (`GCRV`), both with the marker, Revision History and External References. `arckit-uk-gcloud` is not in `PLUGIN_SOURCES`, so neither mirrors into `.arckit/templates/`.
 
 - **A fourth check in `scripts/check-doc-control-resolution.py`**: a command declaring a `doc-type:` must reference a template file. The first three checks walk *templates* and ask who reads them, so a command with no template was invisible to them — which is why `GCMP` and `GCRV` needed a separate sweep rather than surfacing in the #760 pass. `doc-type: none` commands are out of scope. Both exemption lists (`NO_READER_KNOWN`, `NO_TEMPLATE_KNOWN`) are now empty, and a test asserts they stay that way.

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A guard that per-type quality-checklist checks match the artefact's own regime ladder** (#790, follow-up to #787). `scripts/check-quality-checklist-ladders.py` asserts that a section for a doc-type whose regime hard-routes — AT, AU, CA, FR, NL, UAE — never demands a classification from a different regime's ladder. That state is invisible at runtime: the artefact renders `Diffusion Restreinte` from `document-control-fr.md`, the check demands `OFFICIAL-SENSITIVE`, and a correctly classified artefact fails the check its own command gates on. Seven sections were in it until #788, every one from copying a UK section when adding an overlay type.
+
+  Derived end to end from `config/doc-types.mjs` (`DOC_TYPES`, `REGIME_PARTIALS`, `UK_FALLBACK_BY_DESIGN`) and each partial's own `**Classification**` row, so a new regime extends the guard with no edit here. Enumerating the schemes by hand is the defect #788 fixed *in the checklist itself*, where a list of three had drifted from a registry of six, and a test asserts no ladder value is hardcoded in the guard.
+
+  Anchored on the two assertion phrasings actually in use rather than scanning for ladder tokens. A bare token scan cannot work: `OFFICIAL` and `SECRET` sit on three ladders at once, and `Open`, `Shared`, `Secret` and `Confidential` are ordinary English — the #787 detection pass false-positived on FITAA's *"Open Items"*. The four fall-through regimes (UK, MOD, EU, US) are deliberately not policed, because they resolve through user config and can legitimately render a UAE or AT ladder.
+
+  Resolution is per plugin, matching `check-quality-checklist-refs.py`: `${CLAUDE_PLUGIN_ROOT}` has no cross-plugin fallback, so each overlay is checked against its own checklist and its own partials. Run against the tree as it stood before #788 it reports all seven, in each of the 16 copies; `tests/plugin/test_quality_checklist_ladders.py` reproduces that failure against the real registry, because a guard that cannot demonstrate a failure reads as coverage.
+
 - **Two new `arckit-uk-gcloud` templates**: `gcloud-competitors-template.md` (`GCMP`) and `review-template.md` (`GCRV`), both with the marker, Revision History and External References. `arckit-uk-gcloud` is not in `PLUGIN_SOURCES`, so neither mirrors into `.arckit/templates/`.
 
 - **A fourth check in `scripts/check-doc-control-resolution.py`**: a command declaring a `doc-type:` must reference a template file. The first three checks walk *templates* and ask who reads them, so a command with no template was invisible to them — which is why `GCMP` and `GCRV` needed a separate sweep rather than surfacing in the #760 pass. `doc-type: none` commands are out of scope. Both exemption lists (`NO_READER_KNOWN`, `NO_TEMPLATE_KNOWN`) are now empty, and a test asserts they stay that way.

--- a/scripts/check-quality-checklist-ladders.py
+++ b/scripts/check-quality-checklist-ladders.py
@@ -1,0 +1,322 @@
+#!/usr/bin/env python3
+"""Assert no per-type quality-checklist section asserts a foreign regime's ladder.
+
+`references/quality-checklist.md` is what a command reads to verify the artefact
+it just wrote. Since #744 routed the Document Control classification ladder by
+regime, a per-type section can assert a classification the artefact never
+renders: `document-control-fr.md` puts `Diffusion Restreinte` in the header while
+the checklist demanded `OFFICIAL-SENSITIVE`, so the artefact was correct and
+failed its own check. Seven sections were in that state (six FR plus `ATDSG`)
+until PR #788 fixed them, and every one arose the same way, by copying a UK
+section when adding an overlay type. Nothing guarded it; this does (#790).
+
+The check is derived end to end, not hand-maintained:
+
+  * code -> regime            `config/doc-types.mjs`, `DOC_TYPES`
+  * regime -> partial         `config/doc-types.mjs`, `REGIME_PARTIALS`
+  * does the regime route?    `config/doc-types.mjs`, `UK_FALLBACK_BY_DESIGN`
+  * partial -> ladder         the partial's own `**Classification**` row
+
+Adding a regime therefore extends this guard automatically. Enumerating the
+schemes by hand is the defect #788 fixed in the checklist itself, where a list of
+three had drifted from a registry of six, so it is not repeated here.
+
+Resolution is PER PLUGIN. `${CLAUDE_PLUGIN_ROOT}` resolves to each plugin's own
+root with no cross-plugin fallback, so a command in `arckit-fr` reads that
+plugin's checklist against that plugin's partials. Both are synced copies and
+`sync-shared-assets.py --check` holds them byte-identical, but this guard does
+not assume it has run. The doc-type registry is read from core, because core is
+the only plugin that ships `config/` at all — see `_partials/RENDERING.md`.
+
+Only the six hard-routing regimes are policed (AT, AU, CA, FR, NL, UAE). A
+fall-through regime (UK, MOD, EU, US) resolves through user config and can
+legitimately render a UAE or AT ladder for a UAE- or AT-configured operator, so
+asserting a UK value there is not drift.
+
+Deliberately NOT checked:
+
+  * Anything outside an anchored Document Control assertion. A bare scan for
+    ladder tokens cannot work: `OFFICIAL` and `SECRET` sit on three ladders at
+    once, and `Open`, `Shared`, `Secret` and `Confidential` are ordinary English
+    -- the detection pass for #787 false-positived on FITAA's "Open Items". The
+    anchors below are the phrasings actually in use.
+  * The parenthetical after an assertion. `classified Eingeschränkt (or
+    Vertraulich where ...)` is free prose, and policing tokens inside it
+    reintroduces exactly the noise the anchors exist to avoid. The primary
+    asserted value is checked; the escalation note is not.
+  * Case and accents. `DIFFUSION RESTREINTE` is how a DR document is marked in
+    French practice and is not a foreign-ladder defect.
+  * `plugins/arckit-claude/plugins/**`, the generated publish-layout mirror.
+    Drift there is a sync failure and `tests/plugin/test_release_process.py`
+    already catches it.
+
+Exit 0 when clean, 1 otherwise.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+import unicodedata
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+PLUGINS_DIR = ROOT / "plugins"
+CORE = PLUGINS_DIR / "arckit-claude"
+
+# Generated publish-layout mirror -- see module docstring.
+MIRROR_DIR = PLUGINS_DIR / "arckit-claude/plugins"
+
+MJS_REL = Path("config/doc-types.mjs")
+CHECKLIST_REL = Path("references/quality-checklist.md")
+PARTIALS_REL = Path("templates/_partials")
+
+SECTION_RE = re.compile(r"^### ([A-Z0-9][A-Z0-9-]*)\s", re.M)
+
+# The two Document Control assertion phrasings in the tree. Anchored on the
+# bullet and on "Document ... classified" / "Classification:" so that ordinary
+# uses of the word ("Change classified as EVOLUTIONARY", "Every provider
+# classified as designated CTP") are not read as classification assertions.
+ASSERT_RE = re.compile(
+    r"^\s*[-*]\s+(?:Document(?:\s+itself)?\s+classified|Classification:)\s+(.+?)\s*$"
+)
+
+# `| **Classification** | [PUBLIC / OFFICIAL / ...] |` in a Document Control partial.
+LADDER_RE = re.compile(r"^\|\s*\*\*Classification\*\*\s*\|\s*\[(.+?)\]\s*\|", re.M)
+
+
+def norm(value: str) -> str:
+    """Casefold, strip accents, collapse whitespace -- see docstring."""
+    decomposed = unicodedata.normalize("NFKD", value)
+    stripped = "".join(c for c in decomposed if not unicodedata.combining(c))
+    return re.sub(r"\s+", " ", stripped).strip().casefold()
+
+
+def block(text: str, export_name: str, open_char: str, close_char: str) -> str:
+    """Balanced-delimiter slice of `export const NAME = ...` from doc-types.mjs.
+
+    Regex rather than a node subprocess: this must run in CI without assuming a
+    node toolchain, matching check-doc-type-registry.py.
+    """
+    start = text.index(f"export const {export_name} = ")
+    depth = 0
+    for i in range(start, len(text)):
+        if text[i] == open_char:
+            depth += 1
+        elif text[i] == close_char:
+            depth -= 1
+            if depth == 0:
+                return text[start : i + 1]
+    raise ValueError(f"unterminated {export_name} block in {MJS_REL}")
+
+
+def load_registry(mjs: Path) -> tuple[dict[str, str], dict[str, str], set[str]]:
+    """(code -> regime, regime -> partial filename, fall-through regimes)."""
+    text = mjs.read_text(encoding="utf-8")
+
+    regime_of: dict[str, str] = {}
+    for m in re.finditer(
+        r"^\s*'([A-Z0-9-]+)':\s*\{(.*)$", block(text, "DOC_TYPES", "{", "}"), re.M
+    ):
+        found = re.search(r"regime:\s*'([A-Z]+)'", m.group(2))
+        if found:
+            regime_of[m.group(1)] = found.group(1)
+
+    partial_of = dict(
+        re.findall(
+            r"^\s*([A-Z]+):\s*'([^']+)'", block(text, "REGIME_PARTIALS", "{", "}"), re.M
+        )
+    )
+
+    fallthrough = set(
+        re.findall(
+            r"'([A-Z]+)'", block(text, "UK_FALLBACK_BY_DESIGN", "(", ")")
+        )
+    )
+
+    return regime_of, partial_of, fallthrough
+
+
+def ladder_for(plugin: Path, partial_name: str) -> list[str] | None:
+    """Classification values from a plugin's own partial, falling back to core."""
+    for base in (plugin, CORE):
+        path = base / PARTIALS_REL / partial_name
+        if path.is_file():
+            found = LADDER_RE.search(path.read_text(encoding="utf-8"))
+            if found:
+                return [v.strip() for v in found.group(1).split("/") if v.strip()]
+    return None
+
+
+def primary_regime(partial_name: str) -> str:
+    """`document-control-uk.md` -> `UK`.
+
+    Four regimes share the UK partial, so naming them all in a failure message
+    buries the point. The filename convention is the one
+    scripts/tests/test-regime-registration.mjs already enforces.
+    """
+    return Path(partial_name).stem.replace("document-control-", "").upper()
+
+
+def asserted_values(line: str) -> list[str]:
+    """Primary classification value(s) on an assertion line.
+
+    Drops a trailing parenthetical or dash-led aside and the `minimum`
+    qualifier, then splits an `X or Y` pair. The dash must be whitespace
+    delimited: a bare `-` would cut `OFFICIAL-SENSITIVE` down to `OFFICIAL`,
+    which reports the wrong value and, worse, one that IS on another ladder.
+    See the module docstring for why the aside itself is not policed.
+    """
+    raw = ASSERT_RE.match(line)
+    if not raw:
+        return []
+    value = re.sub(r"\s*\(.*$", "", raw.group(1))
+    value = re.sub(r"\s+[—–-]\s+.*$", "", value)
+    out = []
+    for part in re.split(r"\s+or\s+|\s*/\s*", value):
+        part = re.sub(r"\s+minimum\b.*$", "", part).strip().rstrip(".,;:")
+        if part:
+            out.append(part)
+    return out
+
+
+def plugin_dirs() -> list[Path]:
+    return sorted(
+        p for p in PLUGINS_DIR.iterdir() if p.is_dir() and (p / ".claude-plugin").is_dir()
+    )
+
+
+def check_plugin(
+    plugin: Path,
+    regime_of: dict[str, str],
+    partial_of: dict[str, str],
+    routing: set[str],
+) -> tuple[list[tuple[Path, int, str, str, str, list[str]]], int]:
+    """(failures, assertions seen) for one plugin's checklist copy."""
+    checklist = plugin / CHECKLIST_REL
+    if not checklist.is_file():
+        return [], 0
+
+    # Every partial, not just the hard-routing ones. A UK value in an FR section
+    # is the defect's signature, and saying so names the cause (a copied UK
+    # section) instead of reporting the value as unrecognised.
+    ladders: dict[str, set[str]] = {}
+    for partial_name in sorted(set(partial_of.values())):
+        values = ladder_for(plugin, partial_name)
+        if values is None:
+            raise SystemExit(
+                f"ERROR: {plugin.name} has no readable {partial_name} "
+                f"and core carries none either"
+            )
+        ladders[partial_name] = {norm(v) for v in values}
+
+    rel = checklist.relative_to(ROOT)
+    failures = []
+    seen = 0
+    code = None
+
+    for lineno, line in enumerate(checklist.read_text(encoding="utf-8").splitlines(), 1):
+        heading = SECTION_RE.match(line)
+        if heading:
+            code = heading.group(1)
+            continue
+        values = asserted_values(line)
+        if not values or code is None:
+            continue
+        seen += 1
+        regime = regime_of.get(code)
+        if regime is None or regime not in routing:
+            continue
+        allowed = ladders[partial_of[regime]]
+        for value in values:
+            if norm(value) in allowed:
+                continue
+            elsewhere = sorted(
+                primary_regime(name) for name, vals in ladders.items() if norm(value) in vals
+            )
+            failures.append((rel, lineno, code, regime, value, elsewhere))
+
+    return failures, seen
+
+
+def main() -> int:
+    mjs = CORE / MJS_REL
+    if not mjs.is_file():
+        print(f"ERROR: {mjs.relative_to(ROOT)} not found", file=sys.stderr)
+        return 1
+
+    regime_of, partial_of, fallthrough = load_registry(mjs)
+    routing = {r for r in partial_of if r not in fallthrough}
+    if not routing:
+        print(
+            "ERROR: no hard-routing regimes parsed from config/doc-types.mjs — "
+            "REGIME_PARTIALS or UK_FALLBACK_BY_DESIGN has been reshaped and the "
+            "parser no longer matches it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    failures: list[tuple[Path, int, str, str, str, list[str]]] = []
+    total = 0
+    checklists = 0
+
+    for plugin in plugin_dirs():
+        if plugin == MIRROR_DIR or MIRROR_DIR in plugin.parents:
+            continue
+        found, seen = check_plugin(plugin, regime_of, partial_of, routing)
+        if (plugin / CHECKLIST_REL).is_file():
+            checklists += 1
+        failures.extend(found)
+        total += seen
+
+    if total == 0:
+        print(
+            "ERROR: no Document Control classification assertions found in any "
+            "quality-checklist.md — the phrasing has probably changed and "
+            "ASSERT_RE no longer matches it.",
+            file=sys.stderr,
+        )
+        return 1
+
+    if failures:
+        print(
+            f"FAIL {len(failures)} per-type check(s) asserting a classification the "
+            f"artefact will never render:",
+            file=sys.stderr,
+        )
+        for rel, lineno, code, regime, value, elsewhere in failures:
+            where = (
+                f"on the {'/'.join(elsewhere)} ladder"
+                if elsewhere
+                else "on no registered ladder"
+            )
+            print(
+                f"  {rel}:{lineno}  ### {code} ({regime}) asserts "
+                f"{value!r} — {where}, not {regime}'s",
+                file=sys.stderr,
+            )
+        example = sorted(routing)[0]
+        print(
+            "\n  The regime hard-routes, so the Document Control header renders the\n"
+            "  regime's own ladder whoever runs the command. A check demanding another\n"
+            "  ladder fails a correct artefact. Ladders are listed per regime in\n"
+            f"  plugins/arckit-claude/templates/_partials/RENDERING.md (e.g. {example}).\n"
+            "  Fix plugins/arckit-claude/references/quality-checklist.md (the canonical\n"
+            "  copy), then run: python3 scripts/sync-shared-assets.py\n"
+            "                and python3 scripts/sync-claude-plugin-layout.py\n"
+            "  Check the command's own inline checklist too — it usually carries the\n"
+            "  same assertion, and fixing only the shared file leaves them contradicting.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"Quality-checklist ladder check OK: {total} classification assertion(s) "
+        f"across {checklists} plugin checklist(s), all on their own regime's ladder "
+        f"({len(routing)} hard-routing regimes: {', '.join(sorted(routing))})."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/plugin/test_quality_checklist_ladders.py
+++ b/tests/plugin/test_quality_checklist_ladders.py
@@ -1,0 +1,239 @@
+"""Tests for scripts/check-quality-checklist-ladders.py.
+
+The guard exists because a per-type check can demand a classification the
+artefact never renders. Since #744 hard-routed the Document Control ladder by
+regime, an FR artefact renders `Diffusion Restreinte` from
+`document-control-fr.md` while the checklist still demanded `OFFICIAL-SENSITIVE`
+— so a correctly classified artefact failed the check its own command gates on.
+Seven sections were in that state until PR #788 (issue #787), and every one
+arose by copying a UK section when adding an overlay type.
+
+The negative tests are the ones that matter. #790 asked for proof the guard can
+fail, because a guard that cannot demonstrate a failure reads as coverage. The
+`test_reproduces_the_*` cases below are that proof, and they use the real
+registry and the real partials rather than a hardcoded ladder, so they cannot
+drift from what the artefact actually renders.
+"""
+
+import importlib.util
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+GUARD = REPO_ROOT / "scripts/check-quality-checklist-ladders.py"
+CORE_CHECKLIST = REPO_ROOT / "plugins/arckit-claude/references/quality-checklist.md"
+
+# The seven sections PR #788 fixed, with the value each must now assert. Six FR
+# plus ATDSG; the values are the ones #752 settled for the command bodies.
+PR788_SECTIONS = {
+    "IRN": "Diffusion Restreinte",
+    "EBIOS": "Diffusion Restreinte",
+    "ANSSI": "Diffusion Restreinte",
+    "CARTO": "Diffusion Restreinte",
+    "ALGO": "Non protégé",
+    "PSSI": "Diffusion Restreinte",
+    "ATDSG": "Eingeschränkt",
+}
+
+
+def load_guard():
+    spec = importlib.util.spec_from_file_location("check_quality_checklist_ladders", GUARD)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def make_plugin(root: Path, name: str, sections: dict[str, list[str]]) -> Path:
+    """Minimal plugin carrying only a checklist.
+
+    No `templates/_partials`, so `ladder_for` falls back to the real core copy
+    and the test runs against the ladders the artefact actually renders.
+    """
+    plugin = root / name
+    (plugin / ".claude-plugin").mkdir(parents=True)
+    (plugin / ".claude-plugin/plugin.json").write_text(json.dumps({"name": name}))
+    (plugin / "references").mkdir()
+    body = "# Quality Checklist\n\n## Per-Type Checks\n\n"
+    for code, lines in sections.items():
+        body += f"### {code} -- Thing\n\n"
+        body += "".join(f"- {line}\n" for line in lines)
+        body += "\n"
+    (plugin / "references/quality-checklist.md").write_text(body, encoding="utf-8")
+    return plugin
+
+
+def run_against(module, plugins_dir: Path) -> int:
+    """Point the guard at a synthetic tree, keeping the real core registry."""
+    module.PLUGINS_DIR = plugins_dir
+    module.ROOT = plugins_dir.parent
+    module.MIRROR_DIR = plugins_dir / "__no_mirror__"
+    return module.main()
+
+
+def section_body(checklist: str, code: str) -> str:
+    guard = load_guard()
+    lines = checklist.splitlines()
+    out, capturing = [], False
+    for line in lines:
+        heading = guard.SECTION_RE.match(line)
+        if heading:
+            capturing = heading.group(1) == code
+            continue
+        if capturing:
+            out.append(line)
+    return "\n".join(out)
+
+
+def test_guard_exists():
+    assert GUARD.is_file(), "quality-checklist ladder guard missing"
+
+
+def test_guard_passes_on_current_tree():
+    result = subprocess.run(
+        ["python3", str(GUARD)], capture_output=True, text=True, cwd=REPO_ROOT
+    )
+    assert result.returncode == 0, f"guard failed:\n{result.stdout}\n{result.stderr}"
+
+
+def test_guard_is_wired_into_ci():
+    workflow = (REPO_ROOT / ".github/workflows/lint-markdown.yml").read_text()
+    assert "check-quality-checklist-ladders.py" in workflow, "guard not run in CI"
+
+
+# --- the #787 defect, reproduced ------------------------------------------------
+
+
+@pytest.mark.parametrize("code,uk_value", [("IRN", "OFFICIAL-SENSITIVE"), ("ALGO", "PUBLIC")])
+def test_reproduces_the_787_defect(tmp_path, capsys, code, uk_value):
+    # Exactly the pre-#788 wording: an FR section asserting a UK ladder value.
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", {code: [f"Document classified {uk_value}"]})
+    assert run_against(load_guard(), plugins) == 1
+    err = capsys.readouterr().err
+    assert uk_value in err and "on the UK ladder, not FR's" in err
+
+
+def test_reproduces_the_atdsg_defect(tmp_path, capsys):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", {"ATDSG": ["Document classified OFFICIAL-SENSITIVE"]})
+    assert run_against(load_guard(), plugins) == 1
+    assert "on the UK ladder, not AT's" in capsys.readouterr().err
+
+
+def test_passes_when_the_value_is_on_the_own_ladder(tmp_path):
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(
+        plugins,
+        "arckit-fake",
+        {
+            "IRN": ["Document classified Diffusion Restreinte minimum"],
+            "ATDSG": ["Document classified Eingeschränkt (or Vertraulich where it applies)"],
+            "DR": ["Document itself classified DIFFUSION RESTREINTE"],
+        },
+    )
+    assert run_against(load_guard(), plugins) == 0
+
+
+def test_fallthrough_regime_may_assert_a_uk_value(tmp_path):
+    # UK, MOD, EU and US resolve through user config, so a UAE-configured
+    # operator can legitimately render a UAE ladder for them. Policing those
+    # would fail correct content — only the six hard-routing regimes are checked.
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", {"TCOP": ["Document classified OFFICIAL-SENSITIVE"]})
+    assert run_against(load_guard(), plugins) == 0
+
+
+def test_fails_if_phrasing_stops_matching(tmp_path, capsys):
+    # If the assertion wording is reworded tree-wide, ASSERT_RE silently matches
+    # nothing and every section "passes". Guard must refuse to pass empty.
+    plugins = tmp_path / "plugins"
+    plugins.mkdir()
+    make_plugin(plugins, "arckit-fake", {"IRN": ["Some check with no classification"]})
+    assert run_against(load_guard(), plugins) == 1
+    assert "no Document Control classification assertions found" in capsys.readouterr().err
+
+
+# --- parsing --------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "line,expected",
+    [
+        ("- Document classified Diffusion Restreinte minimum", ["Diffusion Restreinte"]),
+        ("- Document itself classified DIFFUSION RESTREINTE", ["DIFFUSION RESTREINTE"]),
+        ("- Document classified Non protégé (notice must be public)", ["Non protégé"]),
+        ("- Classification: Offen", ["Offen"]),
+        # The hyphen bug: a bare `-` strip cut this to OFFICIAL, which is itself
+        # a real ladder value, so the guard reported the wrong token as foreign.
+        ("- Document classified OFFICIAL-SENSITIVE", ["OFFICIAL-SENSITIVE"]),
+        ("- Document classified Eingeschränkt or Vertraulich", ["Eingeschränkt", "Vertraulich"]),
+        # Not classification assertions — both occur in the checklist today.
+        ("- Change classified as EVOLUTIONARY, TRANSFORMATIONAL or CORRECTIVE", []),
+        ("- Every provider classified as designated CTP, material non-CTP", []),
+        # The documented false positive from the #787 detection pass: `Open` is
+        # on the UAE ladder and also ordinary English.
+        ("- Open Items record which regulations may post-date the artefact", []),
+    ],
+)
+def test_assertion_parsing(line, expected):
+    assert load_guard().asserted_values(line) == expected
+
+
+def test_ladders_are_read_from_the_partials_not_hardcoded():
+    guard = load_guard()
+    core = REPO_ROOT / "plugins/arckit-claude"
+    fr = guard.ladder_for(core, "document-control-fr.md")
+    assert fr is not None and "Diffusion Restreinte" in fr
+    assert "OFFICIAL-SENSITIVE" not in fr
+    # Enumerating schemes by hand is the defect #788 fixed in the checklist, where
+    # a list of three had drifted from a registry of six. Check the code, not the
+    # docstring, which necessarily quotes the values to explain itself.
+    code = GUARD.read_text().split('"""', 2)[-1]
+    for value in ("Diffusion Restreinte", "Eingeschränkt", "Protected B", "Ongerubriceerd"):
+        assert value not in code, f"{value!r} hardcoded — ladder values must stay derived"
+
+
+def test_registry_parses_all_six_hard_routing_regimes():
+    guard = load_guard()
+    regime_of, partial_of, fallthrough = guard.load_registry(
+        REPO_ROOT / "plugins/arckit-claude/config/doc-types.mjs"
+    )
+    routing = {r for r in partial_of if r not in fallthrough}
+    assert routing == {"AT", "AU", "CA", "FR", "NL", "UAE"}
+    assert regime_of["IRN"] == "FR" and regime_of["ATDSG"] == "AT"
+    assert guard.primary_regime(partial_of["UK"]) == "UK"
+
+
+# --- regression lock on the seven -----------------------------------------------
+
+
+@pytest.mark.parametrize("code,expected", sorted(PR788_SECTIONS.items()))
+def test_pr788_sections_assert_their_own_ladder(code, expected):
+    body = section_body(CORE_CHECKLIST.read_text(encoding="utf-8"), code)
+    assert body, f"### {code} missing from the core checklist"
+    assert expected in body, f"### {code} no longer asserts {expected}"
+    assert "OFFICIAL-SENSITIVE" not in body, f"### {code} has regained a UK assertion"
+
+
+def test_every_plugin_copy_is_checked():
+    # Resolution is per plugin: ${CLAUDE_PLUGIN_ROOT} has no cross-plugin
+    # fallback, so an overlay reads its own copy. Checking core alone would pass
+    # a drifted overlay.
+    guard = load_guard()
+    with_checklist = [
+        p for p in guard.plugin_dirs() if (p / guard.CHECKLIST_REL).is_file()
+    ]
+    assert len(with_checklist) >= 15, f"only {len(with_checklist)} checklists found"
+
+
+def test_generated_mirror_is_excluded():
+    guard = load_guard()
+    assert guard.MIRROR_DIR == REPO_ROOT / "plugins/arckit-claude/plugins"
+    assert guard.MIRROR_DIR not in guard.plugin_dirs()


### PR DESCRIPTION
Ships the guard from #790, scoped to `references/quality-checklist.md`. Does not touch the per-command convention question, which is tracked separately (see below).

## The defect

Since #744 hard-routed the Document Control classification ladder by regime, a per-type checklist section can demand a classification the artefact never renders. `document-control-fr.md` puts `Diffusion Restreinte` in the header; the checklist demanded `OFFICIAL-SENSITIVE`; a correctly classified artefact failed the check its own command gates on. Seven sections were in that state until #788, every one from copying a UK section when adding an overlay type. Nothing guarded it.

`scripts/check-quality-checklist-ladders.py` asserts that a section for a doc-type whose regime hard-routes (AT, AU, CA, FR, NL, UAE) only asserts values on that regime's own ladder.

## Proof it fails (#790 step 4)

Against the tree at `9e346f6e` (pre-#788), it reports all seven, in each of the 16 checklist copies:

```text
### IRN   (FR) asserts 'OFFICIAL-SENSITIVE' — on the UK ladder, not FR's
### EBIOS (FR) asserts 'OFFICIAL-SENSITIVE' — on the UK ladder, not FR's
### ANSSI (FR) asserts 'OFFICIAL-SENSITIVE' — on the UK ladder, not FR's
### CARTO (FR) asserts 'OFFICIAL-SENSITIVE' — on the UK ladder, not FR's
### ALGO  (FR) asserts 'PUBLIC'             — on the UK ladder, not FR's
### PSSI  (FR) asserts 'OFFICIAL-SENSITIVE' — on the UK ladder, not FR's
### ATDSG (AT) asserts 'OFFICIAL-SENSITIVE' — on the UK ladder, not AT's
```

On `main`: `128 classification assertion(s) across 16 plugin checklist(s), all on their own regime's ladder`.

`tests/plugin/test_quality_checklist_ladders.py` reproduces that failure against the **real** registry and partials rather than a hardcoded fixture, so the proof cannot go stale as ladders change.

## Design

**Derived end to end, not hand-maintained.** Code to regime from `DOC_TYPES`, regime to partial from `REGIME_PARTIALS`, routing from `UK_FALLBACK_BY_DESIGN`, and the ladder from the partial's own `**Classification**` row. A new regime extends the guard with no edit here. Enumerating the schemes by hand is precisely the defect #788 fixed *in the checklist*, where a list of three had drifted from a registry of six, so a test asserts no ladder value is hardcoded in the guard.

**Anchored, not a token scan** (#790 blocker 2). `OFFICIAL` and `SECRET` sit on three ladders at once, and `Open`, `Shared`, `Secret` and `Confidential` are ordinary English — the #787 detection pass false-positived on FITAA's *"Open Items"*. Anchoring on the two phrasings in use also keeps `Change classified as EVOLUTIONARY` and `Every provider classified as designated CTP` out of scope, both live in the checklist today. Each is a test case.

One bug worth calling out from development: stripping a trailing aside on a bare `-` cut `OFFICIAL-SENSITIVE` down to `OFFICIAL`, which is itself a real ladder value, so the guard reported the wrong token as foreign and attributed it to AU. The dash strip is now whitespace-delimited, with a regression test.

**Fall-through regimes are deliberately not policed.** UK, MOD, EU and US resolve through user config and can legitimately render a UAE or AT ladder for an operator configured that way, so a UK value there is not drift.

**Resolution is per plugin**, matching `check-quality-checklist-refs.py`. `${CLAUDE_PLUGIN_ROOT}` has no cross-plugin fallback, so each overlay is checked against its own checklist and its own partials rather than against core.

## Deliberately out of scope

- **The four per-command conventions** (#790 blocker 1). Those live in overlay *command* files, not the checklist, and every AT example cited for the ambiguity (`at-bvergg.md:125` and friends) is a command file. In the checklist there is exactly one AT assertion, `ATDSG`, and it is pure AT ladder. So the convention call does not gate this guard, and this guard does not pre-empt it.
- **The parenthetical after an assertion.** `classified Eingeschränkt (or Vertraulich where ...)` is free prose; policing tokens inside it reintroduces the noise the anchors exist to avoid. The primary value is checked, the escalation note is not.
- **Case and accents.** `DIFFUSION RESTREINTE` is how a DR document is marked in French practice, not a foreign-ladder defect.

## Honest blast radius

The guard protects 8 assertions across 157 sections. AU, CA, NL and UAE (40 hard-routed doc-types) assert no classification in the checklist at all, so it is silent on them. Its value is a prospective regression-lock on the way the seven arose, not coverage.

## Verification

- `python3 scripts/check-quality-checklist-ladders.py` — clean
- `python3 -m pytest tests/plugin/test_quality_checklist_ladders.py -q` — 29 passed
- `check_references.py`, `check_recipes.py`, `check_doctype_collisions.py`, `check-doc-type-registry.py`, `check-quality-checklist-refs.py`, `check-doc-control-resolution.py` — all OK
- `sync-shared-assets.py --check` — clean
- `npx markdownlint-cli2` on both CHANGELOGs — 0 issues

Closes #790.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VKbHCujejpxkgvh47BndDE
