### PR TITLE
test: guard command, agent and skill frontmatter against duplicate keys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Duplicate-key guard on command, agent and skill frontmatter.** PyYAML's `safe_load` keeps the last value of a repeated key and says nothing, so a pasted-twice `description:` or a second `handoffs:` block would load cleanly and silently discard the first, and `test_commands_structure.py` would not notice. `tests/plugin/test_frontmatter_duplicate_keys.py` parses every plugin's `commands/`, the core `agents/` and every plugin's `skills/` with a loader that raises on the first duplicate. All 300-odd files are clean today; the guard exists because a suspected duplicate in `search.md` turned out to be a display artefact, and the cheap way to be sure next time is a test.
+
 ## [6.14.0] — 2026-09-03
 
 ### Added

--- a/tests/plugin/test_frontmatter_duplicate_keys.py
+++ b/tests/plugin/test_frontmatter_duplicate_keys.py
@@ -1,0 +1,69 @@
+"""No command, agent or skill frontmatter carries a duplicate mapping key.
+
+PyYAML's SafeLoader keeps the last value of a repeated key and says nothing,
+so a pasted-twice `description:` or a second `handoffs:` block would load
+without error and silently discard the first. The structural tests use
+safe_load and would not notice. This loader raises on the first duplicate.
+Scope: every plugin's commands/, the core agents/, every plugin's skills/.
+"""
+
+from __future__ import annotations
+
+import glob
+import os
+
+import pytest
+import yaml
+
+REPO_ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "..", ".."))
+
+
+class DuplicateKeyError(yaml.YAMLError):
+    pass
+
+
+class StrictLoader(yaml.SafeLoader):
+    pass
+
+
+def _construct_mapping(loader, node, deep=False):
+    seen = set()
+    for key_node, _ in node.value:
+        key = loader.construct_object(key_node, deep=deep)
+        if key in seen:
+            raise DuplicateKeyError(f"duplicate key {key!r} at line {key_node.start_mark.line + 1}")
+        seen.add(key)
+    return yaml.SafeLoader.construct_mapping(loader, node, deep)
+
+
+StrictLoader.add_constructor(yaml.resolver.BaseResolver.DEFAULT_MAPPING_TAG, _construct_mapping)
+
+
+def frontmatter_files():
+    patterns = [
+        "plugins/*/commands/*.md",
+        "plugins/arckit-claude/agents/*.md",
+        "plugins/*/skills/*/SKILL.md",
+    ]
+    files = []
+    for pattern in patterns:
+        files.extend(glob.glob(os.path.join(REPO_ROOT, pattern)))
+    return sorted(files)
+
+
+def test_scope_is_not_empty():
+    assert len(frontmatter_files()) > 100
+
+
+@pytest.mark.parametrize("path", frontmatter_files(), ids=lambda p: os.path.relpath(p, REPO_ROOT))
+def test_frontmatter_has_no_duplicate_keys(path):
+    with open(path, encoding="utf-8") as f:
+        content = f.read()
+    if not content.startswith("---"):
+        pytest.skip("no frontmatter")
+    parts = content.split("---", 2)
+    assert len(parts) >= 3, f"{path}: frontmatter not closed"
+    try:
+        yaml.load(parts[1], Loader=StrictLoader)
+    except DuplicateKeyError as e:
+        pytest.fail(f"{os.path.relpath(path, REPO_ROOT)}: {e}")


### PR DESCRIPTION
## Summary

Item 4 from the post-review follow-ups, with a correction. I had reported the search command's `handoffs:` frontmatter as carrying duplicated keys. It does not: the "duplication" was an artefact of how the file was printed during review (frontmatter, then body lines that repeat the handoff wording). A strict scan of every command, agent and skill frontmatter found no duplicate keys anywhere.

The guard is still worth having. PyYAML's `safe_load` keeps the last value of a repeated key and says nothing, so a pasted-twice `description:` or a second `handoffs:` block would load cleanly, silently discard the first, and pass `test_commands_structure.py`. `tests/plugin/test_frontmatter_duplicate_keys.py` parses every plugin's `commands/`, the core `agents/` and every plugin's `skills/` with a loader that raises on the first duplicate, naming the file, key and line.

## Verification

- New test: 1 scope check + one case per file, all pass locally.
- No command, agent or skill file changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7uxRQ6m9c2xPQA1t9pU9
