### PR TITLE
feat: make /arckit:customize list cover the community overlays (#717)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`/arckit:customize list` now covers the community overlays too, closing #717.** Piece 1 fixed the silent-partial-answer; this completes the reachability half. `list` globs `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/` alongside the core tree and renders the overlay templates grouped by owning plugin, derived from the path (`plugins/uk/finance/` is `arckit-uk-finance`). Copy-by-name already reached the overlays as of piece 1, so `/arckit:customize codebase-audit` worked but nothing told you the name existed. Discovery was the last gap.
+
+  Overlay templates are deliberately **not** added to the hardcoded table: `list` renders them from the glob, so a newly added overlay appears without editing the command, and 118 extra rows would bloat a command body that sits in context on every invocation.
+
+  **`all` stays core-only, on purpose**, and now says so as a documented decision rather than an unstated limitation. Expanding it to all 183 would drop twelve UAE, twelve France, twelve Canada and ten US templates into a project that uses none of them.
+
+  `check-customize-table.py` gains a section-aware check that the overlay glob is present in *both* the `list` action and the copy-by-name fallback. A global occurrence count was not enough: `list` losing the glob while the fallback kept it is exactly the regression #717 was about, and the first version of the check did not catch it.
+
 - **`/arckit:customize` no longer presents a core-only result as the full inventory** (#717, piece 1). The command globs `${CLAUDE_PLUGIN_ROOT}/templates/`, which resolves to the plugin it ships in, so the community overlays' templates are invisible to it: 118 of the 183 templates in the repo, or 64%. Nothing in the command's 130-odd lines said so, so `list` presented a core-only list as the complete catalogue and `all` reported success having copied 65 of 183. A user asking for all templates and getting a third of them had no signal that anything was missing.
 
   The reachability fix is piece 2 and is tracked separately. What changes here is that the command stops giving a wrong answer: `list` and `all` state their scope, the "not found" branch checks the overlays before dead-ending, and the command explains how to copy an overlay template by hand. That path uses `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/`, because the core plugin bundles a copy of every overlay under its own root, so no plugin-cache walking is involved.

--- a/docs/guides/customize.md
+++ b/docs/guides/customize.md
@@ -36,18 +36,22 @@ Commands automatically check for custom templates first, falling back to default
 
 ### Scope
 
-In Claude Code, `/arckit:customize` covers the **core `arckit` plugin only**. Community overlay plugins (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) ship their own templates, and `list` and `all` do not cover them. The command will tell you which scope it used.
+In Claude Code, `${CLAUDE_PLUGIN_ROOT}` resolves to the core `arckit` plugin, which also bundles a copy of every community overlay (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest). Both halves are reachable, and the overlays are the larger half of the catalogue:
 
-The core plugin does bundle a copy of every overlay, so an overlay template can still be copied by hand:
+| Action | Scope |
+|--------|-------|
+| `list` | Core and overlays, grouped by plugin |
+| `/arckit:customize <name>` | Core and overlays |
+| `all` | Core only, deliberately |
+
+`all` stays core-only because a UK project has no use for twelve UAE templates. Copy overlay templates by name instead:
 
 ```bash
-# Locate it under the installed core plugin, then copy it
-find ~/.claude/plugins/cache -path '*/arckit/*/plugins/*/templates/codebase-audit-template.md' \
-  | sort -V | tail -1 \
-  | xargs -I{} cp {} .arckit/templates-custom/codebase-audit-template.md
+/arckit:customize codebase-audit     # ships in arckit-repo
+/arckit:customize uae-ai-charter     # ships in arckit-uae
 ```
 
-Ask `/arckit:customize codebase-audit` and the command will locate it for you and explain the copy. Making this a first-class path is tracked on [issue #717](https://github.com/tractorjuice/arc-kit/issues/717).
+Whichever action you use, the command states the scope it applied. The overlay copy is the version bundled with your installed core plugin, which can lag a separately installed overlay.
 
 On the CLI and the non-Claude extensions this distinction does not apply: `arckit init` writes every template into a single flat `.arckit/templates/` directory.
 
@@ -123,6 +127,6 @@ rm .arckit/templates-custom/requirements-template.md
 | `data-model-template.md` | `/arckit:data-model` |
 | `sow-template.md` | `/arckit:sow` |
 | `pages-template.html` | `/arckit:pages` |
-| ... | (run `/arckit:customize list` for the full core list) |
+| ... | (run `/arckit:customize list` for the full list) |
 
-The core plugin ships 65 templates and the overlays add well over a hundred more, so the extract above is a sample rather than a catalogue. `/arckit:customize list` is the authoritative core list.
+The core plugin ships 65 templates and the overlays add well over a hundred more, so the extract above is a sample rather than a catalogue. `/arckit:customize list` is the authoritative list and covers both.

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -9,6 +9,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`/arckit:customize list` now covers the community overlays too, closing #717.** Piece 1 fixed the silent-partial-answer; this completes the reachability half. `list` globs `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/` alongside the core tree and renders the overlay templates grouped by owning plugin, derived from the path (`plugins/uk/finance/` is `arckit-uk-finance`). Copy-by-name already reached the overlays as of piece 1, so `/arckit:customize codebase-audit` worked but nothing told you the name existed. Discovery was the last gap.
+
+  Overlay templates are deliberately **not** added to the hardcoded table: `list` renders them from the glob, so a newly added overlay appears without editing the command, and 118 extra rows would bloat a command body that sits in context on every invocation.
+
+  **`all` stays core-only, on purpose**, and now says so as a documented decision rather than an unstated limitation. Expanding it to all 183 would drop twelve UAE, twelve France, twelve Canada and ten US templates into a project that uses none of them.
+
+  `check-customize-table.py` gains a section-aware check that the overlay glob is present in *both* the `list` action and the copy-by-name fallback. A global occurrence count was not enough: `list` losing the glob while the fallback kept it is exactly the regression #717 was about, and the first version of the check did not catch it.
+
 - **`/arckit:customize` no longer presents a core-only result as the full inventory** (#717, piece 1). The command globs `${CLAUDE_PLUGIN_ROOT}/templates/`, which resolves to the plugin it ships in, so the community overlays' templates are invisible to it: 118 of the 183 templates in the repo, or 64%. Nothing in the command's 130-odd lines said so, so `list` presented a core-only list as the complete catalogue and `all` reported success having copied 65 of 183. A user asking for all templates and getting a third of them had no signal that anything was missing.
 
   The reachability fix is piece 2 and is tracked separately. What changes here is that the command stops giving a wrong answer: `list` and `all` state their scope, the "not found" branch checks the overlays before dead-ending, and the command explains how to copy an overlay template by hand. That path uses `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/`, because the core plugin bundles a copy of every overlay under its own root, so no plugin-cache walking is involved.

--- a/plugins/arckit-claude/commands/customize.md
+++ b/plugins/arckit-claude/commands/customize.md
@@ -21,7 +21,13 @@ ArcKit uses document templates to generate consistent architecture artifacts. Us
 - **Defaults**: `${CLAUDE_PLUGIN_ROOT}/templates/` (shipped with ArcKit, refreshed by `arckit init`)
 - **User overrides**: `.arckit/templates-custom/` (your customizations, preserved across updates)
 
-**Scope: this command covers the core `arckit` plugin only.** `${CLAUDE_PLUGIN_ROOT}` resolves to the plugin the command itself ships in, so the templates that community overlay plugins ship (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) are not in the glob. They are the larger half of the catalogue. Never present a core-only result as the complete inventory; see "Copy an overlay template" below for how to copy one.
+**Scope.** `${CLAUDE_PLUGIN_ROOT}` resolves to the core `arckit` plugin, which also bundles a copy of every community overlay (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) under `${CLAUDE_PLUGIN_ROOT}/plugins/`. Both halves are therefore reachable, and the overlays are the larger half of the catalogue:
+
+- **`list`** covers core **and** overlays
+- **Copying by name** covers core and overlays
+- **`all`** covers core only, deliberately, because a UK project has no use for twelve UAE templates
+
+Whichever scope an action has, **say which one you used**. Never present a core-only result as the complete inventory.
 
 ## Instructions
 
@@ -36,13 +42,18 @@ The user may request:
 
 ### 2. **List Available Templates**
 
-If user wants to see available templates, use Glob to find `${CLAUDE_PLUGIN_ROOT}/templates/*-template.md` and `${CLAUDE_PLUGIN_ROOT}/templates/*-template.html`, then extract the template name from each filename (strip the `-template.md`/`.html` suffix).
+Glob **both** template trees, then strip the `-template.md`/`.html` suffix from each filename to get the short name:
 
-**State the scope before the table**, in these words or close to them:
+1. **Core**: `${CLAUDE_PLUGIN_ROOT}/templates/*-template.md` and `${CLAUDE_PLUGIN_ROOT}/templates/*-template.html`
+2. **Overlays**: `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/*-template.md` and `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/*-template.html`
 
-> Showing the NN templates in the core `arckit` plugin. Community overlay plugins ship their own templates, which this list does not cover.
+For an overlay hit, derive the owning plugin from the path segments between `plugins/` and `templates/`: join them with `-` and prefix `arckit-`. So `plugins/uae/templates/` is `arckit-uae` and `plugins/uk/finance/templates/` is `arckit-uk-finance`. Overlay directories nest one or two levels deep, which is why the glob needs `**`.
 
-Display as a table:
+State the totals first, in these words or close to them:
+
+> NN templates available: NN in the core `arckit` plugin, NN across NN community overlay plugins.
+
+Then display the core templates as a table:
 
 | Template | Command | Description |
 |----------|---------|-------------|
@@ -112,6 +123,18 @@ Display as a table:
 | `wardley-map` | `/arckit:wardley` | Wardley Map documentation |
 | `wardley-value-chain` | `/arckit:wardley.value-chain` | Wardley value chain decomposition |
 
+Then list the overlay templates, grouped by owning plugin, ordered by descending count. Render these from the glob results, not from a hardcoded list, so a newly added overlay appears without this file changing:
+
+| Plugin | Templates |
+|--------|-----------|
+| `arckit-uae` | `uae-ai-charter`, `uae-classification`, ... |
+
+Close with the line that makes the two halves actionable:
+
+> Copy any of these by name, for example `/arckit:customize uae-ai-charter`. `/arckit:customize all` copies the core set only.
+
+If the user asked to list a single plugin's templates (e.g. "list arckit-repo"), show only that group.
+
 ### 3. **Copy Template(s)**
 
 **Copy specific template:**
@@ -136,13 +159,11 @@ Display as a table:
 
 **Copy an overlay template:**
 
-Templates belonging to a community overlay plugin cannot be reached through `${CLAUDE_PLUGIN_ROOT}/templates/`, but the core plugin bundles a copy of every overlay under its own root, so they can still be read and copied by hand:
+Templates belonging to a community overlay plugin are not in the core `templates/` glob, but the core plugin bundles a copy of every overlay under its own root, so copy one exactly as you would a core template:
 
 1. Glob `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/{name}-template.*` to locate the file (overlay directories nest one or two levels deep, e.g. `plugins/uae/`, `plugins/uk/finance/`)
 2. Read it, update the origin banner as under "Copy specific template" above, and Write it to `.arckit/templates-custom/{name}-template.{ext}`
 3. Tell the user which overlay it came from, and that the copy is the version bundled with the installed core plugin, which can lag a separately installed overlay
-
-Tracked on issue #717, which will make this path a first-class part of the command.
 
 ### 4. **Show Template Info**
 
@@ -225,7 +246,7 @@ After completing the request, show:
 
 **Action**: [Listed templates / Copied X template(s)]
 
-**Scope**: Core `arckit` plugin ([N] templates). Overlay plugin templates not included.
+**Scope**: [Core + overlays ([N] templates) for `list` and copy-by-name / Core `arckit` plugin only ([N] templates) for `all`]
 
 **Location**: `.arckit/templates-custom/`
 

--- a/plugins/arckit-claude/docs/guides/customize.md
+++ b/plugins/arckit-claude/docs/guides/customize.md
@@ -36,18 +36,22 @@ Commands automatically check for custom templates first, falling back to default
 
 ### Scope
 
-In Claude Code, `/arckit:customize` covers the **core `arckit` plugin only**. Community overlay plugins (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest) ship their own templates, and `list` and `all` do not cover them. The command will tell you which scope it used.
+In Claude Code, `${CLAUDE_PLUGIN_ROOT}` resolves to the core `arckit` plugin, which also bundles a copy of every community overlay (`arckit-uae`, `arckit-ca`, `arckit-uk-nhs`, `arckit-repo` and the rest). Both halves are reachable, and the overlays are the larger half of the catalogue:
 
-The core plugin does bundle a copy of every overlay, so an overlay template can still be copied by hand:
+| Action | Scope |
+|--------|-------|
+| `list` | Core and overlays, grouped by plugin |
+| `/arckit:customize <name>` | Core and overlays |
+| `all` | Core only, deliberately |
+
+`all` stays core-only because a UK project has no use for twelve UAE templates. Copy overlay templates by name instead:
 
 ```bash
-# Locate it under the installed core plugin, then copy it
-find ~/.claude/plugins/cache -path '*/arckit/*/plugins/*/templates/codebase-audit-template.md' \
-  | sort -V | tail -1 \
-  | xargs -I{} cp {} .arckit/templates-custom/codebase-audit-template.md
+/arckit:customize codebase-audit     # ships in arckit-repo
+/arckit:customize uae-ai-charter     # ships in arckit-uae
 ```
 
-Ask `/arckit:customize codebase-audit` and the command will locate it for you and explain the copy. Making this a first-class path is tracked on [issue #717](https://github.com/tractorjuice/arc-kit/issues/717).
+Whichever action you use, the command states the scope it applied. The overlay copy is the version bundled with your installed core plugin, which can lag a separately installed overlay.
 
 On the CLI and the non-Claude extensions this distinction does not apply: `arckit init` writes every template into a single flat `.arckit/templates/` directory.
 
@@ -123,6 +127,6 @@ rm .arckit/templates-custom/requirements-template.md
 | `data-model-template.md` | `/arckit:data-model` |
 | `sow-template.md` | `/arckit:sow` |
 | `pages-template.html` | `/arckit:pages` |
-| ... | (run `/arckit:customize list` for the full core list) |
+| ... | (run `/arckit:customize list` for the full list) |
 
-The core plugin ships 65 templates and the overlays add well over a hundred more, so the extract above is a sample rather than a catalogue. `/arckit:customize list` is the authoritative core list.
+The core plugin ships 65 templates and the overlays add well over a hundred more, so the extract above is a sample rather than a catalogue. `/arckit:customize list` is the authoritative list and covers both.

--- a/scripts/check-customize-table.py
+++ b/scripts/check-customize-table.py
@@ -20,16 +20,19 @@ This script asserts three things:
   2. every table row names a template that exists on disk
   3. every table row's `/arckit:<command>` reference resolves to a real command
 
-It also checks that the command still states its scope. `/arckit:customize` can
-only reach the core plugin's templates -- `${CLAUDE_PLUGIN_ROOT}` resolves to the
-plugin the command ships in, so the overlays' templates (the larger half of the
-catalogue) are invisible to it. Saying "copied all templates" after a core-only
-pass is a wrong answer, not a terse one, so the scope wording is load-bearing and
-guarded against silent removal.
+It also guards the command's scope handling, which is the half of #717 that was
+the actual bug. `list` and copy-by-name reach the overlays through
+`${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/`, because the core plugin bundles a
+copy of every overlay under its own root; `all` stays core-only by design,
+because a UK project has no use for twelve UAE templates. Saying "copied all
+templates" after a core-only pass is a wrong answer, not a terse one, so both
+the overlay glob and the scope wording are load-bearing and guarded against
+silent removal.
 
-Scope note: this guard deliberately covers the CORE table only. Overlay
-templates are not expected to appear in it. When #717 makes overlay templates
-first-class, widen the disk-side glob rather than relaxing the assertions.
+Scope note: only the CORE table is checked against disk. Overlay templates are
+deliberately NOT tabled -- `list` renders them from the glob, so a new overlay
+appears without this file changing, and 118 extra rows would bloat a command
+body that sits in context on every invocation.
 
 Usage:
     python3 scripts/check-customize-table.py           # report drift, exit 1 if any
@@ -51,12 +54,31 @@ TEMPLATES = REPO_ROOT / "plugins" / "arckit-claude" / "templates"
 TEMPLATE_SUFFIX = re.compile(r"-template\.(md|html)$")
 ROW = re.compile(r"^\| `([^`]+)` \| `/arckit:([^`]+)` \| (.+?) \|$", re.M)
 
-# Phrases that make the partial scope explicit to the user. The command must keep
-# saying this somewhere; the exact sentence may be reworded.
+# The overlay glob is the capability; the phrases are the promise made to the
+# user about scope. Both must survive editing. Exact sentences may be reworded,
+# but these fragments are the load-bearing part.
+OVERLAY_GLOB = "${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/"
+# The glob has to appear in BOTH actions that promise overlay coverage, so a
+# global occurrence count is not enough: `list` losing it while the copy
+# fallback keeps it is exactly the silent-partial-answer regression #717 was
+# about. Sections are the numbered `### N. **Title**` headings.
+OVERLAY_GLOB_SECTIONS = ("List Available Templates", "Copy Template(s)")
+SECTION = re.compile(r"^### \d+\. \*\*(.+?)\*\*$", re.M)
 SCOPE_MARKERS = (
-    "core `arckit` plugin only",
-    "does not cover",
+    "covers core only",
+    "Never present a core-only result as the complete inventory",
 )
+
+
+def split_sections(text: str) -> dict[str, str]:
+    """Map each numbered `### N. **Title**` heading to the body beneath it."""
+    matches = list(SECTION.finditer(text))
+    return {
+        match.group(1): text[
+            match.end() : matches[i + 1].start() if i + 1 < len(matches) else len(text)
+        ]
+        for i, match in enumerate(matches)
+    }
 
 
 def core_templates() -> set[str]:
@@ -123,13 +145,30 @@ def main() -> int:
             + "".join(f"  {name} -> /arckit:{command}\n" for name, command in unresolved)
         )
 
+    sections = split_sections(text)
+    missing_glob = [
+        title
+        for title in OVERLAY_GLOB_SECTIONS
+        if OVERLAY_GLOB not in sections.get(title, "")
+    ]
+    if missing_glob:
+        failures.append(
+            "customize.md no longer reaches overlay templates. Expected the glob\n"
+            f"  {OVERLAY_GLOB}\n"
+            "  in each of these sections, and it is missing from:\n"
+            + "".join(f"  ### {title}\n" for title in missing_glob)
+            + "  Without it the action silently drops the larger half of the\n"
+            "  catalogue (arc-kit#717).\n"
+        )
+
     absent_markers = [marker for marker in SCOPE_MARKERS if marker not in text]
     if absent_markers:
         failures.append(
             "customize.md no longer states its scope. Missing wording:\n"
             + "".join(f"  {marker!r}\n" for marker in absent_markers)
-            + "  The command reaches core templates only; a core-only result must\n"
-            "  never be presented as the full inventory (arc-kit#717).\n"
+            + "  `all` is core-only while `list` and copy-by-name are not; a\n"
+            "  core-only result must never be presented as the full inventory\n"
+            "  (arc-kit#717).\n"
         )
 
     if failures:
@@ -141,7 +180,7 @@ def main() -> int:
 
     print(
         f"customize table OK: {len(tabled)} rows match {len(on_disk)} core templates, "
-        "all command references resolve, scope stated."
+        "all command references resolve, overlay glob present, scope stated."
     )
     return 0
 


### PR DESCRIPTION
Piece 2 of #717, and the last gap. Closes the issue.

## What was left

Piece 1 (#821) already made copy-by-name reach the overlays, so `/arckit:customize codebase-audit` worked end to end. But `list` still globbed the core tree only, so nothing told a user that name existed. **Discovery was the remaining gap**, and it was the one thing #717's acceptance criteria still had outstanding.

## What changed

**`list` covers both trees.** It globs `${CLAUDE_PLUGIN_ROOT}/plugins/**/templates/` alongside the core tree and renders overlay templates grouped by owning plugin, derived from the path segments between `plugins/` and `templates/` (`plugins/uk/finance/` is `arckit-uk-finance`). It states both totals up front and closes with a line showing how to copy one.

**Overlay templates are deliberately not added to the hardcoded table.** `list` renders them from the glob, so a newly added overlay appears without editing the command, and 118 extra rows would bloat a command body that sits in context on every invocation. The table stays the core reference.

**`all` stays core-only, on purpose.** It now reads as a documented decision rather than an unstated limitation. Expanding it to all 183 would drop twelve UAE, twelve France, twelve Canada and ten US templates into a project that uses none of them.

| Action | Scope |
|--------|-------|
| `list` | Core and overlays, grouped by plugin |
| `/arckit:customize <name>` | Core and overlays |
| `all` | Core only, deliberately |

**Two bits of piece 1 wording are now spent** and removed: the claim that overlay templates are "copied by hand" (the command does the copy itself, which I got wrong in #821's description) and the forward reference to this issue.

## Guard fix

`check-customize-table.py`'s overlay check was too weak as shipped in #821. It counted occurrences of the glob across the whole file, and the glob appears four times, so removing it from `list` while the copy fallback kept it left two occurrences and the check stayed green. That is precisely the silent-partial-answer regression #717 was about.

It is now section-aware, requiring the glob in both the `list` action and the copy-by-name fallback. Verified by removing it from each section independently:

| Reintroduced fault | Detected | Names the section |
|---|---|---|
| Glob removed from `list` only | yes | `### List Available Templates` |
| Glob removed from copy section only | yes | `### Copy Template(s)` |
| `all` core-only promise deleted | yes | n/a |
| "Never present a core-only result" rule deleted | yes | n/a |
| Phantom table row | yes | n/a |

## Testing

- `pytest tests` : 1545 passed, 225 skipped
- `npx markdownlint-cli2` on all changed markdown: 0 issues
- `python scripts/converter.py` re-run; generated output gitignored, no tracked drift
- `sync-shared-assets.py --check`, `check-guide-parity.py --check`, and all 17 `check-*` guards green

Closes #717.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CMhNeNM12vHqHzVXNNhwCH
