### PR TITLE
docs: no tables in articles; make the release article a documented release step

### DIFF
--- a/.arckit/memory/sessions.md
+++ b/.arckit/memory/sessions.md
@@ -10,6 +10,15 @@ Automated session summaries captured by the ArcKit session-learner hook.
   - chore: bump version to 4.6.1
   - fix: trim skill descriptions to fit 250-char context cap (#215) (#266)
 
+### 2026-08-31 23:45 — general
+
+- **Effort:** max
+- **Commits:** 1 | **Files changed:** 5
+- **Artifacts:** none detected
+- **Summary:**
+  - docs: add the arckit-oaa standalone plugin article (#831)
+- **Telemetry:** 25 tool calls (p50=21ms, p95=2928ms)
+
 ### 2026-08-31 16:59 — general
 
 - **Effort:** max
@@ -290,11 +299,4 @@ Automated session summaries captured by the ArcKit session-learner hook.
   - docs: replace Atomic Task Graph hero with polished design (#661)
   - docs: add Atomic Task Graph article validating ArcKit build harness (#660)
 - **Telemetry:** 186 tool calls (p50=64ms, p95=310134ms) | by agent: arckit-deepbook:arckit-deepbook-writer(68 calls, p95=9ms), main(65 calls, p95=8758ms), arckit-deepbook:arckit-deepbook(53 calls, p95=434032ms)
-
-### 2026-07-21 20:04 — failure (rate_limit)
-
-- **Status:** session interrupted by API error
-- **Effort:** xhigh
-- **Commits:** 0 | **Files changed:** 0
-- **Artifacts:** none detected
 

--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -106,6 +106,12 @@ After step 11, confirm the GitHub Release was created (the `release.yml` workflo
 `vX.Y.Z` tag push). Also confirm every standalone repo has a `vX.Y.Z` tag and GitHub
 Release, then report the release URLs and which standalone repos were pushed.
 
+Then write the release article for the major features — `docs/articles/YYYY-MM-DD-<slug>.md`
+plus a hero generator script, force-added past the drafts-folder gitignore. **No Markdown
+tables** — LinkedIn and Medium do not render them; write comparisons as prose. See
+"Release article" in RELEASING.md for the full conventions (voice, hero style, community
+block, contributor credits).
+
 ## Common Gotchas
 
 The highest-signal failures — collected from real releases. Read these before running anything.
@@ -160,6 +166,9 @@ The highest-signal failures — collected from real releases. Read these before 
   including the public-but-proprietary `plugin/uk/gcloud/` overlay and its license exception. It
   now creates/preserves standalone repo `vX.Y.Z` tags and GitHub Releases; use
   `ARCKIT_SKIP_EXTENSION_RELEASES=1` only when intentionally doing a commit-only sync.
+- **Tables in release articles.** LinkedIn and Medium do not render Markdown tables — a
+  comparison pasted there lands as a wall of pipes. Write it as prose. Articles live in the
+  gitignored `docs/articles/` drafts folder; force-add the keepers (`git add -f`).
 - **Do not put release numbers in extension READMEs.** Extension release identity lives in
   `VERSION` files, manifests, Git tags, and GitHub Releases. README-pinned versions drift and
   are blocked by `tests/plugin/test_release_process.py`.

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -143,6 +143,22 @@ After step 11, verify the umbrella GitHub Release and every standalone GitHub Re
 - `tractorjuice/arckit-vibe`
 - `tractorjuice/arckit-kimi`
 
+### Release article
+
+Every release with major features gets a write-up in `docs/articles/`
+(`YYYY-MM-DD-<slug>.md`), in the voice of the existing pieces, with a hero
+generator script in the house style (1200×630, see the `generate-hero-*.py`
+siblings). The directory is gitignored as a drafts folder — force-add the
+keepers with `git add -f`, as every published article has been.
+
+**No Markdown tables in articles.** LinkedIn and Medium do not render them —
+a comparison lands as a wall of pipes. Write it as prose instead.
+
+End with the `<!-- arckit:community-block -->` section, and credit
+contributors by @handle in the article *and* in the CHANGELOG entry — the
+handle appearing in a CHANGELOG is what makes `check-contributor-credits.py`
+enforce their card on the contributors page.
+
 ### PyPI (`arckit-cli`)
 
 Step 11's tag push also publishes the CLI to PyPI, via the `pypi` job in

--- a/docs/articles/2026-09-01-arckit-oaa-standalone-plugin.md
+++ b/docs/articles/2026-09-01-arckit-oaa-standalone-plugin.md
@@ -44,15 +44,7 @@ The `oaa-full` recipe runs all five in order on top of the foundation. One revie
 
 ## O-AA or TOGAF ADM?
 
-The two overlays answer different situations, and the decision guide ships in the plugin README. Condensed:
-
-| Dimension | `arckit-togaf-adm` | `arckit-oaa` |
-|-----------|--------------------|--------------|
-| Cadence | Quarterly architecture boards | 2–4 week sprints |
-| Artefacts | Full deliverables | 1–2 page canvases, max 2/sprint |
-| Delivery | Stage-gate | Backlog-driven, iterative |
-| Security | Dedicated gate | Backlog item per sprint |
-| Pick when | Full regulatory audit, many stakeholder gates | Hard deadline under 8 weeks, agile culture |
+The two overlays answer different situations, and the decision guide ships in the plugin README. The short version: the TOGAF overlay runs on quarterly architecture boards, produces full deliverables, moves through stage gates, and treats security as a dedicated gate — pick it when you face a full regulatory audit and dozens of stakeholder sign-offs. O-AA runs in two-to-four-week sprints, produces one-to-two-page canvases capped at two per sprint, delivers from a backlog, and puts security on that backlog every sprint — pick it when the deadline is under eight weeks and the culture is already agile.
 
 They are complementary, not competitors. A workable pattern is TOGAF ADM for the enterprise baseline, then O-AA to execute individual capabilities at sprint velocity. One core install satisfies both plugins' version pins, and the namespaces (`/arckit-togaf-adm:` vs `/arckit-oaa:`) and doc-type codes never collide.
 


### PR DESCRIPTION
## Summary

- **Articles must not contain Markdown tables** — LinkedIn and Medium don't render them. The O-AA vs TOGAF ADM comparison table in `2026-09-01-arckit-oaa-standalone-plugin.md` is rewritten as prose (the article now has zero table lines; the only other article with tables is the long-published June usage-signals piece, left as is).
- **`docs/RELEASING.md` gains a 'Release article' section**: every release with major features gets a write-up in `docs/articles/` with a hero generator script, force-added past the drafts-folder gitignore (the established precedent), ending with the community block, crediting contributors by @handle in both the article and the CHANGELOG (which is what arms `check-contributor-credits.py`), and **no tables**.
- **The `/release` skill** points at that section from its post-flow steps and carries the no-tables rule as a gotcha.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01X6mjxfQb9qrWrxaBRkDpQw