### PR TITLE
docs: rewrite the three arckit-uk-gcloud skill descriptions in request-class style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`arckit-uk-gcloud` skill descriptions rewritten in request-class style.** The three overlay skills (`cloud-security`, `gcloud-framework`, `sfia-skills`) were the last still describing themselves with quoted phrase lists — twenty-odd utterances each. Each now names the class of question it answers and ends with a *not needed when* clause handing off to the `/arckit-uk-gcloud:` command that writes the document, the convention the five core skills adopted in #840. Bodies unchanged; the nested mirror under `plugins/arckit-claude/plugins/uk/gcloud/` re-synced.
+
 ### Added
 
 - **Duplicate-key guard on command, agent and skill frontmatter.** PyYAML's `safe_load` keeps the last value of a repeated key and says nothing, so a pasted-twice `description:` or a second `handoffs:` block would load cleanly and silently discard the first, and `test_commands_structure.py` would not notice. `tests/plugin/test_frontmatter_duplicate_keys.py` parses every plugin's `commands/`, the core `agents/` and every plugin's `skills/` with a loader that raises on the first duplicate. All 300-odd files are clean today; the guard exists because a suspected duplicate in `search.md` turned out to be a display artefact, and the cheap way to be sure next time is a test.

--- a/plugins/arckit-claude/plugins/uk/gcloud/skills/cloud-security/SKILL.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/skills/cloud-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Cloud Security & Compliance
-description: This skill should be used when the user asks about "ISO 27001", "Cyber Essentials", "NCSC principles", "cloud security", "what certifications", "SOC 2", "data protection", "UK GDPR", "security clearance", "PCI DSS", "compliance framework", "CSA STAR", "DSPT", "Technology Code of Practice", "AI Playbook", "what evidence do I need", "security certification", "NHS data", "BPSS", "SC clearance", "DV clearance", "what security do I need", "certification cost", "ISO 22301", or needs guidance on security certifications, compliance requirements, and evidence for G-Cloud submissions.
+description: "Answers a G-Cloud supplier's questions about security certifications and compliance evidence: ISO 27001, Cyber Essentials, SOC 2, CSA STAR, PCI DSS, DSPT, the NCSC 14 cloud security principles, UK GDPR and data protection, BPSS, SC and DV clearances, and what evidence a submission needs. Not needed when the request is for a security evidence document or an SDD security section; /arckit-uk-gcloud:security and the sdd-lot commands produce those."
 ---
 
 # Cloud Security & Compliance

--- a/plugins/arckit-claude/plugins/uk/gcloud/skills/gcloud-framework/SKILL.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/skills/gcloud-framework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: G-Cloud Framework Questions
-description: This skill should be used when the user asks about "character limit", "how many features", "what lots", "CCS questions", "service categories", "declaration questions", "word limit", "mandatory exclusion", "service name limit", "pricing format", "what questions does CCS ask", "lot 1 categories", "lot 2 categories", "lot 3 categories", "how many words", "features limit", "benefits limit", "service description limit", "framework questions", "marketplace questions", "G-Cloud question structure", or needs quick lookups on Digital Marketplace field constraints and lot structures.
+description: "Answers quick questions about the Digital Marketplace question structure for a G-Cloud submission: character and word limits, how many features and benefits, lot 1, 2 and 3 categories, the service and declaration questions CCS asks, pricing format and mandatory exclusion grounds. Not needed when the request is for the submission content itself; /arckit-uk-gcloud:service-design, pricing, declaration and the sdd-lot commands write that."
 ---
 
 # G-Cloud Framework Questions

--- a/plugins/arckit-claude/plugins/uk/gcloud/skills/sfia-skills/SKILL.md
+++ b/plugins/arckit-claude/plugins/uk/gcloud/skills/sfia-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: SFIA Skills & Day Rates
-description: This skill should be used when the user asks about "SFIA level", "SFIA skills", "day rate", "what level is", "solution architect level", "Lot 3 roles", "DDaT roles", "AI skills framework", "cloud migration roles", "consultancy rates", "SFIA mapping", "role to SFIA", "skill level", "cloud support roles", "what SFIA level", "rate card", "SFIA 8", "junior consultant rate", "senior consultant rate", "principal consultant", "DevOps engineer level", "security engineer level", "project manager SFIA", or needs guidance on SFIA levels, role mappings, day rates, and Lot 3 service team compositions.
+description: "Answers questions about SFIA 8 levels, role-to-skill mappings, DDaT role equivalents, consultancy day-rate benchmarks and Lot 3 cloud-support team shapes for a G-Cloud submission. Not needed when the request is for the Lot 3 service definition or the pricing document; /arckit-uk-gcloud:sdd-lot3 and pricing produce those from the same data."
 ---
 
 # SFIA Skills & Day Rates

