### PR TITLE
ci: pin every GitHub Action to a commit SHA, and guard it (#466 item 17)

### DIFF
--- a/.github/workflows/codex-plugin.yml
+++ b/.github/workflows/codex-plugin.yml
@@ -23,13 +23,13 @@ jobs:
   codex-plugin:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "20"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -14,6 +14,8 @@ on:
       - "scripts/check-guide-parity.py"
       - "scripts/check-doc-type-registry.py"
       - "scripts/check-agent-frontmatter.py"
+      - "scripts/check-action-pins.py"
+      - ".github/workflows/*.yml"
       - "scripts/sync-shared-assets.py"
       - "scripts/standardise-colon.py"
       - "package.json"
@@ -59,6 +61,8 @@ on:
       - "scripts/check-guide-parity.py"
       - "scripts/check-doc-type-registry.py"
       - "scripts/check-agent-frontmatter.py"
+      - "scripts/check-action-pins.py"
+      - ".github/workflows/*.yml"
       - "scripts/sync-shared-assets.py"
       - "scripts/standardise-colon.py"
       - "package.json"
@@ -97,13 +101,13 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: DavidAnson/markdownlint-cli2-action@v19
+      - uses: DavidAnson/markdownlint-cli2-action@992badcdf24e3b8eb7e87ff9287fe931bcb00c6e # v20
         with:
           globs: "**/*.md"
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.11"
 
@@ -158,7 +162,10 @@ jobs:
       - name: Agent frontmatter (tools allowlist present, no stray files in agents/) (#466)
         run: python3 scripts/check-agent-frontmatter.py
 
-      - uses: actions/setup-node@v4
+      - name: GitHub Actions are pinned to commit SHAs (#466 item 17)
+        run: python3 scripts/check-action-pins.py
+
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5
         with:
           node-version: "20"
 

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -23,9 +23,9 @@ jobs:
     name: Full Python suite
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
         with:
           fetch-depth: 0
 
@@ -39,6 +39,19 @@ jobs:
   # tab -> GitHub Actions, with these exact values or the exchange is rejected:
   #   Owner: tractorjuice   Repository: arc-kit
   #   Workflow: release.yml   Environment: pypi
+  #
+  # STATUS 2026-08-19: that setup has NOT been done, so this job has failed on
+  # every release since it was added (v6.8.0, v6.9.0, v6.10.0, v6.11.0) and
+  # `arckit-cli` on PyPI is still 6.4.1. The failure is:
+  #
+  #   Trusted publishing exchange failure:
+  #   * `invalid-publisher`: valid token, but no corresponding publisher
+  #
+  # which means the OIDC token minted fine and PyPI has no publisher matching
+  # the claims. It is a PyPI-side configuration step, not a defect in this
+  # workflow, and nothing in this repository can fix it. The claims presented
+  # are the four values above; they must match the PyPI entry exactly,
+  # including the environment name.
   pypi:
     name: Publish to PyPI
     runs-on: ubuntu-latest
@@ -49,9 +62,9 @@ jobs:
       # `contents: write` above does not carry it.
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: "3.12"
 
@@ -78,7 +91,7 @@ jobs:
           echo "Publishing arckit-cli $BUILT"
 
       - name: Publish to PyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
+        uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
         with:
           # Makes re-running a partially failed release a no-op rather than a
           # hard failure on "file already exists".

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/check-action-pins.py`, wired into `lint-markdown.yml`** (#466 item 17). Asserts every `uses:` reference in `.github/workflows/` is a full 40-character commit SHA carrying a `# <version>` comment. Catches three shapes: a mutable tag, a mutable branch, and a SHA with no version comment (which is pinned but unreadable, so nobody can tell when it went stale). Each was verified against a deliberately reintroduced instance.
+
 - **The three cloud-research commands now run as three-tier reader/orchestrator/writer splits** (#466, item 1 remainder). `/arckit:aws-research`, `/arckit:azure-research` and `/arckit:gcp-research` complete the item: **every research agent in ArcKit is now split**, and `arckit-framework` is the only single-tier agent left, deliberately exempt as synthesis-only over artefacts already in the repository.
 
   **Three readers, one writer, one schema.** Each provider keeps its own reader, allowlisting only that provider's MCP server — an AWS reader must not be able to reach Microsoft Learn, and that is the whole point of the tier. They share `arckit-cloud-research-writer`, because a writer holds no network tools and there is nothing to isolate between providers; sharing it is what keeps the three artefacts structurally comparable, which is what makes them worth putting side by side in `/arckit:evaluate`.
@@ -81,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Every GitHub Action is pinned to a commit SHA** (#466 item 17). All 13 references across the four workflows were on floating tags, and `pypa/gh-action-pypi-publish` was on `release/v1` — a moving **branch**, which advances on every release of that action with no version boundary at all.
+
+  This is not hypothetical hygiene. A tag or branch resolves to whatever it points at *when the workflow runs*, so whoever controls the action repository can repoint one and every downstream workflow picks up the new code silently. ArcKit's workflows run with `contents: write`, and the release workflow additionally holds `id-token: write` for PyPI trusted publishing, so a repointed tag is an arbitrary-code-execution path into a job holding publish credentials.
+
+  Pins were taken at the **current major**, not the version in use: `actions/checkout` v4→v5, `actions/setup-python` v5→v6, `actions/setup-node` v4→v5, `markdownlint-cli2-action` v19→v20, `gh-action-pypi-publish` `release/v1`→v1.14.2 (the same commit that branch pointed at). Pinning at the old majors would have frozen a deprecation GitHub has already announced: the v6.11.0 release log carries `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5`.
+
 - **`/arckit:research`'s build-vs-buy verdict is now a rule applied to computed numbers, not a judgement.** Buy when the top option scores ≥ 70 and costs less than building; build when nothing clears 50 or everything above it costs more; hybrid when the top option scores well but covers under 70% of required capabilities; and `insufficient evidence` when fewer than two options published pricing at all — that last case previously produced a confident recommendation from a single data point. The build option's cost is an orchestrator estimate and is now explicitly labelled as one, because no reader ever fetched it.
 
 - **`docs/READER-PATTERN.md`** now records which agents have been split and names the five that remain (`aws-research`, `azure-research`, `gcp-research`, `gov-code-search`, `gov-landscape`).
@@ -88,6 +96,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Corrected the Agent System section of `CLAUDE.md`** (#466). It claimed 16 agents (there are 19), said the reader/writer subagents are "dispatched only by the corresponding orchestrator agent" (`READER-PATTERN.md` step 5 requires the orchestrator to be the slash command, and the command bodies say so explicitly), and listed `arckit-datascout`, `arckit-gov-reuse` and `arckit-grants` as the agents their commands delegate to, which stopped being true at #446. Those three files are now documented for what they actually are: pre-split monoliths retained solely because the converter replaces a command body wholesale with the agent prompt for non-Claude targets, which cannot dispatch subagents. The MCP tool-naming example in the same section was also wrong — it gave the bare `mcp__<server>__<tool>` form.
 
 ### Fixed
+
+- **Documented why the PyPI publish job has never worked**, in the job itself (#730). The job was added at v6.8.0 and has failed on every release since — v6.8.0, v6.9.0, v6.10.0 and v6.11.0 — leaving `arckit-cli` on PyPI at 6.4.1, which is the exact problem #730 added it to solve. It is not a regression and not a defect in the workflow: the failure is
+
+  ```text
+  Trusted publishing exchange failure:
+  * `invalid-publisher`: valid token, but no corresponding publisher
+  ```
+
+  meaning the OIDC token mints correctly and PyPI has no Trusted Publisher matching the claims. The one-time PyPI-side setup the job's own comment documents (Owner `tractorjuice`, Repository `arc-kit`, Workflow `release.yml`, Environment `pypi`) was never completed. **Nothing in this repository can fix it**, so the job now carries a dated status block recording the failure and the exact claims that must match, rather than leaving each release to rediscover it.
 
 - **Restored the `tools:` allowlist, `effort:` and `maxTurns:` on `arckit-datascout`, `arckit-grants` and `arckit-gov-reuse`** (#466). PR #445 migrated all ten research agents off a `disallowedTools` denylist onto an explicit `tools:` allowlist, so that tools added by future Claude Code versions cannot auto-grant to an existing agent. PR #446 — the three-tier reader/writer split — silently reverted it on exactly the three agents it touched, and the regression survived three months and seven minor releases. Both changes are recorded as shipped in #466's own "already done" list.
 

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`scripts/check-action-pins.py`, wired into `lint-markdown.yml`** (#466 item 17). Asserts every `uses:` reference in `.github/workflows/` is a full 40-character commit SHA carrying a `# <version>` comment. Catches three shapes: a mutable tag, a mutable branch, and a SHA with no version comment (which is pinned but unreadable, so nobody can tell when it went stale). Each was verified against a deliberately reintroduced instance.
+
 - **The three cloud-research commands now run as three-tier reader/orchestrator/writer splits** (#466, item 1 remainder). `/arckit:aws-research`, `/arckit:azure-research` and `/arckit:gcp-research` complete the item: **every research agent in ArcKit is now split**, and `arckit-framework` is the only single-tier agent left, deliberately exempt as synthesis-only over artefacts already in the repository.
 
   **Three readers, one writer, one schema.** Each provider keeps its own reader, allowlisting only that provider's MCP server — an AWS reader must not be able to reach Microsoft Learn, and that is the whole point of the tier. They share `arckit-cloud-research-writer`, because a writer holds no network tools and there is nothing to isolate between providers; sharing it is what keeps the three artefacts structurally comparable, which is what makes them worth putting side by side in `/arckit:evaluate`.
@@ -81,6 +83,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Every GitHub Action is pinned to a commit SHA** (#466 item 17). All 13 references across the four workflows were on floating tags, and `pypa/gh-action-pypi-publish` was on `release/v1` — a moving **branch**, which advances on every release of that action with no version boundary at all.
+
+  This is not hypothetical hygiene. A tag or branch resolves to whatever it points at *when the workflow runs*, so whoever controls the action repository can repoint one and every downstream workflow picks up the new code silently. ArcKit's workflows run with `contents: write`, and the release workflow additionally holds `id-token: write` for PyPI trusted publishing, so a repointed tag is an arbitrary-code-execution path into a job holding publish credentials.
+
+  Pins were taken at the **current major**, not the version in use: `actions/checkout` v4→v5, `actions/setup-python` v5→v6, `actions/setup-node` v4→v5, `markdownlint-cli2-action` v19→v20, `gh-action-pypi-publish` `release/v1`→v1.14.2 (the same commit that branch pointed at). Pinning at the old majors would have frozen a deprecation GitHub has already announced: the v6.11.0 release log carries `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5`.
+
 - **`/arckit:research`'s build-vs-buy verdict is now a rule applied to computed numbers, not a judgement.** Buy when the top option scores ≥ 70 and costs less than building; build when nothing clears 50 or everything above it costs more; hybrid when the top option scores well but covers under 70% of required capabilities; and `insufficient evidence` when fewer than two options published pricing at all — that last case previously produced a confident recommendation from a single data point. The build option's cost is an orchestrator estimate and is now explicitly labelled as one, because no reader ever fetched it.
 
 - **`docs/READER-PATTERN.md`** now records which agents have been split and names the five that remain (`aws-research`, `azure-research`, `gcp-research`, `gov-code-search`, `gov-landscape`).
@@ -88,6 +96,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Corrected the Agent System section of `CLAUDE.md`** (#466). It claimed 16 agents (there are 19), said the reader/writer subagents are "dispatched only by the corresponding orchestrator agent" (`READER-PATTERN.md` step 5 requires the orchestrator to be the slash command, and the command bodies say so explicitly), and listed `arckit-datascout`, `arckit-gov-reuse` and `arckit-grants` as the agents their commands delegate to, which stopped being true at #446. Those three files are now documented for what they actually are: pre-split monoliths retained solely because the converter replaces a command body wholesale with the agent prompt for non-Claude targets, which cannot dispatch subagents. The MCP tool-naming example in the same section was also wrong — it gave the bare `mcp__<server>__<tool>` form.
 
 ### Fixed
+
+- **Documented why the PyPI publish job has never worked**, in the job itself (#730). The job was added at v6.8.0 and has failed on every release since — v6.8.0, v6.9.0, v6.10.0 and v6.11.0 — leaving `arckit-cli` on PyPI at 6.4.1, which is the exact problem #730 added it to solve. It is not a regression and not a defect in the workflow: the failure is
+
+  ```text
+  Trusted publishing exchange failure:
+  * `invalid-publisher`: valid token, but no corresponding publisher
+  ```
+
+  meaning the OIDC token mints correctly and PyPI has no Trusted Publisher matching the claims. The one-time PyPI-side setup the job's own comment documents (Owner `tractorjuice`, Repository `arc-kit`, Workflow `release.yml`, Environment `pypi`) was never completed. **Nothing in this repository can fix it**, so the job now carries a dated status block recording the failure and the exact claims that must match, rather than leaving each release to rediscover it.
 
 - **Restored the `tools:` allowlist, `effort:` and `maxTurns:` on `arckit-datascout`, `arckit-grants` and `arckit-gov-reuse`** (#466). PR #445 migrated all ten research agents off a `disallowedTools` denylist onto an explicit `tools:` allowlist, so that tools added by future Claude Code versions cannot auto-grant to an existing agent. PR #446 — the three-tier reader/writer split — silently reverted it on exactly the three agents it touched, and the regression survived three months and seven minor releases. Both changes are recorded as shipped in #466's own "already done" list.
 

--- a/scripts/check-action-pins.py
+++ b/scripts/check-action-pins.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""Assert every GitHub Action in .github/workflows/ is pinned to a full commit SHA.
+
+A `uses: owner/repo@v4` reference resolves whatever that tag points at *when the
+workflow runs*. Tags are mutable: whoever controls the action repository can
+repoint one at new code, and every downstream workflow picks it up silently on
+the next run. Actions here run with `contents: write` and, in the release
+workflow, with `id-token: write` for PyPI trusted publishing, so a repointed tag
+is an arbitrary-code-execution path into a job holding publish credentials.
+
+`pypa/gh-action-pypi-publish@release/v1` was worse still: a moving *branch*,
+which advances on every release of that action with no version boundary at all.
+
+A 40-hex SHA is immutable. The trailing `# vN` comment records the human-readable
+version the SHA corresponds to, so a reader can tell at a glance what is pinned
+and Dependabot can still propose upgrades.
+
+Exit 0 on success, 1 on any violation.
+"""
+
+import pathlib
+import re
+import sys
+
+WORKFLOWS = pathlib.Path(__file__).resolve().parent.parent / ".github" / "workflows"
+
+USES = re.compile(r"^\s*(?:-\s*)?uses:\s*(?P<ref>\S+)(?:\s+#\s*(?P<comment>.*))?$")
+SHA = re.compile(r"^[0-9a-f]{40}$")
+# Local (./path) and container (docker://) references have no upstream tag to pin.
+EXEMPT_PREFIXES = ("./", ".\\", "docker://")
+
+
+def main():
+    if not WORKFLOWS.is_dir():
+        print(f"No workflows directory at {WORKFLOWS}")
+        return 0
+
+    errors = []
+    checked = 0
+
+    for workflow in sorted(WORKFLOWS.glob("*.y*ml")):
+        for lineno, line in enumerate(workflow.read_text().splitlines(), 1):
+            match = USES.match(line)
+            if not match:
+                continue
+            ref = match.group("ref")
+            if ref.startswith(EXEMPT_PREFIXES):
+                continue
+
+            checked += 1
+            where = f"{workflow.name}:{lineno}"
+
+            if "@" not in ref:
+                errors.append(f"{where}: `{ref}` has no version reference at all")
+                continue
+
+            action, _, version = ref.rpartition("@")
+            if not SHA.match(version):
+                kind = "branch" if "/" in version else "tag"
+                errors.append(
+                    f"{where}: `{action}` is pinned to the mutable {kind} `{version}`. "
+                    f"Pin to a full 40-character commit SHA with a trailing `# {version}` comment."
+                )
+                continue
+
+            if not match.group("comment"):
+                errors.append(
+                    f"{where}: `{action}` is SHA-pinned but has no `# <version>` comment, "
+                    f"so a reader cannot tell what version it is or when it went stale."
+                )
+
+    if errors:
+        print("GitHub Action pin check FAILED:\n")
+        for err in errors:
+            print(f"  - {err}")
+        print(f"\n{len(errors)} problem(s) found across {checked} action reference(s).")
+        return 1
+
+    print(f"Action pin check passed ({checked} action reference(s), all SHA-pinned).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes item 17 of #466, and documents a second finding that turned up in the same workflow.

## The exposure

All **13** `uses:` references across the four workflows were on floating tags, and `pypa/gh-action-pypi-publish` was on `release/v1` — a moving **branch**, which advances on every release of that action with no version boundary at all.

A tag or branch resolves to whatever it points at *when the workflow runs*. Whoever controls the action repository can repoint one, and every downstream workflow picks up the new code silently on the next run.

That matters more than usual here because of what these jobs hold:

- every workflow: `contents: write`
- `release.yml`: additionally `id-token: write`, for PyPI trusted publishing

So a repointed tag is an arbitrary-code-execution path into a job holding publish credentials.

## Pinned at the current major, not the version in use

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | `@v4` | `fbc6f39…` `# v5` |
| `actions/setup-python` | `@v5` | `ece7cb0…` `# v6` |
| `actions/setup-node` | `@v4` | `a0853c2…` `# v5` |
| `DavidAnson/markdownlint-cli2-action` | `@v19` | `992badc…` `# v20` |
| `pypa/gh-action-pypi-publish` | `@release/v1` | `dc37677…` `# v1.14.2` |

Pinning at the *old* majors would have frozen a deprecation GitHub has already announced. The v6.11.0 release log carries:

> `Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: actions/checkout@v4, actions/setup-python@v5`

`gh-action-pypi-publish@v1.14.2` is the same commit `release/v1` currently points at, so that one is a pure pin with no behaviour change today.

**CI result on the bumps:** the Node 20 warning is gone for `checkout`, `setup-python` and `setup-node`. `markdownlint-cli2-action@v20` still targets Node 20 upstream, so one warning remains and this PR cannot clear it — the alternative is staying on v19, which carries the same warning plus an older markdownlint. v20 reports `0 error(s)` on the tree, so the bump is safe.

## The guard

`scripts/check-action-pins.py`, wired into `lint-markdown.yml` (which now also triggers on `.github/workflows/*.yml`). Three shapes, each verified against a deliberately reintroduced instance:

- mutable tag → `is pinned to the mutable tag \`v5\``
- mutable branch → `is pinned to the mutable branch \`release/v1\``
- SHA with no `# version` comment → pinned but unreadable, so nobody can tell what it is or when it went stale

Local `./path` and `docker://` references are exempt, since they have no upstream tag to pin.

## Second finding: the PyPI publish job has never worked

I went looking because item 17 touches `release.yml`. The publish job has failed on **every release since it was added** — v6.8.0, v6.9.0, v6.10.0, v6.11.0 — and `arckit-cli` on PyPI is still at **6.4.1**, which is precisely the problem #730 added the job to solve.

It is not a regression and not a defect in the workflow:

```text
Trusted publishing exchange failure:
* `invalid-publisher`: valid token, but no corresponding publisher
  (Publisher with matching claims was not found)
```

The OIDC token mints correctly. PyPI has no Trusted Publisher matching the claims, because **the one-time PyPI-side setup that the job's own comment documents was never completed**. The claims presented are:

```text
Owner: tractorjuice   Repository: arc-kit
Workflow: release.yml  Environment: pypi
```

**Nothing in this repository can fix this** — it needs someone with PyPI access to add that entry under the project's Publishing tab → GitHub Actions, matching all four values including the environment name.

What this PR does is stop each release rediscovering it: the job now carries a dated status block recording the failure, the versions it has affected, and the exact claims that must match. I've deliberately not disabled or `continue-on-error`'d the job — it *should* keep failing loudly until the publisher exists.

## Verification

```
python3 scripts/check-action-pins.py   # 13 references, all SHA-pinned
python3 -m pytest tests/ -q            # 1545 passed, 225 skipped
npx markdownlint-cli2 "**/*.md"        # 0 issues
```

The real test of the major bumps is this PR's own CI run, which exercises all four workflows on the new pins — including whether `markdownlint-cli2-action@v20` flags anything `v19` did not. If it does, that one drops back to the v19 SHA.

Refs #466.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011ZrnfZmbdk33YD34j4Ys7H
