### PR TITLE
fix: make bump-version.sh work on macOS (BSD sed, bash 3.2)

### DIFF
--- a/.arckit/memory/sessions.md
+++ b/.arckit/memory/sessions.md
@@ -10,6 +10,15 @@ Automated session summaries captured by the ArcKit session-learner hook.
   - chore: bump version to 4.6.1
   - fix: trim skill descriptions to fit 250-char context cap (#215) (#266)
 
+### 2026-08-31 10:04 — general
+
+- **Effort:** max
+- **Commits:** 1 | **Files changed:** 91
+- **Artifacts:** none detected
+- **Summary:**
+  - chore: bump version to 6.13.0 (#829)
+- **Telemetry:** 100 tool calls (p50=58ms, p95=6905ms)
+
 ### 2026-08-31 08:58 — general
 
 - **Effort:** max
@@ -281,13 +290,6 @@ Automated session summaries captured by the ArcKit session-learner hook.
 - **Artifacts:** none detected
 
 ### 2026-07-21 19:23 — failure (rate_limit)
-
-- **Status:** session interrupted by API error
-- **Effort:** xhigh
-- **Commits:** 0 | **Files changed:** 0
-- **Artifacts:** none detected
-
-### 2026-07-21 19:04 — failure (rate_limit)
 
 - **Status:** session interrupted by API error
 - **Effort:** xhigh

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -119,6 +119,12 @@ The highest-signal failures — collected from real releases. Read these before 
 - **Skipping extension tests.** Run the step 4 extension suite after `converter.py`. It validates
   Codex, Gemini, OpenCode, Copilot, Vibe, Paperclip, release inventory, version alignment, and
   platform-specific command rewrites before anything is tagged.
+- **Releasing from a Mac.** `bump-version.sh` runs on stock macOS (BSD sed, bash 3.2) and asserts
+  every substitution lands — a `does not contain "…" after edit` error is pattern drift, not a
+  sed-flavour problem. `tag-plugins.sh` and `push-extensions.sh` still need bash ≥ 4:
+  `brew install bash`, then `/opt/homebrew/bin/bash scripts/…`. Full macOS notes (uv commands for
+  the converter and tests, the `http.postBuffer` fix for `protocol error: bad line length` pushes,
+  `GH_TOKEN` via `gh auth token`) live in RELEASING.md's "Releasing from macOS" section.
 - **Hardcoding the plugin list.** The Claude marketplace now ships 16 plugins (core plus
   regional, sector, method, agent-architecture, tooling, and supplier overlays) and keeps growing. Older examples listed
   only 7, silently skipping newer plugins. Discover plugins dynamically (step 7) -- this is the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to ArcKit will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`scripts/bump-version.sh` works on macOS.** Its four `sed -i -E` edits silently no-op'd under BSD sed — which parses `-E` as `-i`'s backup suffix and then evaluates the expression as BRE, where `+` is a literal — so a Mac-run bump left `pyproject.toml`, the README release links, and the `docs/README.md` footer at the old version and scattered `*-E` backup files; the v6.13.0 release shipped those edits by hand. The seds now write to a temp file and move it back (as the script's jq edits always did) and assert the expected literal landed, so a pattern that stops matching fails the bump loudly instead of silently. Verified end-to-end under `/bin/bash` 3.2 on macOS: full bump, idempotent same-version re-run, and a deliberate pattern-drift failure.
+
+  The landing assertion also settles the fifth sed's fate: `docs/index.html` lost its visible "Version X.Y.Z - Month Year" line long ago, so that sed had matched nothing for years while the JSON-LD `softwareVersion` — what search engines actually read — sat stale at 4.21.0. The section now updates that field, and it is brought current to 6.13.0.
+
+  The two `mapfile` calls became `while read` loops so the script runs under macOS's stock bash 3.2, with the community-plugin loop's empty-array expansion guarded (`set -u` treats expanding an empty array as unbound before bash 4.4) and an explicit error when `marketplace.json` yields no plugin names. `docs/RELEASING.md` gains a "Releasing from macOS" section covering what still differs on a Mac: `tag-plugins.sh` / `push-extensions.sh` need a brew-installed bash ≥ 4, the uv invocations for `converter.py` and the extension test suite, the `http.postBuffer` fix for `protocol error: bad line length` pushes, and sourcing `GH_TOKEN` from `gh auth token`. The `/release` skill's gotchas point at it.
+
 ## [6.13.0] — 2026-08-31
 
 ### Added

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,6 +37,27 @@ ArcKit ships in multiple formats, each with its own version file. They are all b
 | `scripts/push-extensions.sh [name...]` | Pushes standalone distribution dirs to their separate GitHub repos (`tractorjuice/arckit-claude`, `tractorjuice/arckit-gemini`, `tractorjuice/arckit-codex`, etc.), then creates or preserves each repo's `vX.Y.Z` tag and GitHub Release. The `claude` target publishes the full Claude Code marketplace repo: core plugin at the root, with overlays under structured `plugins/...` paths. Uses `GH_TOKEN`. Skips repos that don't yet exist on GitHub. Set `ARCKIT_SKIP_EXTENSION_RELEASES=1` only for a commit-only sync |
 | `.github/workflows/release.yml` | Creates the GitHub Release automatically on `v*` tag push (tag-push triggered, does not commit back to main) |
 
+## Releasing from macOS
+
+Releases were cut on GNU/Linux until v6.13.0, and the helper scripts grew Linux assumptions. What to know on a Mac:
+
+- **`bump-version.sh` runs on a stock Mac** (BSD sed, bash 3.2) as of the fix that followed v6.13.0. It avoids `sed -i` entirely — BSD sed parses `sed -i -E` as `-i` with backup suffix `-E`, so the old in-place edits silently no-op'd on macOS and left `*-E` backup files; the v6.13.0 release shipped its `pyproject.toml`, README and `docs/README.md` bumps by hand because of this. The script now also asserts each substitution landed: an `Error: <file> does not contain "…" after edit` failure means the target file drifted from the pattern (the fate of the old `docs/index.html` sed, which matched nothing after the page's visible version line was removed) — fix the pattern or the file; it is not a sed-flavour problem.
+- **`tag-plugins.sh` and `push-extensions.sh` need bash ≥ 4** (`mapfile`, `declare -A`); macOS ships bash 3.2. `brew install bash`, then invoke explicitly — `/opt/homebrew/bin/bash scripts/push-extensions.sh` — because Homebrew's bash can be shadowed by `/bin/bash` on `PATH`.
+- **`converter.py` and the step-7 test suite need Python ≥ 3.11** (`tomllib`) plus PyYAML / pytest / jsonschema. No project venv is required with uv:
+
+  ```bash
+  uv run --no-project --python 3.12 --with pyyaml python scripts/converter.py
+  uv run --no-project --python 3.12 --with pytest --with pyyaml --with jsonschema \
+    python -m pytest tests/codex/test_codex_extension.py \
+    tests/gemini tests/opencode tests/copilot \
+    tests/vibe/test_vibe_extension.py \
+    tests/paperclip/test_commands_json.py \
+    tests/plugin/test_release_process.py
+  ```
+
+- **If `git push` fails with `protocol error: bad line length` / `unexpected disconnect while reading sideband packet`**, raise the HTTP post buffer: `git config http.postBuffer 157286400`. `push-extensions.sh` pushes from temporary clones that do not see repo-local config — inject it via the environment instead: `GIT_CONFIG_COUNT=1 GIT_CONFIG_KEY_0=http.postBuffer GIT_CONFIG_VALUE_0=157286400 ./scripts/push-extensions.sh`.
+- **`GH_TOKEN` for step 12** can come from an authenticated gh CLI: `GH_TOKEN=$(gh auth token) ./scripts/push-extensions.sh`.
+
 ## Development Workflow
 
 All changes go through a feature branch and are merged to `main` via PR. **Never push directly to `main`.**

--- a/docs/index.html
+++ b/docs/index.html
@@ -397,7 +397,7 @@
                 "applicationSubCategory": "Enterprise Architecture Governance",
                 "operatingSystem": "macOS, Linux, Windows",
                 "description": "ArcKit is The Enterprise Architecture Governance Harness: open-source, covering strategy, architecture, delivery, and assurance, distributed as a plugin or extension for AI coding assistants — Claude Code, Gemini CLI, GitHub Copilot, OpenAI Codex CLI, and OpenCode CLI. It wraps the assistant with slash commands across an official UK Government baseline plus community-contributed jurisdiction and sector overlays (EU, France, Austria, Canada, UAE, Australia, USA, UK Finance, UK NHS, UK G-Cloud) that generate architecture artefacts using versioned templates with full traceability.",
-                "softwareVersion": "4.21.0",
+                "softwareVersion": "6.13.0",
                 "license": "https://github.com/tractorjuice/arc-kit/blob/main/LICENSE",
                 "codeRepository": "https://github.com/tractorjuice/arc-kit",
                 "offers": {

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to the ArcKit Claude Code plugin will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+- **`scripts/bump-version.sh` works on macOS.** Its four `sed -i -E` edits silently no-op'd under BSD sed — which parses `-E` as `-i`'s backup suffix and then evaluates the expression as BRE, where `+` is a literal — so a Mac-run bump left `pyproject.toml`, the README release links, and the `docs/README.md` footer at the old version and scattered `*-E` backup files; the v6.13.0 release shipped those edits by hand. The seds now write to a temp file and move it back (as the script's jq edits always did) and assert the expected literal landed, so a pattern that stops matching fails the bump loudly instead of silently. Verified end-to-end under `/bin/bash` 3.2 on macOS: full bump, idempotent same-version re-run, and a deliberate pattern-drift failure.
+
+  The landing assertion also settles the fifth sed's fate: `docs/index.html` lost its visible "Version X.Y.Z - Month Year" line long ago, so that sed had matched nothing for years while the JSON-LD `softwareVersion` — what search engines actually read — sat stale at 4.21.0. The section now updates that field, and it is brought current to 6.13.0.
+
+  The two `mapfile` calls became `while read` loops so the script runs under macOS's stock bash 3.2, with the community-plugin loop's empty-array expansion guarded (`set -u` treats expanding an empty array as unbound before bash 4.4) and an explicit error when `marketplace.json` yields no plugin names. `docs/RELEASING.md` gains a "Releasing from macOS" section covering what still differs on a Mac: `tag-plugins.sh` / `push-extensions.sh` need a brew-installed bash ≥ 4, the uv invocations for `converter.py` and the extension test suite, the `http.postBuffer` fix for `protocol error: bad line length` pushes, and sourcing `GH_TOKEN` from `gh auth token`. The `/release` skill's gotchas point at it.
+
 ## [6.13.0] — 2026-08-31
 
 ### Fixed

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -36,21 +36,26 @@ echo ""
 # `arckit-claude` separately mirrors how the script (and marketplace.json)
 # treats it as the umbrella plugin all community overlays depend on.
 
-mapfile -t ALL_PLUGINS < <(
+# `while read` rather than mapfile so the script runs under macOS's stock
+# bash 3.2 (mapfile is bash 4+, and `/usr/bin/env bash` resolves to /bin/bash
+# 3.2 on a Mac without a brew-installed bash).
+ALL_PLUGINS=()
+while IFS= read -r p; do ALL_PLUGINS+=("$p"); done < <(
   find . -maxdepth 4 -path '*/.claude-plugin/plugin.json' -not -path '*/node_modules/*' \
     | sed -E 's|^\./||; s|/\.claude-plugin/plugin\.json$||' \
     | sort
 )
-COMMUNITY_PLUGINS=()
-for p in "${ALL_PLUGINS[@]}"; do
-  [[ "$p" == "plugins/arckit-claude" ]] && continue
-  COMMUNITY_PLUGINS+=("$p")
-done
 
 if [[ ${#ALL_PLUGINS[@]} -eq 0 ]]; then
   echo "Error: no plugins discovered on disk." >&2
   exit 1
 fi
+
+COMMUNITY_PLUGINS=()
+for p in "${ALL_PLUGINS[@]}"; do
+  [[ "$p" == "plugins/arckit-claude" ]] && continue
+  COMMUNITY_PLUGINS+=("$p")
+done
 
 # ── Drift check: every plugin on disk must be in marketplace.json ──────────
 #
@@ -58,9 +63,15 @@ fi
 # (description, keywords, etc.). Catches the v5.3.0 backfill gotcha where a
 # new plugin shipped without its marketplace entry.
 
-mapfile -t MARKETPLACE_PLUGIN_NAMES < <(
+MARKETPLACE_PLUGIN_NAMES=()
+while IFS= read -r m; do MARKETPLACE_PLUGIN_NAMES+=("$m"); done < <(
   jq -r '.plugins[].name' .claude-plugin/marketplace.json | sort
 )
+
+if [[ ${#MARKETPLACE_PLUGIN_NAMES[@]} -eq 0 ]]; then
+  echo "Error: no plugins found in .claude-plugin/marketplace.json." >&2
+  exit 1
+fi
 MISSING_FROM_MARKETPLACE=()
 for p in "${ALL_PLUGINS[@]}"; do
   plugin_name=$(jq -r '.name' "$p/.claude-plugin/plugin.json")
@@ -91,6 +102,28 @@ update_file() {
   UPDATED=$((UPDATED + 1))
 }
 
+# ── Portable in-place sed with landing check ────────────────────────────────
+#
+# BSD (macOS) sed parses `sed -i -E` as -i with backup suffix "-E": it writes
+# a `file-E` backup, evaluates the expression as BRE (where `+` is a literal),
+# and every substitution silently no-ops — which left pyproject.toml stale
+# during the v6.13.0 release until fixed by hand. Avoid -i entirely: write to
+# a temp file and move it back, exactly like the jq edits below. Then assert
+# the expected literal is present, so a pattern that stops matching the file
+# (the fate of the old docs/index.html "Version X.Y.Z - Month Year" sed)
+# fails the bump loudly instead of silently. `grep -qF` keeps a re-run with
+# the same version idempotent.
+sed_edit() {
+  local expr="$1" file="$2" expect="$3"
+  sed -E "$expr" "$file" > "${file}.tmp"
+  mv "${file}.tmp" "$file"
+  if ! grep -qF "$expect" "$file"; then
+    echo "Error: $file does not contain \"$expect\" after edit." >&2
+    echo "       The sed pattern no longer matches this file — fix the pattern or the file." >&2
+    exit 1
+  fi
+}
+
 # ── 1. VERSION (plain text) ────────────────────────────────────────────────
 
 echo "$NEW_VERSION" > VERSION
@@ -98,24 +131,32 @@ update_file "VERSION" "overwrite"
 
 # ── 2. pyproject.toml ──────────────────────────────────────────────────────
 
-sed -i -E "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"$NEW_VERSION\"/" pyproject.toml
+sed_edit "s/^version = \"[0-9]+\.[0-9]+\.[0-9]+\"/version = \"$NEW_VERSION\"/" pyproject.toml \
+  "version = \"$NEW_VERSION\""
 update_file "pyproject.toml" "version field"
 
 # ── 3. README.md (2 occurrences: badge-style link with version in text and URL) ──
 
-sed -i -E "s/\[v[0-9]+\.[0-9]+\.[0-9]+\]\(https:\/\/github\.com\/tractorjuice\/arc-kit\/releases\/tag\/v[0-9]+\.[0-9]+\.[0-9]+\)/[v$NEW_VERSION](https:\/\/github.com\/tractorjuice\/arc-kit\/releases\/tag\/v$NEW_VERSION)/g" README.md
+sed_edit "s/\[v[0-9]+\.[0-9]+\.[0-9]+\]\(https:\/\/github\.com\/tractorjuice\/arc-kit\/releases\/tag\/v[0-9]+\.[0-9]+\.[0-9]+\)/[v$NEW_VERSION](https:\/\/github.com\/tractorjuice\/arc-kit\/releases\/tag\/v$NEW_VERSION)/g" README.md \
+  "[v$NEW_VERSION](https://github.com/tractorjuice/arc-kit/releases/tag/v$NEW_VERSION)"
 update_file "README.md" "release links (2 occurrences)"
 
 # ── 4. docs/README.md ──────────────────────────────────────────────────────
 
-sed -i -E "s/\*\*ArcKit Version\*\*: [0-9]+\.[0-9]+\.[0-9]+/**ArcKit Version**: $NEW_VERSION/" docs/README.md
+sed_edit "s/\*\*ArcKit Version\*\*: [0-9]+\.[0-9]+\.[0-9]+/**ArcKit Version**: $NEW_VERSION/" docs/README.md \
+  "**ArcKit Version**: $NEW_VERSION"
 update_file "docs/README.md" "footer version"
 
-# ── 5. docs/index.html (version + month) ───────────────────────────────────
+# ── 5. docs/index.html (JSON-LD softwareVersion) ────────────────────────────
+#
+# The page's visible "Version X.Y.Z - Month Year" line this section once
+# targeted was removed long ago; the JSON-LD SoftwareApplication block (which
+# feeds search engines' rich results) is what still carries a version, and it
+# had sat stale at 4.21.0 while the old sed matched nothing.
 
-MONTH_YEAR=$(date +"%B %Y")
-sed -i -E "s/Version [0-9]+\.[0-9]+\.[0-9]+ - [A-Za-z]+ [0-9]{4}/Version $NEW_VERSION - $MONTH_YEAR/" docs/index.html
-update_file "docs/index.html" "version + date → $MONTH_YEAR"
+sed_edit "s/\"softwareVersion\": \"[0-9]+\.[0-9]+\.[0-9]+\"/\"softwareVersion\": \"$NEW_VERSION\"/" docs/index.html \
+  "\"softwareVersion\": \"$NEW_VERSION\""
+update_file "docs/index.html" "JSON-LD softwareVersion"
 
 # ── 6. plugins/arckit-claude/VERSION ───────────────────────────────────────
 
@@ -157,7 +198,9 @@ update_file ".claude-plugin/marketplace.json" "all .plugins[].version (metadata.
 # any arckit-*/.claude-plugin/plugin.json directory is treated as a
 # community plugin (excluding the core arckit-claude).
 
-for plugin_dir in "${COMMUNITY_PLUGINS[@]}"; do
+# ${arr[@]+…} guards the expansion: bash 3.2's `set -u` treats expanding an
+# empty array as an unbound-variable error (fixed in bash 4.4).
+for plugin_dir in ${COMMUNITY_PLUGINS[@]+"${COMMUNITY_PLUGINS[@]}"}; do
   manifest="${plugin_dir}/.claude-plugin/plugin.json"
   version_file="${plugin_dir}/VERSION"
   if [[ -f "$manifest" ]]; then


### PR DESCRIPTION
## Summary

The v6.13.0 release exposed that `bump-version.sh` was Linux-only: its four `sed -i -E` edits silently no-op on macOS (BSD sed reads `-E` as `-i`'s backup suffix and evaluates the expression as BRE, where `+` is literal), leaving `pyproject.toml`, the README release links and `docs/README.md` at the old version plus stray `*-E` backup files. A stale `pyproject.toml` fails release.yml's tag-vs-built-version guard.

- Replace `sed -i` with a `sed_edit` helper: temp-file write + `mv` (same pattern as the script's jq edits) and a `grep -qF` assertion that the expected literal landed — pattern drift now fails the bump loudly instead of silently, and same-version re-runs stay idempotent.
- Repoint section 5 at what `docs/index.html` actually carries: the old `Version X.Y.Z - Month Year` sed matched nothing (the visible line was removed long ago) while the JSON-LD `softwareVersion` — what search engines read — sat stale at **4.21.0**. The section now updates that field, and this PR brings it current to 6.13.0.
- Replace the two `mapfile` calls with `while read` loops so the script runs under macOS's stock bash 3.2, guard the community-plugin loop's empty-array expansion (`set -u` unbound before bash 4.4), and error explicitly when marketplace.json yields no plugin names.
- New **"Releasing from macOS"** section in `docs/RELEASING.md` (brew bash ≥ 4 for `tag-plugins.sh`/`push-extensions.sh`, uv invocations for converter/tests, the `http.postBuffer` fix for `protocol error: bad line length` pushes, `GH_TOKEN` via `gh auth token`), and a matching `/release` skill gotcha.

## Testing

In a disposable `git archive` copy, under `/bin/bash` 3.2 with BSD sed:

- Full bump to 9.9.9: exit 0, all four sed targets updated, no `*-E` strays, 52 files updated
- Same-version re-run: exit 0 (idempotent)
- Deliberate pattern drift (footer line removed): exit 1 with `Error: docs/README.md does not contain "**ArcKit Version**: 9.9.10" after edit`
- `bash -n` clean on bash 3.2 and 5.3; markdownlint 0 issues; `check-contributor-credits.py` and `tests/plugin/test_release_process.py` pass

## Follow-up (not in this PR)

The `=X.Y.Z` dependency-pin prose in `README.md` and `plugins/arckit-oaa/README.md` is still a manual edit at release time — automating it needs a decision on how tightly to pattern-match backtick-wrapped pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6mjxfQb9qrWrxaBRkDpQw