--- a/plugins/arckit-uk-gcloud/skills/cloud-security/SKILL.md
+++ b/plugins/arckit-uk-gcloud/skills/cloud-security/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: Cloud Security & Compliance
-description: This skill should be used when the user asks about "ISO 27001", "Cyber Essentials", "NCSC principles", "cloud security", "what certifications", "SOC 2", "data protection", "UK GDPR", "security clearance", "PCI DSS", "compliance framework", "CSA STAR", "DSPT", "Technology Code of Practice", "AI Playbook", "what evidence do I need", "security certification", "NHS data", "BPSS", "SC clearance", "DV clearance", "what security do I need", "certification cost", "ISO 22301", or needs guidance on security certifications, compliance requirements, and evidence for G-Cloud submissions.
+description: "Answers a G-Cloud supplier's questions about security certifications and compliance evidence: ISO 27001, Cyber Essentials, SOC 2, CSA STAR, PCI DSS, DSPT, the NCSC 14 cloud security principles, UK GDPR and data protection, BPSS, SC and DV clearances, and what evidence a submission needs. Not needed when the request is for a security evidence document or an SDD security section; /arckit-uk-gcloud:security and the sdd-lot commands produce those."
 ---
 
 # Cloud Security & Compliance

--- a/plugins/arckit-uk-gcloud/skills/gcloud-framework/SKILL.md
+++ b/plugins/arckit-uk-gcloud/skills/gcloud-framework/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: G-Cloud Framework Questions
-description: This skill should be used when the user asks about "character limit", "how many features", "what lots", "CCS questions", "service categories", "declaration questions", "word limit", "mandatory exclusion", "service name limit", "pricing format", "what questions does CCS ask", "lot 1 categories", "lot 2 categories", "lot 3 categories", "how many words", "features limit", "benefits limit", "service description limit", "framework questions", "marketplace questions", "G-Cloud question structure", or needs quick lookups on Digital Marketplace field constraints and lot structures.
+description: "Answers quick questions about the Digital Marketplace question structure for a G-Cloud submission: character and word limits, how many features and benefits, lot 1, 2 and 3 categories, the service and declaration questions CCS asks, pricing format and mandatory exclusion grounds. Not needed when the request is for the submission content itself; /arckit-uk-gcloud:service-design, pricing, declaration and the sdd-lot commands write that."
 ---
 
 # G-Cloud Framework Questions

--- a/plugins/arckit-uk-gcloud/skills/sfia-skills/SKILL.md
+++ b/plugins/arckit-uk-gcloud/skills/sfia-skills/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: SFIA Skills & Day Rates
-description: This skill should be used when the user asks about "SFIA level", "SFIA skills", "day rate", "what level is", "solution architect level", "Lot 3 roles", "DDaT roles", "AI skills framework", "cloud migration roles", "consultancy rates", "SFIA mapping", "role to SFIA", "skill level", "cloud support roles", "what SFIA level", "rate card", "SFIA 8", "junior consultant rate", "senior consultant rate", "principal consultant", "DevOps engineer level", "security engineer level", "project manager SFIA", or needs guidance on SFIA levels, role mappings, day rates, and Lot 3 service team compositions.
+description: "Answers questions about SFIA 8 levels, role-to-skill mappings, DDaT role equivalents, consultancy day-rate benchmarks and Lot 3 cloud-support team shapes for a G-Cloud submission. Not needed when the request is for the Lot 3 service definition or the pricing document; /arckit-uk-gcloud:sdd-lot3 and pricing produce those from the same data."
 ---
 
 # SFIA Skills & Day Rates


### PR DESCRIPTION
## Summary

Follow-up to #840, which rewrote the five core skill descriptions. The three `arckit-uk-gcloud` skills (`cloud-security`, `gcloud-framework`, `sfia-skills`) were the last still describing themselves with quoted phrase lists, twenty-odd utterances each. Each now names the class of question it answers and ends with a *not needed when* clause handing off to the `/arckit-uk-gcloud:` command that writes the document. Bodies are unchanged. The nested mirror under `plugins/arckit-claude/plugins/uk/gcloud/` is re-synced.

## Verification

- `claude plugin validate plugins/arckit-uk-gcloud/skills` passes.
- Overlay-namespacing, release-process and duplicate-key tests pass.
- markdownlint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7uxRQ6m9c2xPQA1t9pU9