### PR TITLE
docs: state what ArcKit does not do (#466 items 9 and 21)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A repository-level statement of what ArcKit does not do** (#466, items 9 and 21). Every community overlay already carried a "review by qualified DPO / CSO / federal counsel before reliance" banner. The officially-maintained baseline carried none, and it is the baseline that ships `/arckit:dpia`, `/arckit:secure`, `/arckit:mod-secure`, `/arckit:atrs`, `/arckit:jsp-936` and `/arckit:sobc`. A grep for disclaimer language across `README.md` and every `docs/*.md` returned nothing, so the unsupported overlays were better hedged than the supported core.
+
+  `README.md` gains a `## What ArcKit does not do` section, placed immediately before the UK Government Compliance section so a reader meets the limits before the compliance claims. It enumerates them concretely rather than generically: a generated DPIA is not a completed DPIA, because UK GDPR Article 35 places the assessment on the controller and Article 36 requires ICO consultation where high residual risk remains; Secure by Design and JSP 936 packs are input to an assurance decision made by named accountable individuals, not the decision itself; the EU overlay drafts documentation referencing the AI Act, NIS2, DORA and the CRA but performs no conformity assessment and is not a notified-body activity; DCB0129 / DCB0160 need a registered Clinical Safety Officer. It closes with who must review what, and states that it applies to all of ArcKit rather than only the community overlays.
+
+  Two cross-cutting limits are stated because neither is obvious from an artefact that looks finished: citations reflect the moment they were fetched, and generated content can be wrong — schema validation and deterministic scoring reduce the blast radius of a hostile or inaccurate source page without making its facts true.
+
+  `docs/index.html` carries a condensed version of the same statement, because a disclaimer that exists only on GitHub and not on arckit.org is half a fix.
+
 - **`/arckit:research` now runs as a three-tier reader/orchestrator/writer split** (#466, item 1 remainder). It was the largest untrusted-input surface left in the plugin and the last single-tier agent holding `Bash`, `Write` and `WebFetch` in one context: vendor sites, pricing pages, marketplaces and AI-generated comparison pages are written to persuade, and the agent that read them could also execute and write.
 
   - `arckit-research-reader` (`WebSearch`, `WebFetch`, `Read`, `Glob`, `Grep`, `TodoWrite` — no `Write`, `Edit`, `Bash` or `Agent`) fetches evidence for one research category and returns JSON.

--- a/README.md
+++ b/README.md
@@ -28,6 +28,8 @@ ArcKit is a toolkit for enterprise architects that transforms architecture gover
 - 🔗 Maintaining requirements traceability
 - 📎 Citation traceability for external documents (inline `[DOC-CN]` markers with source quotes)
 
+> ArcKit produces **DRAFT artefacts for qualified people to review**, not legal, regulatory, clinical, or security advice. See [What ArcKit does not do](#what-arckit-does-not-do).
+
 ---
 
 ## Quick Start
@@ -334,6 +336,38 @@ ArcKit provides:
 - ✅ **AI Assistance**: Let AI handle document generation, you focus on decisions
 - ✅ **Enforced Traceability**: Automatic gap detection and coverage analysis
 - ✅ **Version Control**: Git-based workflow for all architecture artifacts
+
+---
+
+## What ArcKit does not do
+
+ArcKit generates **DRAFT artefacts for qualified people to review**. It is not legal, regulatory, clinical, or security advice, and no output it produces is a submission, a certification, an accreditation, or a compliance decision. Every artefact carries `Status: DRAFT` until a named accountable person signs it off, and that is the point at which responsibility for the content transfers to your organisation.
+
+Concretely, and regardless of how complete an artefact looks:
+
+- **A `/arckit:dpia` output is not a completed DPIA.** UK GDPR Article 35 places the assessment on the controller, and Article 36 requires prior consultation with the ICO where high residual risk remains. ArcKit drafts the document. The controller and the Data Protection Officer own it, and only they can conclude it.
+- **`/arckit:secure` and `/arckit:mod-secure` do not produce an assurance decision.** NCSC CAF outcomes, Cyber Essentials certification, and MOD Secure by Design assurance are all judged by named accountable individuals and, where relevant, by certification bodies. A generated assessment is input to that judgement, never a substitute for it.
+- **`/arckit:atrs` and `/arckit:ai-playbook` do not make an algorithmic tool lawful, fair, or transparent.** An ATRS record is published by the department after its own internal clearance, and the UK Government AI Playbook principles are obligations on the deploying organisation.
+- **The EU overlay does not perform conformity assessment.** It drafts documentation referencing the AI Act, NIS2, DORA, CRA, DSA and the Data Act. It is not a notified-body activity, it does not determine your risk classification, and it does not track amendments or implementing acts as they are made.
+- **`/arckit:jsp-936` and the NHS clinical safety commands are not assurance either.** Defence AI assurance requires the accountable authority; DCB0129 and DCB0160 require a suitably registered Clinical Safety Officer.
+- **No output is a procurement decision.** Research, scoring, and evaluation commands rank options against stated criteria. The Senior Responsible Owner and the procurement officer decide, under whatever framework rules apply to them.
+
+Two limits apply to everything above:
+
+1. **Citations reflect the moment they were fetched.** Commands cite sources at fetch time and record the URL, but legislation, standards, framework agreements, and vendor pricing all change. A citation that resolved when the artefact was generated may not describe the current text.
+2. **Generated content can be wrong.** Output is produced by a language model, and research commands extract from third-party web pages that may themselves be inaccurate or written to mislead. ArcKit isolates that extraction behind schema validation and keeps scoring deterministic, which reduces the blast radius but does not make the underlying facts true.
+
+### Who must review what
+
+Before any ArcKit artefact is relied on, published, or submitted:
+
+- Data protection artefacts (DPIA, records of processing): Data Protection Officer
+- Security and assurance artefacts: CISO, or the assessing authority for the relevant regime
+- Clinical safety artefacts: a registered Clinical Safety Officer
+- Business cases and procurement artefacts: Senior Responsible Owner and procurement or commercial lead
+- Anything referencing a regulation, in any jurisdiction: qualified legal counsel for that jurisdiction
+
+The community overlays each carry their own, narrower version of this warning. This section applies to **all** of ArcKit, including the officially-maintained core commands.
 
 ---
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -715,6 +715,13 @@
                 </a>
             </div>
             <p class="govuk-body govuk-!-margin-top-4"><a href="commands.html" class="govuk-link">Browse all commands &rarr;</a></p>
+
+            <div class="app-feature-card govuk-!-margin-top-6" style="border-color: #d4351c; border-width: 3px; padding: 1.5rem;" id="limits">
+                <h3 class="govuk-heading-s">What ArcKit does not do</h3>
+                <p class="govuk-body-s">ArcKit generates <strong>DRAFT artefacts for qualified people to review</strong>. It is not legal, regulatory, clinical, or security advice, and no output it produces is a submission, a certification, an accreditation, or a compliance decision.</p>
+                <p class="govuk-body-s">A generated DPIA is not a completed DPIA: UK GDPR Article&nbsp;35 places the assessment on the controller. A generated Secure by Design or JSP&nbsp;936 pack is not an assurance decision. The EU overlay drafts documentation referencing the AI Act, NIS2, DORA and the CRA; it does not perform conformity assessment. Clinical safety artefacts require a registered Clinical Safety Officer. Citations reflect the moment they were fetched, and generated content can be wrong.</p>
+                <p class="govuk-body-s govuk-!-margin-bottom-0"><a href="https://github.com/tractorjuice/arc-kit#what-arckit-does-not-do" class="govuk-link">Read the full limitations and review requirements</a></p>
+            </div>
         </div>
 
         <!-- 4b. Government Code Discovery -->

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **A repository-level statement of what ArcKit does not do** (#466, items 9 and 21). Every community overlay already carried a "review by qualified DPO / CSO / federal counsel before reliance" banner. The officially-maintained baseline carried none, and it is the baseline that ships `/arckit:dpia`, `/arckit:secure`, `/arckit:mod-secure`, `/arckit:atrs`, `/arckit:jsp-936` and `/arckit:sobc`. A grep for disclaimer language across `README.md` and every `docs/*.md` returned nothing, so the unsupported overlays were better hedged than the supported core.
+
+  `README.md` gains a `## What ArcKit does not do` section, placed immediately before the UK Government Compliance section so a reader meets the limits before the compliance claims. It enumerates them concretely rather than generically: a generated DPIA is not a completed DPIA, because UK GDPR Article 35 places the assessment on the controller and Article 36 requires ICO consultation where high residual risk remains; Secure by Design and JSP 936 packs are input to an assurance decision made by named accountable individuals, not the decision itself; the EU overlay drafts documentation referencing the AI Act, NIS2, DORA and the CRA but performs no conformity assessment and is not a notified-body activity; DCB0129 / DCB0160 need a registered Clinical Safety Officer. It closes with who must review what, and states that it applies to all of ArcKit rather than only the community overlays.
+
+  Two cross-cutting limits are stated because neither is obvious from an artefact that looks finished: citations reflect the moment they were fetched, and generated content can be wrong — schema validation and deterministic scoring reduce the blast radius of a hostile or inaccurate source page without making its facts true.
+
+  `docs/index.html` carries a condensed version of the same statement, because a disclaimer that exists only on GitHub and not on arckit.org is half a fix.
+
 - **`/arckit:research` now runs as a three-tier reader/orchestrator/writer split** (#466, item 1 remainder). It was the largest untrusted-input surface left in the plugin and the last single-tier agent holding `Bash`, `Write` and `WebFetch` in one context: vendor sites, pricing pages, marketplaces and AI-generated comparison pages are written to persuade, and the agent that read them could also execute and write.
 
   - `arckit-research-reader` (`WebSearch`, `WebFetch`, `Read`, `Glob`, `Grep`, `TodoWrite` — no `Write`, `Edit`, `Bash` or `Agent`) fetches evidence for one research category and returns JSON.


### PR DESCRIPTION
Closes items 9 and 21 of #466.

## The asymmetry this fixes

Every community overlay carries an explicit warning:

> ⚠️ Output should be reviewed by qualified DPO / CISO / Vergabejurist / legal counsel before reliance.

The **officially-maintained baseline carried none** — and it is the baseline that ships `/arckit:dpia`, `/arckit:secure`, `/arckit:mod-secure`, `/arckit:atrs`, `/arckit:jsp-936` and `/arckit:sobc`. A grep for disclaimer language across `README.md` and every `docs/*.md` returned nothing, and none of those six commands carries a caveat in its own body either.

So the *unsupported* parts of ArcKit were better hedged than the *supported* core, which is exactly backwards.

## What was added

A `## What ArcKit does not do` section in `README.md`, placed immediately before `## UK Government Compliance` so a reader meets the limits before the compliance claims, with a pointer from the intro so it is reachable without scrolling.

It enumerates concretely rather than generically, which is the part item 21 asked for:

- **A generated DPIA is not a completed DPIA.** UK GDPR Article 35 places the assessment on the controller; Article 36 requires prior ICO consultation where high residual risk remains.
- **`/arckit:secure` and `/arckit:mod-secure` produce input to an assurance decision, not the decision.** NCSC CAF outcomes, Cyber Essentials and MOD Secure by Design are judged by named accountable individuals and certification bodies.
- **`/arckit:atrs` and `/arckit:ai-playbook` do not make an algorithmic tool lawful, fair or transparent.** An ATRS record is published by the department after its own clearance.
- **The EU overlay performs no conformity assessment.** It drafts documentation referencing the AI Act, NIS2, DORA, CRA, DSA and the Data Act. It is not a notified-body activity, it does not determine your risk classification, and it does not track amendments or implementing acts.
- **JSP 936 and the NHS clinical safety commands are not assurance either.** DCB0129 and DCB0160 require a suitably registered Clinical Safety Officer.
- **No output is a procurement decision.**

Plus two cross-cutting limits, stated because neither is obvious from an artefact that *looks* finished:

1. **Citations reflect the moment they were fetched.** Legislation, standards, framework agreements and vendor pricing all move.
2. **Generated content can be wrong.** Research commands extract from third-party pages that may be inaccurate or written to mislead. Schema validation and deterministic scoring (#808) reduce the blast radius; they do not make the underlying facts true.

It closes with a **who must review what** list, and states explicitly that it applies to all of ArcKit including the core commands, not only the community overlays.

## The site too

`docs/index.html` gets a condensed version in the Jurisdictions section, where the compliance claims are made. A disclaimer that exists only on GitHub and not on arckit.org is half a fix.

## Verification

```
python3 scripts/converter.py                  # OK
python3 scripts/check-guide-site-links.py     # OK, 242 guides reachable
python3 scripts/check-llms-txt.py             # OK, 186 commands, all links resolve
python3 scripts/check_references.py           # 898 files, no broken references
python3 -m pytest tests/ -q                   # 1545 passed, 225 skipped
npx markdownlint-cli2 "**/*.md"               # 0 issues in 3821 files
```

`docs/index.html` tag balance verified at 0 with an HTML parser.

## Deliberately not in scope

Adding a per-command caveat to the six high-stakes core commands. That is a larger change touching command bodies and templates, and it should be a `_partials` fragment resolved at render time rather than six hand-written blocks that will drift. Worth its own issue if you want it.

Refs #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZrnfZmbdk33YD34j4Ys7H