### PR TITLE
fix(agents): restore the tools allowlist #446 stripped, and guard it (#466)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -13,6 +13,7 @@ on:
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
       - "scripts/check-doc-type-registry.py"
+      - "scripts/check-agent-frontmatter.py"
       - "scripts/sync-shared-assets.py"
       - "scripts/standardise-colon.py"
       - "package.json"
@@ -57,6 +58,7 @@ on:
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
       - "scripts/check-doc-type-registry.py"
+      - "scripts/check-agent-frontmatter.py"
       - "scripts/sync-shared-assets.py"
       - "scripts/standardise-colon.py"
       - "package.json"
@@ -152,6 +154,9 @@ jobs:
 
       - name: create-project.sh invocations are ones the script accepts (#775, #777)
         run: python3 scripts/check-create-project-invocations.py --check
+
+      - name: Agent frontmatter (tools allowlist present, no stray files in agents/) (#466)
+        run: python3 scripts/check-agent-frontmatter.py
 
       - uses: actions/setup-node@v4
         with:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Restored the `tools:` allowlist, `effort:` and `maxTurns:` on `arckit-datascout`, `arckit-grants` and `arckit-gov-reuse`** (#466). PR #445 migrated all ten research agents off a `disallowedTools` denylist onto an explicit `tools:` allowlist, so that tools added by future Claude Code versions cannot auto-grant to an existing agent. PR #446 — the three-tier reader/writer split — silently reverted it on exactly the three agents it touched, and the regression survived three months and seven minor releases. Both changes are recorded as shipped in #466's own "already done" list.
+
+  The cause was mechanical, not a hand-edit. `converter.py::copy_agent_stripped()` pops the five `CLAUDE_ONLY_AGENT_FIELDS` and rebuilds the block with `yaml.dump()`; run with its destination pointing at the source tree it strips `effort`/`maxTurns`/`tools` from the plugin itself and leaves an alphabetised `description, model, name` block with the description reflowed from a `|` literal into a single-quoted folded scalar. All three damaged files carried that signature exactly; the other sixteen agents kept their authored field order. Until now those three ran with every tool in the harness, at session effort, with no turn cap.
+
+  `arckit-gov-reuse`'s MCP entry is restored in the `mcp__plugin_arckit_govreposcrape__search_uk_gov_code` form rather than the bare `mcp__govreposcrape__…` it originally shipped with, which matches nothing in plugin context.
+
+- **`READER-PATTERN.md` is no longer registered as a dispatchable agent** (#466). Claude Code registers *every* `.md` under a plugin's `agents/` directory, including one with no frontmatter, which then resolves to an unrestricted tool grant. A design reference therefore surfaced as an agent named `READER-PATTERN` with "All tools", and `claude plugin details arckit` billed it as a 2–7K on-invoke skill — it was listed as one in README's own footprint table, captured from that command. Moved to `plugins/arckit-claude/docs/READER-PATTERN.md`, next to `DEPENDENCY-MATRIX.md`.
+
+  Not to `references/`: that tree is read at runtime by 55 commands and is consequently copied into all 15 overlay plugins by `sync-shared-assets.py`, while no command has ever read this document.
+
+### Added
+
+- **`scripts/check-agent-frontmatter.py`, wired into `lint-markdown.yml`** (#466). Asserts that every agent declares a non-empty `tools:` allowlist, that `agents/` contains nothing but `arckit-*.md` agent files, that no file carries the `copy_agent_stripped()` writeback signature, and that MCP entries use the `mcp__plugin_<package>_<server>__<tool>` prefix. Each of the four checks was verified against a deliberately reintroduced instance of the defect it guards. Fourteen `check-*.py` guards existed and not one looked at `agents/`, which is why both defects above went unobserved.
+
+### Changed
+
+- **Corrected the Agent System section of `CLAUDE.md`** (#466). It claimed 16 agents (there are 19), said the reader/writer subagents are "dispatched only by the corresponding orchestrator agent" (`READER-PATTERN.md` step 5 requires the orchestrator to be the slash command, and the command bodies say so explicitly), and listed `arckit-datascout`, `arckit-gov-reuse` and `arckit-grants` as the agents their commands delegate to, which stopped being true at #446. Those three files are now documented for what they actually are: pre-split monoliths retained solely because the converter replaces a command body wholesale with the agent prompt for non-Claude targets, which cannot dispatch subagents. The MCP tool-naming example in the same section was also wrong — it gave the bare `mcp__<server>__<tool>` form.
+
 ## [6.11.0] — 2026-08-19
 
 ### Documentation

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -94,19 +94,21 @@ Some commands delegate to **autonomous agents** (`plugins/arckit-claude/agents/a
 | Agent | Command | Purpose |
 |-------|---------|---------|
 | `arckit-research` | `/arckit:research` | Market research, vendor evaluation, build vs buy, TCO |
-| `arckit-datascout` | `/arckit:datascout` | Data source discovery, API catalogue search |
+| `arckit-datascout` | *(non-Claude only)* | Data source discovery, API catalogue search |
 | `arckit-aws-research` | `/arckit:aws-research` | AWS via AWS Knowledge MCP |
 | `arckit-azure-research` | `/arckit:azure-research` | Azure via Microsoft Learn MCP |
 | `arckit-gcp-research` | `/arckit:gcp-research` | GCP via Google Developer Knowledge MCP |
 | `arckit-framework` | `/arckit:framework` | Transform artifacts into a structured framework |
-| `arckit-gov-reuse` | `/arckit:gov-reuse` | Government code reuse via govreposcrape |
+| `arckit-gov-reuse` | *(non-Claude only)* | Government code reuse via govreposcrape |
 | `arckit-gov-code-search` | `/arckit:gov-code-search` | Government code semantic search |
 | `arckit-gov-landscape` | `/arckit:gov-landscape` | Government code landscape analysis |
-| `arckit-grants` | `/arckit:grants` | UK government grants and funding research |
+| `arckit-grants` | *(non-Claude only)* | UK government grants and funding research |
 
-**Reader/writer subagents** (6 internal, not user-invocable): `datascout`, `grants`, and `gov-reuse` follow the three-tier orchestrator pattern (`plugins/arckit-claude/agents/READER-PATTERN.md`). Each ships a `arckit-{name}-reader.md` (web/MCP evidence gathering, returns JSON) and `arckit-{name}-writer.md` (renders validated payload into artefact, no network tools). Dispatched only by the corresponding orchestrator agent. **Total: 16 agents** (10 single-tier + 6 reader/writer subagents).
+**Reader/writer subagents** (9 internal, not user-invocable): `datascout`, `grants`, `gov-reuse` and `tenders` follow the three-tier orchestrator pattern (`plugins/arckit-claude/docs/READER-PATTERN.md`); `competitors` reuses `arckit-tenders-reader` and ships only a writer. Each ships a `arckit-{name}-reader.md` (web/MCP evidence gathering, returns JSON) and a `arckit-{name}-writer.md` (renders validated payload into artefact, no network tools). **Total: 19 agents** (10 single-tier + 9 reader/writer subagents).
 
-**Agent frontmatter**: valid fields are `name` (required), `description` (required), `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `initialPrompt`. `tools` is an allowlist (only the listed tools are available); `disallowedTools` is a denylist applied first, then the allowlist is resolved against what remains. Heavy-research agents in this plugin use `tools` (allowlist) for prompt-injection hardening — see `plugins/arckit-claude/agents/arckit-research.md` for the canonical shape, including MCP tool naming (`mcp__<server>__<tool>`). Fields like `color` and `permissionMode` remain invalid in plugin context. Claude-only fields (`effort`, `initialPrompt`, `maxTurns`, `disallowedTools`, `tools`) are stripped by the converter.
+**The orchestrator is the slash command, not an agent file.** For every split command the dispatch, schema-validation and scoring logic lives in `commands/{name}.md` and runs in the main thread, where `Agent` is reliably available — see READER-PATTERN.md for why this is a deliberate choice rather than a platform limitation. The matching `agents/arckit-{datascout,grants,gov-reuse}.md` files are the **pre-split monoliths, retained only because `converter.py` replaces a command body wholesale with the agent prompt when generating non-Claude targets** (those runtimes cannot dispatch subagents). Do not delete them; do not treat them as the Claude execution path either. They still register as dispatchable Claude agents, so they must keep a `tools:` allowlist — PR #446 stripped it from all three and nobody noticed for three months (#466).
+
+**Agent frontmatter**: valid fields are `name` (required), `description` (required), `model`, `effort`, `maxTurns`, `tools`, `disallowedTools`, `initialPrompt`. `tools` is an allowlist (only the listed tools are available); `disallowedTools` is a denylist applied first, then the allowlist is resolved against what remains. Heavy-research agents in this plugin use `tools` (allowlist) for prompt-injection hardening — see `plugins/arckit-claude/agents/arckit-research.md` for the canonical shape, including MCP tool naming (`mcp__plugin_arckit_<server>__<tool>` — the bare `mcp__<server>__<tool>` form matches nothing in plugin context). Fields like `color` and `permissionMode` remain invalid in plugin context. Claude-only fields (`effort`, `initialPrompt`, `maxTurns`, `disallowedTools`, `tools`) are stripped by the converter. `scripts/check-agent-frontmatter.py` (CI) asserts every agent declares a `tools:` allowlist, that `agents/` holds nothing but agent files, and that no file carries the alphabetised `description, model, name` block `copy_agent_stripped()` leaves behind when it is accidentally run against the plugin source.
 
 Agents are Claude Code only — Codex/OpenCode/Gemini equivalents inline the full agent prompt.
 

--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ Public demonstration repositories showcase complete ArcKit deliverables:
 
 Token cost of installing the `arckit` core plugin in a Claude Code session, captured from `claude plugin details arckit` on v2.1.143+:
 
-- **Always-on per session: ~10,042 tokens** — added to every session's system context, covering the 73 command-skills + 5 utility skills (`architecture-workflow`, `arckit-build`, `mermaid-syntax`, `plantuml-syntax`, `wardley-mapping`) + 16 agent descriptors. Hooks (9 events) and MCP servers (6) are harness-resolved at runtime and not counted.
+- **Always-on per session: ~10,042 tokens** — added to every session's system context, covering the 73 command-skills + 5 utility skills (`architecture-workflow`, `arckit-build`, `mermaid-syntax`, `plantuml-syntax`, `wardley-mapping`) + 19 agent descriptors. Hooks (9 events) and MCP servers (6) are harness-resolved at runtime and not counted.
 - **On-invoke: ~250 to ~60K tokens per command** — paid only when a specific skill or agent fires. Most commands are in the 5–10K range.
 
 ### On-invoke cost by command
@@ -298,7 +298,7 @@ Costs are estimates from the Claude Code tokenizer and may differ from actual us
 | Tier | Range | Commands |
 |------|-------|----------|
 | Lightweight | <2K | `start`, `init`, `build`, `search`, `impact`, `navigator`, `graph-report`, `framework`, `gov-landscape`, `aws-research`, `azure-research`, `gcp-research` |
-| Standard | 2–7K | `customize`, `score`, `principles`, `mermaid-syntax`, `plantuml-syntax`, `architecture-workflow`, `datascout`, `tenders`, `competitors`, `evaluate`, `hld-review`, `mlops`, `devops`, `finops`, `research`, `tcop`, `wardley-mapping`, `template-builder`, `glossary`, `dld-review`, `traceability`, `stakeholders`, `presentation`, `dfd`, `operationalize`, `requirements`, `maturity-model`, `data-model`, `gov-reuse`, `strategy`, `presentation`, `atrs`, `gov-code-search`, `READER-PATTERN` |
+| Standard | 2–7K | `customize`, `score`, `principles`, `mermaid-syntax`, `plantuml-syntax`, `architecture-workflow`, `datascout`, `tenders`, `competitors`, `evaluate`, `hld-review`, `mlops`, `devops`, `finops`, `research`, `tcop`, `wardley-mapping`, `template-builder`, `glossary`, `dld-review`, `traceability`, `stakeholders`, `presentation`, `dfd`, `operationalize`, `requirements`, `maturity-model`, `data-model`, `gov-reuse`, `strategy`, `presentation`, `atrs`, `gov-code-search` |
 | Heavy | 7–15K | `wardley.value-chain`, `gcloud-clarify`, `ai-playbook`, `sow`, `sobc`, `risk`, `secure`, `dpia`, `dos`, `mod-secure`, `plan`, `conformance`, `roadmap`, `health`, `wardley.doctrine`, `wardley.gameplay`, `pages`, `servicenow`, `gcloud-search`, `principles-compliance`, `story`, `wardley`, `wardley.climate`, `data-mesh-contract`, `platform-design`, `adr`, `arckit-build`, `grants` |
 | Research-heavy | 15–25K | `service-assessment`, `analyze`, `backlog`, `diagram` |
 | Specialist | >25K | `jsp-936` (~60K — MOD JSP 936 AI assurance, defence-only) |

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **Restored the `tools:` allowlist, `effort:` and `maxTurns:` on `arckit-datascout`, `arckit-grants` and `arckit-gov-reuse`** (#466). PR #445 migrated all ten research agents off a `disallowedTools` denylist onto an explicit `tools:` allowlist, so that tools added by future Claude Code versions cannot auto-grant to an existing agent. PR #446 — the three-tier reader/writer split — silently reverted it on exactly the three agents it touched, and the regression survived three months and seven minor releases. Both changes are recorded as shipped in #466's own "already done" list.
+
+  The cause was mechanical, not a hand-edit. `converter.py::copy_agent_stripped()` pops the five `CLAUDE_ONLY_AGENT_FIELDS` and rebuilds the block with `yaml.dump()`; run with its destination pointing at the source tree it strips `effort`/`maxTurns`/`tools` from the plugin itself and leaves an alphabetised `description, model, name` block with the description reflowed from a `|` literal into a single-quoted folded scalar. All three damaged files carried that signature exactly; the other sixteen agents kept their authored field order. Until now those three ran with every tool in the harness, at session effort, with no turn cap.
+
+  `arckit-gov-reuse`'s MCP entry is restored in the `mcp__plugin_arckit_govreposcrape__search_uk_gov_code` form rather than the bare `mcp__govreposcrape__…` it originally shipped with, which matches nothing in plugin context.
+
+- **`READER-PATTERN.md` is no longer registered as a dispatchable agent** (#466). Claude Code registers *every* `.md` under a plugin's `agents/` directory, including one with no frontmatter, which then resolves to an unrestricted tool grant. A design reference therefore surfaced as an agent named `READER-PATTERN` with "All tools", and `claude plugin details arckit` billed it as a 2–7K on-invoke skill — it was listed as one in README's own footprint table, captured from that command. Moved to `plugins/arckit-claude/docs/READER-PATTERN.md`, next to `DEPENDENCY-MATRIX.md`.
+
+  Not to `references/`: that tree is read at runtime by 55 commands and is consequently copied into all 15 overlay plugins by `sync-shared-assets.py`, while no command has ever read this document.
+
+### Added
+
+- **`scripts/check-agent-frontmatter.py`, wired into `lint-markdown.yml`** (#466). Asserts that every agent declares a non-empty `tools:` allowlist, that `agents/` contains nothing but `arckit-*.md` agent files, that no file carries the `copy_agent_stripped()` writeback signature, and that MCP entries use the `mcp__plugin_<package>_<server>__<tool>` prefix. Each of the four checks was verified against a deliberately reintroduced instance of the defect it guards. Fourteen `check-*.py` guards existed and not one looked at `agents/`, which is why both defects above went unobserved.
+
+### Changed
+
+- **Corrected the Agent System section of `CLAUDE.md`** (#466). It claimed 16 agents (there are 19), said the reader/writer subagents are "dispatched only by the corresponding orchestrator agent" (`READER-PATTERN.md` step 5 requires the orchestrator to be the slash command, and the command bodies say so explicitly), and listed `arckit-datascout`, `arckit-gov-reuse` and `arckit-grants` as the agents their commands delegate to, which stopped being true at #446. Those three files are now documented for what they actually are: pre-split monoliths retained solely because the converter replaces a command body wholesale with the agent prompt for non-Claude targets, which cannot dispatch subagents. The MCP tool-naming example in the same section was also wrong — it gave the bare `mcp__<server>__<tool>` form.
+
 ## [6.11.0] — 2026-08-19
 
 ### Documentation

--- a/plugins/arckit-claude/agents/arckit-datascout.md
+++ b/plugins/arckit-claude/agents/arckit-datascout.md
@@ -1,72 +1,38 @@
 ---
-description: 'Use this agent when the user needs to discover external data sources
-  — APIs, datasets, open data portals, and commercial data providers — to fulfil project
-  requirements. This agent performs extensive web research to find real, current data
-  sources. Examples:
-
-
-  <example>
-
-  Context: User has a project with requirements and wants to find external data sources
-
-  user: "/arckit:datascout Discover data sources for the fuel price transparency project"
-
-  assistant: "I''ll launch the datascout agent to discover external data sources for
-  the fuel price transparency project. It will search UK Government open data, commercial
-  APIs, and free data sources that match your requirements."
-
-  <commentary>
-
-  The datascout agent is ideal here because it needs to perform many WebSearch and
-  WebFetch calls to discover APIs, check documentation, verify rate limits, and assess
-  data quality. Running as an agent keeps this research isolated.
-
-  </commentary>
-
-  </example>
-
-
-  <example>
-
-  Context: User wants to find APIs and datasets for their project
-
-  user: "What external data sources and APIs are available for this project?"
-
-  assistant: "I''ll launch the datascout agent to systematically discover and evaluate
-  external data sources, APIs, and datasets that can fulfil your project''s data requirements."
-
-  <commentary>
-
-  Any request for external data source discovery should trigger this agent since it
-  involves heavy web research across government portals, API catalogues, and commercial
-  providers.
-
-  </commentary>
-
-  </example>
-
-
-  <example>
-
-  Context: User needs UK Government open data for their project
-
-  user: "Find what government open data we can use for the smart meter app"
-
-  assistant: "I''ll launch the datascout agent to search UK Government open data portals,
-  the API catalogue at api.gov.uk, and data.gov.uk for relevant datasets and APIs."
-
-  <commentary>
-
-  UK Government data discovery requires searching multiple portals (api.gov.uk, data.gov.uk,
-  department developer hubs) which benefits from agent isolation.
-
-  </commentary>
-
-  </example>
-
-  '
-model: inherit
 name: arckit-datascout
+maxTurns: 50
+tools: ["Read", "Glob", "Grep", "Write", "Bash", "TodoWrite", "WebSearch", "WebFetch"]
+effort: max
+description: |
+  Use this agent when the user needs to discover external data sources — APIs, datasets, open data portals, and commercial data providers — to fulfil project requirements. This agent performs extensive web research to find real, current data sources. Examples:
+
+  <example>
+  Context: User has a project with requirements and wants to find external data sources
+  user: "/arckit:datascout Discover data sources for the fuel price transparency project"
+  assistant: "I'll launch the datascout agent to discover external data sources for the fuel price transparency project. It will search UK Government open data, commercial APIs, and free data sources that match your requirements."
+  <commentary>
+  The datascout agent is ideal here because it needs to perform many WebSearch and WebFetch calls to discover APIs, check documentation, verify rate limits, and assess data quality. Running as an agent keeps this research isolated.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to find APIs and datasets for their project
+  user: "What external data sources and APIs are available for this project?"
+  assistant: "I'll launch the datascout agent to systematically discover and evaluate external data sources, APIs, and datasets that can fulfil your project's data requirements."
+  <commentary>
+  Any request for external data source discovery should trigger this agent since it involves heavy web research across government portals, API catalogues, and commercial providers.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User needs UK Government open data for their project
+  user: "Find what government open data we can use for the smart meter app"
+  assistant: "I'll launch the datascout agent to search UK Government open data portals, the API catalogue at api.gov.uk, and data.gov.uk for relevant datasets and APIs."
+  <commentary>
+  UK Government data discovery requires searching multiple portals (api.gov.uk, data.gov.uk, department developer hubs) which benefits from agent isolation.
+  </commentary>
+  </example>
+model: inherit
 ---
 
 You are an enterprise data source discovery specialist. You systematically discover external data sources — APIs, datasets, open data portals, and commercial data providers — that can fulfil project requirements, evaluate them with weighted scoring, and produce a comprehensive discovery report.

--- a/plugins/arckit-claude/agents/arckit-gov-reuse.md
+++ b/plugins/arckit-claude/agents/arckit-gov-reuse.md
@@ -1,72 +1,46 @@
 ---
-description: 'Use this agent when the user wants to discover reusable UK government
-  open-source code before building from scratch. This agent searches 24,500+ government
-  repositories via govreposcrape and assesses candidates for reusability. Examples:
-
-
-  <example>
-
-  Context: User has a project and wants to check for existing government code
-
-  user: "/arckit:gov-reuse Check for existing government code for appointment booking"
-
-  assistant: "I''ll launch the gov-reuse agent to search 24,500+ UK government repositories
-  for existing appointment booking implementations and assess their reusability."
-
-  <commentary>
-
-  The gov-reuse agent is ideal here because it performs multiple govreposcrape searches
-  per capability, then uses WebFetch on each candidate''s GitHub page to assess reusability.
-  Running as an agent keeps this research isolated.
-
-  </commentary>
-
-  </example>
-
-
-  <example>
-
-  Context: User wants to avoid rebuilding what government already has
-
-  user: "Has anyone in government already built a case management system we could
-  reuse?"
-
-  assistant: "I''ll launch the gov-reuse agent to search government repositories for
-  case management implementations and assess which ones could be forked, used as a
-  library, or referenced."
-
-  <commentary>
-
-  Any request to find existing government code for reuse should trigger this agent
-  since it involves searching and deep assessment of multiple repositories.
-
-  </commentary>
-
-  </example>
-
-
-  <example>
-
-  Context: User wants reuse assessment after creating requirements
-
-  user: "Before we start building, check what the government has already built for
-  this"
-
-  assistant: "I''ll launch the gov-reuse agent to systematically search government
-  repositories for each capability in your requirements and produce a reuse assessment."
-
-  <commentary>
-
-  Pre-build reuse check requires reading requirements, extracting capabilities, and
-  searching for each — benefits from agent isolation.
-
-  </commentary>
-
-  </example>
-
-  '
-model: inherit
 name: arckit-gov-reuse
+maxTurns: 40
+tools:
+  - Read
+  - Glob
+  - Grep
+  - Write
+  - Bash
+  - TodoWrite
+  - WebFetch
+  - mcp__plugin_arckit_govreposcrape__search_uk_gov_code
+effort: max
+description: |
+  Use this agent when the user wants to discover reusable UK government open-source code before building from scratch. This agent searches 24,500+ government repositories via govreposcrape and assesses candidates for reusability. Examples:
+
+  <example>
+  Context: User has a project and wants to check for existing government code
+  user: "/arckit:gov-reuse Check for existing government code for appointment booking"
+  assistant: "I'll launch the gov-reuse agent to search 24,500+ UK government repositories for existing appointment booking implementations and assess their reusability."
+  <commentary>
+  The gov-reuse agent is ideal here because it performs multiple govreposcrape searches per capability, then uses WebFetch on each candidate's GitHub page to assess reusability. Running as an agent keeps this research isolated.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to avoid rebuilding what government already has
+  user: "Has anyone in government already built a case management system we could reuse?"
+  assistant: "I'll launch the gov-reuse agent to search government repositories for case management implementations and assess which ones could be forked, used as a library, or referenced."
+  <commentary>
+  Any request to find existing government code for reuse should trigger this agent since it involves searching and deep assessment of multiple repositories.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants reuse assessment after creating requirements
+  user: "Before we start building, check what the government has already built for this"
+  assistant: "I'll launch the gov-reuse agent to systematically search government repositories for each capability in your requirements and produce a reuse assessment."
+  <commentary>
+  Pre-build reuse check requires reading requirements, extracting capabilities, and searching for each — benefits from agent isolation.
+  </commentary>
+  </example>
+model: inherit
 ---
 
 You are an enterprise architecture reuse specialist. You systematically search UK government open-source repositories to discover existing implementations that can be reused, adapted, or referenced, reducing build effort and promoting cross-government collaboration.

--- a/plugins/arckit-claude/agents/arckit-grants.md
+++ b/plugins/arckit-claude/agents/arckit-grants.md
@@ -1,53 +1,29 @@
 ---
-description: 'Use this agent when the user needs to research UK funding opportunities
-  for a project, including government grants (UKRI, Innovate UK, NIHR, DSIT), charitable
-  foundations (Wellcome, Nesta), social impact funding, and accelerator programmes.
-  This agent performs extensive web research autonomously. Examples:
-
-
-  <example>
-
-  Context: User has a project and wants to find relevant UK grants
-
-  user: "/arckit:grants Research funding opportunities for the NHS appointment booking
-  project"
-
-  assistant: "I''ll launch the grants agent to research UK funding opportunities for
-  the NHS appointment booking project. It will search government grants, charitable
-  foundations, and accelerators, then produce an eligibility-scored report."
-
-  <commentary>
-
-  The grants agent is ideal here because it needs to perform dozens of WebSearch and
-  WebFetch calls across multiple UK funding bodies. Running as an agent keeps this
-  context-heavy work isolated.
-
-  </commentary>
-
-  </example>
-
-
-  <example>
-
-  Context: User wants to explore funding after creating requirements
-
-  user: "Are there any UK grants we could apply for with this project?"
-
-  assistant: "I''ll launch the grants agent to discover and evaluate UK funding opportunities
-  based on your project requirements."
-
-  <commentary>
-
-  Even without the explicit slash command, the request for grant/funding research
-  should trigger this agent since it involves heavy web research.
-
-  </commentary>
-
-  </example>
-
-  '
-model: inherit
 name: arckit-grants
+maxTurns: 50
+tools: ["Read", "Glob", "Grep", "Write", "Bash", "TodoWrite", "WebSearch", "WebFetch"]
+effort: max
+description: |
+  Use this agent when the user needs to research UK funding opportunities for a project, including government grants (UKRI, Innovate UK, NIHR, DSIT), charitable foundations (Wellcome, Nesta), social impact funding, and accelerator programmes. This agent performs extensive web research autonomously. Examples:
+
+  <example>
+  Context: User has a project and wants to find relevant UK grants
+  user: "/arckit:grants Research funding opportunities for the NHS appointment booking project"
+  assistant: "I'll launch the grants agent to research UK funding opportunities for the NHS appointment booking project. It will search government grants, charitable foundations, and accelerators, then produce an eligibility-scored report."
+  <commentary>
+  The grants agent is ideal here because it needs to perform dozens of WebSearch and WebFetch calls across multiple UK funding bodies. Running as an agent keeps this context-heavy work isolated.
+  </commentary>
+  </example>
+
+  <example>
+  Context: User wants to explore funding after creating requirements
+  user: "Are there any UK grants we could apply for with this project?"
+  assistant: "I'll launch the grants agent to discover and evaluate UK funding opportunities based on your project requirements."
+  <commentary>
+  Even without the explicit slash command, the request for grant/funding research should trigger this agent since it involves heavy web research.
+  </commentary>
+  </example>
+model: inherit
 ---
 
 You are a UK grants and funding research specialist. You conduct systematic research across UK government grant bodies, charitable foundations, social impact investors, and accelerator programmes to identify funding opportunities that match project requirements.

--- a/plugins/arckit-claude/docs/READER-PATTERN.md
+++ b/plugins/arckit-claude/docs/READER-PATTERN.md
@@ -4,6 +4,18 @@
 > with a JSON-Schema-validated handoff between reader and orchestrator.
 > First implemented for `arckit-datascout` (issue #442 item 1).
 
+> **This document lives in `docs/`, not `agents/`.** Claude Code registers
+> *every* `.md` under a plugin's `agents/` directory as a dispatchable
+> agent, including one with no frontmatter — which then resolves to an
+> unrestricted tool grant. While this file sat in `agents/` it surfaced as
+> an agent named `READER-PATTERN` with "All tools", and `claude plugin
+> details arckit` billed it as a 2–7K on-invoke skill. Keep design
+> references out of `agents/`; `scripts/check-agent-frontmatter.py`
+> enforces it. It is not in `references/` either: that tree is read at
+> runtime by 55 commands and is therefore copied into every overlay plugin
+> by `sync-shared-assets.py`, whereas this is a maintainer document no
+> command ever reads.
+
 ## Why
 
 Research-heavy agents in ArcKit (`arckit-research`, `arckit-datascout`,
@@ -65,7 +77,8 @@ arckit-claude/
 │                                         # holds Agent + Bash, dispatches reader and writer.
 ├── agents/
 │   ├── arckit-{name}-reader.md           # Reader subagent (subagent: true)
-│   ├── arckit-{name}-writer.md           # Writer subagent (subagent: true)
+│   └── arckit-{name}-writer.md           # Writer subagent (subagent: true)
+├── docs/
 │   └── READER-PATTERN.md                 # This document
 ├── schemas/
 │   ├── {name}-handoff.schema.json        # JSON Schema 2020-12

--- a/scripts/check-agent-frontmatter.py
+++ b/scripts/check-agent-frontmatter.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Guard the security-relevant frontmatter on plugin agent files.
+
+Three failure modes, all of which have already shipped to users once:
+
+1. **Missing `tools:` allowlist.** PR #445 migrated every research agent
+   from a `disallowedTools` denylist to an explicit `tools:` allowlist so
+   that tools added by future Claude Code versions do not auto-grant to
+   existing agents. PR #446 then silently reverted it on three of them.
+
+2. **Silent frontmatter stripping.** The regression in (1) was mechanical:
+   `converter.py::copy_agent_stripped()` pops `CLAUDE_ONLY_AGENT_FIELDS`
+   and rebuilds the block with `yaml.dump()`. Run with its destination
+   pointing at the source tree, it strips `tools`/`effort`/`maxTurns` from
+   the plugin itself and leaves behind a tell-tale alphabetised
+   `description, model, name` block. Nothing detected it for three months
+   and seven minor releases.
+
+3. **Non-agent files in `agents/`.** Claude Code registers every `.md`
+   under `agents/` as a dispatchable agent. A file with no frontmatter
+   still registers, and resolves to an unrestricted tool grant --- which
+   is what happened to `READER-PATTERN.md`.
+
+Exit 0 on success, 1 on any violation.
+"""
+
+import os
+import sys
+
+import yaml
+
+PLUGIN_ROOT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.abspath(__file__))),
+    "plugins",
+)
+
+# Fields converter.py strips for non-Claude targets. If a file in the plugin
+# source is missing ALL of these while carrying exactly the keys yaml.dump
+# leaves behind, it has almost certainly been through copy_agent_stripped().
+CLAUDE_ONLY_AGENT_FIELDS = ("effort", "initialPrompt", "maxTurns", "disallowedTools", "tools")
+STRIPPED_SIGNATURE = {"description", "model", "name"}
+
+
+def agent_dirs():
+    """Yield every plugins/*/agents directory that exists."""
+    for entry in sorted(os.listdir(PLUGIN_ROOT)):
+        candidate = os.path.join(PLUGIN_ROOT, entry, "agents")
+        if os.path.isdir(candidate):
+            yield entry, candidate
+
+
+def parse_frontmatter(path):
+    """Return (frontmatter_dict_or_None, error_string_or_None)."""
+    with open(path, "r", encoding="utf-8") as handle:
+        content = handle.read()
+    if not content.startswith("---"):
+        return None, "no YAML frontmatter"
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return None, "unterminated YAML frontmatter"
+    try:
+        return yaml.safe_load(parts[1]) or {}, None
+    except yaml.YAMLError as exc:
+        return None, f"unparseable frontmatter: {exc}"
+
+
+def main():
+    errors = []
+
+    for plugin, directory in agent_dirs():
+        for filename in sorted(os.listdir(directory)):
+            if not filename.endswith(".md"):
+                continue
+            path = os.path.join(directory, filename)
+            rel = os.path.relpath(path, os.path.dirname(PLUGIN_ROOT))
+
+            # (3) Only agent files belong here. Claude Code registers
+            # everything else as an all-tools agent.
+            if not filename.startswith("arckit-"):
+                errors.append(
+                    f"{rel}: not an agent file. Claude Code registers every .md under "
+                    f"agents/ as a dispatchable agent, so a reference doc here surfaces "
+                    f"with an unrestricted tool grant. Move it to {plugin}/docs/."
+                )
+                continue
+
+            frontmatter, error = parse_frontmatter(path)
+            if error:
+                errors.append(f"{rel}: {error}")
+                continue
+
+            for required in ("name", "description"):
+                if not frontmatter.get(required):
+                    errors.append(f"{rel}: missing required `{required}:`")
+
+            # (1) Every agent needs an explicit allowlist. Deny-by-default
+            # is the whole point; absence grants every tool in the harness.
+            if "tools" not in frontmatter:
+                errors.append(
+                    f"{rel}: no `tools:` allowlist. Without one this agent receives every "
+                    f"tool in the harness, including tools added by future Claude Code "
+                    f"versions (see PR #445)."
+                )
+            elif not isinstance(frontmatter["tools"], list) or not frontmatter["tools"]:
+                errors.append(f"{rel}: `tools:` must be a non-empty list")
+
+            # (2) The converter-writeback signature.
+            if set(frontmatter) == STRIPPED_SIGNATURE:
+                errors.append(
+                    f"{rel}: frontmatter is exactly {sorted(STRIPPED_SIGNATURE)}, the shape "
+                    f"converter.py::copy_agent_stripped() leaves behind. The Claude-only "
+                    f"fields ({', '.join(CLAUDE_ONLY_AGENT_FIELDS)}) were stripped from the "
+                    f"plugin source. Restore them from git history."
+                )
+
+            # Plugin MCP tools resolve only under the mcp__plugin_<pkg>_<server>__
+            # prefix; a bare mcp__<server>__<tool> entry matches nothing.
+            for tool in frontmatter.get("tools", []) or []:
+                if isinstance(tool, str) and tool.startswith("mcp__") and not tool.startswith("mcp__plugin_"):
+                    errors.append(
+                        f"{rel}: tool `{tool}` uses the bare MCP prefix, which matches nothing "
+                        f"in plugin context. Use mcp__plugin_<package>_<server>__<tool>."
+                    )
+
+    if errors:
+        print("Agent frontmatter check FAILED:\n")
+        for err in errors:
+            print(f"  - {err}")
+        print(f"\n{len(errors)} problem(s) found.")
+        return 1
+
+    total = sum(
+        len([f for f in os.listdir(d) if f.endswith(".md")]) for _, d in agent_dirs()
+    )
+    print(f"Agent frontmatter check passed ({total} agent files).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes the two shipped-but-reverted items found while reviewing #466, and adds the guard that makes the class of defect non-recurring.

## The regression

PR #445 migrated all ten research agents from a `disallowedTools` denylist to an explicit `tools:` allowlist, so tools added by future Claude Code versions cannot auto-grant to an existing agent. **PR #446 — the three-tier reader/writer split — silently reverted it on exactly the three agents it touched.** It stayed reverted for three months and seven minor releases. Both PRs are recorded as shipped in #466's own "already done" list, so the tracker's accounting was wrong.

Until this PR, `arckit-datascout`, `arckit-grants` and `arckit-gov-reuse` ran with **every tool in the harness**, at session effort, with no turn cap. This session's own agent listing confirmed it: `arckit:arckit-gov-reuse … (Tools: All tools)`.

### Cause

Not a hand-edit. `converter.py::copy_agent_stripped()` pops the five `CLAUDE_ONLY_AGENT_FIELDS` and rebuilds the frontmatter with `yaml.dump()`. Run with its destination pointing at the source tree, it strips `effort`/`maxTurns`/`tools` from the plugin itself and leaves a tell-tale alphabetised block:

```
description: 'Use this agent when the user needs to research UK funding…   <- folded scalar
model: inherit
name: arckit-grants
```

All three damaged files carried that signature exactly. The other sixteen agents kept their authored field order and `|` literal descriptions.

`arckit-gov-reuse`'s MCP entry is restored as `mcp__plugin_arckit_govreposcrape__search_uk_gov_code`, not the bare `mcp__govreposcrape__…` it originally shipped with, which matches nothing in plugin context.

## A reference doc registered as an all-tools agent

Claude Code registers *every* `.md` under a plugin's `agents/` directory, including one with no frontmatter, which then resolves to an unrestricted tool grant. `READER-PATTERN.md` therefore surfaced as an agent named `READER-PATTERN` with "All tools", and `claude plugin details arckit` billed it as a 2–7K on-invoke skill — it was listed as one in README's footprint table, which is captured from that command.

Moved to `plugins/arckit-claude/docs/`, beside `DEPENDENCY-MATRIX.md`. **Not** to `references/`: that tree is read at runtime by 55 commands and is consequently copied into all 15 overlay plugins by `sync-shared-assets.py`, while no command has ever read this document.

## The guard

`scripts/check-agent-frontmatter.py`, wired into `lint-markdown.yml`, asserts:

1. every agent declares a non-empty `tools:` allowlist;
2. `agents/` contains nothing but `arckit-*.md` agent files;
3. no file carries the `copy_agent_stripped()` writeback signature;
4. MCP entries use the `mcp__plugin_<package>_<server>__<tool>` prefix.

Each check was verified by deliberately reintroducing the defect it guards and confirming a non-zero exit. Fourteen `check-*.py` guards already existed and **not one looked at `agents/`**, which is why both defects above went unobserved.

## CLAUDE.md corrections

The Agent System section claimed **16 agents** (there are 19); said the reader/writer subagents are "dispatched only by the corresponding orchestrator agent" when `READER-PATTERN.md` step 5 and every split command body require the orchestrator to be the **slash command** running in the main thread; listed `arckit-datascout`/`arckit-gov-reuse`/`arckit-grants` as their commands' delegation target, untrue since #446; and gave the bare `mcp__<server>__<tool>` form as the MCP naming example.

Those three agent files are now documented for what they are: pre-split monoliths retained **only** because `converter.py` replaces a command body wholesale with the agent prompt for non-Claude targets, which cannot dispatch subagents. They must not be deleted, and must not be treated as the Claude execution path.

## Scope

Deliberately excludes the Item 1 remainder (`arckit-research` and the five other unsplit agents). That is the follow-up PR.

## Verification

```
python3 scripts/converter.py                  # OK, no writeback into plugin source
python3 scripts/check-agent-frontmatter.py    # passed (19 agent files)
python3 scripts/sync-shared-assets.py --check # All 11 shared assets present in 15 community plugins
python3 -m pytest tests/ -q                   # 1541 passed, 225 skipped
npx markdownlint-cli2 "**/*.md"               # 0 issues in 3819 files
```

Agent file bodies are byte-identical to `main`; the diff is confined to frontmatter.

Refs #466, #442. Reverts the frontmatter loss from #446, restores #445.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZrnfZmbdk33YD34j4Ys7H