### PR TITLE
fix: stop /arckit:customize reporting a core-only result as the full inventory (#717)

### DIFF
--- a/.github/workflows/lint-markdown.yml
+++ b/.github/workflows/lint-markdown.yml
@@ -12,6 +12,7 @@ on:
       - "scripts/check_recipes.py"
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
+      - "scripts/check-customize-table.py"
       - "scripts/check-doc-type-registry.py"
       - "scripts/check-agent-frontmatter.py"
       - "scripts/check-action-pins.py"
@@ -59,6 +60,7 @@ on:
       - "scripts/check_recipes.py"
       - "scripts/check_doctype_collisions.py"
       - "scripts/check-guide-parity.py"
+      - "scripts/check-customize-table.py"
       - "scripts/check-doc-type-registry.py"
       - "scripts/check-agent-frontmatter.py"
       - "scripts/check-action-pins.py"
@@ -128,6 +130,9 @@ jobs:
 
       - name: Guide-tree parity check (docs/guides vs plugin copy)
         run: python3 scripts/check-guide-parity.py --check
+
+      - name: Customize template-table check (table vs templates on disk)
+        run: python3 scripts/check-customize-table.py --check
 
       - name: Doc-type registry references (recipes, commands, pages.md)
         run: python3 scripts/check-doc-type-registry.py

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`/arckit:customize` no longer presents a core-only result as the full inventory** (#717, piece 1). The command globs `${CLAUDE_PLUGIN_ROOT}/templates/`, which resolves to the plugin it ships in, so the community overlays' templates are invisible to it: 118 of the 183 templates in the repo, or 64%. Nothing in the command's 130-odd lines said so, so `list` presented a core-only list as the complete catalogue and `all` reported success having copied 65 of 183. A user asking for all templates and getting a third of them had no signal that anything was missing.
+
+  The reachability fix is piece 2 and is tracked separately. What changes here is that the command stops giving a wrong answer: `list` and `all` state their scope, the "not found" branch checks the overlays before dead-ending, and the command explains how to copy an overlay template by hand. That path uses `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/`, because the core plugin bundles a copy of every overlay under its own root, so no plugin-cache walking is involved.
+
+- **The `customize.md` template table matches the templates on disk.** It had drifted in both directions. Twenty core templates were absent from it (`competitors`, `conformance-assessment`, `data-source-profile`, `dfd`, `framework-overview`, `gcp-research`, `glossary`, the four `gov-*` and `wardley-*` sets, `grants`, `maturity-model`, `presentation`, `tech-note`, `tenders`, `vendor-profile`), and one row named `uk-gov-tcop`, a template that has never existed, so asking for it hit the "source template does not exist" branch while the docs said it was valid. The table now carries all 65 core templates, sorted, with the phantom row removed.
+
+- **`docs/guides/customize.md` describes the plugin's template locations correctly.** It told plugin users that defaults live in `.arckit/templates/`, which is the CLI and non-Claude-extension story; under the Claude Code plugin they live in `${CLAUDE_PLUGIN_ROOT}/templates/`. The guide now covers both, states the same overlay scope as the command, and stops implying that its truncated sample table is the catalogue.
+
+### Added
+
+- **`scripts/check-customize-table.py`, wired into `lint-markdown.yml`.** Holds the table to the templates on disk: every core template has a row, every row names a template that exists, every row's `/arckit:<command>` reference resolves to a real command file, and no template is listed twice. It also asserts the scope wording is still present, so the silent-partial-answer failure mode cannot come back by deletion. All five failure modes were verified against deliberately reintroduced instances, including the exact `uk-gov-tcop` row this PR removes.
+
+  This fits the existing guard pattern (`check-doc-type-registry.py`, `check-multi-instance-parity.py`, `check-guide-parity.py`). Nothing had ever looked at this table, which is why it drifted through both halves undetected.
+
 ## [6.12.0] — 2026-08-19
 
 ### Added

--- a/docs/guides/customize.md
+++ b/docs/guides/customize.md
@@ -28,10 +28,28 @@
 
 | Location | Purpose |
 |----------|---------|
-| `.arckit/templates/` | Default templates (refreshed by `arckit init`) |
+| `${CLAUDE_PLUGIN_ROOT}/templates/` | Default templates (Claude Code plugin) |
+| `.arckit/templates/` | Default templates (CLI and non-Claude extensions, refreshed by `arckit init`) |
 | `.arckit/templates-custom/` | Your customizations (preserved across updates) |
 
 Commands automatically check for custom templates first, falling back to defaults.
+
+### Scope
+
+In Claude Code, `/arckit:customize` covers the **core `arckit` plugin only**. Community overlay plugins (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) ship their own templates, and `list` and `all` do not cover them. The command will tell you which scope it used.
+
+The core plugin does bundle a copy of every overlay, so an overlay template can still be copied by hand:
+
+```bash
+# Locate it under the installed core plugin, then copy it
+find ~/.claude/plugins/cache -path '*/arckit/*/plugins/*/templates/codebase-audit-template.md' \
+  | sort -V | tail -1 \
+  | xargs -I{} cp {} .arckit/templates-custom/codebase-audit-template.md
+```
+
+Ask `/arckit:customize codebase-audit` and the command will locate it for you and explain the copy. Making this a first-class path is tracked on [issue #717](https://github.com/tractorjuice/arc-kit/issues/717).
+
+On the CLI and the non-Claude extensions this distinction does not apply: `arckit init` writes every template into a single flat `.arckit/templates/` directory.
 
 ---
 
@@ -105,4 +123,6 @@ rm .arckit/templates-custom/requirements-template.md
 | `data-model-template.md` | `/arckit:data-model` |
 | `sow-template.md` | `/arckit:sow` |
 | `pages-template.html` | `/arckit:pages` |
-| ... | (run `/arckit:customize list` for full list) |
+| ... | (run `/arckit:customize list` for the full core list) |
+
+The core plugin ships 65 templates and the overlays add well over a hundred more, so the extract above is a sample rather than a catalogue. `/arckit:customize list` is the authoritative core list.

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`/arckit:customize` no longer presents a core-only result as the full inventory** (#717, piece 1). The command globs `${CLAUDE_PLUGIN_ROOT}/templates/`, which resolves to the plugin it ships in, so the community overlays' templates are invisible to it: 118 of the 183 templates in the repo, or 64%. Nothing in the command's 130-odd lines said so, so `list` presented a core-only list as the complete catalogue and `all` reported success having copied 65 of 183. A user asking for all templates and getting a third of them had no signal that anything was missing.
+
+  The reachability fix is piece 2 and is tracked separately. What changes here is that the command stops giving a wrong answer: `list` and `all` state their scope, the "not found" branch checks the overlays before dead-ending, and the command explains how to copy an overlay template by hand. That path uses `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/`, because the core plugin bundles a copy of every overlay under its own root, so no plugin-cache walking is involved.
+
+- **The `customize.md` template table matches the templates on disk.** It had drifted in both directions. Twenty core templates were absent from it (`competitors`, `conformance-assessment`, `data-source-profile`, `dfd`, `framework-overview`, `gcp-research`, `glossary`, the four `gov-*` and `wardley-*` sets, `grants`, `maturity-model`, `presentation`, `tech-note`, `tenders`, `vendor-profile`), and one row named `uk-gov-tcop`, a template that has never existed, so asking for it hit the "source template does not exist" branch while the docs said it was valid. The table now carries all 65 core templates, sorted, with the phantom row removed.
+
+- **`docs/guides/customize.md` describes the plugin's template locations correctly.** It told plugin users that defaults live in `.arckit/templates/`, which is the CLI and non-Claude-extension story; under the Claude Code plugin they live in `${CLAUDE_PLUGIN_ROOT}/templates/`. The guide now covers both, states the same overlay scope as the command, and stops implying that its truncated sample table is the catalogue.
+
+### Added
+
+- **`scripts/check-customize-table.py`, wired into `lint-markdown.yml`.** Holds the table to the templates on disk: every core template has a row, every row names a template that exists, every row's `/arckit:<command>` reference resolves to a real command file, and no template is listed twice. It also asserts the scope wording is still present, so the silent-partial-answer failure mode cannot come back by deletion. All five failure modes were verified against deliberately reintroduced instances, including the exact `uk-gov-tcop` row this PR removes.
+
+  This fits the existing guard pattern (`check-doc-type-registry.py`, `check-multi-instance-parity.py`, `check-guide-parity.py`). Nothing had ever looked at this table, which is why it drifted through both halves undetected.
+
 ## [6.12.0] — 2026-08-19
 
 ### Added

--- a/plugins/arckit-claude/commands/customize.md
+++ b/plugins/arckit-claude/commands/customize.md
@@ -21,6 +21,8 @@ ArcKit uses document templates to generate consistent architecture artifacts. Us
 - **Defaults**: `${CLAUDE_PLUGIN_ROOT}/templates/` (shipped with ArcKit, refreshed by `arckit init`)
 - **User overrides**: `.arckit/templates-custom/` (your customizations, preserved across updates)
 
+**Scope: this command covers the core `arckit` plugin only.** `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin the command itself ships in, so the templates that community overlay plugins ship (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) are not in the glob. They are the larger half of the catalogue. Never present a core-only result as the complete inventory; see "Copy an overlay template" below for how to copy one.
+
 ## Instructions
 
 ### 1. **Parse User Request**
@@ -36,6 +38,10 @@ The user may request:
 
 If user wants to see available templates, use Glob to find `${CLAUDE_PLUGIN_ROOT}/templates/*-template.md` and `${CLAUDE_PLUGIN_ROOT}/templates/*-template.html`, then extract the template name from each filename (strip the `-template.md`/`.html` suffix).
 
+**State the scope before the table**, in these words or close to them:
+
+> Showing the NN templates in the core `arckit` plugin. Community overlay plugins ship their own templates, which this list does not cover.
+
 Display as a table:
 
 | Template | Command | Description |
@@ -48,23 +54,37 @@ Display as a table:
 | `aws-research` | `/arckit:aws-research` | AWS service research findings |
 | `azure-research` | `/arckit:azure-research` | Azure service research findings |
 | `backlog` | `/arckit:backlog` | Product backlog with user stories |
+| `competitors` | `/arckit:competitors` | Competitor landscape and market share |
+| `conformance-assessment` | `/arckit:conformance` | Architecture conformance assessment |
 | `data-mesh-contract` | `/arckit:data-mesh-contract` | Data product contracts |
 | `data-model` | `/arckit:data-model` | Data model with GDPR compliance |
+| `data-source-profile` | `/arckit:datascout` | Per-source data profile (multi-instance) |
 | `datascout` | `/arckit:datascout` | External data source discovery |
 | `devops` | `/arckit:devops` | DevOps strategy and CI/CD |
+| `dfd` | `/arckit:dfd` | Yourdon-DeMarco data flow diagrams |
 | `dld-review` | `/arckit:dld-review` | Detailed design review |
 | `dos-requirements` | `/arckit:dos` | Digital Outcomes & Specialists |
 | `dpia` | `/arckit:dpia` | Data Protection Impact Assessment |
 | `evaluation-criteria` | `/arckit:evaluate` | Vendor evaluation framework |
 | `finops` | `/arckit:finops` | FinOps cloud cost management |
+| `framework-overview` | `/arckit:framework` | Framework overview and executive guide |
 | `gcloud-clarify` | `/arckit:gcloud-clarify` | G-Cloud clarification questions |
 | `gcloud-requirements` | `/arckit:gcloud-search` | G-Cloud service requirements |
+| `gcp-research` | `/arckit:gcp-research` | Google Cloud service research findings |
+| `glossary` | `/arckit:glossary` | Consolidated project glossary |
+| `gov-code-search` | `/arckit:gov-code-search` | UK government code search report |
+| `gov-landscape` | `/arckit:gov-landscape` | UK government domain landscape |
+| `gov-reuse` | `/arckit:gov-reuse` | Government code reuse assessment |
+| `grants` | `/arckit:grants` | UK grants and funding research |
 | `hld-review` | `/arckit:hld-review` | High-level design review |
 | `jsp-936` | `/arckit:jsp-936` | MOD AI assurance (JSP 936) |
+| `maturity-model` | `/arckit:maturity-model` | Capability maturity model |
 | `mlops` | `/arckit:mlops` | MLOps strategy |
 | `mod-secure-by-design` | `/arckit:mod-secure` | MOD Secure by Design |
 | `operationalize` | `/arckit:operationalize` | Operational readiness pack |
+| `pages` | `/arckit:pages` | GitHub Pages site (HTML/CSS/JS) |
 | `platform-design` | `/arckit:platform-design` | Platform Design Toolkit |
+| `presentation` | `/arckit:presentation` | MARP governance board slides |
 | `principles-compliance-assessment` | `/arckit:principles-compliance` | Principles compliance scorecard |
 | `project-plan` | `/arckit:plan` | Project plan with timeline |
 | `requirements` | `/arckit:requirements` | Business & technical requirements |
@@ -78,14 +98,19 @@ Display as a table:
 | `stakeholder-drivers` | `/arckit:stakeholders` | Stakeholder analysis |
 | `story` | `/arckit:story` | Project story with timeline |
 | `tcop-review` | `/arckit:tcop` | Technology Code of Practice |
+| `tech-note` | `/arckit:research` | Per-candidate technical note (multi-instance) |
+| `tenders` | `/arckit:tenders` | Procurement market intelligence |
 | `traceability-matrix` | `/arckit:traceability` | Requirements traceability |
 | `uk-gov-ai-playbook` | `/arckit:ai-playbook` | AI Playbook compliance |
 | `uk-gov-atrs` | `/arckit:atrs` | Algorithmic Transparency Record |
-| `uk-gov-tcop` | `/arckit:tcop` | TCoP review template |
 | `ukgov-secure-by-design` | `/arckit:secure` | UK Gov Secure by Design |
+| `vendor-profile` | `/arckit:research` | Per-vendor profile (multi-instance) |
 | `vendor-scoring` | `/arckit:evaluate` | Vendor scoring matrix |
+| `wardley-climate` | `/arckit:wardley.climate` | Wardley climatic patterns assessment |
+| `wardley-doctrine` | `/arckit:wardley.doctrine` | Wardley doctrine maturity assessment |
+| `wardley-gameplay` | `/arckit:wardley.gameplay` | Wardley gameplay analysis |
 | `wardley-map` | `/arckit:wardley` | Wardley Map documentation |
-| `pages` | `/arckit:pages` | GitHub Pages site (HTML/CSS/JS) |
+| `wardley-value-chain` | `/arckit:wardley.value-chain` | Wardley value chain decomposition |
 
 ### 3. **Copy Template(s)**
 
@@ -97,12 +122,27 @@ Display as a table:
    - Find: ``> **Template Origin**: Official | **ArcKit Version**: [VERSION] | **Command**: `/arckit.{command}` ``
    - Replace with: ``> **Template Origin**: Custom | **Based On**: `/arckit.{command}` | **ArcKit Version**: [VERSION]``
 4. Use the Write tool to save it to `.arckit/templates-custom/{name}-template.{ext}` (the directory will be created automatically)
-5. If the source template does not exist, inform the user and suggest running `/arckit:customize list`
+5. If the source template does not exist, do **not** stop at "not found". Glob `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/{name}-template.*` before answering: if it matches, the template ships in an overlay plugin, so follow "Copy an overlay template" below. Only if both globs come back empty, tell the user it does not exist and suggest `/arckit:customize list`.
 
 **Copy all templates:**
 
 1. Use Glob to find all `${CLAUDE_PLUGIN_ROOT}/templates/*-template.md` and `${CLAUDE_PLUGIN_ROOT}/templates/*-template.html` files
 2. For each template found, use Read to load it, update the origin banner (change `Template Origin: Official` to `Template Origin: Custom | Based On: /arckit.{command}`), and Write to save it to `.arckit/templates-custom/`
+3. **Report the scope, not just the count.** "all" here means all *core* templates. Say so explicitly, and say that overlay templates were not included:
+
+   > Copied NN core `arckit` templates. Community overlay plugins ship their own templates, which `all` does not cover.
+
+   Reporting "copied all templates" after a core-only pass is a wrong answer, not a terse one.
+
+**Copy an overlay template:**
+
+Templates belonging to a community overlay plugin cannot be reached through `${CLAUDE_PLUGIN_ROOT}/templates/`, but the core plugin bundles a copy of every overlay under its own root, so they can still be read and copied by hand:
+
+1. Glob `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/{name}-template.*` to locate the file (overlay directories nest one or two levels deep, e.g. `plugins/uae/`, `plugins/uk/finance/`)
+2. Read it, update the origin banner as under "Copy specific template" above, and Write it to `.arckit/templates-custom/{name}-template.{ext}`
+3. Tell the user which overlay it came from, and that the copy is the version bundled with the installed core plugin, which can lag a separately installed overlay
+
+Tracked on issue #717, which will make this path a first-class part of the command.
 
 ### 4. **Show Template Info**
 
@@ -184,6 +224,8 @@ After completing the request, show:
 ## Template Customization Complete ✅
 
 **Action**: [Listed templates / Copied X template(s)]
+
+**Scope**: Core `arckit` plugin ([N] templates). Overlay plugin templates not included.
 
 **Location**: `.arckit/templates-custom/`
 

--- a/plugins/arckit-claude/docs/guides/customize.md
+++ b/plugins/arckit-claude/docs/guides/customize.md
@@ -28,10 +28,28 @@
 
 | Location | Purpose |
 |----------|---------|
-| `.arckit/templates/` | Default templates (refreshed by `arckit init`) |
+| `${CLAUDE_PLUGIN_ROOT}/templates/` | Default templates (Claude Code plugin) |
+| `.arckit/templates/` | Default templates (CLI and non-Claude extensions, refreshed by `arckit init`) |
 | `.arckit/templates-custom/` | Your customizations (preserved across updates) |
 
 Commands automatically check for custom templates first, falling back to defaults.
+
+### Scope
+
+In Claude Code, `/arckit:customize` covers the **core `arckit` plugin only**. Community overlay plugins (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) ship their own templates, and `list` and `all` do not cover them. The command will tell you which scope it used.
+
+The core plugin does bundle a copy of every overlay, so an overlay template can still be copied by hand:
+
+```bash
+# Locate it under the installed core plugin, then copy it
+find ~/.claude/plugins/cache -path '*/arckit/*/plugins/*/templates/codebase-audit-template.md' \
+  | sort -V | tail -1 \
+  | xargs -I{} cp {} .arckit/templates-custom/codebase-audit-template.md
+```
+
+Ask `/arckit:customize codebase-audit` and the command will locate it for you and explain the copy. Making this a first-class path is tracked on [issue #717](https://github.com/tractorjuice/arc-kit/issues/717).
+
+On the CLI and the non-Claude extensions this distinction does not apply: `arckit init` writes every template into a single flat `.arckit/templates/` directory.
 
 ---
 
@@ -105,4 +123,6 @@ rm .arckit/templates-custom/requirements-template.md
 | `data-model-template.md` | `/arckit:data-model` |
 | `sow-template.md` | `/arckit:sow` |
 | `pages-template.html` | `/arckit:pages` |
-| ... | (run `/arckit:customize list` for full list) |
+| ... | (run `/arckit:customize list` for the full core list) |
+
+The core plugin ships 65 templates and the overlays add well over a hundred more, so the extract above is a sample rather than a catalogue. `/arckit:customize list` is the authoritative core list.

--- a/scripts/check-customize-table.py
+++ b/scripts/check-customize-table.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Hold `/arckit:customize`'s hardcoded template table to the templates on disk.
+
+`plugins/arckit-claude/commands/customize.md` carries a table mapping template
+short names to the command that writes them. The `list` action globs rather than
+reading the table, so the table is documentation rather than control flow -- but
+it is documentation the user is invited to act on, and it drifted in BOTH
+directions before anything watched it (arc-kit#717):
+
+  * 20 core templates were missing from it, so `/arckit:customize list` showed
+    rows the table did not explain and the table under-reported the catalogue by
+    a third.
+  * one row named `uk-gov-tcop`, a template that has never existed. Asking for it
+    hit the "source template does not exist" branch while the docs said it was
+    valid.
+
+This script asserts three things:
+
+  1. every core template on disk has a table row
+  2. every table row names a template that exists on disk
+  3. every table row's `/arckit:<command>` reference resolves to a real command
+
+It also checks that the command still states its scope. `/arckit:customize` can
+only reach the core plugin's templates -- `${CLAUDE_PLUGIN_ROOT}` resolves to the
+plugin the command ships in, so the overlays' templates (the larger half of the
+catalogue) are invisible to it. Saying "copied all templates" after a core-only
+pass is a wrong answer, not a terse one, so the scope wording is load-bearing and
+guarded against silent removal.
+
+Scope note: this guard deliberately covers the CORE table only. Overlay
+templates are not expected to appear in it. When #717 makes overlay templates
+first-class, widen the disk-side glob rather than relaxing the assertions.
+
+Usage:
+    python3 scripts/check-customize-table.py           # report drift, exit 1 if any
+    python3 scripts/check-customize-table.py --check   # same (CI-friendly alias)
+"""
+
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+COMMANDS = REPO_ROOT / "plugins" / "arckit-claude" / "commands"
+CUSTOMIZE = COMMANDS / "customize.md"
+TEMPLATES = REPO_ROOT / "plugins" / "arckit-claude" / "templates"
+
+TEMPLATE_SUFFIX = re.compile(r"-template\.(md|html)$")
+ROW = re.compile(r"^\| `([^`]+)` \| `/arckit:([^`]+)` \| (.+?) \|$", re.M)
+
+# Phrases that make the partial scope explicit to the user. The command must keep
+# saying this somewhere; the exact sentence may be reworded.
+SCOPE_MARKERS = (
+    "core `arckit` plugin only",
+    "does not cover",
+)
+
+
+def core_templates() -> set[str]:
+    """Short names of every template the core plugin ships (top level only)."""
+    return {
+        TEMPLATE_SUFFIX.sub("", path.name)
+        for path in TEMPLATES.iterdir()
+        if path.is_file() and TEMPLATE_SUFFIX.search(path.name)
+    }
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--check", action="store_true", help="CI-friendly alias")
+    parser.parse_args()
+
+    text = CUSTOMIZE.read_text(encoding="utf-8")
+    rows = ROW.findall(text)
+    if not rows:
+        print(
+            f"FAIL {CUSTOMIZE.relative_to(REPO_ROOT)}: no template table found.\n"
+            "     Expected rows shaped `| `name` | `/arckit:command` | description |`.",
+            file=sys.stderr,
+        )
+        return 1
+
+    tabled = {name for name, _command, _description in rows}
+    on_disk = core_templates()
+    failures: list[str] = []
+
+    duplicates = sorted({n for n, _c, _d in rows if [r[0] for r in rows].count(n) > 1})
+    if duplicates:
+        failures.append(
+            "Template listed more than once in the table:\n"
+            + "".join(f"  {name}\n" for name in duplicates)
+        )
+
+    missing = sorted(on_disk - tabled)
+    if missing:
+        failures.append(
+            f"{len(missing)} core template(s) on disk with no table row:\n"
+            + "".join(f"  {name}-template.*\n" for name in missing)
+            + "  Add a row to the table in customize.md.\n"
+        )
+
+    phantom = sorted(tabled - on_disk)
+    if phantom:
+        failures.append(
+            f"{len(phantom)} table row(s) naming a template that does not exist:\n"
+            + "".join(f"  {name}\n" for name in phantom)
+            + "  /arckit:customize <name> will fail for these. Remove or correct the row.\n"
+        )
+
+    unresolved = sorted(
+        {
+            (name, command)
+            for name, command, _description in rows
+            if not (COMMANDS / f"{command}.md").is_file()
+        }
+    )
+    if unresolved:
+        failures.append(
+            f"{len(unresolved)} table row(s) pointing at a command that does not exist:\n"
+            + "".join(f"  {name} -> /arckit:{command}\n" for name, command in unresolved)
+        )
+
+    absent_markers = [marker for marker in SCOPE_MARKERS if marker not in text]
+    if absent_markers:
+        failures.append(
+            "customize.md no longer states its scope. Missing wording:\n"
+            + "".join(f"  {marker!r}\n" for marker in absent_markers)
+            + "  The command reaches core templates only; a core-only result must\n"
+            "  never be presented as the full inventory (arc-kit#717).\n"
+        )
+
+    if failures:
+        print(
+            f"FAIL {CUSTOMIZE.relative_to(REPO_ROOT)}\n\n" + "\n".join(failures),
+            file=sys.stderr,
+        )
+        return 1
+
+    print(
+        f"customize table OK: {len(tabled)} rows match {len(on_disk)} core templates, "
+        "all command references resolve, scope stated."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Piece 1 of #717. The reachability fix is piece 2 and is tracked separately on the issue; this PR stops the command giving a wrong answer, and guards the table that had drifted through both halves undetected.

## The problem

`/arckit:customize` globs `${CLAUDE_PLUGIN_ROOT}/templates/`, which resolves to the plugin the command itself ships in, so every community overlay's templates are invisible to it: **118 of the 183 templates in the repo, or 64%**. Nothing in the command's 130-odd lines said so, so `list` presented a core-only list as the complete catalogue and `all` reported success having copied 65 of 183. A user asking for every template and getting a third of them had no signal that anything was missing.

Separately, the hardcoded 46-row table had drifted in both directions: 20 core templates were absent from it, and one row named `uk-gov-tcop`, a template that has never existed, so `/arckit:customize uk-gov-tcop` hit the "source template does not exist" branch while the docs said it was valid.

## What changed

**`plugins/arckit-claude/commands/customize.md`**

- `list` and `all` now state their scope explicitly. `all` is told, in as many words, that reporting "copied all templates" after a core-only pass is a wrong answer rather than a terse one.
- The "source template does not exist" branch checks the overlays before dead-ending.
- A new "Copy an overlay template" sub-block explains the manual path, including which overlay the file came from and the version-skew caveat.
- The table now carries all 65 core templates, sorted, with the phantom `uk-gov-tcop` row removed.

**`docs/guides/customize.md`** told plugin users that defaults live in `.arckit/templates/`, which is the CLI and non-Claude-extension story. It now covers both locations, states the same overlay scope, and stops implying that its truncated sample table is the catalogue. Synced to the plugin tree with `check-guide-parity.py --sync`.

**`scripts/check-customize-table.py`** (new, wired into `lint-markdown.yml`) holds the table to the templates on disk.

## The overlay path does not walk the plugin cache

Worth calling out because the issue originally assumed otherwise, and it is why piece 2 will be a much smaller change than first scoped. The core plugin bundles a copy of every overlay under its own root, so overlay templates are reachable with a plugin-root-relative glob. Verified against an installed 6.11.0, not just the source tree:

```console
$ R=~/.claude/plugins/cache/arckit-claude/arckit/6.11.0
$ find "$R/plugins" -path '*/templates/*-template.md' | wc -l
118
$ find "$R/plugins" -name 'codebase-audit-template.md'
${CLAUDE_PLUGIN_ROOT}/plugins/repo/templates/codebase-audit-template.md
```

That last file is the one #706 needed. `/arckit:customize` ships in core, so core is always installed whenever the command is runnable, and at matching versions the bundled and standalone copies are byte-identical (diffed clean at 6.11.0).

## Claude-plugin-only

The converted targets glob `.arckit/templates/*-template.md`, a flat directory carrying 172-173 templates, so Codex, Gemini, OpenCode, Copilot, Kimi, Vibe and Paperclip already see the full inventory. They are unchanged, deliberately.

## Guard verification

Each of the five failure modes was verified against a deliberately reintroduced instance, including the exact `uk-gov-tcop` row this PR removes:

| Reintroduced fault | Detected |
|---|---|
| Phantom row (`uk-gov-tcop` restored) | yes |
| Missing row (`glossary` row deleted) | yes |
| Dead command reference (`/arckit:glossry`) | yes |
| Duplicate row | yes |
| Scope wording removed | yes |

The scope check exists because the silent-partial-answer failure mode is the actual bug here; a table guard alone would let it come back by deletion.

## Testing

- `pytest tests` : 1545 passed, 225 skipped
- `npx markdownlint-cli2` on all changed markdown: 0 issues
- `python scripts/converter.py` re-run; all generated output is gitignored, no tracked drift
- `sync-shared-assets.py --check`, `check-guide-parity.py --check`, and all 17 `check-*` guards green

Closes nothing on its own; #717 stays open for piece 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMhNeNM12vHqHzVXNNhwCH
