### PR TITLE
docs(guides): add OrcaRouter as an organisational LLM gateway in BYO-LLM guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **OrcaRouter as a first-class organisational LLM gateway in the BYO-LLM guide.** `docs/guides/byo-llm.md` Route 3 now lists [OrcaRouter](https://www.orcarouter.ai) alongside LiteLLM, Portkey and TrueFoundry, with a dedicated config block for pointing Claude Code at `https://api.orcarouter.ai` (key prefix `sk-orca-`). Model discovery picks up the same `provider/model` namespace OpenRouter uses, and the gateway-level, zero-trust agent security runs on the same endpoint with no application code changes. Synced to the plugin guide copy via `check-guide-parity.py`.
+
 ### Fixed
 
 - **Mermaid ER guard rails for `/arckit:data-model` and the `mermaid-syntax` skill (#435).** `/arckit:diagram` has carried the `PK, FK` comma rule since #78; `/arckit:data-model` never did, and it is the command that emitted the `uuid tenant_id FK UK` attribute that failed to render in #435. Adds a Mermaid ERD Rules block to `data-model.md`, a combined-key note to both copies of `data-model-template.md`, and three ER rows to the skill's gotchas table (combined keys, attribute comments, cardinality tokens) in place of a "missing semicolons in ER" row that described no real error. The skill's `paths:` now auto-activates on `ARC-*-DATA-*.md` as well as `ARC-*-DIAG-*.md`, having never fired on the artefact class that broke. Note the rule is *not* "one key per attribute" as #435 states — Mermaid accepts multiple keys comma-separated; `FK UK` fails only for the missing comma. Every claim verified against `mermaid@11.15.0`: `FK UK` and `PK_FK` are parse errors, `FK, UK` and `PK, FK` parse.

--- a/docs/guides/byo-llm.md
+++ b/docs/guides/byo-llm.md
@@ -133,7 +133,7 @@ You lose everything that is Claude Code only: parallel `Agent` dispatch and ther
 
 ## Route 3: An organisational LLM gateway
 
-If your organisation already runs LiteLLM, Portkey, TrueFoundry, or Anthropic's own Claude apps gateway, Claude Code connects to it with the same two variables as Route 1:
+If your organisation already runs LiteLLM, Portkey, TrueFoundry, [OrcaRouter](https://www.orcarouter.ai), or Anthropic's own Claude apps gateway, Claude Code connects to it with the same two variables as Route 1:
 
 ```bash
 export ANTHROPIC_BASE_URL=https://gateway.example.internal
@@ -147,6 +147,19 @@ Two things are worth knowing:
 **Model discovery is off by default.** Set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` to have Claude Code query the gateway's `/v1/models` at startup and add the results to the `/model` picker. Only IDs containing `claude` or `anthropic` survive the filter, so a gateway serving models under other aliases needs the `ANTHROPIC_DEFAULT_*_MODEL` variables instead.
 
 For rollout across a team, distribute the base URL and credential through a [managed settings file](https://code.claude.com/docs/en/settings#settings-files) rather than asking each developer to export variables.
+
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Point Claude Code at the OrcaRouter base URL and use the API key (prefix `sk-orca-`) as the credential:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.orcarouter.ai
+export ANTHROPIC_AUTH_TOKEN=sk-orca-...
+```
+
+Model discovery (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`) surfaces OrcaRouter's model catalogue under the same `provider/model` namespace OpenRouter uses (for example `orcarouter/fusion-flash`); for tiers remapped from the OrcaRouter side, set the `ANTHROPIC_DEFAULT_*_MODEL` variables instead, as above.
 
 ---
 

--- a/plugins/arckit-claude/docs/guides/byo-llm.md
+++ b/plugins/arckit-claude/docs/guides/byo-llm.md
@@ -133,7 +133,7 @@ You lose everything that is Claude Code only: parallel `Agent` dispatch and ther
 
 ## Route 3: An organisational LLM gateway
 
-If your organisation already runs LiteLLM, Portkey, TrueFoundry, or Anthropic's own Claude apps gateway, Claude Code connects to it with the same two variables as Route 1:
+If your organisation already runs LiteLLM, Portkey, TrueFoundry, [OrcaRouter](https://www.orcarouter.ai), or Anthropic's own Claude apps gateway, Claude Code connects to it with the same two variables as Route 1:
 
 ```bash
 export ANTHROPIC_BASE_URL=https://gateway.example.internal
@@ -147,6 +147,19 @@ Two things are worth knowing:
 **Model discovery is off by default.** Set `CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1` to have Claude Code query the gateway's `/v1/models` at startup and add the results to the `/model` picker. Only IDs containing `claude` or `anthropic` survive the filter, so a gateway serving models under other aliases needs the `ANTHROPIC_DEFAULT_*_MODEL` variables instead.
 
 For rollout across a team, distribute the base URL and credential through a [managed settings file](https://code.claude.com/docs/en/settings#settings-files) rather than asking each developer to export variables.
+
+### OrcaRouter
+
+[OrcaRouter](https://www.orcarouter.ai) is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. It runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.
+
+Point Claude Code at the OrcaRouter base URL and use the API key (prefix `sk-orca-`) as the credential:
+
+```bash
+export ANTHROPIC_BASE_URL=https://api.orcarouter.ai
+export ANTHROPIC_AUTH_TOKEN=sk-orca-...
+```
+
+Model discovery (`CLAUDE_CODE_ENABLE_GATEWAY_MODEL_DISCOVERY=1`) surfaces OrcaRouter's model catalogue under the same `provider/model` namespace OpenRouter uses (for example `orcarouter/fusion-flash`); for tiers remapped from the OrcaRouter side, set the `ANTHROPIC_DEFAULT_*_MODEL` variables instead, as above.
 
 ---
 


### PR DESCRIPTION
This lets ArcKit users point Claude Code at [OrcaRouter](https://www.orcarouter.ai) as a first-class organisational LLM gateway instead of treating it as an anonymous custom base URL. Teams on the BYO-LLM route get the same two-variable setup they already use for LiteLLM, Portkey and TrueFoundry, plus model discovery that surfaces OrcaRouter's `provider/model` catalogue (for example `orcarouter/fusion-flash`) straight into the `/model` picker.

OrcaRouter is an OpenAI-compatible AI gateway built for both models and agents. Like OpenRouter, it exposes a provider/model namespace across many models — but it also combines adaptive routing, automatic failover, zero-markup inference, observability, guardrails, and agent-tool governance behind the same endpoint. Adding `orcarouter` to Route 3 means this project's users can use that stack directly, without treating OrcaRouter as an anonymous custom base URL. It also runs gateway-level, zero-trust security for AI agents on the same endpoint — screening every prompt/response and governing every tool call on a default-deny basis, with no application code changes.

The change mirrors the existing Route 3 entries: a named gateway bullet plus a config block using the same `ANTHROPIC_BASE_URL` / `ANTHROPIC_AUTH_TOKEN` variables, with the key prefix documented so the two-variable setup is copy-paste ready. The guide copy under `plugins/arckit-claude/docs/guides/` was synced via `python scripts/check-guide-parity.py --sync`; `--check` passes (234 shared guides identical) and `markdownlint-cli2` reports 0 errors on the three changed files. The `CHANGELOG.md` entry follows the existing Unreleased convention. Live connectivity to the documented base URL was verified with a real key before opening this PR.

Discord: discord.gg/YEubt8enRA · X: https://x.com/OrcaRouter

I'm an engineer on the OrcaRouter team.
