### PR TITLE
fix: slugify accents correctly on stock macOS bash 3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`slugify` produces the right slug on stock macOS bash 3.2.** The accent transliteration in `scripts/bash/common.sh` (and the plugin copy) used a quoted multibyte pattern in `${var//pattern/repl}`, which bash 3.2 mis-splits, so a project named "Café Modernisation" got the directory `caf-e-modernisation` on any Mac without a Homebrew bash; bash 5 handled it, which is why CI on Ubuntu never saw it and the 27 `test_slugify.py` failures looked like a local-only quirk. Both sides of the substitution are now unquoted (the table holds letters only, so nothing needs quoting), with a comment naming the quirk. All 102 slugify cases pass on bash 3.2 and bash 5.
+
 ### Changed
 
 - **`arckit-uk-gcloud` skill descriptions rewritten in request-class style.** The three overlay skills (`cloud-security`, `gcloud-framework`, `sfia-skills`) were the last still describing themselves with quoted phrase lists — twenty-odd utterances each. Each now names the class of question it answers and ends with a *not needed when* clause handing off to the `/arckit-uk-gcloud:` command that writes the document, the convention the five core skills adopted in #840. Bodies unchanged; the nested mirror under `plugins/arckit-claude/plugins/uk/gcloud/` re-synced.

--- a/plugins/arckit-claude/CHANGELOG.md
+++ b/plugins/arckit-claude/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`slugify` produces the right slug on stock macOS bash 3.2.** The accent transliteration in `scripts/bash/common.sh` (and the plugin copy) used a quoted multibyte pattern in `${var//pattern/repl}`, which bash 3.2 mis-splits, so a project named "Café Modernisation" got the directory `caf-e-modernisation` on any Mac without a Homebrew bash; bash 5 handled it, which is why CI on Ubuntu never saw it and the 27 `test_slugify.py` failures looked like a local-only quirk. Both sides of the substitution are now unquoted (the table holds letters only, so nothing needs quoting), with a comment naming the quirk. All 102 slugify cases pass on bash 3.2 and bash 5.
+
 ## [6.14.0] — 2026-09-03
 
 ### Added

--- a/plugins/arckit-claude/scripts/bash/common.sh
+++ b/plugins/arckit-claude/scripts/bash/common.sh
@@ -181,10 +181,15 @@ slugify() {
         'Ź:z' 'ź:z' 'Ż:z' 'ż:z' 'Ž:z' 'ž:z'
     )
 
+    # Both sides are deliberately unquoted. bash 3.2 (stock macOS) mis-splits
+    # a *quoted* multibyte pattern or replacement in ${var//pattern/repl},
+    # turning "Café" into "caf-e"; the table holds letters only, so there is
+    # no glob or metacharacter to protect. tests/plugin/test_slugify.py runs
+    # under whatever `bash` is on PATH, so a Mac catches a regression here.
     for pair in "${translit[@]}"; do
         from="${pair%%:*}"
         to="${pair#*:}"
-        s="${s//"$from"/"$to"}"
+        s="${s//$from/$to}"
     done
 
     # LC_ALL=C keeps both steps byte-oriented, so the slug never depends on the

--- a/scripts/bash/common.sh
+++ b/scripts/bash/common.sh
@@ -181,10 +181,15 @@ slugify() {
         'Ź:z' 'ź:z' 'Ż:z' 'ż:z' 'Ž:z' 'ž:z'
     )
 
+    # Both sides are deliberately unquoted. bash 3.2 (stock macOS) mis-splits
+    # a *quoted* multibyte pattern or replacement in ${var//pattern/repl},
+    # turning "Café" into "caf-e"; the table holds letters only, so there is
+    # no glob or metacharacter to protect. tests/plugin/test_slugify.py runs
+    # under whatever `bash` is on PATH, so a Mac catches a regression here.
     for pair in "${translit[@]}"; do
         from="${pair%%:*}"
         to="${pair#*:}"
-        s="${s//"$from"/"$to"}"
+        s="${s//$from/$to}"
     done
 
     # LC_ALL=C keeps both steps byte-oriented, so the slug never depends on the


### PR DESCRIPTION
## Summary

The 27 local `test_slugify.py` failures were not a test quirk. `slugify` in `scripts/bash/common.sh` (and the plugin copy) transliterates accents with a **quoted** multibyte pattern in `${var//pattern/repl}`, which bash 3.2 mis-splits, so on any Mac without a Homebrew bash a project named "Café Modernisation" gets the directory `caf-e-modernisation` from `create-project.sh`. bash 5 handles it, which is why CI on Ubuntu never saw it.

Both sides of the substitution are now unquoted — the table holds letters only, so there is no glob or metacharacter to protect — with a comment naming the quirk so nobody re-quotes it. Upgrading bash locally would have fixed one machine and left the bug in the product.

## Verification

- `slugify "Café Zürich ÉCOLE"` → `cafe-zurich-ecole` and `"Straße Łódź İstanbul"` → `strasse-lodz-istanbul` under stock bash 3.2.
- `test_slugify.py`: 102 pass (was 75 pass / 27 fail on this Mac); parity of the two bash copies holds; full plugin suite now fully green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KR7uxRQ6m9c2xPQA1t9pU9